### PR TITLE
Fix benchmark after LocalPackageStore change

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/packagemanager/PackageStore.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/PackageStore.java
@@ -39,6 +39,14 @@ public class PackageStore {
             Paths.get(System.getProperty("user.dir")).resolve("local_artifact_source");
 
     private static final ObjectMapper OBJECT_MAPPER = SerializerFactory.getRecipeSerializer();
+    private Path packageStorePath = LOCAL_CACHE_PATH;
+
+    public PackageStore() {
+    }
+
+    public PackageStore(Path packageStorePath) {
+        this.packageStorePath = packageStorePath;
+    }
 
     /**
      * Get package versions with the most preferred version first.
@@ -75,7 +83,7 @@ public class PackageStore {
      */
     public Package getRecipe(PackageIdentifier pkg) {
         // TODO: to be implemented.
-        LocalPackageStoreDeprecated localPackageStore = new LocalPackageStoreDeprecated(LOCAL_CACHE_PATH);
+        LocalPackageStoreDeprecated localPackageStore = new LocalPackageStoreDeprecated(packageStorePath);
         try {
             return localPackageStore.getPackage(pkg.getName(), pkg.getVersion()).get();
         } catch (PackagingException e) {
@@ -92,7 +100,7 @@ public class PackageStore {
      *
      */
     List<Semver> getPackageVersionsIfExists(final String packageName) throws UnexpectedPackagingException {
-        Path srcPkgRoot = getPackageStorageRoot(packageName, LOCAL_CACHE_PATH);
+        Path srcPkgRoot = getPackageStorageRoot(packageName, packageStorePath);
         List<Semver> versions = new ArrayList<>();
 
         if (!Files.exists(srcPkgRoot) || !Files.isDirectory(srcPkgRoot)) {
@@ -142,7 +150,7 @@ public class PackageStore {
      */
     private Optional<String> getPackageRecipe(final String packageName, final Semver packageVersion)
             throws PackagingException, IOException {
-        Path srcPkgRoot = getPackageVersionStorageRoot(packageName, packageVersion.toString(), LOCAL_CACHE_PATH);
+        Path srcPkgRoot = getPackageVersionStorageRoot(packageName, packageVersion.toString(), packageStorePath);
 
         if (!Files.exists(srcPkgRoot) || !Files.isDirectory(srcPkgRoot)) {
             return Optional.empty();

--- a/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -10,8 +10,8 @@ import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
 import com.aws.iot.evergreen.jmh.profilers.ForcedGcMemoryProfiler;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
+import com.aws.iot.evergreen.packagemanager.PackageStore;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
-import com.aws.iot.evergreen.packagemanager.plugins.LocalPackageStore;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -38,7 +38,7 @@ public class DependencyResolverBenchmark {
     @Measurement(iterations = 20)
     @Warmup(iterations = 5)
     @State(Scope.Benchmark)
-    public static abstract class DRIntegration {
+    public abstract static class DRIntegration {
         private DeploymentDocument jobDoc = new DeploymentDocument("mockJob1",Arrays.asList("boto3", "awscli"), Arrays.asList(
                 new DeploymentPackageConfiguration("boto3", "1.9.128", "", new HashSet<>(), new ArrayList<>()),
                 new DeploymentPackageConfiguration("awscli", "1.16.144", "", new HashSet<>(), new ArrayList<>())
@@ -59,7 +59,7 @@ public class DependencyResolverBenchmark {
             // For now, hardcode to be under root of kernel package
             Path packagePath = Paths.get(System.getProperty("user.dir"))
                     .resolve("src/test/evergreen-kernel-benchmark/mock_artifact_source");
-            resolver = new DependencyResolver(new LocalPackageStore(packagePath), kernel);
+            resolver = new DependencyResolver(new PackageStore(packagePath), kernel);
         }
 
         @TearDown(Level.Invocation)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
After 25dae279067cd0d3a5a826191bd69849a16c9fd4 our benchmark broke due to the change to LocalPackageStore. This PR fixes that change so that our benchmarks work again.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
