### PR TITLE
Fixes and changes to make docker experience more stable

### DIFF
--- a/src/main/java/com/aws/iot/util/Exec.java
+++ b/src/main/java/com/aws/iot/util/Exec.java
@@ -31,7 +31,7 @@ public class Exec {
     private String[] cmds;
     private File dir = userdir;
     private Process process;
-    private long timeout = 30;
+    private long timeout = 120;
     private TimeUnit timeunit = TimeUnit.SECONDS;
     private IntConsumer whenDone;
     private static final Consumer<CharSequence> NOP = s->{};

--- a/src/test/resources/com/aws/iot/gg2k/config.yaml
+++ b/src/test/resources/com/aws/iot/gg2k/config.yaml
@@ -57,6 +57,7 @@
       macos:
           skipif: exists /Applications/Docker.app
           script: |-
+            find $(brew --cache)/downloads/ -name *Docker.dmg.incomplete | xargs rm -f
             brew cask install docker
     requires:
         macos:
@@ -78,7 +79,12 @@
   hello-docker:
       requires: docker
       startup: docker run hello-world
-      shutdown: docker stop hello-world
+
+  hello-docker-nginx:
+      requires: docker
+      startup:  docker run --cidfile=cid nginx
+      shutdown: cat cid | xargs docker stop
+
   monitoring:
     install:
       debian: |-
@@ -101,7 +107,7 @@
       install:
           skipif: true
           all: echo All installed
-      requires: jdk11, git, hello-docker, localhttp
+      requires: jdk11, git, hello-docker, hello-docker-nginx, localhttp
       xyzzy: localhttp
       startup: |-
         pwd


### PR DESCRIPTION
*Description of changes:*

Increased Exec timeout to allow docker to complete.
Added clean up script to remove partials from brew/downloads to workaround the curl: (22) The requested URL returned error: 416 error
Removed the shutdown line for the hello-docker script. The Hello-world container starts and terminates almost immediately (as it doesn’t have a long running process within it), so the shutdown is not required.
Added a new nginx container (that has a long running process) as a sample of how to start and stop a docker container

The Docker installation on a Mac require human intervention for the first time install. Once the daemon is up and running, things become a lot more smoother.

*Testing:*

Log from my local testing.


-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.aws.iot.util.JsonEndpointTest
ServerSocket ServerSocket[addr=0.0.0.0/0.0.0.0,localport=34242]
        0.0.0.0/0.0.0.0
JsonEndpoint server starting
Connecting to socket Socket[addr=localhost/127.0.0.1,port=34242,localport=62301]
Password:Connected to EP2 Socket[addr=localhost/127.0.0.1,port=34242,localport=62301]
Connected to EP1 Socket[addr=/127.0.0.1,port=62301,localport=34242]
Wrote EP2 {op:"ping",syncid:0}
Read JsonEndpoint Reader {op:"ping",syncid:0}
Wrote EP1 {op:"reply",forid:0,value:"Hello..."}
Read JsonEndpoint Reader {op:"reply",forid:0,value:"Hello from 8c8590cf6680.ant.amazon.com"}
Handling reply to EP2 0
Starting callback EP2 com.aws.iot.util.JsonEndpointTest$$Lambda$39/0x00000008000de440@5f88593c
Got it!  Hello from 8c8590cf6680.ant.amazon.com
JsonEndpoint server stopping
JsonEndpoint JsonEndpoint serverjava.net.SocketException: Socket closed
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.24 sec
Running com.aws.iot.util.CoerceTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec
Running com.aws.iot.util.JsonUtilTest
{a:"hello",b:42,c:7.5,d:[1,2,3],e:[17,"foo"],f:["bar",18],g:true,NaN:NaN}
{a:"hello",b:42,c:7.5,d:[1,2,3],e:[17,"foo"],f:["bar",18],g:true,NaN:NaN}
{a:"hello",b:42,c:7.5,d:[1,2,3],e:[17,"foo"],f:["bar",18],g:true,NaN:NaN}
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec
Running com.aws.iot.util.UtilsTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec
Running com.aws.iot.util.ExecTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 sec
Running com.aws.iot.util.LLTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec
Running com.aws.iot.util.UnsyncBufferedInputStreamTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.052 sec
Running com.aws.iot.util.EZPluginsTest
/Users/chabom/work/AWS/IoT/sg/aws-greengrass-kernel
com.aws.iot.util.EZPluginsTest.A
A:Hello
com.aws.iot.util.EZPluginsTest.B
B:Hello
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.188 sec
Running com.aws.iot.util.UnsyncBufferedOutputStreamTest
Buffer size 2047
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec
Running com.aws.iot.config.ConfigurationTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.078 sec
Running com.aws.iot.dependency.LifecycleTest
Creating  c1/1
Creating  c2/2
Hello from c3: com.aws.iot.dependency.LifecycleTest$c3@57250572::null
Startup c1/1
Startup c2/2
  C3=com.aws.iot.dependency.LifecycleTest$c3@57250572::c2/2
Install c1/1
Shutdown c2/2
Shutdown c1/1
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 sec
Running com.aws.iot.gg2k.GG2KTest
tdir = /Users/chabom/gg2ktest
Reading file:/Users/chabom/work/AWS/IoT/sg/aws-greengrass-kernel/target/test-classes/com/aws/iot/gg2k/config.yaml
root path = /Users/chabom/gg2ktest
        /Users/chabom/gg2ktest/config
Sending log to stdout
2019-07-12T23:32:39.507630Z; ok; install; jdk11:New
2019-07-12T23:32:39.628771Z; ok; Skipping; jdk11.install.macos
2019-07-12T23:32:39.628829Z; ok; awaitingStartup; jdk11
2019-07-12T23:32:39.629437Z; ok; install; homebrew:New
2019-07-12T23:32:39.630211Z; ok; Skipping; homebrew.install.macos
2019-07-12T23:32:39.630231Z; ok; awaitingStartup; homebrew
2019-07-12T23:32:39.630283Z; ok; install; git:New
2019-07-12T23:32:39.630500Z; ok; Skipping; git.install.macos
2019-07-12T23:32:39.630510Z; ok; awaitingStartup; git
2019-07-12T23:32:39.630780Z; ok; install; docker:New
2019-07-12T23:32:39.630865Z; ok; Skipping; docker.install.macos
2019-07-12T23:32:39.630872Z; ok; awaitingStartup; docker
2019-07-12T23:32:39.630933Z; ok; install; hello-docker
2019-07-12T23:32:39.630943Z; ok; awaitingStartup; hello-docker
2019-07-12T23:32:39.631176Z; ok; install; hello-docker-nginx
2019-07-12T23:32:39.631194Z; ok; awaitingStartup; hello-docker-nginx
2019-07-12T23:32:39.729718Z; ok; install; main:New
2019-07-12T23:32:39.729767Z; ok; run; main.install.all
2019-07-12T23:32:39.737781Z; ok; stdout; All installed

Done
2019-07-12T23:32:39.738660Z; ok; awaitingStartup; main
2019-07-12T23:32:39.738766Z; ok; startup; homebrew
2019-07-12T23:32:39.738794Z; ok; startup; jdk11
2019-07-12T23:32:39.739558Z; ok; startup; git
2019-07-12T23:32:39.739582Z; ok; startup; docker
2019-07-12T23:32:39.739596Z; ok; startup; hello-docker
2019-07-12T23:32:39.739604Z; ok; run; hello-docker.startup
2019-07-12T23:32:39.745314Z; ok; run; docker.startup.macos
2019-07-12T23:32:39.745361Z; ok; startup; hello-docker-nginx
2019-07-12T23:32:39.752026Z; ok; run; hello-docker-nginx.startup
2019-07-12T23:32:39.752078Z; ok; Starting httpd
2019-07-12T23:32:39.760501Z; ok; startup; main
2019-07-12T23:32:39.760537Z; ok; run; main.startup
2019-07-12T23:32:39.770283Z; ok; stdout; /Users/chabom/gg2ktest/work

2019-07-12T23:32:39.777953Z; ok; stdout; Fri Jul 12 16:32:39 PDT 2019

Victory!
2019-07-12T23:32:39.779126Z; ok; stdout; RUNNING

2019-07-12T23:32:39.805806Z; ok; shutdown; docker:Shutdown
2019-07-12T23:32:39.806056Z; ok; Finished; docker:Shutdown
2019-07-12T23:32:39.845261Z; ok; Finished starting httpd
2019-07-12T23:32:40.001446Z; warn; stderr; docker: Container ID file found, make sure the other container isn't running or delete cid.

2019-07-12T23:32:40.001489Z; warn; stderr; See 'docker run --help'.

2019-07-12T23:32:40.005576Z; ok; shutdown; hello-docker-nginx
2019-07-12T23:32:40.005688Z; ok; run; hello-docker-nginx.shutdown
2019-07-12T23:32:40.056734Z; ok; stdout; adfb3ace31e42bada9e61974eeb46065f28ca7b52508cf0ffdc80d694c310cb0

2019-07-12T23:32:40.060622Z; ERROR; Failed; 125; hello-docker-nginx:Shutdown
2019-07-12T23:32:40.656935Z; ok; stdout; 

2019-07-12T23:32:40.656974Z; ok; stdout; Hello from Docker!

2019-07-12T23:32:40.656981Z; ok; stdout; This message shows that your installation appears to be working correctly.

2019-07-12T23:32:40.657027Z; ok; stdout; 

2019-07-12T23:32:40.657035Z; ok; stdout; To generate this message, Docker took the following steps:

2019-07-12T23:32:40.657053Z; ok; stdout;  1. The Docker client contacted the Docker daemon.

2019-07-12T23:32:40.657059Z; ok; stdout;  2. The Docker daemon pulled the "hello-world" image from the Docker Hub.

2019-07-12T23:32:40.657066Z; ok; stdout;     (amd64)

2019-07-12T23:32:40.657071Z; ok; stdout;  3. The Docker daemon created a new container from that image which runs the

2019-07-12T23:32:40.657085Z; ok; stdout;     executable that produces the output you are currently reading.

2019-07-12T23:32:40.657090Z; ok; stdout;  4. The Docker daemon streamed that output to the Docker client, which sent it

2019-07-12T23:32:40.657093Z; ok; stdout;     to your terminal.

2019-07-12T23:32:40.657095Z; ok; stdout; 

2019-07-12T23:32:40.657129Z; ok; stdout; To try something more ambitious, you can run an Ubuntu container with:

2019-07-12T23:32:40.657138Z; ok; stdout;  $ docker run -it ubuntu bash

2019-07-12T23:32:40.657143Z; ok; stdout; 

2019-07-12T23:32:40.657161Z; ok; stdout; Share images, automate workflows, and more with a free Docker ID:

2019-07-12T23:32:40.657175Z; ok; stdout;  https://hub.docker.com/

2019-07-12T23:32:40.657183Z; ok; stdout; 

2019-07-12T23:32:40.657190Z; ok; stdout; For more examples and ideas, visit:

2019-07-12T23:32:40.657226Z; ok; stdout;  https://docs.docker.com/get-started/

2019-07-12T23:32:40.657238Z; ok; stdout; 

2019-07-12T23:32:41.151318Z; ok; shutdown; hello-docker:Shutdown
2019-07-12T23:32:41.151451Z; ok; Finished; hello-docker:Shutdown
2019-07-12T23:32:49.807846Z; ok; stdout; Fri Jul 12 16:32:49 PDT 2019

Victory!
2019-07-12T23:32:49.808131Z; ok; stdout; RUNNING

2019-07-12T23:32:59.824785Z; ok; stdout; Fri Jul 12 16:32:59 PDT 2019

Victory!
2019-07-12T23:32:59.825004Z; ok; stdout; RUNNING

2019-07-12T23:33:09.837008Z; ok; stdout; Fri Jul 12 16:33:09 PDT 2019

Victory!
2019-07-12T23:33:09.837206Z; ok; stdout; RUNNING

2019-07-12T23:33:19.848247Z; ok; stdout; Fri Jul 12 16:33:19 PDT 2019

Victory!
Running correctly
2019-07-12T23:33:19.848449Z; ok; stdout; RUNNING

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.422 sec
2019-07-12T23:33:19.850223Z; ok; Installing software; main
2019-07-12T23:33:19.855732Z; ok; shutdown; main:Shutdown
2019-07-12T23:33:19.855761Z; ok; shutdown; jdk11:Shutdown
2019-07-12T23:33:19.855767Z; ok; shutdown; git:Shutdown
2019-07-12T23:33:19.855781Z; ok; Shutting down httpd
2019-07-12T23:33:19.859909Z; ok; shutdown; homebrew:Shutdown

Results :

Tests run: 21, Failures: 0, Errors: 0, Skipped: 0

[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ gg2-kernel ---
[INFO] Building jar: /Users/chabom/work/AWS/IoT/sg/aws-greengrass-kernel/target/gg2-kernel-1.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  44.974 s
[INFO] Finished at: 2019-07-12T16:33:20-07:00
[INFO] ------------------------------------------------------------------------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
