### PR TITLE
Bug fix and behavior improvement in lifecycle handling.

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/util/Exec.java
+++ b/src/main/java/com/aws/iot/evergreen/util/Exec.java
@@ -131,6 +131,17 @@ public class Exec {
                 appendStackTrace(ex, stderr);
         }
     }
+
+    public boolean terminated() {
+        return this.process == null || !this.process.isAlive();
+    }
+
+    public void terminateForcibly() {
+        if (!terminated()) {
+            this.process.destroyForcibly();
+        }
+    }
+
     public String asString() {
         StringBuilder sb = new StringBuilder();
         Consumer<CharSequence> f = s -> sb.append(s);

--- a/src/test/java/com/aws/iot/evergreen/dependency/LifecycleTest.java
+++ b/src/test/java/com/aws/iot/evergreen/dependency/LifecycleTest.java
@@ -53,6 +53,7 @@ public class LifecycleTest {
         assertTrue(v.getState().isFunctioningProperly());
         context.shutdown();
         try { Thread.sleep(50); } catch (InterruptedException ex) { }
+
         assertTrue(v.shutdownCalled,v.toString());
         assertTrue(v.C2.shutdownCalled, v.C2.toString());
         System.out.println("XYXXY: "+v.getState());
@@ -76,12 +77,13 @@ public class LifecycleTest {
         }
         @Override public void startup() {
             startupCalled = true;
-            // Depen dependencies must be started first
+            // Dependencies must be started first
+            System.out.println("C2 state in C1" + C2.getState().toString());
             assertTrue(C2.getState().isFunctioningProperly());
             System.out.println("Startup "+this);
             super.startup();
         }
-        @Override public void shutdown() { 
+        @Override public void shutdown() {
             shutdownCalled = true;
             System.out.println("Shutdown "+this);
             super.shutdown();
@@ -109,7 +111,7 @@ public class LifecycleTest {
             System.out.println("  C3="+C3);
             super.startup();
         }
-        @Override public void shutdown() { 
+        @Override public void shutdown() {
             shutdownCalled = true;
             System.out.println("Shutdown "+this);
             super.shutdown();


### PR DESCRIPTION
1. Previously, when a 'run' command exits 0, GenericExternalService will
set service state to 'Finished' which in turn triggers shutdown()
invocation. This behavior makes daemon-like services not able to work
because their 'run' command spawns a separate process and exits early.
This commit change the behavior to not set states to 'Finished' for
non-periodic services.

2. Fix the behavior in installOnly mode , where previously both EvergreenService and Kernel
try to set service states to AwaitStartUp and cause conflicts.

3. Kill running processes when shutdown is called and process fail to
terminate.

4. When kernel shut down, wait for tasks in the
ScheduledThreadPoolExecutor to finish.

5. minor logging fixes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
