### PR TITLE
Add JUnit 5 Extension to Capture Runtime Metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,24 @@
                             <value>TEXT</value>
                         </property>
                     </systemProperties>
+                    <argLine>${surefire.argLine} -Xms1m</argLine>
+                    <excludes>
+                        <exclude>**/InitTestSuite.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <test>InitTestSuite</test>
+                            <skipTests>false</skipTests>
+                        </configuration>
+                    </execution>
+
                     <execution>
                         <id>unit-tests</id>
                         <phase>test</phase>
@@ -169,7 +185,8 @@
                             <skipTests>false</skipTests>
                             <excludedGroups>*</excludedGroups>
                             <groups>Integration</groups>
-                            <reuseForks>false</reuseForks> <!-- This will make sure to spawn a fresh jvm for each test -->
+                            <reuseForks>false
+                            </reuseForks> <!-- This will make sure to spawn a fresh jvm for each test -->
                         </configuration>
                     </execution>
                 </executions>
@@ -234,6 +251,7 @@
                     <excludes>
                         <exclude>**/*Exception*</exclude>
                     </excludes>
+                    <propertyName>surefire.argLine</propertyName>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/test/java/com/aws/iot/evergreen/extension/InitTestSuite.java
+++ b/src/test/java/com/aws/iot/evergreen/extension/InitTestSuite.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.extension;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+
+public class InitTestSuite {
+    // This test case runs once per test suite execution before the suite starts.
+    // Put logic here which should run only once before all tests.
+    @Test
+    public void init() throws Exception {
+        File surefireReportDir = new File(System.getProperty("surefireReportDir", "target/surefire-reports"));
+        if (!surefireReportDir.exists()) {
+            surefireReportDir.mkdirs();
+        }
+
+        File reportFile = surefireReportDir.toPath().resolve("junitReport.json").toFile();
+        if (reportFile.exists()) {
+            // Clear out the report file so we're not continually appending to it
+            new FileWriter(reportFile, false).close();
+        }
+    }
+}

--- a/src/test/java/com/aws/iot/evergreen/extension/PerformanceReporting.java
+++ b/src/test/java/com/aws/iot/evergreen/extension/PerformanceReporting.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.extension;
+
+import com.aws.iot.evergreen.util.Utils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.ValueIterator;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.lang.management.ClassLoadingMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class PerformanceReporting
+        implements Extension, BeforeAllCallback, BeforeTestExecutionCallback, AfterTestExecutionCallback {
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create("com.aws.iot.evergreen.extension");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ScheduledExecutorService exec = new ScheduledThreadPoolExecutor(1);
+    private static final MemoryMXBean MEMORY_BEAN = ManagementFactory.getMemoryMXBean();
+    private static final ClassLoadingMXBean CLASS_BEAN = ManagementFactory.getClassLoadingMXBean();
+    private ScheduledFuture<?> running;
+    private static File reportFile;
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) throws Exception {
+        // Request that we first gc to make sure that we start as small as possible
+        Runtime.getRuntime().gc();
+        context.getStore(NAMESPACE).put(context.getDisplayName(), new LinkedList<RuntimeInfo>());
+
+        // Refresh the stats every 50ms, taking the maximum of each value every time
+        running = exec.scheduleAtFixedRate(() -> {
+            ((List<RuntimeInfo>) context.getStore(NAMESPACE).get(context.getDisplayName()))
+                    .add(new RuntimeInfo(MEMORY_BEAN.getHeapMemoryUsage().getUsed(),
+                            MEMORY_BEAN.getNonHeapMemoryUsage().getUsed(), CLASS_BEAN.getLoadedClassCount()));
+        }, 0, 50, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) throws Exception {
+        running.cancel(false);
+        List<RuntimeInfo> infoList = (List<RuntimeInfo>) context.getStore(NAMESPACE).get(context.getDisplayName());
+        double maxHeapMemoryMB = infoList.stream().mapToLong(x -> x.heapMemory).max().getAsLong() / 1024.0 / 1024.0;
+        double maxNonHeapMemoryMB =
+                infoList.stream().mapToLong(x -> x.nonHeapMemory).max().getAsLong() / 1024.0 / 1024.0;
+        long maxLoadedClassCount = infoList.stream().mapToLong(x -> x.loadedClassCount).max().getAsLong();
+
+        double avgHeapMemoryMB =
+                infoList.stream().mapToLong(x -> x.heapMemory).average().getAsDouble() / 1024.0 / 1024.0;
+        double avgNonHeapMemoryMB =
+                infoList.stream().mapToLong(x -> x.nonHeapMemory).average().getAsDouble() / 1024.0 / 1024.0;
+        double avgLoadedClassCount = infoList.stream().mapToLong(x -> x.loadedClassCount).average().getAsDouble();
+
+        Map<String, String> perfValueMap = Utils.immutableMap("name", context.getRequiredTestMethod().getName(), "classname",
+                context.getRequiredTestClass().getName(), "maxHeapMemoryMB", maxHeapMemoryMB, "maxNonHeapMemoryMB",
+                maxNonHeapMemoryMB, "maxLoadedClassCount", maxLoadedClassCount, "avgHeapMemoryMB", avgHeapMemoryMB,
+                "avgNonHeapMemoryMB", avgNonHeapMemoryMB, "avgLoadedClassCount", avgLoadedClassCount);
+
+        ValueIterator<?> existing = null;
+        try {
+            existing = JSON.std.anySequenceFrom(reportFile);
+        } catch (JSONObjectException ignored) {
+        }
+
+        try (FileWriter fileWriter = new FileWriter(reportFile, false);
+             SequenceWriter seqWriter = MAPPER.writer().writeValuesAsArray(fileWriter)) {
+            if (existing != null) {
+                seqWriter.writeAll(existing.readAll());
+            }
+            seqWriter.write(perfValueMap);
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        File surefireReportDir = new File(System.getProperty("surefireReportDir", "target/surefire-reports"));
+        if (!surefireReportDir.exists()) {
+            surefireReportDir.mkdirs();
+        }
+
+        reportFile = surefireReportDir.toPath().resolve("junitReport.json").toFile();
+        if (!reportFile.exists()) {
+            reportFile.createNewFile();
+        }
+    }
+
+    @AllArgsConstructor
+    private static class RuntimeInfo {
+        long heapMemory;
+        long nonHeapMemory;
+        long loadedClassCount;
+    }
+}

--- a/src/test/java/com/aws/iot/evergreen/ipc/IPCServicesTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/IPCServicesTest.java
@@ -2,6 +2,7 @@ package com.aws.iot.evergreen.ipc;
 
 import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.extension.PerformanceReporting;
 import com.aws.iot.evergreen.ipc.config.KernelIPCClientConfig;
 import com.aws.iot.evergreen.ipc.services.lifecycle.LifecycleImpl;
 import com.aws.iot.evergreen.ipc.services.servicediscovery.LookupResourceRequest;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.net.URI;
 import java.util.List;
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(PerformanceReporting.class)
 @Tag("Integration")
 public class IPCServicesTest {
 

--- a/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
@@ -4,12 +4,14 @@
 package com.aws.iot.evergreen.kernel;
 
 import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.extension.PerformanceReporting;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.jr.ob.JSON;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(PerformanceReporting.class)
 @Tag("Integration")
 public class KernelTest {
     static final int[] gc = new int[10];

--- a/src/test/java/com/aws/iot/evergreen/kernel/ServiceConfigMergingTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/ServiceConfigMergingTest.java
@@ -1,11 +1,13 @@
 package com.aws.iot.evergreen.kernel;
 
 import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.extension.PerformanceReporting;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +21,7 @@ import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(PerformanceReporting.class)
 @Tag("Integration")
 public class ServiceConfigMergingTest {
     private Kernel kernel;

--- a/src/test/java/com/aws/iot/evergreen/util/ExecTest.java
+++ b/src/test/java/com/aws/iot/evergreen/util/ExecTest.java
@@ -4,8 +4,10 @@
 
 package com.aws.iot.evergreen.util;
 
+import com.aws.iot.evergreen.extension.PerformanceReporting;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
+@ExtendWith(PerformanceReporting.class)
 @Tag("Integration")
 public class ExecTest {
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Create `junitReport.json` file containing runtime metrics from annotated test classes. These metrics include: max heap memory, max off-heap memory, and max loaded classes.

**Why is this change necessary:**
This change will enable us to collect metrics from test runs and compare memory usage between runs.

**How was this change tested:**
All unit and integ tests are passing and manually verified that the output file is created with proper output.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
