### PR TITLE
Use self-hosted GitHub runner

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8

--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   flake:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -23,7 +23,7 @@ jobs:
       - name: Analyze Test Run
         run: >-
           pip3 -q install agithub &&
-          python3 .github/scripts/flake.py --cmd "mvn -ntp -q verify" -i 8 --token "${{ github.token }}"
+          python3 .github/scripts/flake.py --cmd "mvn -ntp -q verify" -i 10 --token "${{ github.token }}"
           --out-dir "failed_tests/"
       - name: Upload Errors
         uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -23,7 +23,7 @@ jobs:
           # of our Java SDK, then we can relax this to just the "hashFiles" and exclude "sha"
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
       - name: Build with Maven
-        run: mvn -ntp verify
+        run: mvn -ntp clean verify
       - name: Convert Jacoco to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco.xml src/main/java > target/jacoco-report/cobertura.xml
       - name: Upload Coverage
@@ -58,7 +58,7 @@ jobs:
           # Only delete artifacts older than this, measured in seconds.
           minimumAge: 5184000 # optional, default is 0. Set to 5.184e+6 (60 days)
   e2e-test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     steps:
       - uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
         run: mvn -ntp surefire:test@integration-tests -Dgroups="E2E" -DexcludedGroups="" -Dsurefire.argLine=""
   publish:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2

--- a/src/main/java/com/aws/iot/evergreen/config/PlatformResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/config/PlatformResolver.java
@@ -26,7 +26,6 @@ public class PlatformResolver {
     private static final Map<String, Integer> RANKS = initializeRanks();
 
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-    @SuppressWarnings({"checkstyle:emptycatchblock"})
     private static Map<String, Integer> initializeRanks() {
         Map<String, Integer> ranks = new HashMap<>();
         // figure out what OS we're running and add applicable tags
@@ -81,7 +80,6 @@ public class PlatformResolver {
         } catch (UnknownHostException ex) {
             logger.atError().log("Error getting hostname", ex);
         }
-
         return ranks;
     }
 

--- a/src/test/java/com/aws/iot/evergreen/config/ConfigurationTest.java
+++ b/src/test/java/com/aws/iot/evergreen/config/ConfigurationTest.java
@@ -6,6 +6,7 @@ package com.aws.iot.evergreen.config;
 import com.aws.iot.evergreen.dependency.Context;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.jr.ob.JSON;
+import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
@@ -16,9 +17,9 @@ import java.util.Map;
 
 import static com.aws.iot.evergreen.util.Coerce.toInt;
 import static com.fasterxml.jackson.jr.ob.JSON.Feature.PRETTY_PRINT_OUTPUT;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({"PMD.DetachedTestCase", "PMD.UnusedLocalVariable"})
 public class ConfigurationTest {
@@ -100,9 +101,9 @@ public class ConfigurationTest {
             assertNotNull(inputStream);
             //            System.out.println("resource: " + deepToString(inputStream, 200) + "\n\t" + getClass()
             //            .getName());
-            //            dump(config,"Before");
+//            dump(testConfig,"Before");
             testConfig.mergeMap(0, (Map) JSON.std.with(new YAMLFactory()).anyFrom(inputStream));
-            //            dump(config,"After");
+//            dump(testConfig,"After");
             Topics platforms = testConfig.findTopics("platforms");
             //            platforms.forEachTopicSet(n -> System.out.println(n.name));
 
@@ -124,9 +125,8 @@ public class ConfigurationTest {
             StringWriter sw = new StringWriter();
             JSON.std.with(PRETTY_PRINT_OUTPUT).with(new YAMLFactory()).write(testConfig.toPOJO(), sw);
             String tc = sw.toString();
-            assertTrue(tc.contains("\"{platform.invoke} {name}\""), tc);
-            assertTrue(tc.contains("dependencies:\n" +
-                                           "    - \"greenlake\""));
+            assertThat(tc, StringContains.containsString("\"{platform.invoke} {name}\""));
+            assertThat(tc, StringContains.containsString("dependencies:\n    - \"greenlake\""));
         }
     }
 

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageTest.java
@@ -7,6 +7,7 @@ import com.aws.iot.evergreen.config.PlatformResolver;
 import com.aws.iot.evergreen.packagemanager.TestHelper;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.collection.IsMapContaining;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,20 +25,28 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PackageTest {
+    private static Map<String, Integer> backupRanks;
+    private static Field ranksField;
 
     @BeforeAll
     static void beforeAll() throws Exception {
-        Field ranksField = PlatformResolver.class.getDeclaredField("RANKS");
+        ranksField = PlatformResolver.class.getDeclaredField("RANKS");
         ranksField.setAccessible(true);
 
         Field modifiersField = Field.class.getDeclaredField("modifiers");
         modifiersField.setAccessible(true);
         modifiersField.setInt(ranksField, ranksField.getModifiers() & ~Modifier.FINAL);
 
+        backupRanks = (Map<String, Integer>) ranksField.get(null);
         ranksField.set(null, new HashMap<String, Integer>() {{
             put("macos", 99);
             put("linux", 1);
         }});
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        ranksField.set(null, backupRanks);
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Switches our GitHub actions to use a fleet of 3 (right now) self-hosted runners running within our EG-dev account's EC2. This will resolve the issue of billing for GitHub actions. It may also help us in future to connect to beta endpoints as well as potentially using IAM roles more easily.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
