### PR TITLE
Use logger API in kernel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,20 @@
                 <configuration>
                     <skipTests>true</skipTests>
                     <trimStackTrace>false</trimStackTrace>
+                    <systemProperties>
+                        <property>
+                            <name>log.level</name>
+                            <value>INFO</value>
+                        </property>
+                        <property>
+                            <name>log.store</name>
+                            <value>CONSOLE</value>
+                        </property>
+                        <property>
+                            <name>log.fmt</name>
+                            <value>JSON</value>
+                        </property>
+                    </systemProperties>
                 </configuration>
                 <executions>
                     <execution>
@@ -144,6 +158,7 @@
                             <skipTests>false</skipTests>
                             <excludedGroups>*</excludedGroups>
                             <groups>Integration</groups>
+                            <reuseForks>false</reuseForks> <!-- This will make sure to spawn a fresh jvm for each test -->
                         </configuration>
                     </execution>
                 </executions>
@@ -188,7 +203,7 @@
                     <logViolationsToConsole>true</logViolationsToConsole>
                     <configLocation>checkstyle.xml</configLocation>
                     <violationSeverity>warning</violationSeverity>
-                    <!-- 36 is the total number of warning at this moment. Set it as the max allowed so that
+                    <!-- This is the total number of warning at this moment. Set it as the max allowed so that
                     we don't introduce more violations in new code. -->
                     <maxAllowedViolations>36</maxAllowedViolations>
                 </configuration>

--- a/src/main/java/com/aws/iot/evergreen/builtin/services/servicediscovery/ServiceDiscoveryAgent.java
+++ b/src/main/java/com/aws/iot/evergreen/builtin/services/servicediscovery/ServiceDiscoveryAgent.java
@@ -15,7 +15,6 @@ import com.aws.iot.evergreen.ipc.services.servicediscovery.ServiceDiscoveryRespo
 import com.aws.iot.evergreen.ipc.services.servicediscovery.UpdateResourceRequest;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.util.LockScope;
