### PR TITLE
Propose new interfaces in deployment/package flow

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
@@ -1,0 +1,39 @@
+package com.aws.iot.evergreen.deployment;
+
+import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
+import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.packagemanager.DependencyResolver;
+import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
+import com.aws.iot.evergreen.packagemanager.PackageCache;
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class DeploymentTask implements Callable<Void> {
+    private final DependencyResolver dependencyResolver;
+    private final PackageCache packageCache;
+    private final KernelConfigResolver kernelConfigResolver;
+    private final Kernel kernel;
+    private final DeploymentDocument document;
+
+    public DeploymentTask(DependencyResolver dependencyResolver, PackageCache packageCache,
+                          KernelConfigResolver kernelConfigResolver, Kernel kernel, DeploymentDocument document) {
+        this.dependencyResolver = dependencyResolver;
+        this.packageCache = packageCache;
+        this.kernelConfigResolver = kernelConfigResolver;
+        this.kernel = kernel;
+        this.document = document;
+    }
+
+
+    @Override
+    public Void call() throws Exception {
+        List<PackageIdentifier> desiredPackages = dependencyResolver.resolveDependencies(document);
+        packageCache.preparePackages(desiredPackages).get();
+        Map<Object, Object> newConfig = kernelConfigResolver.resolve(desiredPackages, document);
+        kernel.mergeInNewConfig(document.getDeploymentId(), document.getTimestamp(), newConfig);
+        return null;
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -1,0 +1,28 @@
+package com.aws.iot.evergreen.packagemanager;
+
+import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DependencyResolver {
+    private final PackageRegistry packageRegistry;
+
+    public DependencyResolver(PackageRegistry packageRegistry) {
+        this.packageRegistry = packageRegistry;
+    }
+
+    /**
+     * Create the full list of packages to be run on the device from a deployment document.
+     * It also resolves the conflicts between the packages specified in the deployment document and the existing
+     * running packages on the device.
+     * @param document deployment document
+     * @return a full list of packages to be run on the device
+     * @throws PackageVersionConflictException when a package version conflict cannot be resolved
+     */
+    public List<PackageIdentifier> resolveDependencies(DeploymentDocument document) throws PackageVersionConflictException {
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -1,0 +1,28 @@
+package com.aws.iot.evergreen.packagemanager;
+
+import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KernelConfigResolver {
+    private final PackageCache packageCache;
+
+    public KernelConfigResolver(PackageCache packageCache) {
+        this.packageCache = packageCache;
+    }
+
+    /**
+     * Create a kernel config map from a list of package identifiers and deployment document.
+     * For each package, it first retrieves its recipe, then merge the parameter values into the recipe, and last
+     * transform it to a kernel config key-value pair.
+     * @param pkgs a list of package identifiers
+     * @param document deployment document
+     * @return a kernel config map
+     */
+    public Map<Object, Object> resolve(List<PackageIdentifier> pkgs, DeploymentDocument document) {
+        return new HashMap<>();
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/PackageCache.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/PackageCache.java
@@ -1,0 +1,31 @@
+package com.aws.iot.evergreen.packagemanager;
+
+import com.aws.iot.evergreen.packagemanager.models.Package;
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+public class PackageCache {
+
+    /**
+     * Make sure all the specified packages exist in the package cache. Download them from remote repository if
+     * they don't exist.
+     * @param pkgs a list of packages.
+     * @return a future to notify once this is finished.
+     */
+    public Future<Void> preparePackages(List<PackageIdentifier> pkgs) {
+        // TODO: to be implemented.
+        return null;
+    }
+
+    /**
+     * Retrieve the recipe of a package.
+     * @param pkg package identifier
+     * @return package recipe
+     */
+    public Package getRecipe(PackageIdentifier pkg) {
+        // TODO: to be implemented.
+        return null;
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageIdentifier.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageIdentifier.java
@@ -1,0 +1,8 @@
+package com.aws.iot.evergreen.packagemanager.models;
+
+import com.vdurmont.semver4j.Semver;
+
+public class PackageIdentifier {
+    String Name;
+    Semver version;
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Propose new interfaces in the deployment/package flow. 
`DeploymentTask` is the entry point to execute a deployment specified by a deployment document. It depends on four classes: `DependencyResolver`, `PackageCache`, `KernelConfigResolver` and `Kernel`.

`DeploymentResolver` -- Generates the full list of packages that will be run on the device. It needs to resolve the conflict between the new packages in the deployment document and those existing packages running on the device with the help of `PackageRegistry`.
`PackageCache` -- Prepares the artifact and recipe for the packages that will be run on the device. With the help of `PackageDownloader`, it fetched any package that doesn't exist on the device from a remote repository specified by the customer. PackageCache also manages other aspects of local packages, such as removing unused packages and managing the storage spaces. This can be renamed to `PackageStore`.
`KernelConfigResolver` -- Generates the new kernel config map. It retrieves the package recipe for each package, merge in the runtime parameter values, and transform them to the kernel config map.
`Kernel` -- Merges in the new kernel config map into the kernel and restarts services if necessary.

Additional helper classes for managing packages locally:

`PackageRegistry` -- Keeps tracking the current running packages (active) on the device. Might not be needed if the same information can be retrieved from the kernel.
`PackageDownloader` -- a utility responsible for downloading packages from a remote repository.


**Why is this change necessary:**
To make the code more readable, easier to maintain.
**How was this change tested:**
Not tested
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
