### PR TITLE
Refactor dependency resolution for packages

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
@@ -9,9 +9,12 @@ import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
 import com.aws.iot.evergreen.packagemanager.PackageCache;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
+import com.aws.iot.evergreen.packagemanager.exceptions.UnexpectedPackagingException;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import lombok.AllArgsConstructor;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,9 +52,9 @@ public class DeploymentTask implements Callable<Void> {
             kernel.mergeInNewConfig(document.getDeploymentId(), document.getTimestamp(), newConfig).get();
             logger.atInfo().setEventType(DEPLOYMENT_TASK_EVENT_TYPE)
                     .addKeyValue("deploymentId", document.getDeploymentId()).log("Finish deployment task");
-        } catch (PackageVersionConflictException e) {
+        } catch (PackageVersionConflictException | UnexpectedPackagingException e) {
             throw new NonRetryableDeploymentTaskFailureException(e);
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (ExecutionException | InterruptedException | IOException | PackagingException e) {
             throw new RetryableDeploymentTaskFailureException(e);
         }
         return null;

--- a/src/main/java/com/aws/iot/evergreen/deployment/model/DeploymentDocument.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/model/DeploymentDocument.java
@@ -5,6 +5,7 @@ package com.aws.iot.evergreen.deployment.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Builder
+@AllArgsConstructor
 // TODO: pull this class to a library to share with cloud services. SIM: https://sim.amazon.com/issues/P33788350
 public class DeploymentDocument {
 

--- a/src/main/java/com/aws/iot/evergreen/deployment/model/DeploymentPackageConfiguration.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/model/DeploymentPackageConfiguration.java
@@ -28,12 +28,14 @@ public class DeploymentPackageConfiguration {
     @JsonProperty("ResolvedVersion")
     String resolvedVersion;
 
+    @Deprecated
     @JsonProperty("VersionConstraint")
     String versionConstraint;
 
     @JsonProperty("Parameters")
     Set<PackageParameter> parameters;
 
+    @Deprecated
     @JsonProperty("Dependencies")
     List<PackageIdentifier> listOfDependencies;
 

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -3,19 +3,46 @@
 
 package com.aws.iot.evergreen.packagemanager;
 
+import com.aws.iot.evergreen.config.Node;
+import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
+import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
+import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
+import com.aws.iot.evergreen.logging.api.Logger;
+import com.aws.iot.evergreen.logging.impl.LogManager;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
+import com.aws.iot.evergreen.packagemanager.exceptions.UnexpectedPackagingException;
+import com.aws.iot.evergreen.packagemanager.models.Package;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+import com.aws.iot.evergreen.packagemanager.plugins.PackageStore;
+import com.vdurmont.semver4j.Requirement;
+import com.vdurmont.semver4j.Semver;
 import lombok.AllArgsConstructor;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
 
 @AllArgsConstructor
 public class DependencyResolver {
-    // TODO: temporarily suppress this warning which will be gone after these fields get used.
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "URF_UNREAD_FIELD")
-    private final PackageRegistry packageRegistry;
+    private static final Logger logger = LogManager.getLogger(DependencyResolver.class);
+    private static final String ROOT_REQUIREMENT_KEY = "ROOT";
+
+    private final PackageStore store;
+    @Inject
+    private final Kernel kernel;
 
     /**
      * Create the full list of packages to be run on the device from a deployment document.
@@ -23,12 +50,289 @@ public class DependencyResolver {
      * running packages on the device.
      *
      * @param document deployment document
-     * @return a map of packages to be run on the device to version constraints
+     * @return a list of packages to be run on the device
      * @throws PackageVersionConflictException when a package version conflict cannot be resolved
-     * @throws InterruptedException            when the running thread is interrupted
+     * @throws IOException                     when a package cannot be retrieved from the package store
+     * @throws PackagingException              for other package errors
      */
-    public List<PackageIdentifier> resolveDependencies(DeploymentDocument document)
-            throws PackageVersionConflictException, InterruptedException {
-        return new ArrayList<>();
+    public List<PackageIdentifier> resolveDependencies(final DeploymentDocument document)
+            throws PackageVersionConflictException, IOException, PackagingException {
+
+        // A map of package version constraints {packageName => {dependingPackageName => versionConstraint}} to be
+        // maintained and updated. This information needs to be tracked because: 1. One package can have multiple
+        // depending packages posing different version constraints. 2. When the version of a depending package changes,
+        // the version constraints will also change accordingly. 3. The information also shows the complete dependency
+        // tree.
+        Map<String, Map<String, String>> packageNameToVersionConstraints = new HashMap<>();
+
+        // List of root packages to be resolved
+        Set<String> rootPackagesToResolve = new LinkedHashSet<>(document.getRootPackages());
+
+        // Get a list of package configurations with pinned versions
+        for (DeploymentPackageConfiguration dpc : document.getDeploymentPackageConfigurationList()) {
+            logger.atDebug().addKeyValue("packageName", dpc.getPackageName())
+                    .addKeyValue("version", dpc.getResolvedVersion()).log("Found package configuration");
+            packageNameToVersionConstraints.putIfAbsent(dpc.getPackageName(), new HashMap<>());
+            packageNameToVersionConstraints.get(dpc.getPackageName())
+                    .put(ROOT_REQUIREMENT_KEY, dpc.getResolvedVersion());
+        }
+
+        // Merge the active root packages on the device
+        mergeActiveRootPackages(rootPackagesToResolve, packageNameToVersionConstraints);
+        logger.atInfo().setEventType("resolve-dependencies-start").addKeyValue("rootPackages", rootPackagesToResolve)
+                .addKeyValue("versionConstraints", packageNameToVersionConstraints).log();
+
+        // Map of package name and resolved version
+        Map<String, Semver> resolvedPackageNameToVersion = new HashMap<>();
+        boolean resolved = resolveDependencyTree(resolvedPackageNameToVersion, packageNameToVersionConstraints,
+                rootPackagesToResolve);
+        if (!resolved) {
+            throw new PackageVersionConflictException("Unresolved packages: " + rootPackagesToResolve);
+        }
+
+        logger.atInfo().setEventType("resolve-dependencies-done").addKeyValue("packages", resolvedPackageNameToVersion)
+                .log();
+        return resolvedPackageNameToVersion.entrySet().stream()
+                .map(e -> new PackageIdentifier(e.getKey(), e.getValue())).collect(Collectors.toList());
+    }
+
+    /**
+     * Implementation of finding one possible solution for package dependency resolution with backtracking. In each
+     * call stack, it tries to resolve one package in the packagesToResolve set, by iterating and exploring
+     * each possible version of this package based on the current known version constraints in
+     * packageNameToVersionConstraints. When exploring one version of the package, all its unresolved dependency
+     * packages will be added to packagesToResolve, and dependency version constraints will be updated to
+     * packageNameToVersionConstraints. Eventually resolved package with version will be returned in
+     * resolvedPackageNameToVersion, or errors thrown with packagesToResolve of unresolved packages.
+     *
+     * @param resolvedPackageNameToVersion    map of package names to a pinned version, which is resolved
+     * @param packageNameToVersionConstraints map of package names (A) to a map of depending package names (B) to the
+     *                                        version requirements (from B to A)
+     * @param packagesToResolve               set of package names, which is yet to be resolved
+     * @return true when one way to resolve the version of all packages is found, false otherwise
+     * @throws PackagingException for all package errors
+     * @throws IOException        when a package cannot be retrieved from the package store
+     */
+    private boolean resolveDependencyTree(Map<String, Semver> resolvedPackageNameToVersion,
+                                          Map<String, Map<String, String>> packageNameToVersionConstraints,
+                                          Set<String> packagesToResolve)
+            throws PackagingException, IOException, PackageVersionConflictException {
+
+        if (packagesToResolve.isEmpty()) {
+            return true;
+        }
+
+        // Get any one package from the to-be-resolved list
+        String pkgName = packagesToResolve.iterator().next();
+        logger.atDebug().setEventType("resolve-package-start").addKeyValue("packageName", pkgName).log();
+
+        // Compile a list of versions to explore for this package in order
+        List<Semver> versionsToExplore = getVersionsToExplore(pkgName, packageNameToVersionConstraints.get(pkgName));
+
+        for (Semver version : versionsToExplore) {
+            logger.atTrace().setEventType("resolve-package-attempt").addKeyValue("packageName", pkgName).addKeyValue(
+                    "version", version).log();
+
+            // Get package recipe
+            Package pkgRecipe = getPackage(pkgName, version);
+
+            // Get dependency map (of package name to version constraints) for the current platform
+            Map<String, String> dependencyNameToVersionConstraints = getPackageDependencies(pkgRecipe);
+
+            // Note: All changes in Step 1 should be revertible in Step 3
+            // 1.1. Generate additional new packages to resolve, which are discovered from dependencies
+            Set<String> newDependencyPackagesToResolve = new HashSet<>();
+
+            boolean conflictsInDependency = false;
+            // Go over dependency map to see if any has been resolved
+            for (Map.Entry<String, String> entry : dependencyNameToVersionConstraints.entrySet()) {
+                String depPkgName = entry.getKey();
+
+                if (resolvedPackageNameToVersion.containsKey(depPkgName)) {
+                    Semver resolvedVersion = resolvedPackageNameToVersion.get(entry.getKey());
+                    String newRequirement = entry.getValue();
+                    if (!Requirement.buildNPM(newRequirement).isSatisfiedBy(resolvedVersion)) {
+                        // If a dependency package is already resolved, but the version does not satisfy the current
+                        // version constraints, there is a conflict.
+                        // Try another package version.
+                        conflictsInDependency = true;
+                        logger.atDebug().addKeyValue("packageName", depPkgName)
+                                .addKeyValue("resolvedVersion", resolvedVersion)
+                                .addKeyValue("dependingPackage", pkgName)
+                                .addKeyValue("versionConstraints", newRequirement)
+                                .log("Resolved package version does not satisfy new version constraints of the "
+                                        + "depending package");
+                        break;
+                    }
+                } else if (!packagesToResolve.contains(depPkgName)) {
+                    // Only add if not already added. Make the change revertible later
+                    newDependencyPackagesToResolve.add(depPkgName);
+                }
+            }
+            if (conflictsInDependency) {
+                continue;
+            }
+            packagesToResolve.addAll(newDependencyPackagesToResolve);
+            logger.atTrace().addKeyValue("packageName", pkgName).addKeyValue("packageVersion", version).addKeyValue(
+                    "dependencies", newDependencyPackagesToResolve).log("Found new dependencies to resolve");
+
+            // 1.2. Update all dependency version constraints of this package
+            for (Map.Entry<String, String> entry : dependencyNameToVersionConstraints.entrySet()) {
+                packageNameToVersionConstraints.putIfAbsent(entry.getKey(), new HashMap<>());
+                packageNameToVersionConstraints.get(entry.getKey()).put(pkgName, entry.getValue());
+            }
+
+            // 1.3. Resolve current package version
+            resolvedPackageNameToVersion.put(pkgName, version);
+            packagesToResolve.remove(pkgName);
+
+            // 2. Resolve the rest packages recursively
+            if (resolveDependencyTree(resolvedPackageNameToVersion, packageNameToVersionConstraints,
+                    packagesToResolve)) {
+                logger.atDebug().setEventType("resolve-package-done").addKeyValue("packageName", pkgName).addKeyValue(
+                        "version", version).log();
+                return true;
+            }
+
+            // Found conflicts in step 2, so revert all step 1 changes
+            // 3.1. Mark current package as unresolved
+            packagesToResolve.add(pkgName);
+            resolvedPackageNameToVersion.remove(pkgName);
+
+            // 3.2. Remove dependency version constraints of this package
+            for (Map.Entry<String, String> entry : dependencyNameToVersionConstraints.entrySet()) {
+                packageNameToVersionConstraints.get(entry.getKey()).remove(pkgName);
+            }
+
+            // 3.3. Remove newly-introduced dependency packages
+            packagesToResolve.removeAll(newDependencyPackagesToResolve);
+
+        }
+
+        logger.atDebug().setEventType("resolve-package-backtrack").addKeyValue("packageName", pkgName).log(
+                "Exhaust all possible versions of package without a solution. Backtracking...");
+        return false;
+    }
+
+    /**
+     * Get a ordered list of possible versions to explore for the given package.
+     *
+     * @param pkgName                      name of the package to be explored
+     * @param packageToVersionConstraints list of version constraints for the package
+     * @return list of versions as Semver instances
+     * @throws UnexpectedPackagingException when a package cannot be retrieved from the package store
+     */
+    protected List<Semver> getVersionsToExplore(final String pkgName,
+                                                final Map<String, String> packageToVersionConstraints)
+            throws UnexpectedPackagingException, PackageVersionConflictException {
+
+        List<Semver> versionList = new ArrayList<>();
+        logger.atDebug().addKeyValue("packageName", pkgName).addKeyValue("versionConstraints",
+                packageToVersionConstraints).log("Parsing version constraints for dependency package");
+        Requirement req = Requirement.buildNPM(mergeSemverRequirements(packageToVersionConstraints.values()));
+
+        if (packageToVersionConstraints.containsKey(ROOT_REQUIREMENT_KEY)) {
+            // Assume all root packages should use the pinned version.
+            Semver pinnedVersion = new Semver(packageToVersionConstraints.get(ROOT_REQUIREMENT_KEY));
+            if (!req.isSatisfiedBy(pinnedVersion)) {
+                throw new PackageVersionConflictException("Conflicts in root package version constraints. Package: "
+                        + pkgName + ", version constraints: " + req.toString());
+            }
+            versionList.add(pinnedVersion);
+            return versionList;
+        }
+
+        // Add active package version running on the device
+        Optional<String> version = getPackageVersionIfActive(pkgName);
+        Semver activeVersion = null;
+        if (version.isPresent() && req.isSatisfiedBy(version.get())) {
+            activeVersion = new Semver(version.get());
+            logger.atDebug().addKeyValue("packageName", pkgName).addKeyValue("version", activeVersion)
+                    .log("Found current active version for dependency package");
+            versionList.add(activeVersion);
+        }
+
+        // Find out all available versions in package store
+        // TODO: Update priorities to be "version available on disk > latest version on the cloud > other versions on
+        // the cloud"
+        List<Semver> allVersions = store.getPackageVersionsIfExists(pkgName);
+        for (Semver v : allVersions) {
+            if (req.isSatisfiedBy(v) && !v.equals(activeVersion)) {
+                versionList.add(v);
+            }
+        }
+        logger.atDebug().addKeyValue("packageName", pkgName).addKeyValue("versionList", versionList)
+                .log("Found possible versions for dependency package");
+
+        return versionList;
+    }
+
+    protected String mergeSemverRequirements(final Collection<String> packageVersionConstraintList) {
+        // TODO: See if there's a better way to get the union of version constraints
+        return packageVersionConstraintList.stream().map(Requirement::buildNPM).map(Requirement::toString)
+                .collect(Collectors.joining(" "));
+    }
+
+    protected Optional<String> getPackageVersionIfActive(final String packageName) {
+        EvergreenService service;
+        try {
+            service = EvergreenService.locate(kernel.context, packageName);
+        } catch (ServiceLoadException e) {
+            logger.atWarn().setCause(e).addKeyValue("packageName", packageName).log("Fail to load package");
+            return Optional.empty();
+        }
+        return getServiceVersion(service);
+    }
+
+    private void mergeActiveRootPackages(Set<String> rootPackages,
+                                    Map<String, Map<String, String>> packageNameToVersionConstraints) {
+        Set<EvergreenService> activeServices = kernel.getMain().getDependencies().keySet();
+        for (EvergreenService s: activeServices) {
+            Optional<String> version = getServiceVersion(s);
+            if (!version.isPresent()) {
+                // Assume 1P services if version is not present. 1P services don't need resolution
+                continue;
+            }
+
+            String serviceName = s.getName();
+            if (!rootPackages.contains(serviceName)) {
+                // If the service package does not exist in root packages, still use the current version on the device
+                rootPackages.add(serviceName);
+                packageNameToVersionConstraints.putIfAbsent(serviceName, new HashMap<>());
+                packageNameToVersionConstraints.get(serviceName).putIfAbsent(ROOT_REQUIREMENT_KEY, version.get());
+                logger.atDebug().addKeyValue("packageName", serviceName).addKeyValue("version", version.get())
+                        .log("Merge active root packages");
+            }
+        }
+    }
+
+    protected Optional<String> getServiceVersion(final EvergreenService service) {
+        Node versionNode = service.config.getChild(KernelConfigResolver.VERSION_CONFIG_KEY);
+        if (versionNode instanceof Topic) {
+            return Optional.of(((Topic) versionNode).getOnce().toString());
+        }
+        return Optional.empty();
+    }
+
+    private Package getPackage(final String pkgName, final Semver version) throws PackagingException, IOException {
+        // TODO: handle exceptions with retry
+        Optional<Package> optionalPackage = store.getPackage(pkgName, version);
+        if (!optionalPackage.isPresent()) {
+            throw new UnexpectedPackagingException("Unexpected error in job document: package-version doesn't exist "
+                    + pkgName + "-" + version);
+        }
+        return optionalPackage.get();
+    }
+
+    // Get dependency map for the current platform
+    private Map<String, String> getPackageDependencies(final Package pkg) throws UnexpectedPackagingException {
+        return pkg.getDependencies();
+        // TODO: Add platform keyword
+        //Object dependencyListForPlatform = PlatformResolver.resolvePlatform((Map) pkg.getDependencies());
+        //if (!(dependencyListForPlatform instanceof Map)) {
+        //   throw new UnexpectedPackagingException("Unexpected format of dependency map: " +
+        //   dependencyListForPlatform);
+        //}
+        //return (Map<String, String>) dependencyListForPlatform;
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -25,8 +25,7 @@ import java.util.stream.Collectors;
 public class KernelConfigResolver {
 
     private static final String SERVICE_DEPENDENCIES_CONFIG_KEY = "dependencies";
-    private static final String VERSION_CONFIG_KEY = "version";
-    private static final String VERSION_CONSTRAINT_CONFIG_KEY = "versionconstraint";
+    protected static final String VERSION_CONFIG_KEY = "version";
     private static final String SERVICE_NAMESPACE_CONFIG_KEY = "services";
     private static final String PARAMETER_REFERENCE_FORMAT = "{{params:%s.value}}";
 

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
@@ -10,6 +10,7 @@ import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
 import com.aws.iot.evergreen.packagemanager.PackageCache;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,11 +84,12 @@ public class DeploymentTaskTest {
     }
 
     @Test
-    public void GIVEN_deploymentDocument_WHEN_resolveDependencies_interrupted_THEN_deploymentTask_aborted()
+    public void GIVEN_deploymentDocument_WHEN_resolveDependencies_errored_THEN_deploymentTask_aborted()
             throws Exception {
-        when(mockDependencyResolver.resolveDependencies(deploymentDocument)).thenThrow(new InterruptedException());
+        when(mockDependencyResolver.resolveDependencies(deploymentDocument)).thenThrow(
+                new PackagingException("mock error"));
         Exception thrown = assertThrows(RetryableDeploymentTaskFailureException.class, () -> deploymentTask.call());
-        assertThat(thrown.getCause(), isA(InterruptedException.class));
+        assertThat(thrown.getCause(), isA(PackagingException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache, times(0)).preparePackages(anyList());
         verify(mockKernelConfigResolver, times(0)).resolve(anyList(), eq(deploymentDocument), anySet());

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.packagemanager;
+
+import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
+import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
+import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
+import com.aws.iot.evergreen.packagemanager.exceptions.UnexpectedPackagingException;
+import com.aws.iot.evergreen.packagemanager.models.Package;
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+import com.aws.iot.evergreen.packagemanager.plugins.PackageStore;
+import com.vdurmont.semver4j.Requirement;
+import com.vdurmont.semver4j.Semver;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DependencyResolverTest {
+    @Mock
+    private PackageStore mockPackageStore;
+
+    @Mock
+    private Kernel kernel;
+
+    @Mock
+    private EvergreenService mainService;
+
+    @BeforeAll
+    public static void Setup() {
+        System.setProperty("log.fmt", "TEXT");
+        System.setProperty("log.store", "CONSOLE");
+        System.setProperty("log.level", "TRACE");
+    }
+
+    @Nested
+    class MergeSemverRequirementsTest {
+        @Spy
+        private DependencyResolver resolver = new DependencyResolver(mockPackageStore, kernel);
+
+        @Test
+        public void GIVEN_list_of_version_ranges_WHEN_get_union_THEN_get_version_range() {
+            List<String> constraints = new LinkedList<>();
+            constraints.add("<3.0");
+            constraints.add(">1.0");
+            constraints.add(">2.0");
+            String req = resolver.mergeSemverRequirements(constraints);
+            assertEquals("<3.0 >1.0 >2.0", req);
+
+            Requirement r = Requirement.buildNPM(req);
+            assertFalse(r.isSatisfiedBy("1.0.1"));
+            assertTrue(r.isSatisfiedBy("2.0.1"));
+        }
+
+        @Test
+        public void GIVEN_list_of_version_range_and_pinned_version_WHEN_get_union_THEN_get_pinned_version() {
+            List<String> constraints = new LinkedList<>();
+            constraints.add("<3.0");
+            constraints.add("1.0.0");
+            String req = resolver.mergeSemverRequirements(constraints);
+            assertEquals("<3.0 =1.0.0", req);
+
+            Requirement r = Requirement.buildNPM(req);
+            assertFalse(r.isSatisfiedBy("1.0.1"));
+            assertTrue(r.isSatisfiedBy("1.0.0"));
+        }
+
+        @Test
+        public void GIVEN_list_of_version_range_with_conflicts_WHEN_get_union_THEN_get_no_version_match() {
+            List<String> constraints = new LinkedList<>();
+            constraints.add(">4.0");
+            constraints.add("<3.0");
+            String req = resolver.mergeSemverRequirements(constraints);
+            assertEquals(">4.0 <3.0", req);
+
+            Requirement r = Requirement.buildNPM(req);
+            assertFalse(r.isSatisfiedBy("4.0.1"));
+            assertFalse(r.isSatisfiedBy("2.0.0"));
+        }
+    }
+
+    @Nested
+    class GetVersionsToExploreTest{
+        @Test
+        public void GIVEN_package_not_active_WHEN_get_versions_THEN_get_version_within_constraint() throws UnexpectedPackagingException, PackageVersionConflictException {
+            when(mockPackageStore.getPackageVersionsIfExists("testPackage")).thenReturn(Arrays.asList(new Semver("1.2" +
+                    ".0"), new Semver("1.1.0"), new Semver("1.0.0")));
+            DependencyResolver resolver = spy(new DependencyResolver(mockPackageStore, kernel));
+            doReturn(Optional.empty()).when(resolver).getPackageVersionIfActive(any());
+
+            Map<String, String> versionConstraints = new HashMap<>();
+            versionConstraints.putIfAbsent("mock", ">1.0");
+            List<Semver> versions = resolver.getVersionsToExplore("testPackage", versionConstraints);
+            assertEquals(Arrays.asList(new Semver("1.2.0"), new Semver("1.1.0")), versions);
+        }
+
+        @Test
+        public void GIVEN_package_active_WHEN_get_versions_THEN_get_active_version_first() throws UnexpectedPackagingException, PackageVersionConflictException {
+            when(mockPackageStore.getPackageVersionsIfExists("testPackage")).thenReturn(Arrays.asList(new Semver("1" +
+                    ".2.0"), new Semver("1.1.0"), new Semver("1.0.0")));
+            DependencyResolver resolver = spy(new DependencyResolver(mockPackageStore, kernel));
+            doReturn(Optional.of("1.1.0")).when(resolver).getPackageVersionIfActive(any());
+
+            Map<String, String> versionConstraints = new HashMap<>();
+            versionConstraints.putIfAbsent("mock", ">1.0");
+            List<Semver> versions = resolver.getVersionsToExplore("testPackage", versionConstraints);
+            assertEquals(Arrays.asList(new Semver("1.1.0"), new Semver("1.2.0")), versions);
+        }
+    }
+
+    @Nested
+    class ResolveDependenciesTest{
+        private final Semver v1_1_0 = new Semver("1.1.0");
+        private final Semver v1_0_0 = new Semver("1.0.0");
+        private final String pkgA = "A";
+        private final String pkgB1 = "B1";
+        private final String pkgB2 = "B2";
+        private final String pkgC1 = "C1";
+
+        @Mock
+        EvergreenService mockServiceB1;
+
+        @Mock
+        EvergreenService mockServiceB2;
+
+        /**
+         *    A
+         *  /   \
+         *  B1  B2
+         *  \
+         *  C1
+         */
+        @Test
+        public void GIVEN_package_A_WHEN_resolve_dependencies_THEN_resolve_A_and_dependency_versions()
+                throws PackageVersionConflictException, IOException, PackagingException {
+            Map<String, String> dependenciesA_1_x = new HashMap<>();
+            dependenciesA_1_x.put(pkgB1, "1.0");
+            dependenciesA_1_x.put(pkgB2, ">1.0");
+
+            Map<String, String> dependenciesB1_1_x = new HashMap<>();
+            dependenciesB1_1_x.put(pkgC1, "1.0.0");
+
+            when(mockPackageStore.getPackageVersionsIfExists(pkgB1)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+            when(mockPackageStore.getPackageVersionsIfExists(pkgB2)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+            when(mockPackageStore.getPackageVersionsIfExists(pkgC1)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+
+            when(mockPackageStore.getPackage(pkgA, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgA, v1_0_0, "", ""
+                    , Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesA_1_x, Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB1, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgB1, v1_0_0, "",
+                    "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesB1_1_x,
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB2, v1_1_0)).thenReturn(Optional.of(new Package(null, pkgB2, v1_1_0,
+                    "", "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgC1, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgC1, v1_0_0, "",
+                    "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
+                    Collections.emptyList())));
+
+            when(kernel.getMain()).thenReturn(mainService);
+            when(mainService.getDependencies()).thenReturn(Collections.emptyMap());
+
+            DependencyResolver resolver = spy(new DependencyResolver(mockPackageStore, kernel));
+            doReturn(Optional.empty()).when(resolver).getPackageVersionIfActive(any());
+
+            DeploymentDocument doc = new DeploymentDocument("mockJob1", Arrays.asList(pkgA),
+                    Arrays.asList(new DeploymentPackageConfiguration(pkgA, v1_0_0.toString(), "", new HashSet<>(),
+                            new ArrayList<>())), "mockGroup1", 1L);
+            List<PackageIdentifier> result = resolver.resolveDependencies(doc);
+
+            assertEquals(4, result.size());
+            assertThat(result, containsInAnyOrder(new PackageIdentifier(pkgA, v1_0_0),
+                    new PackageIdentifier(pkgB1, v1_0_0), new PackageIdentifier(pkgB2, v1_1_0),
+                    new PackageIdentifier(pkgC1, v1_0_0)));
+        }
+
+        /**
+         *    A
+         *  /
+         *  B1   B2
+         *  \   /
+         *   C1
+         */
+        @Test
+        public void GIVEN_package_A_B2_WHEN_dependencies_overlap_THEN_satisfy_both()
+                throws PackageVersionConflictException, IOException, PackagingException {
+            Map<String, String> dependenciesA_1_x = new HashMap<>();
+            dependenciesA_1_x.put(pkgB1, "1.0");
+
+            Map<String, String> dependenciesB1_1_x = new HashMap<>();
+            dependenciesB1_1_x.put(pkgC1, "<1.1.0");
+
+            Map<String, String> dependenciesB2_1_x = new HashMap<>();
+            dependenciesB2_1_x.put(pkgC1, ">=1.0.0");
+
+            when(mockPackageStore.getPackageVersionsIfExists(pkgB1)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+            when(mockPackageStore.getPackageVersionsIfExists(pkgC1)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+
+            when(mockPackageStore.getPackage(pkgA, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgA, v1_0_0, "", ""
+                    , Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesA_1_x, Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB1, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgB1, v1_0_0, "",
+                    "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesB1_1_x,
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB2, v1_1_0)).thenReturn(Optional.of(new Package(null, pkgB2, v1_1_0,
+                    "", "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesB2_1_x,
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgC1, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgC1, v1_0_0, "",
+                    "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgC1, v1_1_0)).thenReturn(Optional.of(new Package(null, pkgC1, v1_1_0, "",
+                    "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
+                    Collections.emptyList())));
+
+            when(kernel.getMain()).thenReturn(mainService);
+            when(mainService.getDependencies()).thenReturn(Collections.emptyMap());
+
+            DependencyResolver resolver = spy(new DependencyResolver(mockPackageStore, kernel));
+            doReturn(Optional.empty()).when(resolver).getPackageVersionIfActive(any());
+
+            // top-level package order: A, B2
+            DeploymentDocument doc = new DeploymentDocument("mockJob1", Arrays.asList(pkgA, pkgB2), Arrays.asList(
+                    new DeploymentPackageConfiguration(pkgA, v1_0_0.toString(), "", new HashSet<>(), new ArrayList<>()),
+                    new DeploymentPackageConfiguration(pkgB2, v1_1_0.toString(), "", new HashSet<>(), new ArrayList<>())
+            ), "mockGroup1", 1L);
+            List<PackageIdentifier> result = resolver.resolveDependencies(doc);
+
+            assertEquals(4, result.size());
+            assertThat(result, containsInAnyOrder(new PackageIdentifier(pkgA, v1_0_0),
+                    new PackageIdentifier(pkgB1, v1_0_0), new PackageIdentifier(pkgB2, v1_1_0),
+                    new PackageIdentifier(pkgC1, v1_0_0)));
+
+            // top-level package order: B2, A
+            doc = new DeploymentDocument("mockJob2", Arrays.asList(pkgB2, pkgA), Arrays.asList(
+                    new DeploymentPackageConfiguration(pkgA, v1_0_0.toString(), "", new HashSet<>(), new ArrayList<>()),
+                    new DeploymentPackageConfiguration(pkgB2, v1_1_0.toString(), "", new HashSet<>(), new ArrayList<>())
+            ), "mockGroup1", 1L);
+            result = resolver.resolveDependencies(doc);
+
+            assertEquals(4, result.size());
+            assertThat(result, containsInAnyOrder(new PackageIdentifier(pkgA, v1_0_0),
+                    new PackageIdentifier(pkgB1, v1_0_0), new PackageIdentifier(pkgB2, v1_1_0),
+                    new PackageIdentifier(pkgC1, v1_0_0)));
+        }
+
+        /**
+         *    A
+         *  /
+         *  B1   B2
+         *  \   /
+         *   C1
+         */
+        @Test
+        public void GIVEN_package_A_B2_WHEN_dependencies_conflict_THEN_throws_conflict_error()
+                throws IOException, PackagingException {
+            Map<String, String> dependenciesA_1_x = new HashMap<>();
+            dependenciesA_1_x.put(pkgB1, "1.0");
+
+            Map<String, String> dependenciesB1_1_x = new HashMap<>();
+            dependenciesB1_1_x.put(pkgC1, "<1.0");
+
+            Map<String, String> dependenciesB2_1_x = new HashMap<>();
+            dependenciesB2_1_x.put(pkgC1, ">1.1");
+
+            when(mockPackageStore.getPackageVersionsIfExists(pkgB1)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+            when(mockPackageStore.getPackageVersionsIfExists(pkgC1)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+
+            when(mockPackageStore.getPackage(pkgA, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgA, v1_0_0, "", ""
+                    , Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesA_1_x, Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB1, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgB1, v1_0_0, "",
+                    "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesB1_1_x,
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB2, v1_1_0)).thenReturn(Optional.of(new Package(null, pkgB2, v1_1_0,
+                    "", "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesB2_1_x,
+                    Collections.emptyList())));
+
+            when(kernel.getMain()).thenReturn(mainService);
+            when(mainService.getDependencies()).thenReturn(Collections.emptyMap());
+
+            DependencyResolver resolver = spy(new DependencyResolver(mockPackageStore, kernel));
+            doReturn(Optional.empty()).when(resolver).getPackageVersionIfActive(any());
+
+            // top-level package order: A, B2
+            DeploymentDocument doc = new DeploymentDocument("mockJob1", Arrays.asList(pkgA, pkgB2), Arrays.asList(
+                    new DeploymentPackageConfiguration(pkgA, v1_0_0.toString(), "", new HashSet<>(), new ArrayList<>()),
+                    new DeploymentPackageConfiguration(pkgB2, v1_1_0.toString(), "", new HashSet<>(), new ArrayList<>())
+            ), "mockGroup1", 1L);
+
+            Exception thrown = assertThrows(PackageVersionConflictException.class,
+                    () -> resolver.resolveDependencies(doc));
+            assertEquals("Unresolved packages: [B2, A]", thrown.getMessage());
+
+            // top-level package order: B2, A
+            DeploymentDocument doc2 = new DeploymentDocument("mockJob2", Arrays.asList(pkgB2, pkgA), Arrays.asList(
+                    new DeploymentPackageConfiguration(pkgA, v1_0_0.toString(), "", new HashSet<>(), new ArrayList<>()),
+                    new DeploymentPackageConfiguration(pkgB2, v1_1_0.toString(), "", new HashSet<>(), new ArrayList<>())
+            ), "mockGroup1", 1L);
+
+            thrown = assertThrows(PackageVersionConflictException.class,
+                    () -> resolver.resolveDependencies(doc2));
+            assertEquals("Unresolved packages: [A, B2]", thrown.getMessage());
+        }
+
+        /**
+         * (add) A    (update) B1   (keep) B2
+         *        \        |        /
+         *             (update) C1
+         */
+        @Test
+        public void GIVEN_active_packages_WHEN_merge_in_packages_THEN_add_or_update_or_keep_accordingly() throws IOException, PackagingException, PackageVersionConflictException {
+            Map<String, String> dependenciesA_1_x = new HashMap<>();
+            dependenciesA_1_x.put(pkgC1, ">=1.0.0");
+
+            Map<String, String> dependenciesB1_1_0 = new HashMap<>();
+            dependenciesB1_1_0.put(pkgC1, ">=1.0.0");
+
+            Map<String, String> dependenciesB1_1_1 = new HashMap<>();
+            dependenciesB1_1_1.put(pkgC1, ">=1.1.0");
+
+            Map<String, String> dependenciesB2_1_x = new HashMap<>();
+            dependenciesB2_1_x.put(pkgC1, ">=1.0.0");
+
+            when(mockPackageStore.getPackageVersionsIfExists(pkgC1)).thenReturn(Arrays.asList(v1_1_0, v1_0_0));
+
+            when(mockPackageStore.getPackage(pkgA, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgA, v1_0_0, "", ""
+                    , Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesA_1_x, Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB1, v1_1_0)).thenReturn(Optional.of(new Package(null, pkgB1, v1_1_0, "",
+                    "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesB1_1_1,
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgB2, v1_0_0)).thenReturn(Optional.of(new Package(null, pkgB2, v1_0_0,
+                    "", "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), dependenciesB2_1_x,
+                    Collections.emptyList())));
+            when(mockPackageStore.getPackage(pkgC1, v1_1_0)).thenReturn(Optional.of(new Package(null, pkgC1, v1_1_0,
+                    "", "", Collections.emptySet(), Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
+                    Collections.emptyList())));
+
+            when(kernel.getMain()).thenReturn(mainService);
+            Map<EvergreenService, State> serviceMap = new HashMap<>();
+            serviceMap.put(mockServiceB1, State.RUNNING);
+            serviceMap.put(mockServiceB2, State.RUNNING);
+            when(mainService.getDependencies()).thenReturn(serviceMap);
+            when(mockServiceB1.getName()).thenReturn(pkgB1);
+            when(mockServiceB2.getName()).thenReturn(pkgB2);
+
+            DependencyResolver resolver = spy(new DependencyResolver(mockPackageStore, kernel));
+            doReturn(Optional.of(v1_0_0.toString())).when(resolver).getPackageVersionIfActive(pkgC1);
+            doReturn(Optional.of(v1_0_0.toString())).when(resolver).getServiceVersion(mockServiceB1);
+            doReturn(Optional.of(v1_0_0.toString())).when(resolver).getServiceVersion(mockServiceB2);
+
+            // top-level package order: A, B2
+            DeploymentDocument doc = new DeploymentDocument("mockJob1", Arrays.asList(pkgA, pkgB1), Arrays.asList(
+                    new DeploymentPackageConfiguration(pkgA, v1_0_0.toString(), "", new HashSet<>(), new ArrayList<>()),
+                    new DeploymentPackageConfiguration(pkgB1, v1_1_0.toString(), "", new HashSet<>(), new ArrayList<>())
+            ), "mockGroup1", 1L);
+
+            List<PackageIdentifier> result = resolver.resolveDependencies(doc);
+
+            assertEquals(4, result.size());
+            assertThat(result, containsInAnyOrder(new PackageIdentifier(pkgA, v1_0_0),
+                    new PackageIdentifier(pkgB1, v1_1_0), new PackageIdentifier(pkgB2, v1_0_0),
+                    new PackageIdentifier(pkgC1, v1_1_0)));
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactor package resolution to load root packages with pinned versions from job document and use backtracking to find out all package versions in the dependency tree.

Open action items:
- [x] Add logging
- [x] Add more unit tests
- [x] Optimize the logic to get all possible versions
- [x] Rename for better readability 
- [ ] Add error message for conflicting package versions (Will address in seperate PR)
- [ ] ~~Add readme~~
- [ ] Clean up deployment document (may not be in this PR)
- [ ] Add integration test for running dependency resolution for a medium/bigger sized tree and then observe performance statistics for this approach (may not be in this PR)

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
