### PR TITLE
Move lifecycle keywords for services from config root to under 'lifecycle' key

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
@@ -201,7 +201,7 @@ class KernelTest {
         testGroup(0);
         System.out.println("First phase passed, now for the harder stuff");
 
-        kernel.find( "services", "main", "run")
+        kernel.find( "services", "main", "lifecycle", "run")
                 .setValue("while true; do\n" + "        date; sleep 5; echo NEWMAIN\n" + "     " + "   done");
         //            kernel.writeConfig(new OutputStreamWriter(System.out));
         testGroup(1);

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
@@ -89,7 +89,8 @@ class ServiceConfigMergingTest {
         // THEN
         assertTrue(mainRestarted.await(60, TimeUnit.SECONDS));
         assertEquals("redefined", kernel.find("services", "main", "setenv", "HELLO").getOnce());
-        assertThat((String) kernel.find("services", "main", "run").getOnce(), containsString("echo \"Running main\""));
+        assertThat((String) kernel.find("services", "main", "lifecycle", "run").getOnce(),
+                   containsString("echo \"Running main\""));
     }
 
     @Test
@@ -138,7 +139,11 @@ class ServiceConfigMergingTest {
                 }});
 
                 put("new_service", new HashMap<Object, Object>() {{
-                    put("run", "sleep 60");
+                    put("lifecycle", new HashMap<Object, Object>() {{
+                        put("run", new HashMap<Object, Object>() {{
+                            put("script", "sleep 60");
+                        }});
+                    }});
                 }});
             }});
         }}).get(60, TimeUnit.SECONDS);
@@ -201,12 +206,16 @@ class ServiceConfigMergingTest {
                 }});
 
                 put("new_service",new HashMap<Object, Object>() {{
-                    put("run", "sleep 60");
+                    put("lifecycle",new HashMap<Object, Object>() {{
+                            put("run", "sleep 60");
+                    }});
                     put("dependencies", Arrays.asList("new_service2"));
                 }});
 
                 put("new_service2",new HashMap<Object, Object>() {{
-                    put("run", "sleep 60");
+                    put("lifecycle",new HashMap<Object, Object>() {{
+                        put("run", "sleep 60");
+                    }});
                 }});
             }});
         }}).get(60, TimeUnit.SECONDS);

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config.yaml
@@ -1,50 +1,54 @@
 ---
 services:
   jdk11:
-    install:
-      debian:
-        script: |-
-          sudo curl --silent https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/java-11-amazon-corretto-jdk_11.0.4.11-1_amd64.deb > /tmp/corettojdk11.deb 2>/dev/null
-          sudo dpkg --install /tmp/corettojdk11.deb 2>/dev/null
-      macos:
-        script: |-
-          brew tap homebrew/cask-versions
-          brew cask install corretto
+    lifecycle:
+      install:
+        debian:
+          script: |-
+            sudo curl --silent https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/java-11-amazon-corretto-jdk_11.0.4.11-1_amd64.deb > /tmp/corettojdk11.deb 2>/dev/null
+            sudo dpkg --install /tmp/corettojdk11.deb 2>/dev/null
+        macos:
+          script: |-
+            brew tap homebrew/cask-versions
+            brew cask install corretto
     dependencies:
       macos:
         - homebrew
   git:
-    install:
-      debian:
-        skipif: onpath git
-        script: sudo apt-get install git
-      macos:
-        skipif: onpath git
-        script: brew install git
+    lifecycle:
+      install:
+        debian:
+          skipif: onpath git
+          script: sudo apt-get install git
+        macos:
+          skipif: onpath git
+          script: brew install git
     dependencies:
       macos:
         - homebrew
   homebrew:
-    install:
-      macos:
-        skipif: onpath brew
-        script: /usr/bin/ruby -e "$(curl --silent -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    lifecycle:
+      install:
+        macos:
+          skipif: onpath brew
+          script: /usr/bin/ruby -e "$(curl --silent -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
   #launchers:
   docker:
     bashtimeout: 300
