### PR TITLE
Refine behavior of requestRestart() and requestReinstall()

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
@@ -118,8 +118,7 @@ class KernelTest extends BaseITCase {
                         // runErrorRetry restart on error
                         new ExpectedStateTransition("runErrorRetry", State.RUNNING, State.ERRORED),
                         new ExpectedStateTransition("runErrorRetry", State.ERRORED, State.STOPPING),
-                        new ExpectedStateTransition("runErrorRetry", State.STOPPING, State.FINISHED),
-                        new ExpectedStateTransition("runErrorRetry", State.FINISHED, State.INSTALLED),
+                        new ExpectedStateTransition("runErrorRetry", State.STOPPING, State.INSTALLED),
 
                         // main service restart on dependency error
                         new ExpectedStateTransition("runErrorRetry", State.RUNNING, State.ERRORED),

--- a/src/test/java/com/aws/iot/evergreen/kernel/RequestLifecycleChangeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/RequestLifecycleChangeTest.java
@@ -54,15 +54,15 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
 
         desiredStateList.clear();
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
         evergreenService.requestStart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
 
         desiredStateList.clear();
         evergreenService.requestReinstall();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
         evergreenService.requestStart();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
     }
 
     @Test
@@ -84,26 +84,26 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
 
         desiredStateList.clear();
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
         evergreenService.requestStop();
         assertDesiredState(State.FINISHED);
 
         desiredStateList.clear();
         evergreenService.requestReinstall();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
         evergreenService.requestStop();
-        assertDesiredState(State.FINISHED, State.NEW, State.FINISHED);
+        assertDesiredState(State.INSTALLED, State.NEW, State.FINISHED);
     }
 
     @Test
     public void GIVEN_evergreenService_WHEN_requestRestart_called_THEN_deduplicate_correctly() {
         desiredStateList.clear();
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
 
         // calling requestRetart() multiple times doesn't result in duplication
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
 
         // requestRetart() overrides previous requestStop()
         desiredStateList.clear();
@@ -111,7 +111,7 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
         assertDesiredState(State.FINISHED);
 
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
 
         // requestRetart() overrides previous requestStart()
         desiredStateList.clear();
@@ -119,15 +119,15 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
         assertDesiredState(State.RUNNING);
 
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
 
         // requestRestart() doesn't override previous requestReinstall()
         desiredStateList.clear();
         evergreenService.requestReinstall();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
 
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
 
         // requestRestart() doesn't erase reinstall behavior
         setDesiredStateList(State.NEW, State.FINISHED);
@@ -139,25 +139,25 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
     @Test
     public void GIVEN_evergreenService_WHEN_requestReinstall_called_THEN_deduplicate_correctly() {
         evergreenService.requestReinstall();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
 
         // calling requestReinstall() multiple times doesn't result in duplication
         evergreenService.requestReinstall();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
 
         // calling requestRetart() doesn't override requestRe-install
         desiredStateList.clear();
         evergreenService.requestRestart();
-        assertDesiredState(State.FINISHED, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.RUNNING);
         evergreenService.requestReinstall();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
 
         // calling requestRetart() multiple times doesn't result in duplication
         desiredStateList.clear();
         evergreenService.requestStart();
         assertDesiredState(State.RUNNING);
         evergreenService.requestReinstall();
-        assertDesiredState(State.FINISHED, State.NEW, State.RUNNING);
+        assertDesiredState(State.INSTALLED, State.NEW, State.RUNNING);
     }
 
     private void assertDesiredState(State... state) {


### PR DESCRIPTION
Make requestRestart() not go through FINISHED state, so that dependers
won't treat the service as dependencyReady.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
