### PR TITLE
Fix Benchmark commit history fetching

### DIFF
--- a/.github/scripts/cwJMHUpload.py
+++ b/.github/scripts/cwJMHUpload.py
@@ -98,9 +98,12 @@ def main():
         for b in batch(datapoints, 20):
             put_metrics_retryable(cw, namespace, b)
 
+        num_commit_history = 50
+        os.system(f"git fetch --depth={num_commit_history} origin master")
         # Get the last 50 merges to master with the short commit hash and commiter's date
         # Format like: 43a4929 2019-11-24T11:29:22-08:00
-        merges_to_master = subprocess.check_output(["git", "log", "-n", "50", "--merges", "--first-parent", "master",
+        merges_to_master = subprocess.check_output(["git", "log", "-n", num_commit_history, "--merges",
+                                                    "--first-parent", "origin/master",
                                                     "--pretty=format:%h %cI"]).decode("utf-8").strip().split("\n")
 
         annotations = {

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,7 @@
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>3.0.5</version>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <effort>Max</effort>
                     <!-- Reports all bugs (other values are medium and max) -->
                     <threshold>Low</threshold>
@@ -258,6 +259,7 @@
                     <configLocation>checkstyle.xml</configLocation>
                     <violationSeverity>warning</violationSeverity>
                     <maxAllowedViolations>0</maxAllowedViolations>
+                    <skip>${skipTests}</skip>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change calls `get fetch origin master` so that the master branch history will be available for the next call to `git log`. Without this change the `checkout@v2` action only downloads the latest commit to save time, and thus git does not have access to the commit history.

**Why is this change necessary:**

**How was this change tested:**
Created this pull request and enabled the benchmark task to run on pull requests. I saw that it was able to run successfully from the github container.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