-    startup:
-      macos: open /Applications/Docker.app
-    install:
-      skipif: onpath docker
-      debian: |-
-        curl --silent -sSL https://get.docker.com/ | sh
-      fedora: sudo dnf install docker
-      macos:
-        skipif: exists /Applications/Docker.app
-        script: |-
-          find $(brew --cache)/downloads/ -name *Docker.dmg.incomplete | xargs rm -f
-          brew cask install docker
+    lifecycle:
+      startup:
+        macos: open /Applications/Docker.app
+      install:
+        skipif: onpath docker
+        debian: |-
+          curl --silent -sSL https://get.docker.com/ | sh
+        fedora: sudo dnf install docker
+        macos:
+          skipif: exists /Applications/Docker.app
+          script: |-
+            find $(brew --cache)/downloads/ -name *Docker.dmg.incomplete | xargs rm -f
+            brew cask install docker
     dependencies:
       macos:
         - homebrew
@@ -57,57 +61,75 @@ services:
     class: com.aws.iot.httpservice.SimpleHttpServer
 
   greenlake:
-    install:
-      debian: |-
-        sudo add-apt-repository https://aws.amazon.com/iot/apt
-        sudo apt-get install greenlake
+    lifecycle:
+      install:
+        debian: |-
+          sudo add-apt-repository https://aws.amazon.com/iot/apt
+          sudo apt-get install greenlake
     throttleBandwidth: 100 kb/s
   hello-docker:
     dependencies:
       - docker
-    run: docker run --rm hello-world
-    shutdown: (docker stop hello-world; docker rm hello-world; exit 0)2>&1
+    lifecycle:
+      run: docker run --rm hello-world
+      shutdown: (docker stop hello-world; docker rm hello-world; exit 0)2>&1
   hello-docker-nginx:
+    lifecycle:
+      run:  (docker run -d nginx; docker logs -f nginx; exit 0)2>&1
+      shutdown: (docker stop nginx; docker rm nginx; exit 0)2>&1
     dependencies:
       - docker
-    run:  (docker run -d nginx; docker logs -f nginx; exit 0)2>&1
-    shutdown: (docker stop nginx; docker rm nginx; exit 0)2>&1
   monitoring:
-    install:
-      debian: |-
-        sudo add-apt-repository https://aws.amazon.com/iot/apt
-        sudo apt-get install monitoring
+    lifecycle:
+      install:
+        debian: |-
+          sudo add-apt-repository https://aws.amazon.com/iot/apt
+          sudo apt-get install monitoring
     dependencies:
       - greenlake
   mqtt:
+    lifecycle:
+      run:
+        unix: |-
+          pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
+          sh $W/bin/moquette.sh
+      install:
+        unix:
+          skipif: exists $[work]/moquette/bin/moquette.sh
+          script: |-
+            mkdir -p $W || true
+            curl --silent -L https://bintray.com/artifact/download/andsel/generic/moquette-0.12.1.tar.gz | tar -zxf - -C $W;
+      shutdown:
+        unix: pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
     setenv:
       W: $[work]/moquette
-    run:
-      unix: |-
-        pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
-        sh $W/bin/moquette.sh
-    install:
-      unix:
-        skipif: exists $[work]/moquette/bin/moquette.sh
-        script: |-
-          mkdir -p $W || true
-          curl --silent -L https://bintray.com/artifact/download/andsel/generic/moquette-0.12.1.tar.gz | tar -zxf - -C $W;
-    shutdown:
-      unix: pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
 
   fallbackMain:  # This service only gets invoked if the main service fails to even begin to boot
-    startup: echo sudo reboot -force   # TODO: this is stupid.  Should try to talk to cloud
+    lifecycle:
+      startup: echo sudo reboot -force   # TODO: this is stupid.  Should try to talk to cloud
   broken:
