### PR TITLE
Add performance benchmarking on dependency resolution component

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -31,13 +31,9 @@ jobs:
         run: >-
           java -jar src/test/evergreen-kernel-benchmark/target/benchmarks.jar
           -rf json
-          -f 5
-          -wi 0
           -jvmArgs "-Xms1m -Xmx128m -XX:MaxHeapFreeRatio=10 -XX:MinHeapFreeRatio=5 -XX:GCTimeRatio=19
           -XX:NativeMemoryTracking=summary -Xss232k"
           -prof com.aws.iot.evergreen.jmh.profilers.ForcedGcMemoryProfiler
-          -i 1
-          -bm avgt
       - name: Upload JMH Result
         uses: actions/upload-artifact@v1.0.0
         with:

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -218,7 +218,7 @@ public class EvergreenService implements InjectionActions {
                     staticLogger.atInfo().setEventType("evergreen-service-loaded")
                             .addKeyValue("serviceName", ret.getName()).log();
                 } catch (Throwable ex) {
-                    throw new ServiceLoadException("Can't create code-backed service from " + clazz.getSimpleName(),
+                    throw new ServiceLoadException("Can't create Evergreen Service instance " + clazz.getSimpleName(),
                             ex);
                 }
             } else if (serviceRootTopics.isEmpty()) {
@@ -230,7 +230,7 @@ public class EvergreenService implements InjectionActions {
                     staticLogger.atInfo().setEventType("generic-service-loaded")
                             .addKeyValue("serviceName", ret.getName()).log();
                 } catch (Throwable ex) {
-                    throw new ServiceLoadException("Can't create generic service", ex);
+                    throw new ServiceLoadException("Can't create generic service instance " + name, ex);
                 }
             }
             return ret;

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -295,7 +295,8 @@ public class DependencyResolver {
         try {
             service = EvergreenService.locate(kernel.context, packageName);
         } catch (ServiceLoadException e) {
-            logger.atWarn().setCause(e).addKeyValue("packageName", packageName).log("Fail to load package");
+            logger.atDebug().setCause(e).addKeyValue("packageName", packageName).log(
+                    "Failed to get active package in Kernel");
             return Optional.empty();
         }
         return getServiceVersion(service);

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/PyYAML/3.10.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/PyYAML/3.10.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: PyYAML
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '3.10.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/PyYAML/3.13.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/PyYAML/3.13.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: PyYAML
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '3.13.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/awscli/1.16.144/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/awscli/1.16.144/recipe.yaml
@@ -1,0 +1,13 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: awscli
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.16.144'
+Dependencies:
+  botocore: '==1.12.134'
+  colorama: '>=0.2.5 <=0.3.9'
+  docutils: '>=0.10.0'
+  PyYAML: '>=3.10.0 <=3.13.0'
+  rsa: '>=3.1.2 <=3.5.0'
+  s3transfer: '>=0.2.0 <0.3.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/boto3/1.9.128/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/boto3/1.9.128/recipe.yaml
@@ -1,0 +1,10 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: boto3
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.9.128'
+Dependencies:
+  botocore: '>=1.12.128 <1.13.0'
+  jmespath: '>=0.7.1 <1.0.0'
+  s3transfer: '>=0.2.0 <0.3.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/botocore/1.12.128/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/botocore/1.12.128/recipe.yaml
@@ -1,0 +1,11 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: botocore
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.12.128'
+Dependencies:
+  docutils: '>=0.10.0'
+  jmespath: '>=0.7.1 <1.0.0'
+  python-dateutil: '>=2.1.0 <3.0.0'
+  urllib3: '>=1.20.0 <1.25.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/botocore/1.12.134/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/botocore/1.12.134/recipe.yaml
@@ -1,0 +1,11 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: botocore
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.12.134'
+Dependencies:
+  docutils: '>=0.10.0'
+  jmespath: '>=0.7.1 <1.0.0'
+  python-dateutil: '>=2.1.0 <3.0.0'
+  urllib3: '>=1.20.0 <1.25.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/colorama/0.2.5/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/colorama/0.2.5/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: colorama
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.2.5'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/colorama/0.3.9/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/colorama/0.3.9/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: colorama
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.3.9'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/docutils/0.10.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/docutils/0.10.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: docutils
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.10.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/docutils/0.12.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/docutils/0.12.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: docutils
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.12.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/docutils/0.14.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/docutils/0.14.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: docutils
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.14.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/jmespath/0.7.1/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/jmespath/0.7.1/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: jmespath
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.7.1'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/jmespath/0.8.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/jmespath/0.8.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: jmespath
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.8.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/jmespath/0.9.5/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/jmespath/0.9.5/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: jmespath
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.9.5'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/pyasn1/0.1.3/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/pyasn1/0.1.3/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: pyasn1
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.1.3'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/pyasn1/0.4.8/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/pyasn1/0.4.8/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: pyasn1
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.4.8'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/python-dateutil/2.3.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/python-dateutil/2.3.0/recipe.yaml
@@ -1,0 +1,8 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: python-dateutil
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '2.3.0'
+Dependencies:
+  six: ''

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/python-dateutil/2.8.1/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/python-dateutil/2.8.1/recipe.yaml
@@ -1,0 +1,8 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: python-dateutil
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '2.8.1'
+Dependencies:
+  six: '>=1.5.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/rsa/3.1.4/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/rsa/3.1.4/recipe.yaml
@@ -1,0 +1,8 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: rsa
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '3.1.4'
+Dependencies:
+  pyasn1: '>= 0.1.3'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/rsa/3.4.2/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/rsa/3.4.2/recipe.yaml
@@ -1,0 +1,8 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: rsa
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '3.4.2'
+Dependencies:
+  pyasn1: '>= 0.1.3'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.1.13/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.1.13/recipe.yaml
@@ -1,0 +1,8 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: s3transfer
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.1.13'
+Dependencies:
+  botocore: '<2.0.0 >=1.3.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.2.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.2.0/recipe.yaml
@@ -1,0 +1,8 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: s3transfer
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.2.0'
+Dependencies:
+  botocore: '<2.0.0 >=1.12.36'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.2.1/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.2.1/recipe.yaml
@@ -1,0 +1,9 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: s3transfer
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.2.1'
+Dependencies:
+  botocore: '<2.0.0 >=1.12.36'
+

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.3.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/s3transfer/0.3.0/recipe.yaml
@@ -1,0 +1,9 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: s3transfer
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '0.3.0'
+Dependencies:
+  botocore: '<2.0.0 >=1.12.36'
+

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/six/1.14.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/six/1.14.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: six
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.14.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/six/1.5.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/six/1.5.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: six
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.5.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.20.0/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.20.0/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: urllib3
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.20.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.21.1/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.21.1/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: urllib3
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.21.1'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.24.3/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.24.3/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: urllib3
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.24.3'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.25.8/recipe.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/urllib3/1.25.8/recipe.yaml
@@ -1,0 +1,6 @@
+---
+RecipeTemplateVersion: '2020-01-25'
+PackageName: urllib3
+Description: Test recipe for Evergreen packages
+Publisher: EvergreenBenchmarkTest
+Version: '1.25.8'

--- a/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/BasicExampleBenchmark.java
+++ b/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/BasicExampleBenchmark.java
@@ -8,7 +8,16 @@ package com.aws.iot.evergreen.jmh;
 import com.aws.iot.evergreen.jmh.profilers.ForcedGcMemoryProfiler;
 import com.aws.iot.evergreen.kernel.Kernel;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Warmup;
 
+@BenchmarkMode(Mode.AverageTime)
+@Fork(5)
+@Measurement(iterations = 1)
+@Warmup(iterations = 0)
 public class BasicExampleBenchmark {
 
     @Benchmark

--- a/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.jmh.packagemanager;
+
+import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
+import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
+import com.aws.iot.evergreen.jmh.profilers.ForcedGcMemoryProfiler;
+import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.packagemanager.DependencyResolver;
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+import com.aws.iot.evergreen.packagemanager.plugins.LocalPackageStore;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class DependencyResolverBenchmark {
+
+    @BenchmarkMode(Mode.AverageTime)
+    @Fork(1)
+    @Measurement(iterations = 20)
+    @Warmup(iterations = 5)
+    @State(Scope.Benchmark)
+    public static abstract class DRIntegration {
+        private DeploymentDocument jobDoc = new DeploymentDocument("mockJob1",Arrays.asList("boto3", "awscli"), Arrays.asList(
+                new DeploymentPackageConfiguration("boto3", "1.9.128", "", new HashSet<>(), new ArrayList<>()),
+                new DeploymentPackageConfiguration("awscli", "1.16.144", "", new HashSet<>(), new ArrayList<>())
+        ), "mockGroup1", 1L);
+
+        private DependencyResolver resolver;
+        private List<PackageIdentifier> result;
+
+        @Setup
+        public void setup() {
+            Kernel kernel = new Kernel();
+            kernel.parseArgs("-i", DependencyResolverBenchmark.class.getResource(getConfigFile()).toString());
+            // We don't need to launch kernel here. Only configuration parsing and main service loading are
+            // required for this benchmarking.
+
+            // TODO: Update local package store accordingly when the new implementation is ready
+            // TODO: Figure out if there's a better way to load resource directory in local package store
+            // For now, hardcode to be under root of kernel package
+            Path packagePath = Paths.get(System.getProperty("user.dir"))
+                    .resolve("src/test/evergreen-kernel-benchmark/mock_artifact_source");
+            resolver = new DependencyResolver(new LocalPackageStore(packagePath), kernel);
+        }
+
+        @TearDown(Level.Invocation)
+        public void doTeardown() {
+            ForcedGcMemoryProfiler.recordUsedMemory();
+        }
+
+        @Benchmark
+        public List<PackageIdentifier> measure() throws Exception {
+            result = resolver.resolveDependencies(jobDoc);
+            return result;
+        }
+
+        protected abstract String getConfigFile();
+    }
+
+    public static class NewMain extends DRIntegration {
+        @Override
+        protected String getConfigFile() {
+            return "DRBNewConfig.yaml";
+        }
+    }
+
+    public static class StatefulMain extends DRIntegration {
+        @Override
+        protected String getConfigFile() {
+            return "DRBStatefulConfig.yaml";
+        }
+    }
+}

--- a/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/Readme.md
+++ b/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/Readme.md
@@ -1,0 +1,48 @@
+# Setup of Dependency Resolution Benchmark
+## Kernel Config
+The benchmark uses the following config files for two different scenarios:
+1. `DRBNewConfig.yaml`: GIVEN main without any existing packages, WHEN resolve 2 top-level packages, THEN 13 new packages
+ are resolved and
+ added.
+1. `DRBStatefulConfig.yaml`: GIVEN 7 packages exist on the device (Using <service>.version keyword in config), WHEN
+ resolve 2 top-level
+ packages, THEN 6 packages remain the same, 1 updated, and 6 new packages added.
+## Local Package Artifact Store
+The test package example is constructed based on the dependency tree of Python packages `awscli` and `boto3`
+```
+awscli==1.16.144
+  - botocore [required: ==1.12.134, installed: 1.12.134]
+    - docutils [required: >=0.10, installed: 0.14]
+    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
+    - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
+      - six [required: >=1.5, installed: 1.14.0]
+    - urllib3 [required: >=1.20,<1.25, installed: 1.24.2]
+  - colorama [required: >=0.2.5,<=0.3.9, installed: 0.3.9]
+  - docutils [required: >=0.10, installed: 0.14]
+  - PyYAML [required: >=3.10,<=3.13, installed: 3.13]
+  - rsa [required: >=3.1.2,<=3.5.0, installed: 3.4.2]
+    - pyasn1 [required: >=0.1.3, installed: 0.4.5]
+  - s3transfer [required: >=0.2.0,<0.3.0, installed: 0.2.0]
+    - botocore [required: >=1.12.36,<2.0.0, installed: 1.12.134]
+      - docutils [required: >=0.10, installed: 0.14]
+      - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
+      - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
+        - six [required: >=1.5, installed: 1.14.0]
+      - urllib3 [required: >=1.20,<1.25, installed: 1.24.2]
+
+boto3==1.9.128
+  - botocore [required: >=1.12.128,<1.13.0, installed: 1.12.134]
+    - docutils [required: >=0.10, installed: 0.14]
+    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
+    - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
+      - six [required: >=1.5, installed: 1.14.0]
+    - urllib3 [required: >=1.20,<1.25, installed: 1.24.2]
+  - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
+  - s3transfer [required: >=0.2.0,<0.3.0, installed: 0.2.0]
+    - botocore [required: >=1.12.36,<2.0.0, installed: 1.12.134]
+      - docutils [required: >=0.10, installed: 0.14]
+      - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
+      - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
+        - six [required: >=1.5, installed: 1.14.0]
+      - urllib3 [required: >=1.20,<1.25, installed: 1.24.2]
+```

--- a/src/test/evergreen-kernel-benchmark/src/main/resources/com/aws/iot/evergreen/jmh/packagemanager/DRBNewConfig.yaml
+++ b/src/test/evergreen-kernel-benchmark/src/main/resources/com/aws/iot/evergreen/jmh/packagemanager/DRBNewConfig.yaml
@@ -1,0 +1,5 @@
+services:
+  main:
+    lifecycle:
+      run:
+        sleep 100

--- a/src/test/evergreen-kernel-benchmark/src/main/resources/com/aws/iot/evergreen/jmh/packagemanager/DRBStatefulConfig.yaml
+++ b/src/test/evergreen-kernel-benchmark/src/main/resources/com/aws/iot/evergreen/jmh/packagemanager/DRBStatefulConfig.yaml
@@ -1,0 +1,23 @@
+services:
+  main:
+    lifecycle:
+      run:
+        sleep 100
+    dependencies:
+      - s3transfer:INSTALLED
+  s3transfer:
+    version: '0.2.1'
+    lifecycle:
+      install: echo INSTALLED
+  botocore:
+    version: '1.12.128'
+  docutils:
+    version: '0.14.0'
+  jmespath:
+    version: '0.9.5'
+  python-dateutil:
+    version: '2.8.1'
+  six:
+    version: '1.14.0'
+  urllib3:
+    version: '1.24.3'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add performance benchmark test on package dependency resolution. The test creates a real Kernel instance and kernel loads config.yaml as the current state. Kernel is not started however because dependency resolution does not depend on other services or functionalities. I have experimented the alternative to mock kernel using Mockito, but it shows more memory overhead, and similar execution time. See the numbers below.

- Two scenarios are covered.
  - Scenario 1: GIVEN main without any additional packages, WHEN resolve 2 top-level packages,THEN 13 new packages are resolved and added.
  - Scenario 2: GIVEN 7 dependency packages exist on the device, WHEN resolve 2 top-level packages, THEN 6 packages remain the same, 1 updated, and 6 new packages added. (Using `<service>.version` keyword in `config.yaml`)
- Clean up error logging in kernel

**Why is this change necessary:**

**How was this change tested:**
- Warmups, Forks, Measurement iterations and benchmark modes are setup in code. CLI parameters will override the settings in code.
- In the root directory of Kernel package: `java -jar src/test/evergreen-kernel-benchmark/target/benchmarks.jar -rf json -jvmArgs "-Xms1m -Xmx128m -XX:MaxHeapFreeRatio=10 -XX:MinHeapFreeRatio=5 -XX:GCTimeRatio=19 -XX:NativeMemoryTracking=summary -Xss232k" -prof com.aws.iot.evergreen.jmh.profilers.ForcedGcMemoryProfiler packagemanager.*`

Output
```
Benchmark                                                                        Mode  Cnt         Score         Error  Units
DependencyResolverBenchmark.NewMain.measure                                      avgt   20         0.007 ±       0.001   s/op
DependencyResolverBenchmark.NewMain.measure:EG.codeCacheUsed                     avgt   20   7489552.543 ±  313535.018  bytes
DependencyResolverBenchmark.NewMain.measure:EG.compressedClassSpaceUsed          avgt   20   2253794.395 ±    1841.099  bytes
DependencyResolverBenchmark.NewMain.measure:EG.gcTimeMillis                      avgt   20       571.655 ±       6.195     ms
DependencyResolverBenchmark.NewMain.measure:EG.heapUsed                          avgt   20   3569634.335 ±  212782.840  bytes
DependencyResolverBenchmark.NewMain.measure:EG.heapUsed.jmap                     avgt   20   3638659.533 ±  211170.454  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Arena Chunk                  avgt   20   1587483.255 ± 1758048.858  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Class                        avgt   20  25988176.886 ±  168386.636  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Code                         avgt   20   9105043.911 ±  378664.709  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Compiler                     avgt   20    310200.320 ±  620365.471  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.GC                           avgt   20  10418176.000 ±       0.001  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Internal                     avgt   20   5920137.775 ±     931.092  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Java Heap                    avgt   20   6815744.000 ±       0.001  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Native Memory Tracking       avgt   20    658019.711 ±    2165.353  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Symbol                       avgt   20   5233664.000 ±       0.001  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Thread                       avgt   20  11822080.000 ±       0.001  bytes
DependencyResolverBenchmark.NewMain.measure:EG.jcmd.Total                        avgt   20  77858235.837 ± 2123481.591  bytes
DependencyResolverBenchmark.NewMain.measure:EG.metaspaceUsed                     avgt   20  19076514.388 ±   72951.369  bytes
DependencyResolverBenchmark.NewMain.measure:EG.nonHeapUsed                       avgt   20  28818285.532 ±  384082.508  bytes
DependencyResolverBenchmark.NewMain.measure:EG.totalCommitted                    avgt   20  36258692.293 ±  470353.152  bytes
DependencyResolverBenchmark.StatefulMain.measure                                 avgt   20         0.005 ±       0.001   s/op
DependencyResolverBenchmark.StatefulMain.measure:EG.codeCacheUsed                avgt   20   7460058.548 ±  309756.845  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.compressedClassSpaceUsed     avgt   20   2262673.927 ±    1815.961  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.gcTimeMillis                 avgt   20       569.618 ±       7.238     ms
DependencyResolverBenchmark.StatefulMain.measure:EG.heapUsed                     avgt   20   3633495.433 ±  214416.510  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.heapUsed.jmap                avgt   20   3683142.372 ±  208389.957  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Arena Chunk             avgt   20   1827861.385 ± 2679275.232  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Class                   avgt   20  25918832.330 ±  117481.619  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Code                    avgt   20   9052276.221 ±  377008.856  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Compiler                avgt   20    302443.055 ±  407494.223  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.GC                      avgt   20  10422272.000 ±       0.001  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Internal                avgt   20   5949901.834 ±     929.705  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Java Heap               avgt   20   7864320.000 ±       0.001  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Native Memory Tracking  avgt   20    660113.235 ±    2484.199  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Symbol                  avgt   20   5234688.000 ±       0.001  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Thread                  avgt   20  13515776.000 ±       0.001  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.jcmd.Total                   avgt   20  80748911.179 ± 2877542.304  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.metaspaceUsed                avgt   20  19112375.726 ±   73972.237  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.nonHeapUsed                  avgt   20  28833150.881 ±  381504.252  bytes
DependencyResolverBenchmark.StatefulMain.measure:EG.totalCommitted               avgt   20  37343051.611 ±  409136.235  bytes
# The test below uses mock Kernel instance, which is not included in the PR.
Benchmark                                                              Mode  Cnt         Score         Error  Units
DependencyResolverUnit.NewMain.measure                                 avgt   20         0.006 ±       0.002   s/op
DependencyResolverUnit.NewMain.measure:EG.codeCacheUsed                avgt   20   9079801.034 ±  292329.178  bytes
DependencyResolverUnit.NewMain.measure:EG.compressedClassSpaceUsed     avgt   20   3094015.262 ±    1817.149  bytes
DependencyResolverUnit.NewMain.measure:EG.gcTimeMillis                 avgt   20       577.093 ±       7.065     ms
DependencyResolverUnit.NewMain.measure:EG.heapUsed                     avgt   20   5234993.493 ±  203234.307  bytes
DependencyResolverUnit.NewMain.measure:EG.heapUsed.jmap                avgt   20   5285425.424 ±  213004.511  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Arena Chunk             avgt   20   2614166.652 ± 4163753.333  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Class                   avgt   20  30207989.501 ±   93385.868  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Code                    avgt   20  11051058.062 ±  357980.171  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Compiler                avgt   20    296320.000 ±  374223.850  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.GC                      avgt   20  10421775.360 ±    1174.446  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Internal                avgt   20   6015456.815 ±     527.588  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Java Heap               avgt   20   9114746.880 ±  557837.278  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Native Memory Tracking  avgt   20    850866.424 ±    1802.983  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Symbol                  avgt   20   6341913.600 ±     394.377  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Thread                  avgt   20  11580416.000 ±       0.001  bytes
DependencyResolverUnit.NewMain.measure:EG.jcmd.Total                   avgt   20  88494581.812 ± 3904933.852  bytes
DependencyResolverUnit.NewMain.measure:EG.metaspaceUsed                avgt   20  23253969.920 ±   68951.706  bytes
DependencyResolverUnit.NewMain.measure:EG.nonHeapUsed                  avgt   20  35425768.962 ±  359521.249  bytes
DependencyResolverUnit.NewMain.measure:EG.totalCommitted               avgt   20  45023049.956 ±  906821.881  bytes 
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
