### PR TITLE
Add PMD rule for logging without calling .log()

### DIFF
--- a/codestyle/pmd-eg-ruleset.xml
+++ b/codestyle/pmd-eg-ruleset.xml
@@ -81,7 +81,7 @@
     </rule>
     <rule name="AvoidGettingFutureWithoutTimeout"
           language="java"
-          message="Calls to 'get' on Futures must have a timeout"
+          message="Calls to 'get()' on Futures must have a timeout"
           class="net.sourceforge.pmd.lang.rule.XPathRule">
         <description>
             Calls to Future.get() will block forever. This is almost always undesirable.
@@ -99,4 +99,25 @@
             </property>
         </properties>
     </rule>
+
+    <rule name="DoNotLogWithoutLogging"
+          language="java"
+          message="Calls to logger must end with '.log()'"
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            Without a call to .log(), your logging won't actually be appended into the log.
+        </description>
+        <priority>1</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//PrimaryExpression[PrimaryPrefix[pmd-java:typeIs("com.aws.iot.evergreen.logging.api.Logger")] and PrimarySuffix[last()-1][@Image!="log"]]
+]]>
+                </value>
+            </property>
+        </properties>
+    </rule>
+
 </ruleset>

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -185,9 +185,9 @@ public class EvergreenService implements InjectionActions {
             Configuration configuration = context.get(Configuration.class);
             Topics serviceRootTopics = configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, name);
             if (serviceRootTopics == null || serviceRootTopics.isEmpty()) {
-                staticLogger.atWarn().setEventType("service-config-not-found").kv(SERVICE_NAME_KEY, name);
+                staticLogger.atWarn().setEventType("service-config-not-found").kv(SERVICE_NAME_KEY, name).log();
             } else {
-                staticLogger.atInfo().setEventType("service-config-found").kv(SERVICE_NAME_KEY, name)
+                staticLogger.atDebug().setEventType("service-config-found").kv(SERVICE_NAME_KEY, name)
                         .log("Found service definition in configuration file");
             }
             EvergreenService ret;
@@ -936,7 +936,7 @@ public class EvergreenService implements InjectionActions {
                 .collect(Collectors.toSet());
         if (!removedDependencies.isEmpty()) {
             logger.atInfo().setEventType("removing-unused-dependencies")
-                    .addKeyValue("removedDependencies", removedDependencies);
+                    .addKeyValue("removedDependencies", removedDependencies).log();
 
             removedDependencies.forEach(dependency -> {
                 DependencyInfo dependencyInfo = dependencies.remove(dependency);

--- a/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
@@ -145,7 +145,7 @@ public class Kernel extends Configuration /*implements Runnable*/ {
                         // decide to log the error so that the future logging parser can parse the exceptions.
                         RuntimeException rte =
                                 new RuntimeException(String.format("Can't read the config file %s", getArg()), ex);
-                        logger.atError().setEventType("parse-args-error").setCause(rte);
+                        logger.atError().setEventType("parse-args-error").setCause(rte).log();
                         throw rte;
                     }
                     break;
@@ -166,7 +166,7 @@ public class Kernel extends Configuration /*implements Runnable*/ {
                 default:
                     RuntimeException rte =
                             new RuntimeException(String.format("Undefined command line argument: %s", arg));
-                    logger.atError().setEventType("parse-args-error").setCause(rte);
+                    logger.atError().setEventType("parse-args-error").setCause(rte).log();
                     throw rte;
             }
         }
@@ -254,7 +254,7 @@ public class Kernel extends Configuration /*implements Runnable*/ {
         } catch (ServiceLoadException sle) {
             RuntimeException rte =
                     new RuntimeException("Cannot load main service", sle);
-            logger.atError().setEventType("system-boot-error").setCause(rte);
+            logger.atError().setEventType("system-boot-error").setCause(rte).log();
             throw rte;
         }
         Path transactionLogPath = configPath.resolve("config.tlog"); //Paths.get(deTilde("~root/config/config.tlog"));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds PMD rule for calling our logging methods without finalizing the log with `.log()`. Found and fixed violations.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