-    startup: exit -1
+    lifecycle:
+      startup: exit -1
   ticktock:
-    run: echo tick-tock
+    lifecycle:
+      run: echo tick-tock
     periodic: 2 seconds
   setenv:
     ANSWER: 42
   main:
-    install:
-      skipif: true
-      all: echo All installed
+    lifecycle:
+      install:
+        skipif: true
+        all: echo All installed
+      run: |-
+        echo $PATH
+        pwd
+        printenv
+        while true; do
+        date; sleep 5; echo RUNNING
+        done
+      download:
+        hw.jar: http://foo/hw.jar
     dependencies:
       macos:
         - jdk11
@@ -124,15 +146,6 @@ services:
     xyzzy: localhttp, broken
     setenv:
       JUSTME: fancy a spot of tea?
-    run: |-
-      echo $PATH
-      pwd
-      printenv
-      while true; do
-      date; sleep 5; echo RUNNING
-      done
-    download:
-      hw.jar: http://foo/hw.jar
     args: -jar {hw.jar}
   system:
     ServiceSearchList: https://raw.githubusercontent.com/JamesGosling/SailingForecast/master/docs/evg/

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config_broken.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config_broken.yaml
@@ -1,41 +1,44 @@
 services:
   installErrorRetry:
-    install: |-
-      sleep 1
-      if [ -f "/tmp/egInstallErrorRetry" ]; then
-        echo "INSTALL_SUCCEED"
-        rm /tmp/egInstallErrorRetry
-      else
-        echo "INSTALL_FAIL"
-        touch /tmp/egInstallErrorRetry
-        exit 1
-      fi
-    shutdown:
-      rm -f /tmp/egInstallErrorRetry
+    lifecycle:
+      install: |-
+        sleep 1
+        if [ -f "/tmp/egInstallErrorRetry" ]; then
+          echo "INSTALL_SUCCEED"
+          rm /tmp/egInstallErrorRetry
+        else
+          echo "INSTALL_FAIL"
+          touch /tmp/egInstallErrorRetry
+          exit 1
+        fi
+      shutdown:
+        rm -f /tmp/egInstallErrorRetry
 
   runErrorRetry:
-    run: |-
-      sleep 2
-      echo "RUN_BROKEN"
-      exit 1
+    lifecycle:
+      run: |-
+        sleep 2
+        echo "RUN_BROKEN"
+        exit 1
 
   main:
-    install:
-      skipif: true
-      all: echo All installed
+    lifecycle:
+      install:
+        skipif: true
+        all: echo All installed
+      run: |-
+        echo $PATH
+        pwd
+        printenv
+        echo RUNNING
+        while true; do
+        date; sleep 5;
+        done
+      download:
+        hw.jar: http://foo/hw.jar
     dependencies:
       - installErrorRetry
       - runErrorRetry
     setenv:
       JUSTME: fancy a spot of tea?
-    run: |-
-      echo $PATH
-      pwd
-      printenv
-      echo RUNNING
-      while true; do
-      date; sleep 5;
-      done
-    download:
-      hw.jar: http://foo/hw.jar
     args: -jar {hw.jar}

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/delta.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/delta.yaml
@@ -1,11 +1,19 @@
 services:
   ticktock:
-    run: echo tick-tock phase 3
-    periodic: 3 seconds
+    lifecycle:
+      run: echo tick-tock phase 3
+      periodic: 3 seconds
   main:
-    install:
-      skipif: true
-      all: echo All installed
+    lifecycle:
+      install:
+        skipif: true
+        all: echo All installed
+      run: |-
+        echo $PATH xyzzy; pwd
+        printenv
+        while true; do
+        date; sleep 5; echo Now we\'re in phase 3
+        done
     dependencies:
       - jdk11
       - git
@@ -14,11 +22,6 @@ services:
       - frodo
     setenv:
       JUSTME: fancy a spot of coffee?
