### PR TITLE
Update definition of skip if, remove support for arbitrary scripts

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
@@ -1,0 +1,54 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+package com.aws.iot.evergreen.integrationtests.kernel;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.kernel.Kernel;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GenericExternalServiceTest {
+
+    @TempDir
+    Path tempRootDir;
+
+
+    @BeforeEach
+    void before(TestInfo testInfo) {
+        System.out.println("Running test: " + testInfo.getDisplayName());
+        System.setProperty("log.store", "CONSOLE");
+        System.setProperty("log.fmt", "TEXT");
+    }
+
+    @Test
+    void GIVEN_service_config_with_broken_skipif_config_WHEN_launch_service_THEN_service_moves_to_error_state()
+            throws Throwable {
+        // GIVEN
+        Kernel kernel = new Kernel();
+        kernel.parseArgs("-r", tempRootDir.toString(), "-i",
+                getClass().getResource("skipif_broken.yaml").toString());
+
+        CountDownLatch testErrored = new CountDownLatch(1);
+        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals("test") && newState.equals(State.ERRORED)) {
+                testErrored.countDown();
+            }
+        });
+
+        // WHEN
+        kernel.launch();
+
+        // THEN
+        assertTrue(testErrored.await(60, TimeUnit.SECONDS));
+    }
+}

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config.yaml
@@ -119,7 +119,6 @@ services:
   main:
     lifecycle:
       install:
-        skipif: true
         all: echo All installed
       run: |-
         echo $PATH
@@ -139,7 +138,6 @@ services:
         - mqtt
         - ticktock:INSTALLED
       linux:
-        - jdk11
         - git
         - mqtt
         - ticktock:INSTALLED # Remove docker dependency for github code check run due to docker install failure.

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config_broken.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config_broken.yaml
@@ -24,7 +24,6 @@ services:
   main:
     lifecycle:
       install:
-        skipif: true
         all: echo All installed
       run: |-
         echo $PATH

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/delta.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/delta.yaml
@@ -6,7 +6,6 @@ services:
   main:
     lifecycle:
       install:
-        skipif: true
         all: echo All installed
       run: |-
         echo $PATH xyzzy; pwd
@@ -15,7 +14,6 @@ services:
         date; sleep 5; echo Now we\'re in phase 3
         done
     dependencies:
-      - jdk11
       - git
       - mqtt
       - ticktock:INSTALLED

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/skipif_broken.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/skipif_broken.yaml
@@ -1,0 +1,16 @@
+services:
+  test:
+    lifecycle:
+      run:
+        debian:
+          skipif: This is broken
+          script: echo "Running test" && sleep 10
+        macos:
+          skipif: This is broken
+          script: echo "Running test" && sleep 10
+  main:
+    lifecycle:
+      run:
+        script: echo "Running main" && sleep 60
+    dependencies:
+      - test

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -95,6 +95,10 @@ public class EvergreenService implements InjectionActions, Closeable {
         this.config = topics;
         this.context = topics.getContext();
         this.lifecycle = topics.findInteriorChild(SERVICE_LIFECYCLE_NAMESPACE_TOPIC);
+
+        // TODO: Validate syntax for lifecycle keywords and fail early
+        // skipif will require validation for onpath/exists etc. keywords
+
         this.logger = LogManager.getLogger(getName());
         logger.addDefaultKeyValue("serviceName", getName());
         this.state = initStateTopic(topics);

--- a/src/test/resources/com/aws/iot/evergreen/kernel/config.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/kernel/config.yaml
@@ -116,7 +116,6 @@ services:
   main:
     lifecycle:
       install:
-        skipif: true
         all: echo All installed
       run: |-
         echo $PATH


### PR DESCRIPTION
**Issue #, if available:**
https://issues.amazon.com/issues/P33898016

**Description of changes:**
Update the skipif keyword in lifecycle steps to remove support for running arbitrary scripts. The customer can just choose to run scripts in the "script" section.
The skipif keyword will support "onpath", "exists" and other convenience keywords only. More keywords will be added as needed.

**How was this change tested:**
Added an integration test to ensure service moves to error state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
