### PR TITLE
Update dependency resolver interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.jar
 *~
 *.log
+*.metrics
 core
 .idea
 artifact_cache

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
@@ -12,6 +12,7 @@ import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictExc
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import lombok.AllArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -37,10 +38,10 @@ public class DeploymentTask implements Callable<Void> {
             logger.atInfo().setEventType(DEPLOYMENT_TASK_EVENT_TYPE).addKeyValue("deploymentId",
                     document.getDeploymentId())
                     .log("Start deployment task");
-            List<PackageIdentifier> desiredPackages = dependencyResolver.resolveDependencies(document);
+            Map<PackageIdentifier, String> desiredPackages = dependencyResolver.resolveDependencies(document);
             // Block this without timeout because a device can be offline and it can take quite a long time
             // to download a package.
-            packageCache.preparePackages(desiredPackages).get();
+            packageCache.preparePackages(new ArrayList<>(desiredPackages.keySet())).get();
             Map<Object, Object> newConfig = kernelConfigResolver.resolve(desiredPackages, document);
             // Block this without timeout because it can take a long time for the device to update the config
             // (if it's not in a safe window).

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -4,8 +4,8 @@ import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DependencyResolver {
     // TODO: temporarily suppress this warning which will be gone after these fields get used.
@@ -21,12 +21,12 @@ public class DependencyResolver {
      * It also resolves the conflicts between the packages specified in the deployment document and the existing
      * running packages on the device.
      * @param document deployment document
-     * @return a full list of packages to be run on the device
+     * @return a map of packages to be run on the device to version constraints
      * @throws PackageVersionConflictException when a package version conflict cannot be resolved
      * @throws InterruptedException when the running thread is interrupted
      */
-    public List<PackageIdentifier> resolveDependencies(DeploymentDocument document)
+    public Map<PackageIdentifier, String> resolveDependencies(DeploymentDocument document)
             throws PackageVersionConflictException, InterruptedException {
-        return new ArrayList<>();
+        return new HashMap<>();
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -4,7 +4,6 @@ import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class KernelConfigResolver {
@@ -20,12 +19,12 @@ public class KernelConfigResolver {
      * Create a kernel config map from a list of package identifiers and deployment document.
      * For each package, it first retrieves its recipe, then merge the parameter values into the recipe, and last
      * transform it to a kernel config key-value pair.
-     * @param pkgs a list of package identifiers
+     * @param pkgs a map of package identifiers to version constraints
      * @param document deployment document
      * @return a kernel config map
      * @throws InterruptedException when the running thread is interrupted
      */
-    public Map<Object, Object> resolve(List<PackageIdentifier> pkgs, DeploymentDocument document)
+    public Map<Object, Object> resolve(Map<PackageIdentifier, String> pkgs, DeploymentDocument document)
             throws InterruptedException {
         return new HashMap<>();
     }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/Package.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/Package.java
@@ -45,13 +45,13 @@ public class Package {
     // TODO: Migrate to artifact objects, this is only a list of URLs at the moment
     private final List<String> artifacts;
 
-    // TODO clean up this field
-    @Deprecated
     private final Map<String, String> dependencies;
 
     // TODO: Needs discussion, this should probably be removed after integration demo
     private final List<String> requires;
 
+    // TODO clean up this field
+    @Deprecated
     @JsonIgnore
     private Set<Package> dependencyPackages;
 

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
@@ -63,7 +63,7 @@ public class DeploymentTaskTest {
         deploymentTask.call();
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache).preparePackages(anyList());
-        verify(mockKernelConfigResolver).resolve(anyList(), eq(deploymentDocument));
+        verify(mockKernelConfigResolver).resolve(anyMap(), eq(deploymentDocument));
         verify(mockKernel).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
@@ -76,7 +76,7 @@ public class DeploymentTaskTest {
         assertThat(thrown.getCause(), isA(PackageVersionConflictException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache, times(0)).preparePackages(anyList());
-        verify(mockKernelConfigResolver, times(0)).resolve(anyList(), eq(deploymentDocument));
+        verify(mockKernelConfigResolver, times(0)).resolve(anyMap(), eq(deploymentDocument));
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
@@ -87,7 +87,7 @@ public class DeploymentTaskTest {
         assertThat(thrown.getCause(), isA(InterruptedException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache, times(0)).preparePackages(anyList());
-        verify(mockKernelConfigResolver, times(0)).resolve(anyList(), eq(deploymentDocument));
+        verify(mockKernelConfigResolver, times(0)).resolve(anyMap(), eq(deploymentDocument));
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
@@ -103,7 +103,7 @@ public class DeploymentTaskTest {
         assertThat(thrown.getCause(), isA(RetryableDeploymentTaskFailureException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache).preparePackages(anyList());
-        verify(mockKernelConfigResolver, times(0)).resolve(anyList(), eq(deploymentDocument));
+        verify(mockKernelConfigResolver, times(0)).resolve(anyMap(), eq(deploymentDocument));
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
@@ -111,13 +111,13 @@ public class DeploymentTaskTest {
     public void GIVEN_deploymentDocument_WHEN_resolve_kernel_config_interrupted_THEN_deploymentTask_aborted()
             throws Exception {
         when(mockPackageCache.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
-        when(mockKernelConfigResolver.resolve(anyList(), eq(deploymentDocument))).thenThrow(new InterruptedException());
+        when(mockKernelConfigResolver.resolve(anyMap(), eq(deploymentDocument))).thenThrow(new InterruptedException());
 
         Exception thrown = assertThrows(RetryableDeploymentTaskFailureException.class, () -> deploymentTask.call());
         assertThat(thrown.getCause(), isA(InterruptedException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache).preparePackages(anyList());
-        verify(mockKernelConfigResolver).resolve(anyList(), eq(deploymentDocument));
+        verify(mockKernelConfigResolver).resolve(anyMap(), eq(deploymentDocument));
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Small change in DependencyResolver interface to return a map of package identifiers to package version constraints.

**Why is this change necessary:**
After deployment succeeds, the version constraints of each package will be saved per fleet/group.

**How was this change tested:**
Unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