-    run: |-
-      echo $PATH xyzzy; pwd
-      printenv
-      while true; do
-      date; sleep 5; echo Now we\'re in phase 3
-      done
   frodo:
-    run: echo "I'm Frodo"
+    lifecycle:
+      run: echo "I'm Frodo"

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/long_running_services.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/long_running_services.yaml
@@ -5,24 +5,27 @@ services:
       all: "{platform.invoke} {args}"
 
   sleeperB:
-    run: |-
-      while true; do
-      date; echo sleeperB_running; sleep 5
-      done
+    lifecycle:
+      run: |-
+        while true; do
+        date; echo sleeperB_running; sleep 5
+        done
 
   sleeperA:
     dependencies:
       - sleeperB
-    run: |-
-      while true; do
-      date; echo sleeperA_running; sleep 5
-      done
+    lifecycle:
+      run: |-
+        while true; do
+        date; echo sleeperA_running; sleep 5
+        done
 
   main:
     dependencies:
       - sleeperA
       - sleeperB
-    run: |-
-      while true; do
-      date; echo main_running; sleep 5
-      done
+    lifecycle:
+      run: |-
+        while true; do
+        date; echo main_running; sleep 5
+        done

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/single_service.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/single_service.yaml
@@ -1,6 +1,7 @@
 services:
   main:
