### PR TITLE
Replace GitHub client and have benchmark get full commit history

### DIFF
--- a/.github/scripts/cwJMHUpload.py
+++ b/.github/scripts/cwJMHUpload.py
@@ -100,19 +100,19 @@ def main():
 
         num_commit_history = 50
         os.system(f"git fetch --depth={num_commit_history} origin master")
-        # Get the last 50 merges to master with the short commit hash and commiter's date
+        # Get the last 50 commits to master with the short commit hash and commiter's date
         # Format like: 43a4929 2019-11-24T11:29:22-08:00
-        merges_to_master = subprocess.check_output(["git", "log", "-n", str(num_commit_history), "--merges",
-                                                    "--first-parent", "origin/master",
-                                                    "--pretty=format:%h %cI"]).decode("utf-8").strip().split("\n")
+        commits_to_master = subprocess.check_output(["git", "log", "-n", str(num_commit_history),
+                                                     "--first-parent", "origin/master",
+                                                     "--pretty=format:%h %cI"]).decode("utf-8").strip().split("\n")
 
         annotations = {
             "vertical": [
                 {
-                    "label": merge.split(" ")[0],
-                    "value": merge.split(" ")[1],
+                    "label": commit.split(" ")[0],
+                    "value": commit.split(" ")[1],
                     "color": "#16b"  # Annotate with CloudWatch blue
-                } for merge in merges_to_master
+                } for commit in commits_to_master
             ]
         }
 
@@ -124,6 +124,7 @@ def main():
         region = os.getenv("AWS_REGION")
         period = 300
         dashboard_data = {
+            "start": "-P7D",  # Set default time range to 1 week
             "widgets": [
                 {
                     "type": "metric",

--- a/.github/scripts/cwUpload.py
+++ b/.github/scripts/cwUpload.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 
 import boto3
 from retryable import retry
-from github import Github
+from agithub.GitHub import GitHub
 
 
 def batch(iterable, batch_size=1):
@@ -30,13 +30,10 @@ def put_metrics_retryable(cw, namespace, datapoints):
     )
 
 
-@retry(count=10, delay=10)
-def comment_on_pr(comment, pr_number):
-    gh = Github(sys.argv[1])
-    print(gh.get_rate_limit())
-    repo = gh.get_repo(os.getenv("GITHUB_REPOSITORY"))
-    pr = repo.get_pull(pr_number)
-    pr.create_issue_comment(comment)
+def comment_on_pr(comment: str, pr_number):
+    # agithub automatically retries if we get rate limited, once the rate limit period expires
+    gh = GitHub(token=sys.argv[1])
+    gh.repos[os.getenv("GITHUB_REPOSITORY")].issues[pr_number].comments.post(body={"body": str(comment)})
 
 
 def main():
@@ -117,7 +114,6 @@ def main():
                 change_str = f"💥 {change_str}"
         table += f"|{test_path.split(' ')[-1]}|{v}|{change_str}|{' '.join(test_path.split(' ')[0:-1])}|\n"
 
-    print(table)
     if "number" in github_event and len(sys.argv) == 2:
         comment_on_pr(table, github_event["number"])
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -46,5 +46,5 @@ jobs:
       - name: Upload to CloudWatch
         run: >-
           pip3 -q install boto3 setuptools wheel &&
-          pip3 -q install retryable PyGithub &&
+          pip3 -q install retryable agithub &&
           python3 .github/scripts/cwJMHUpload.py

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,7 +54,10 @@ jobs:
         # Use class names instead of the filename
         show_class_names: true
     - name: Upload to CloudWatch
-      run: pip3 -q install boto3 setuptools wheel && pip3 -q install retryable PyGithub && python3 .github/scripts/cwUpload.py ${{ github.token }}
+      run: >-
+        pip3 -q install boto3 setuptools wheel &&
+        pip3 -q install retryable agithub &&
+        python3 .github/scripts/cwUpload.py ${{ github.token }}
     - name: Publish with Maven
       run: mvn -ntp --settings settings.xml clean deploy -DskipTests=true -Daccess-key-id=${{ secrets.evergreen_dev_snapshot_access_key_id }} -Daccess-key-secret=${{ secrets.evergreen_dev_snapshot_access_key_secret }} -Dstargate-snapshot-repository-url=${{ secrets.stargate_dev_snapshot_repository_url }}
       if: github.event_name == 'push'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Replaces PyGitHub with agithub from Mozilla. PyGitHub was making 3 API calls every time to login, get repo, then comment. agithub will only have a single call when we post the comment. Additionally agithub has support for retrying by default for GitHub's rate limiting, so it will auto-retry once the rate limit period is over.

Also changes benchmark dashboard annotations to be all commits to master, not just merges since not every pull request results in a merge commit.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
