### PR TITLE
Fix addDependency() behavior

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/dependency/Context.java
+++ b/src/main/java/com/aws/iot/evergreen/dependency/Context.java
@@ -487,7 +487,7 @@ public class Context implements Closeable {
                             //                            .getName()
                             //                            + " = " + v);
                             if (asService != null && v instanceof EvergreenService) {
-                                asService.addDependency((EvergreenService) v,
+                                asService.addOrUpdateDependency((EvergreenService) v,
                                         startWhen == null ? State.RUNNING : startWhen.value(), true);
                             }
                             logger.atTrace().addKeyValue("class", f.getName()).setEventType("class-inject-complete")

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -730,7 +730,7 @@ public class EvergreenService implements InjectionActions {
      *                                  in 'dependencies' Topic.
      * @throws InputValidationException if the provided arguments are invalid.
      */
-    public synchronized void addDependency(
+    public synchronized void addOrUpdateDependency(
             EvergreenService dependentEvergreenService, State startWhen, boolean isDefault)
             throws InputValidationException {
         if (dependentEvergreenService == null || startWhen == null) {
@@ -938,7 +938,7 @@ public class EvergreenService implements InjectionActions {
                 if (!oldDependencies.containsKey(dependentEvergreenService)) {
                     hasNewService.set(true);
                 }
-                addDependency(dependentEvergreenService, startWhen, false);
+                addOrUpdateDependency(dependentEvergreenService, startWhen, false);
             } catch (InputValidationException e) {
                 logger.atWarn().setCause(e).setEventType("add-dependency")
                         .log("Unable to add dependency {}", dependentEvergreenService);

--- a/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
@@ -286,7 +286,7 @@ public class Kernel extends Configuration /*implements Runnable*/ {
             mainService = getMain();
             autostart.forEach(s -> {
                 try {
-                    mainService.addDependency(EvergreenService.locate(context, s), State.RUNNING, true);
+                    mainService.addOrUpdateDependency(EvergreenService.locate(context, s), State.RUNNING, true);
                 } catch (ServiceLoadException se) {
                     logger.atError().setCause(se).log("Unable to load service {}", s);
                 } catch (InputValidationException e) {

--- a/src/test/java/com/aws/iot/evergreen/kernel/SetupDependencyTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/SetupDependencyTest.java
@@ -33,7 +33,7 @@ public class SetupDependencyTest extends EGServiceTestUtil {
         Mockito.when(dep1.getStateTopic()).thenReturn(depStateTopic);
 
         // WHEN
-        evergreenService.addDependency(dep1, State.INSTALLED, false);
+        evergreenService.addOrUpdateDependency(dep1, State.INSTALLED, false);
 
         // THEN
         Map<EvergreenService, State> dependencies = evergreenService.getDependencies();
@@ -50,14 +50,14 @@ public class SetupDependencyTest extends EGServiceTestUtil {
         Mockito.when(depStateTopic.subscribe(Mockito.any(Subscriber.class))).thenReturn(depStateTopic);
         Mockito.when(dep1.getStateTopic()).thenReturn(depStateTopic);
 
-        evergreenService.addDependency(dep1, State.INSTALLED, false);
+        evergreenService.addOrUpdateDependency(dep1, State.INSTALLED, false);
 
         Map<EvergreenService, State> dependencies = evergreenService.getDependencies();
         Assertions.assertEquals(1, dependencies.size());
         Assertions.assertEquals(State.INSTALLED, dependencies.get(dep1));
 
         // WHEN
-        evergreenService.addDependency(dep1, State.RUNNING, true);
+        evergreenService.addOrUpdateDependency(dep1, State.RUNNING, true);
 
         // THEN
         dependencies = evergreenService.getDependencies();


### PR DESCRIPTION
1. When a dependency is added, don't add the state listener multiple times.
1. When a dependency is removed, remove dependency state listener.
1. Don't update the dependency topic in addDependency() invocation.
 dependencyTopic only track customer provided config store.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
This PR is blocked by https://github.com/aws/aws-greengrass-kernel/pull/133
This PR is part of the https://github.com/aws/aws-greengrass-kernel/pull/123 . 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
