### PR TITLE
Refine deduplicating logic in lifecycle change requests.

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/aws/iot/evergreen/deployment/state/UpdatingKernelState.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/state/UpdatingKernelState.java
@@ -5,13 +5,11 @@ package com.aws.iot.evergreen.deployment.state;
 
 import com.aws.iot.evergreen.deployment.exceptions.DeploymentFailureException;
 import com.aws.iot.evergreen.deployment.model.DeploymentContext;
-import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -291,20 +291,21 @@ public class EvergreenService implements InjectionActions, Closeable {
     }
 
     private Optional<State> peekOrRemoveFirstDesiredState(State activeState) {
-        if (desiredStateList.isEmpty()) {
-            return Optional.empty();
+        synchronized (desiredStateList) {
+            if (desiredStateList.isEmpty()) {
+                return Optional.empty();
+            }
+            State first = desiredStateList.get(0);
+            if (first == activeState) {
+                desiredStateList.remove(first);
+                // ignore remove() return value as it's possible that desiredStateList update
+            }
+            return Optional.ofNullable(first);
         }
-        State first = desiredStateList.get(0);
-        if (first == activeState) {
-            desiredStateList.remove(first);
-            // ignore remove() return value as it's possible that desiredStateList update
-        }
-        return Optional.ofNullable(first);
     }
 
     // Set desiredStateList and override existing desiredStateList.
-    // Expect to have multi-thread access
-    private synchronized void setDesiredState(State... state) {
+    private void setDesiredState(State... state) {
         synchronized (desiredStateList) {
             List<State> newStateList = Arrays.asList(state);
             if (newStateList.equals(desiredStateList)) {
@@ -335,29 +336,62 @@ public class EvergreenService implements InjectionActions, Closeable {
     /**
      * Start Service.
      */
-    public void requestStart() {
-        setDesiredState(State.RUNNING);
+    public final void requestStart() {
+        synchronized (this.desiredStateList) {
+            if (this.desiredStateList.isEmpty()) {
+                this.setDesiredState(State.RUNNING);
+                return;
+            }
+            State lastState = this.desiredStateList.get(this.desiredStateList.size() - 1);
+            if (lastState == State.RUNNING) {
+                return;
+            } else if (lastState == State.FINISHED) {
+                this.desiredStateList.set(this.desiredStateList.size() - 1, State.RUNNING);
+            } else {
+                this.desiredStateList.add(State.RUNNING);
+            }
+        }
     }
 
     /**
      * Stop Service.
      */
-    public void requestStop() {
-        setDesiredState(State.FINISHED);
+    public final void requestStop() {
+        synchronized (this.desiredStateList) {
+            // don't override in the case of re-install
+            int index = this.desiredStateList.indexOf(State.NEW);
+            if (index == -1) {
+                setDesiredState(State.FINISHED);
+                return;
+            }
+            this.desiredStateList.subList(index + 1, this.desiredStateList.size()).clear();
+            this.desiredStateList.add(State.FINISHED);
+        }
     }
 
     /**
      * Restart Service.
      */
-    public void requestRestart() {
-        setDesiredState(State.FINISHED, State.RUNNING);
+    public final void requestRestart() {
+        synchronized (this.desiredStateList) {
+            // don't override in the case of re-install
+            int index = this.desiredStateList.indexOf(State.NEW);
+            if (index == -1) {
+                setDesiredState(State.FINISHED, State.RUNNING);
+                return;
+            }
+            this.desiredStateList.subList(index + 1, this.desiredStateList.size()).clear();
+            this.desiredStateList.add(State.RUNNING);
+        }
     }
 
     /**
      * ReInstall Service.
      */
-    public void requestReinstall() {
-        setDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+    public final void requestReinstall() {
+        synchronized (this.desiredStateList) {
+            setDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        }
     }
 
     private void startStateTransition() throws InterruptedException {

--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -41,15 +41,19 @@ public class GenericExternalService extends EvergreenService {
 
         // when configuration reloads and child Topic changes, restart/re-install the service.
         c.subscribe((what, child) -> {
-            if (c.parentNeedsToKnow() && !child.childOf("shutdown")) {
-                logger.atInfo().setEventType("service-config-change").addKeyValue("configNode", child.getFullName())
-                        .log();
-                if (child.childOf("install")) {
-                    requestReinstall();
-                } else {
-                    requestRestart();
-                }
+            if (!c.parentNeedsToKnow()) {
+                return;
             }
+            logger.atInfo().setEventType("service-config-change")
+                    .addKeyValue("configNode", child.getFullName()).log();
+            if (c.childOf("shutdown")) {
+                return;
+            }
+            if (c.childOf("install")) {
+                requestReinstall();
+                return;
+            }
+            requestRestart();
         });
 
         AuthHandler.registerAuthToken(this);

--- a/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
@@ -285,14 +285,7 @@ public class Kernel extends Configuration /*implements Runnable*/ {
             mainService = getMain();
             autostart.forEach(s -> {
                 try {
-                    if (!s.contains("SafeSystemUpdate")) {
-                        mainService.addDependency(EvergreenService.locate(context, s), State.RUNNING);
-                    } else {
-                        // SafeSystemUpdate will reset to Installed after update.
-                        // This is a hacky way to avoid restarting depending services.
-                        // TODO: Find a proper way handle this situation.
-                        mainService.addDependency(EvergreenService.locate(context, s), State.INSTALLED);
-                    }
+                    mainService.addDependency(EvergreenService.locate(context, s), State.RUNNING);
                 } catch (ServiceLoadException se) {
                     logger.atError().setCause(se).log("Unable to load service {}", s);
                 } catch (InputValidationException e) {
@@ -626,8 +619,6 @@ public class Kernel extends Configuration /*implements Runnable*/ {
                     serviceConfig.keySet().forEach(serviceName -> {
                         try {
                             EvergreenService eg = EvergreenService.locate(context, serviceName);
-                            // TODO: remove requestStart here as each service will handle update behavior based on
-                            // updated fields.
                             eg.requestStart();
                         } catch (ServiceLoadException e) {
                             logger.atError().setCause(e).addKeyValue("serviceName", serviceName)

--- a/src/test/java/com/aws/iot/evergreen/kernel/EvergreenServiceTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/EvergreenServiceTest.java
@@ -3,54 +3,33 @@
 
 package com.aws.iot.evergreen.kernel;
 
-import com.aws.iot.evergreen.config.Topic;
-import com.aws.iot.evergreen.config.Topics;
 import com.aws.iot.evergreen.config.Validator;
-import com.aws.iot.evergreen.dependency.Context;
 import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.testcommons.testutilities.EGServiceTestUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
-class EvergreenServiceTest {
+class EvergreenServiceTest extends EGServiceTestUtil {
 
     public static final String STATE_TOPIC_NAME = "_State";
-    private static final String EVERGREEN_SERVICE_FULL_NAME = "EvergreenServiceFullName";
 
     private EvergreenService evergreenService;
-
-    @Mock
-    private Topics config;
-
-    @Mock
-    private Topic stateTopic;
-
-    @Mock
-    private Topic dependenciesTopic;
-
-    @Mock
-    private Context context;
 
     @Captor
     private ArgumentCaptor<Validator> validatorArgumentCaptor;
 
     @BeforeEach
     void beforeEach() {
-        Mockito.when(config.createLeafChild(eq("_State"))).thenReturn(stateTopic);
-        Mockito.when(config.createLeafChild(eq("dependencies"))).thenReturn(dependenciesTopic);
-        Mockito.when(config.getName()).thenReturn(EVERGREEN_SERVICE_FULL_NAME);
-        Mockito.when(dependenciesTopic.dflt(Mockito.any())).thenReturn(dependenciesTopic);
+        evergreenService = new EvergreenService(initializeMockedConfig());
 
-        evergreenService = new EvergreenService(config);
         evergreenService.context = context;
     }
 

--- a/src/test/java/com/aws/iot/evergreen/kernel/RequestLifecycleChangeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/RequestLifecycleChangeTest.java
@@ -1,0 +1,176 @@
+package com.aws.iot.evergreen.kernel;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+import com.aws.iot.evergreen.config.Topic;
+import com.aws.iot.evergreen.config.Topics;
+import com.aws.iot.evergreen.dependency.Context;
+import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.testcommons.testutilities.EGServiceTestUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestLifecycleChangeTest extends EGServiceTestUtil {
+
+    private EvergreenService evergreenService;
+
+    private static Field desiredStateListField;
+    private List<State> desiredStateList;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        desiredStateListField = EvergreenService.class.getDeclaredField("desiredStateList");
+        desiredStateListField.setAccessible(true);
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        Topics config = initializeMockedConfig();
+        evergreenService = new EvergreenService(config);
+        desiredStateList = (List<State>) desiredStateListField.get(evergreenService);
+    }
+
+    @Test
+    public void GIVEN_evergreenService_WHEN_requestStart_called_THEN_deduplicate_correctly() {
+        desiredStateList.clear();
+        evergreenService.requestStart();
+        assertDesiredState(State.RUNNING);
+
+        // calling requestRetart() multiple times doesn't result in duplication
+        evergreenService.requestStart();
+        assertDesiredState(State.RUNNING);
+
+        // requestRetart() overrides previous requestStop()
+        desiredStateList.clear();
+        evergreenService.requestStop();
+        assertDesiredState(State.FINISHED);
+        evergreenService.requestStart();
+        assertDesiredState(State.RUNNING);
+
+        desiredStateList.clear();
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+        evergreenService.requestStart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+
+        desiredStateList.clear();
+        evergreenService.requestReinstall();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        evergreenService.requestStart();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+    }
+
+    @Test
+    public void GIVEN_evergreenService_WHEN_requestStop_called_THEN_deduplicate_correctly() {
+        desiredStateList.clear();
+        evergreenService.requestStop();
+        assertDesiredState(State.FINISHED);
+
+        // calling requestRetart() multiple times doesn't result in duplication
+        evergreenService.requestStop();
+        assertDesiredState(State.FINISHED);
+
+        // requestRetart() overrides previous requestStop()
+        desiredStateList.clear();
+        evergreenService.requestStart();
+        assertDesiredState(State.RUNNING);
+        evergreenService.requestStop();
+        assertDesiredState(State.FINISHED);
+
+        desiredStateList.clear();
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+        evergreenService.requestStop();
+        assertDesiredState(State.FINISHED);
+
+        desiredStateList.clear();
+        evergreenService.requestReinstall();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        evergreenService.requestStop();
+        assertDesiredState(State.FINISHED, State.NEW, State.FINISHED);
+    }
+
+    @Test
+    public void GIVEN_evergreenService_WHEN_requestRestart_called_THEN_deduplicate_correctly() {
+        desiredStateList.clear();
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+
+        // calling requestRetart() multiple times doesn't result in duplication
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+
+        // requestRetart() overrides previous requestStop()
+        desiredStateList.clear();
+        evergreenService.requestStop();
+        assertDesiredState(State.FINISHED);
+
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+
+        // requestRetart() overrides previous requestStart()
+        desiredStateList.clear();
+        evergreenService.requestStart();
+        assertDesiredState(State.RUNNING);
+
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+
+        // requestRestart() doesn't override previous requestReinstall()
+        desiredStateList.clear();
+        evergreenService.requestReinstall();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+
+        // requestRestart() doesn't erase reinstall behavior
+        setDesiredStateList(State.NEW, State.FINISHED);
+        evergreenService.requestRestart();
+        assertDesiredState(State.NEW, State.RUNNING);
+    }
+
+
+    @Test
+    public void GIVEN_evergreenService_WHEN_requestReinstall_called_THEN_deduplicate_correctly() {
+        evergreenService.requestReinstall();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+
+        // calling requestReinstall() multiple times doesn't result in duplication
+        evergreenService.requestReinstall();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+
+        // calling requestRetart() doesn't override requestRe-install
+        desiredStateList.clear();
+        evergreenService.requestRestart();
+        assertDesiredState(State.FINISHED, State.RUNNING);
+        evergreenService.requestReinstall();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+
+        // calling requestRetart() multiple times doesn't result in duplication
+        desiredStateList.clear();
+        evergreenService.requestStart();
+        assertDesiredState(State.RUNNING);
+        evergreenService.requestReinstall();
+        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+    }
+
+    private void assertDesiredState(State... state) {
+        Assertions.assertArrayEquals(state, desiredStateList.toArray(new State[] {}));
+    }
+
+    private void setDesiredStateList(State... state) {
+        desiredStateList.clear();
+        desiredStateList.addAll(Arrays.asList(state));
+    }
+}

--- a/src/test/java/com/aws/iot/evergreen/testcommons/testutilities/EGServiceTestUtil.java
+++ b/src/test/java/com/aws/iot/evergreen/testcommons/testutilities/EGServiceTestUtil.java
@@ -1,0 +1,40 @@
+package com.aws.iot.evergreen.testcommons.testutilities;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+import com.aws.iot.evergreen.config.Topic;
+import com.aws.iot.evergreen.config.Topics;
+import com.aws.iot.evergreen.dependency.Context;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EGServiceTestUtil {
+
+    public static final String STATE_TOPIC_NAME = "_State";
+    protected String serviceFullName = "EvergreenServiceFullName";
+
+    @Mock
+    protected Topics config;
+
+    @Mock
+    protected Topic stateTopic;
+
+    @Mock
+    protected Topic requiresTopic;
+
+    @Mock
+    protected Context context;
+
+    public Topics initializeMockedConfig() {
+        Mockito.when(config.createLeafChild(eq(STATE_TOPIC_NAME))).thenReturn(stateTopic);
+        Mockito.when(config.createLeafChild(eq("dependencies"))).thenReturn(requiresTopic);
+        Mockito.when(config.getName()).thenReturn(serviceFullName);
+        Mockito.when(requiresTopic.dflt(Mockito.any())).thenReturn(requiresTopic);
+        Mockito.when(config.getContext()).thenReturn(context);
+
+        return config;
+    }
+}


### PR DESCRIPTION
When a service receives restart and start in sequence, 'start' may override the 'restart'.
This can cause merge-config doesn't restart service as expected.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
