### PR TITLE
Store package parameters in kernel config for use in future deployments

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -202,9 +202,9 @@ class DeploymentServiceIntegrationTest {
         assertTrue(services.contains("main"));
         assertTrue(services.contains("YellowSignal"));
         assertTrue(services.contains("RedSignal"));
-        assertThrows(ServiceLoadException.class, () -> EvergreenService.locate(kernel.context, "CustomerApp"));
-        assertThrows(ServiceLoadException.class, () -> EvergreenService.locate(kernel.context, "Mosquitto"));
-        assertThrows(ServiceLoadException.class, () -> EvergreenService.locate(kernel.context, "GreenSignal"));
+        assertThrows(ServiceLoadException.class, () -> kernel.locate("CustomerApp"));
+        assertThrows(ServiceLoadException.class, () -> kernel.locate("Mosquitto"));
+        assertThrows(ServiceLoadException.class, () -> kernel.locate("GreenSignal"));
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -10,7 +10,6 @@ import com.aws.iot.evergreen.dependency.State;
 import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
 import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
 import com.aws.iot.evergreen.integrationtests.e2e.util.Utils;
-import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
@@ -116,7 +115,7 @@ class DeploymentE2ETest {
         Utils.waitForJobToComplete(jobId, Duration.ofMinutes(2));
         // Ensure that main is finished, which is its terminal state, so this means that all updates ought to be done
         assertEquals(State.FINISHED, kernel.getMain().getState());
-        assertEquals(State.FINISHED, EvergreenService.locate(kernel.context, "CustomerApp").getState());
+        assertEquals(State.FINISHED, kernel.locate("CustomerApp").getState());
 
         // Make sure that IoT Job was marked as successful
         assertEquals(JobExecutionStatus.SUCCEEDED, Utils.iotClient.describeJobExecution(
@@ -157,9 +156,9 @@ class DeploymentE2ETest {
 
         // Ensure that main is finished, which is its terminal state, so this means that all updates ought to be done
         assertEquals(State.FINISHED, kernel.getMain().getState());
-        assertEquals(State.FINISHED, EvergreenService.locate(kernel.context, "CustomerApp").getState());
+        assertEquals(State.FINISHED, kernel.locate("CustomerApp").getState());
         assertThrows(ServiceLoadException.class, () -> {
-            EvergreenService.locate(kernel.context, "SomeService").getState();
+            kernel.locate("SomeService").getState();
         });
 
         // Make sure that IoT Job was marked as successful

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
@@ -273,7 +273,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         };
         kernel.context.addGlobalStateChangeListener(listener);
 
-        EvergreenService main = EvergreenService.locate(kernel.context, "main");
+        EvergreenService main = kernel.locate("main");
         kernel.mergeInNewConfig("id", System.currentTimeMillis(), newConfig).get(60, TimeUnit.SECONDS);
 
         // Verify that first merge succeeded.
@@ -347,8 +347,8 @@ class ServiceConfigMergingTest extends BaseITCase {
             }
         });
 
-        EvergreenService main = EvergreenService.locate(kernel.context, "main");
-        EvergreenService sleeperB = EvergreenService.locate(kernel.context, "sleeperB");
+        EvergreenService main = kernel.locate("main");
+        EvergreenService sleeperB = kernel.locate("sleeperB");
         // wait for merge to complete
         future.get(60, TimeUnit.SECONDS);
         //sleeperA should be closed
@@ -359,7 +359,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         // ensuring config value for sleeperA is removed
         assertFalse(kernel.findTopics("services").children.containsKey("sleeperA"));
         // ensure kernel no longer holds a reference of sleeperA
-        assertThrows(ServiceLoadException.class, () -> EvergreenService.locate(kernel.context, "sleeperA"));
+        assertThrows(ServiceLoadException.class, () -> kernel.locate("sleeperA"));
 
         List<String> orderedDependencies = kernel.orderedDependencies().stream()
                 .filter(evergreenService -> evergreenService instanceof GenericExternalService)

--- a/src/main/java/com/aws/iot/evergreen/ipc/AuthHandler.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/AuthHandler.java
@@ -43,10 +43,10 @@ public class AuthHandler implements InjectionActions {
      * @param s service to generate an auth token for
      */
     public static void registerAuthToken(EvergreenService s) {
-        Topic uid = s.config.createLeafChild(SERVICE_UNIQUE_ID_KEY).withParentNeedsToKnow(false);
+        Topic uid = s.getServiceConfig().createLeafChild(SERVICE_UNIQUE_ID_KEY).withParentNeedsToKnow(false);
         String authToken = Utils.generateRandomString(16).toUpperCase();
         uid.withValue(authToken);
-        Topic tokenTopic = s.config.parent.lookup(AUTH_TOKEN_LOOKUP_KEY, authToken);
+        Topic tokenTopic = s.getServiceConfig().parent.lookup(AUTH_TOKEN_LOOKUP_KEY, authToken);
 
         // If the auth token was already registered, that's an issue, so we will retry
         // generating a new token in that case

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -3,8 +3,6 @@
 
 package com.aws.iot.evergreen.kernel;
 
-import com.aws.iot.evergreen.config.Configuration;
-import com.aws.iot.evergreen.config.Node;
 import com.aws.iot.evergreen.config.Subscriber;
 import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.config.Topics;
@@ -22,7 +20,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -47,7 +44,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.inject.Singleton;
 
 import static com.aws.iot.evergreen.util.Utils.getUltimateCause;
 
@@ -64,7 +60,7 @@ public class EvergreenService implements InjectionActions {
     private static final String CURRENT_STATE_METRIC_NAME = "currentState";
     private static final String INVALID_STATE_ERROR_EVENT = "service-invalid-state-error";
 
-    public final Topics config;
+    protected final Topics config;
     public Context context;
 
     private final Object dependencyReadyLock = new Object();
@@ -97,8 +93,6 @@ public class EvergreenService implements InjectionActions {
     // Includes both explicit declared dependencies and implicit ones added through 'autoStart' and @Inject annotation.
     protected final ConcurrentHashMap<EvergreenService, DependencyInfo> dependencies = new ConcurrentHashMap<>();
 
-    // Static logger instance for static methods
-    private static final Logger staticLogger = LogManager.getLogger(EvergreenService.class);
     // Service logger instance
     protected final Logger logger;
 
@@ -175,81 +169,6 @@ public class EvergreenService implements InjectionActions {
             return Optional.of((State) top);
         }
         return Optional.empty();
-    }
-
-
-    /**
-     * Locate an EvergreenService by name from the provided context.
-     *
-     * @param context context to lookup the name in
-     * @param name    name of the service to find
-     * @return found service or null
-     * @throws ServiceLoadException if service cannot load
-     */
-    @SuppressWarnings({"checkstyle:emptycatchblock", "PMD.AvoidCatchingThrowable"})
-    public static EvergreenService locate(Context context, String name) throws ServiceLoadException {
-        return context.getv(EvergreenService.class, name).computeIfEmpty(v -> {
-            Configuration configuration = context.get(Configuration.class);
-            Topics serviceRootTopics = configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, name);
-            if (serviceRootTopics.isEmpty()) {
-                staticLogger.atWarn().setEventType("service-config-not-found").kv(SERVICE_NAME_KEY, name).log();
-            } else {
-                staticLogger.atDebug().setEventType("service-config-found").kv(SERVICE_NAME_KEY, name)
-                        .log("Found service definition in configuration file");
-            }
-
-            // try to find service implementation class from plugins.
-            Class<?> clazz = null;
-            Node n = serviceRootTopics.findLeafChild("class");
-
-            if (n != null) {
-                String cn = Coerce.toString(n);
-                try {
-                    clazz = Class.forName(cn);
-                } catch (Throwable ex) {
-                    throw new ServiceLoadException("Can't load service class from " + cn, ex);
-                }
-            }
-
-            if (clazz == null) {
-                Map<String, Class<?>> si = context.getIfExists(Map.class, "service-implementors");
-                if (si != null) {
-                    staticLogger.atDebug().kv(SERVICE_NAME_KEY, name).log("Attempt to load service from plugins");
-                    clazz = si.get(name);
-                }
-            }
-            EvergreenService ret;
-            // If found class, try to load service class from plugins.
-            if (clazz != null) {
-                try {
-                    Constructor<?> ctor = clazz.getConstructor(Topics.class);
-                    ret = (EvergreenService) ctor.newInstance(serviceRootTopics);
-                    if (clazz.getAnnotation(Singleton.class) != null) {
-                        context.put(ret.getClass(), v);
-                    }
-                    staticLogger.atInfo().setEventType("evergreen-service-loaded").kv(SERVICE_NAME_KEY, ret.getName())
-                            .log();
-                    return ret;
-                } catch (Throwable ex) {
-                    throw new ServiceLoadException("Can't create Evergreen Service instance " + clazz.getSimpleName(),
-                            ex);
-                }
-            }
-
-            if (serviceRootTopics.isEmpty()) {
-                throw new ServiceLoadException("No matching definition in system model for: " + name);
-            }
-
-            // if not found, initialize GenericExternalService
-            try {
-                ret = new GenericExternalService(serviceRootTopics);
-                staticLogger.atInfo().setEventType("generic-service-loaded").kv(SERVICE_NAME_KEY, ret.getName())
-                        .log();
-            } catch (Throwable ex) {
-                throw new ServiceLoadException("Can't create generic service instance " + name, ex);
-            }
-            return ret;
-        });
     }
 
     private Topic initStateTopic(final Topics topics) {
@@ -907,6 +826,10 @@ public class EvergreenService implements InjectionActions {
         return config == null ? getClass().getSimpleName() : config.getName();
     }
 
+    public Topics getServiceConfig() {
+        return config;
+    }
+
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
     @Override
     public void postInject() {
@@ -965,7 +888,7 @@ public class EvergreenService implements InjectionActions {
             }
         }
 
-        EvergreenService d = locate(context, name);
+        EvergreenService d = context.get(Kernel.class).locate(name);
         return new Pair<>(d, x == null ? State.RUNNING : x);
     }
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/Periodicity.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Periodicity.java
@@ -55,7 +55,7 @@ public final class Periodicity {
      */
     @Nullable
     public static Periodicity of(EvergreenService s) {
-        Node n = s.config.getChild("periodic");
+        Node n = s.getServiceConfig().getChild("periodic");
         if (n == null) {
             return null;
         }

--- a/src/main/java/com/aws/iot/evergreen/kernel/ShellRunner.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/ShellRunner.java
@@ -41,7 +41,8 @@ public interface ShellRunner {
                     String ss = s.toString().trim();
                     logger.atWarn().setEventType("shell-runner-stderr").kv(SCRIPT_NAME_KEY, note)
                             .kv(EvergreenService.SERVICE_NAME_KEY, onBehalfOf.getName()).kv("stderr", ss).log();
-                }).setenv("SVCUID", String.valueOf(onBehalfOf.config.findLeafChild(SERVICE_UNIQUE_ID_KEY).getOnce()))
+                }).setenv("SVCUID",
+                        String.valueOf(onBehalfOf.getServiceConfig().findLeafChild(SERVICE_UNIQUE_ID_KEY).getOnce()))
                         .cd(config.workPath.toFile());
             }
             return null;

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -3,7 +3,6 @@
 
 package com.aws.iot.evergreen.packagemanager;
 
-import com.aws.iot.evergreen.config.Node;
 import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
 import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
@@ -302,7 +301,7 @@ public class DependencyResolver {
     protected Optional<String> getPackageVersionIfActive(final String packageName) {
         EvergreenService service;
         try {
-            service = EvergreenService.locate(kernel.context, packageName);
+            service = kernel.locate(packageName);
         } catch (ServiceLoadException e) {
             logger.atDebug().setCause(e).addKeyValue(PACKAGE_NAME_KEY, packageName)
                     .log("Failed to get active package in Kernel");
@@ -331,11 +330,8 @@ public class DependencyResolver {
 
 
     protected Optional<String> getServiceVersion(final EvergreenService service) {
-        Node versionNode = service.config.getChild(KernelConfigResolver.VERSION_CONFIG_KEY);
-        if (versionNode instanceof Topic) {
-            return Optional.of(((Topic) versionNode).getOnce().toString());
-        }
-        return Optional.empty();
+        Topic version = service.getServiceConfig().find(KernelConfigResolver.VERSION_CONFIG_KEY);
+        return version == null ? Optional.empty() : Optional.of(version.getOnce().toString());
     }
 
     private Package getPackage(final String pkgName, final Semver version) throws PackagingException, IOException {

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageParameter.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageParameter.java
@@ -30,10 +30,19 @@ public class PackageParameter {
     //TODO: Json property names should match with other configuration members. They start with capital first letters
     public PackageParameter(@JsonProperty("name") String name, @JsonProperty("value") String value,
                             @JsonProperty("type") String type) {
-        this.name = name;
-        // TODO: Quick fix to get this working, probably can be simplified
-        this.type = ParameterType.valueOf(type.toUpperCase());
+        this(name, value, ParameterType.valueOf(type.toUpperCase()));
+    }
 
+    /**
+     * Create a Package Param object.
+     *
+     * @param name  Name of the parameter
+     * @param value Default value for the parameter
+     * @param type  Parameter Type enum value
+     */
+    public PackageParameter(String name, String value, ParameterType type) {
+        this.name = name;
+        this.type = type;
         // TODO: Validate type and initialize corresponding type here?
         this.value = value;
     }


### PR DESCRIPTION
**Issue #, if available:**
https://issues.amazon.com/issues/P34431383

**Description of changes:**
Store package parameters in kernel config so that when a next deployment comes in for a different group with no values set, previously set values are retained
Move the service locate method to Kernel from EvergreenService.java and make it non static so it's easy to stub from tests

**Why is this change necessary:**
Please see the description above

**How was this change tested:**
mvn verify succeeded

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
