### PR TITLE
Use set() for secondary metric names so they aren't duplicated

### DIFF
--- a/.github/scripts/cwJMHUpload.py
+++ b/.github/scripts/cwJMHUpload.py
@@ -63,7 +63,7 @@ def main():
     cw = boto3.client("cloudwatch")  # type: Client
     datapoints = []
     event_type = os.getenv("GITHUB_EVENT_NAME", "pull_request")
-    secondary_metric_names = []
+    secondary_metric_names = set()
 
     # Generate CloudWatch metrics from our benchmarks
     for benchmark in report:
@@ -91,7 +91,7 @@ def main():
                     "Unit": convert_units(values["scoreUnit"]),
                     "Dimensions": dims
                 })
-                secondary_metric_names.append(metric_name)
+                secondary_metric_names.add(metric_name)
 
     if event_type == "push":
         # Put metrics up to CloudWatch in batches of 20 (their max limit)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use a set instead of a list for collecting secondary metric names so that they aren't duplicated when we have multiple benchmarks.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
