### PR TITLE
Fix state machine from Installed->Finished

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -108,7 +108,7 @@ public class EvergreenService implements InjectionActions, Closeable {
         }
         // TODO: Add more validations
 
-        if (getState().equals(State.Starting) && newState.equals(State.Finished)) {
+        if (getState().equals(State.Installed) && newState.equals(State.Finished)) {
             // if a service doesn't have any run logic, request stop on service to clean up DesiredStateList
             requestStop();
         }


### PR DESCRIPTION
Remove the desiredState when service directly move from Installed to
Finished.

*Issue #, if available:*
Previously, if service set state to Finished in startup() , it will be restarted. This fix stop restarting the service.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
