### PR TITLE
Remove version constraint info handling from config resolver

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -8,8 +8,8 @@ import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictExc
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import lombok.AllArgsConstructor;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 @AllArgsConstructor
 public class DependencyResolver {
@@ -27,8 +27,8 @@ public class DependencyResolver {
      * @throws PackageVersionConflictException when a package version conflict cannot be resolved
      * @throws InterruptedException            when the running thread is interrupted
      */
-    public Map<PackageIdentifier, String> resolveDependencies(DeploymentDocument document)
+    public List<PackageIdentifier> resolveDependencies(DeploymentDocument document)
             throws PackageVersionConflictException, InterruptedException {
-        return new HashMap<>();
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -37,20 +38,19 @@ public class KernelConfigResolver {
      * For each package, it first retrieves its recipe, then merges the parameter values into the recipe, and last
      * transform it to a kernel config key-value pair.
      *
-     * @param packagesToDeploy     map of package identifiers to version constraints for resolved packages that are
-     *                             to be deployed
+     * @param packagesToDeploy     package identifiers for resolved packages that are to be deployed
      * @param document             deployment document
      * @param rootPackagesToRemove top level packages that need to be removed as part of current deployment
      * @return a kernel config map
      * @throws InterruptedException when the running thread is interrupted
      */
-    public Map<Object, Object> resolve(Map<PackageIdentifier, String> packagesToDeploy, DeploymentDocument document,
+    public Map<Object, Object> resolve(List<PackageIdentifier> packagesToDeploy, DeploymentDocument document,
                                        Set<PackageIdentifier> rootPackagesToRemove) throws InterruptedException {
 
         Map<Object, Object> servicesConfig = new HashMap<>();
 
-        packagesToDeploy.forEach((packageIdentifier, versionConstraint) -> servicesConfig
-                .put(packageIdentifier.getName(), getServiceConfig(packageIdentifier, versionConstraint, document)));
+        packagesToDeploy.forEach(packageIdentifier -> servicesConfig
+                .put(packageIdentifier.getName(), getServiceConfig(packageIdentifier, document)));
 
         servicesConfig.put(kernel.getMain().getName(), getUpdatedMainConfig(rootPackagesToRemove, document));
 
@@ -61,8 +61,7 @@ public class KernelConfigResolver {
     /*
      * Processe lifecycle section of each package and add it to the config.
      */
-    private Map<Object, Object> getServiceConfig(PackageIdentifier packageIdentifier, String versionConstraint,
-                                                 DeploymentDocument document) {
+    private Map<Object, Object> getServiceConfig(PackageIdentifier packageIdentifier, DeploymentDocument document) {
 
         Package pkg = packageCache.getRecipe(packageIdentifier);
 
@@ -90,7 +89,6 @@ public class KernelConfigResolver {
         resolvedServiceConfig.put(SERVICE_DEPENDENCIES_CONFIG_KEY, String.join(", ", dependencyServiceNames));
 
         resolvedServiceConfig.put(VERSION_CONFIG_KEY, pkg.getVersion());
-        resolvedServiceConfig.put(VERSION_CONSTRAINT_CONFIG_KEY, versionConstraint);
         return resolvedServiceConfig;
     }
 

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
@@ -52,8 +52,9 @@ public class DeploymentTaskTest {
 
     @BeforeEach
     public void setup() {
-        deploymentTask = new DeploymentTask(mockDependencyResolver, mockPackageCache, mockKernelConfigResolver,
-                mockKernel, logger, deploymentDocument);
+        deploymentTask =
+                new DeploymentTask(mockDependencyResolver, mockPackageCache, mockKernelConfigResolver, mockKernel,
+                        logger, deploymentDocument);
     }
 
     @Test
@@ -64,7 +65,7 @@ public class DeploymentTaskTest {
         deploymentTask.call();
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache).preparePackages(anyList());
-        verify(mockKernelConfigResolver).resolve(anyMap(), eq(deploymentDocument), anySet());
+        verify(mockKernelConfigResolver).resolve(anyList(), eq(deploymentDocument), anySet());
         verify(mockKernel).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
@@ -77,23 +78,25 @@ public class DeploymentTaskTest {
         assertThat(thrown.getCause(), isA(PackageVersionConflictException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache, times(0)).preparePackages(anyList());
-        verify(mockKernelConfigResolver, times(0)).resolve(anyMap(), eq(deploymentDocument), anySet());
+        verify(mockKernelConfigResolver, times(0)).resolve(anyList(), eq(deploymentDocument), anySet());
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
     @Test
-    public void GIVEN_deploymentDocument_WHEN_resolveDependencies_interrupted_THEN_deploymentTask_aborted() throws Exception {
+    public void GIVEN_deploymentDocument_WHEN_resolveDependencies_interrupted_THEN_deploymentTask_aborted()
+            throws Exception {
         when(mockDependencyResolver.resolveDependencies(deploymentDocument)).thenThrow(new InterruptedException());
         Exception thrown = assertThrows(RetryableDeploymentTaskFailureException.class, () -> deploymentTask.call());
         assertThat(thrown.getCause(), isA(InterruptedException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache, times(0)).preparePackages(anyList());
-        verify(mockKernelConfigResolver, times(0)).resolve(anyMap(), eq(deploymentDocument), anySet());
+        verify(mockKernelConfigResolver, times(0)).resolve(anyList(), eq(deploymentDocument), anySet());
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
     @Test
-    public void GIVEN_deploymentDocument_WHEN_preparePackages_interrupted_THEN_deploymentTask_aborted() throws Exception {
+    public void GIVEN_deploymentDocument_WHEN_preparePackages_interrupted_THEN_deploymentTask_aborted()
+            throws Exception {
         lenient().when(mockPackageCache.preparePackages(anyList())).thenReturn(new CompletableFuture<>());
         FutureTask<Void> futureTask = new FutureTask<>(deploymentTask);
         Thread t = new Thread(futureTask);
@@ -104,7 +107,7 @@ public class DeploymentTaskTest {
         assertThat(thrown.getCause(), isA(RetryableDeploymentTaskFailureException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache).preparePackages(anyList());
-        verify(mockKernelConfigResolver, times(0)).resolve(anyMap(), eq(deploymentDocument), anySet());
+        verify(mockKernelConfigResolver, times(0)).resolve(anyList(), eq(deploymentDocument), anySet());
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 
@@ -112,13 +115,14 @@ public class DeploymentTaskTest {
     public void GIVEN_deploymentDocument_WHEN_resolve_kernel_config_interrupted_THEN_deploymentTask_aborted()
             throws Exception {
         when(mockPackageCache.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
-        when(mockKernelConfigResolver.resolve(anyMap(), eq(deploymentDocument), anySet())).thenThrow(new InterruptedException());
+        when(mockKernelConfigResolver.resolve(anyList(), eq(deploymentDocument), anySet()))
+                .thenThrow(new InterruptedException());
 
         Exception thrown = assertThrows(RetryableDeploymentTaskFailureException.class, () -> deploymentTask.call());
         assertThat(thrown.getCause(), isA(InterruptedException.class));
         verify(mockDependencyResolver).resolveDependencies(deploymentDocument);
         verify(mockPackageCache).preparePackages(anyList());
-        verify(mockKernelConfigResolver).resolve(anyMap(), eq(deploymentDocument), anySet());
+        verify(mockKernelConfigResolver).resolve(anyList(), eq(deploymentDocument), anySet());
         verify(mockKernel, times(0)).mergeInNewConfig(eq("TestDeployment"), anyLong(), anyMap());
     }
 }

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolverTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -62,9 +63,7 @@ public class KernelConfigResolverTest {
                 new PackageIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2", Semver.SemverType.NPM));
         PackageIdentifier dependencyPackageIdentifier =
                 new PackageIdentifier(TEST_INPUT_PACKAGE_B, new Semver("2.3", Semver.SemverType.NPM));
-        Map<PackageIdentifier, String> packagesToDeploy = new HashMap<>();
-        packagesToDeploy.put(rootPackageIdentifier, ">1.0");
-        packagesToDeploy.put(dependencyPackageIdentifier, ">2.0");
+        List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier, dependencyPackageIdentifier);
 
         Package rootPackage =
                 getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.singletonMap(TEST_INPUT_PACKAGE_B, "2.3"),
@@ -119,7 +118,7 @@ public class KernelConfigResolverTest {
         // GIVEN
         PackageIdentifier rootPackageIdentifier =
                 new PackageIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2", Semver.SemverType.NPM));
-        Map<PackageIdentifier, String> packagesToDeploy = Collections.singletonMap(rootPackageIdentifier, ">1.0");
+        List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier);
 
         Package rootPackage = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(), Collections.emptyMap());
 
@@ -159,12 +158,12 @@ public class KernelConfigResolverTest {
         // GIVEN
         PackageIdentifier rootPackageIdentifier =
                 new PackageIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2", Semver.SemverType.NPM));
-        Map<PackageIdentifier, String> packagesToDeploy = Collections.singletonMap(rootPackageIdentifier, ">1.0");
+        List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier);
 
         Package rootPackage = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(), Collections.emptyMap());
 
-        Set<PackageIdentifier> rootPackagesToRemove = new HashSet<>(Arrays.asList(new PackageIdentifier(
-                "RemovedService", new Semver("3.4", Semver.SemverType.NPM))));
+        Set<PackageIdentifier> rootPackagesToRemove = new HashSet<>(
+                Arrays.asList(new PackageIdentifier("RemovedService", new Semver("3.4", Semver.SemverType.NPM))));
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig =
                 new DeploymentPackageConfiguration(TEST_INPUT_PACKAGE_A, "1.2", ">1.0", Collections.emptySet(),
@@ -203,7 +202,7 @@ public class KernelConfigResolverTest {
         // GIVEN
         PackageIdentifier rootPackageIdentifier =
                 new PackageIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2", Semver.SemverType.NPM));
-        Map<PackageIdentifier, String> packagesToDeploy = Collections.singletonMap(rootPackageIdentifier, ">1.0");
+        List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier);
 
         Package rootPackage = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(),
                 getSimpleParameterMap(TEST_INPUT_PACKAGE_A));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We decided to not store version constraint for packages in kernel config, and so we do not need to get that information passed from dependency resolver to config resolver

**Why is this change necessary:**
We will get version constraint information from parsing recipes of dependent packages in follow up tasks as discussed in one of the meetings

**How was this change tested:**
tests passed

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