-    run:
-      echo "Running main" && sleep 100
+    lifecycle:
+      run:
+        echo "Running main" && sleep 100
     setenv:
       HELLO: "Hi"

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -50,6 +50,7 @@ import static com.aws.iot.evergreen.util.Utils.getUltimateCause;
 public class EvergreenService implements InjectionActions, Closeable {
     public static final String STATE_TOPIC_NAME = "_State";
     public static final String SERVICES_NAMESPACE_TOPIC = "services";
+    public static final String SERVICE_LIFECYCLE_NAMESPACE_TOPIC = "lifecycle";
 
     public final Topics config;
     public Context context;
@@ -82,6 +83,9 @@ public class EvergreenService implements InjectionActions, Closeable {
     // Service logger instance
     protected final Logger logger;
 
+    // Service lifecycle Topics
+    protected final Topics lifecycle;
+
     /**
      * Constructor for EvergreenService.
      *
@@ -90,6 +94,7 @@ public class EvergreenService implements InjectionActions, Closeable {
     public EvergreenService(Topics topics) {
         this.config = topics;
         this.context = topics.getContext();
+        this.lifecycle = topics.findInteriorChild(SERVICE_LIFECYCLE_NAMESPACE_TOPIC);
         this.logger = LogManager.getLogger(getName());
         logger.addDefaultKeyValue("serviceName", getName());
         this.state = initStateTopic(topics);

--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -139,7 +139,7 @@ public class GenericExternalService extends EvergreenService {
      * @return the status of the run.
      */
     protected RunStatus run(String name, IntConsumer background) {
-        Node n = config.getChild(name);
+        Node n = (lifecycle == null) ? null : lifecycle.getChild(name);
         return n == null ? RunStatus.NothingDone : run(n, background);
     }
 

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -66,6 +66,10 @@ public class KernelConfigResolver {
         Package pkg = packageCache.getRecipe(packageIdentifier);
 
         Map<Object, Object> resolvedServiceConfig = new HashMap<>();
+        Map<Object, Object> resolvedLifecycleConfig = new HashMap<>();
+
+        resolvedServiceConfig.put(EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC,
+                                  resolvedLifecycleConfig);
 
         // TODO : Package recipe format is not in alignment with the changed Kernel config syntax,
         // which leads to inconsistent naming, e.g. lifecycle per new Kernel config syntax is one of several config
@@ -75,7 +79,7 @@ public class KernelConfigResolver {
         // Interpolate parameters
         Set<PackageParameter> resolvedParams = resolveParameterValuesToUse(document, pkg);
         for (Map.Entry<String, Object> configKVPair : pkg.getLifecycle().entrySet()) {
-            resolvedServiceConfig.put(configKVPair.getKey(), interpolate(configKVPair.getValue(), resolvedParams));
+            resolvedLifecycleConfig.put(configKVPair.getKey(), interpolate(configKVPair.getValue(), resolvedParams));
         }
 
         // TODO : Update package recipe format to include all information that service dependencies config

--- a/src/test/resources/com/aws/iot/evergreen/kernel/config.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/kernel/config.yaml
@@ -1,98 +1,108 @@
 ---
 services:
   jdk11:
-    install:
-      debian:
-        script: |-
-          sudo curl --silent https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/java-11-amazon-corretto-jdk_11.0.4.11-1_amd64.deb > /tmp/corettojdk11.deb 2>/dev/null
-          sudo dpkg --install /tmp/corettojdk11.deb 2>/dev/null
-      macos:
-        script: |-
-          brew tap homebrew/cask-versions
-          brew cask install corretto
+    lifecycle:
+      install:
+        debian:
+          script: |-
+            sudo curl --silent https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/java-11-amazon-corretto-jdk_11.0.4.11-1_amd64.deb > /tmp/corettojdk11.deb 2>/dev/null
+            sudo dpkg --install /tmp/corettojdk11.deb 2>/dev/null
+        macos:
+          script: |-
+            brew tap homebrew/cask-versions
+            brew cask install corretto
     dependencies:
       macos:
         - homebrew
   git:
-    install:
-      debian:
-        skipif: onpath git
-        script: sudo apt-get install git
-      macos:
-        skipif: onpath git
-        script: brew install git
+    lifecycle:
+      install:
+        debian:
+          skipif: onpath git
+          script: sudo apt-get install git
+        macos:
+          skipif: onpath git
+          script: brew install git
     dependencies:
       macos:
         - homebrew
   homebrew:
-    install:
-      macos:
-        skipif: onpath brew
-        script: /usr/bin/ruby -e "$(curl --silent -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    lifecycle:
+      install:
+        macos:
+          skipif: onpath brew
+          script: /usr/bin/ruby -e "$(curl --silent -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
   docker:
     bashtimeout: 300
-    startup:
-      macos: open /Applications/Docker.app
-    install:
-      skipif: onpath docker
-      debian: |-
-        curl --silent -sSL https://get.docker.com/ | sh
-      fedora: sudo dnf install docker
-      macos:
-        skipif: exists /Applications/Docker.app
-        script: |-
-          find $(brew --cache)/downloads/ -name *Docker.dmg.incomplete | xargs rm -f
-          brew cask install docker
+    lifecycle:
+      startup:
+        macos: open /Applications/Docker.app
+      install:
+        skipif: onpath docker
+        debian: |-
+          curl --silent -sSL https://get.docker.com/ | sh
+        fedora: sudo dnf install docker
+        macos:
+          skipif: exists /Applications/Docker.app
+          script: |-
+            find $(brew --cache)/downloads/ -name *Docker.dmg.incomplete | xargs rm -f
+            brew cask install docker
     dependencies:
       macos:
         - homebrew
   plain:
-    run:
-      all: "{platform.invoke} {args}"
+    lifecycle:
+      run:
+        all: "{platform.invoke} {args}"
 
   #services:
   localhttp:
     class: com.aws.iot.httpservice.SimpleHttpServer
 
   greenlake:
-    install:
-      debian: |-
-        sudo add-apt-repository https://aws.amazon.com/iot/apt
-        sudo apt-get install greenlake
+    lifecycle:
+      install:
+        debian: |-
+          sudo add-apt-repository https://aws.amazon.com/iot/apt
+          sudo apt-get install greenlake
     throttleBandwidth: 100 kb/s
   hello-docker:
     dependencies:
       - docker
-    run: docker run --rm hello-world
-    shutdown: (docker stop hello-world; docker rm hello-world; exit 0)2>&1
+    lifecycle:
+      run: docker run --rm hello-world
+      shutdown: (docker stop hello-world; docker rm hello-world; exit 0)2>&1
   hello-docker-nginx:
     dependencies:
       - docker
-    run:  (docker run -d nginx; docker logs -f nginx; exit 0)2>&1
-    shutdown: (docker stop nginx; docker rm nginx; exit 0)2>&1
+    lifecycle:
+      run:  (docker run -d nginx; docker logs -f nginx; exit 0)2>&1
+      shutdown: (docker stop nginx; docker rm nginx; exit 0)2>&1
   monitoring:
-    install:
-      debian: |-
-        sudo add-apt-repository https://aws.amazon.com/iot/apt
-        sudo apt-get install monitoring
+    lifecycle:
+      install:
+        debian: |-
+          sudo add-apt-repository https://aws.amazon.com/iot/apt
+          sudo apt-get install monitoring
     dependencies:
       - greenlake
   mqtt:
     setenv:
       W: $[work]/moquette
-    run:
-      unix: |-
-        pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
-        sh $W/bin/moquette.sh
-    install:
-      unix:
-        skipif: exists $[work]/moquette/bin/moquette.sh
-        script: |-
-          mkdir -p $W || true
-          curl --silent -L https://bintray.com/artifact/download/andsel/generic/moquette-0.12.1.tar.gz | tar -zxf - -C $W;
-    shutdown:
-      unix: pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
+    lifecycle:
+      run:
+        unix: |-
+          pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
+          sh $W/bin/moquette.sh
+      install:
+        unix:
+          skipif: exists $[work]/moquette/bin/moquette.sh
+          script: |-
+            mkdir -p $W || true
+            curl --silent -L https://bintray.com/artifact/download/andsel/generic/moquette-0.12.1.tar.gz | tar -zxf - -C $W;
+      shutdown:
+        unix: pkill -9  -f "io[.]moquette[.]broker[.]Server" || true
 
   fallbackMain:  # This service only gets invoked if the main service fails to even begin to boot
     startup: echo sudo reboot -force   # TODO: this is stupid.  Should try to talk to cloud
@@ -104,9 +114,19 @@ services:
   setenv:
     ANSWER: 42
   main:
-    install:
-      skipif: true
-      all: echo All installed
+    lifecycle:
+      install:
+        skipif: true
+        all: echo All installed
+      run: |-
+        echo $PATH
+        pwd
+        printenv
+        while true; do
+        date; sleep 5; echo RUNNING
+        done
+      download:
+        hw.jar: http://foo/hw.jar
     dependencies:
       macos:
         - jdk11
@@ -123,13 +143,4 @@ services:
     xyzzy: localhttp, broken
     setenv:
       JUSTME: fancy a spot of tea?
-    run: |-
-      echo $PATH
-      pwd
-      printenv
-      while true; do
-      date; sleep 5; echo RUNNING
-      done
-    download:
-      hw.jar: http://foo/hw.jar
     args: -jar {hw.jar}


### PR DESCRIPTION
**Issue #, if available:**
https://issues.amazon.com/issues/P33898016

**Description of changes:**
Move lifecycle keywords for services from config root to under 'lifecycle' key

**Why is this change necessary:**
Required as a part of this design change - https://quip-amazon.com/35xMAtuSgvha/Evergreen-Kernel-Configuration-Schema#aeM9CAMettB

**How was this change tested:**
Unit/integration tests updated to match

NOTE: This PR depends on https://github.com/aws/aws-greengrass-kernel/pull/115

Further changes needed in future PRs:
- Remove support for 'skipif' (Separate PR since there are many test files which have skipif, want to keep PR size down)
- Validate keywords under lifecycle (Not a part of this sprint, separate task)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