-import com.aws.iot.evergreen.util.Log;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,9 +35,6 @@ public class ServiceDiscoveryAgent implements InjectionActions {
 
     @Inject
     private Configuration config;
-
-    @Inject
-    private Log log;
 
     @Inject
     private Kernel kernel;

--- a/src/main/java/com/aws/iot/evergreen/config/PlatformResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/config/PlatformResolver.java
@@ -23,6 +23,7 @@ public class PlatformResolver {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
             value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
+    @SuppressWarnings({"checkstyle:emptycatchblock"})
     private static Map<String, Integer> initializeRanks() {
         Map<String, Integer> ranks = new HashMap<>();
         // figure out what OS we're running and add applicable tags

--- a/src/main/java/com/aws/iot/evergreen/ipc/IPCRouter.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/IPCRouter.java
@@ -6,33 +6,30 @@ package com.aws.iot.evergreen.ipc;
 
 import com.aws.iot.evergreen.ipc.common.FrameReader;
 import com.aws.iot.evergreen.ipc.exceptions.IPCException;
-import com.aws.iot.evergreen.util.Log;
+import com.aws.iot.evergreen.logging.api.Logger;
+import com.aws.iot.evergreen.logging.impl.LogManager;
 import io.netty.channel.Channel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 
 /**
  * Class for storing routing between IPC destination names and their handlers.
  */
 @AllArgsConstructor
-@NoArgsConstructor
 public class IPCRouter {
-    @Inject
-    Log log;
-
     private final Map<Integer, IPCCallback> destinationCallbackMap = new ConcurrentHashMap<>();
     private final Map<ConnectionContext, Channel> clientToChannelMap = new ConcurrentHashMap<>();
     private final Map<ClientAndRequestId, CompletableFuture<FrameReader.Message>> requestIdToCallbackMap =
             new ConcurrentHashMap<>();
+
+    private static final Logger logger = LogManager.getLogger(IPCRouter.class);
 
     /**
      * Registers a callback for a destination, Dispatcher will invoke the function for all message with registered
@@ -44,7 +41,6 @@ public class IPCRouter {
      * @throws IPCException if the callback is already registered for a destination
      */
     public void registerServiceCallback(int destination, IPCCallback callback) throws IPCException {
-        log.log(Log.Level.Note, "registering callback for destination ", destination);
         IPCCallback existingFunction = destinationCallbackMap.putIfAbsent(destination, callback);
         if (existingFunction != null) {
             throw new IPCException("callback for destination already registered");

--- a/src/test/java/com/aws/iot/evergreen/ipc/AuthHandlerTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/AuthHandlerTest.java
@@ -10,7 +10,6 @@ import com.aws.iot.evergreen.ipc.services.auth.AuthResponse;
 import com.aws.iot.evergreen.ipc.services.common.ApplicationMessage;
 import com.aws.iot.evergreen.ipc.services.common.IPCUtil;
 import com.aws.iot.evergreen.kernel.EvergreenService;
-import com.aws.iot.evergreen.util.Log;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -69,7 +68,7 @@ class AuthHandlerTest {
         lenient().doAnswer((invocation) -> mockAttrValue = invocation.getArgument(0)).when(mockAttr).set(any());
         lenient().when(mockChannel.remoteAddress()).thenReturn(LocalAddress.ANY);
         lenient().when(mockCtx.writeAndFlush(frameCaptor.capture())).thenReturn(mockChannelFuture);
-        mockAuth = spy(new AuthHandler(mock(Configuration.class), mock(Log.class), mock(IPCRouter.class)));
+        mockAuth = spy(new AuthHandler(mock(Configuration.class), mock(IPCRouter.class)));
     }
 
     @Test
@@ -81,7 +80,7 @@ class AuthHandlerTest {
         assertNotNull(authToken);
         assertEquals(SERVICE_NAME, config.find(AUTH_TOKEN_LOOKUP_KEY, (String) authToken).getOnce());
 
-        AuthHandler auth = new AuthHandler(config, mock(Log.class), mock(IPCRouter.class));
+        AuthHandler auth = new AuthHandler(config, mock(IPCRouter.class));
 
         AuthRequest authRequest = new AuthRequest((String) authToken);
         ApplicationMessage applicationMessage = ApplicationMessage.builder().payload(IPCUtil.encode(authRequest)).version(AUTH_API_VERSION).build();
@@ -97,7 +96,7 @@ class AuthHandlerTest {
     public void GIVEN_service_WHEN_try_to_authenticate_with_bad_token_THEN_is_rejected() throws Exception {
         Configuration config = new Configuration(new Context());
 
-        AuthHandler auth = new AuthHandler(config, mock(Log.class), mock(IPCRouter.class));
+        AuthHandler auth = new AuthHandler(config, mock(IPCRouter.class));
         AuthRequest authRequest = new AuthRequest("MyAuthToken");
         ApplicationMessage applicationMessage = ApplicationMessage.builder().payload(IPCUtil.encode(authRequest)).version(AUTH_API_VERSION).build();
 

--- a/src/test/java/com/aws/iot/evergreen/ipc/IPCChannelHandlerTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/IPCChannelHandlerTest.java
@@ -7,7 +7,7 @@ package com.aws.iot.evergreen.ipc;
 import com.aws.iot.evergreen.ipc.common.BuiltInServiceDestinationCode;
 import com.aws.iot.evergreen.ipc.common.FrameReader;
 import com.aws.iot.evergreen.ipc.exceptions.IPCException;
-import com.aws.iot.evergreen.util.Log;
+import com.aws.iot.evergreen.logging.api.Logger;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
@@ -16,6 +16,7 @@ import io.netty.util.Attribute;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -61,7 +62,7 @@ public class IPCChannelHandlerTest {
 
     @BeforeEach
     public void setupMocks() throws Exception {
-        router = new IPCChannelHandler(mock(Log.class), mockAuth, ipcRouter);
+        router = new IPCChannelHandler(mockAuth, ipcRouter);
 
         when(mockCtx.channel()).thenReturn(mockChannel);
         when(mockChannel.attr(any())).thenReturn((Attribute) mockAttr);

--- a/src/test/java/com/aws/iot/evergreen/ipc/IPCRouterTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/IPCRouterTest.java
@@ -1,9 +1,10 @@
 package com.aws.iot.evergreen.ipc;
 
 import com.aws.iot.evergreen.ipc.exceptions.IPCException;
-import com.aws.iot.evergreen.util.Log;
+import com.aws.iot.evergreen.logging.api.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -15,12 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 public class IPCRouterTest {
-    @Mock
-    Log log;
 
     @Test
     public void GIVEN_function_WHEN_register_callback_THEN_callback_can_be_called() throws Throwable {
-        IPCRouter router = new IPCRouter(log);
+        IPCRouter router = new IPCRouter();
 
         CountDownLatch cdl = new CountDownLatch(1);
         router.registerServiceCallback(100, (a, b) -> {
@@ -34,7 +33,7 @@ public class IPCRouterTest {
 
     @Test
     public void GIVEN_already_registered_function_WHEN_register_callback_THEN_exception_is_thrown() throws Throwable {
-        IPCRouter router = new IPCRouter(log);
+        IPCRouter router = new IPCRouter();
 
         router.registerServiceCallback(100, (a, b) -> null);
 

--- a/src/test/java/com/aws/iot/evergreen/kernel/EvergreenServiceTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/EvergreenServiceTest.java
@@ -5,11 +5,12 @@ import com.aws.iot.evergreen.config.Topics;
 import com.aws.iot.evergreen.config.Validator;
 import com.aws.iot.evergreen.dependency.Context;
 import com.aws.iot.evergreen.dependency.State;
-import com.aws.iot.evergreen.util.Log;
+import com.aws.iot.evergreen.logging.api.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -33,15 +34,13 @@ class EvergreenServiceTest {
     @Mock
     private Context context;
 
-    @Mock
-    private Log log;
-
     @Captor
     private ArgumentCaptor<Validator> validatorArgumentCaptor;
 
     @BeforeEach
     void beforeEach() {
         Mockito.when(config.createLeafChild(Mockito.any())).thenReturn(stateTopic);
+        Mockito.when(config.getFullName()).thenReturn(EVERGREEN_SERVICE_FULL_NAME);
 
         evergreenService = new EvergreenService(config);
         evergreenService.context = context;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactor all log lines to use new logger APIs. Cleanup of previous logger will be done in a separate PR.

Open Items to be addressed later: 
- [ ] One kernel test scans the log output to make sure the execution is successful. With this change, the test will read from log file and make assertions. Should we intercept the console output instead of reading from files?
- [ ] The integration tests are configured to fork new JVM for each test class, so that the logging config is different per JVM. How can we avoid this? Can we rewrite tests to not check log output?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
