### PR TITLE
Fix benchmark, and set to fail on error

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -33,10 +33,12 @@ jobs:
       - name: JMH Benchmark
         # The JVM arguments provided below are intended to tune the JVM to keep the heap as small as possible
         # and to release unused heap space back to the OS
-        # -f 5 -- Sets "forks" to 5 so it will run 5 times in separate JVMs
+        # -foe is "fail on error" so that if an error happens, then the benchmark will be failed instead of silently
+        # pass
         run: >-
           java -jar src/test/evergreen-kernel-benchmark/target/benchmarks.jar
           -rf json
+          -foe true
           -jvmArgs "-Xms1m -Xmx128m -XX:MaxHeapFreeRatio=10 -XX:MinHeapFreeRatio=5 -XX:GCTimeRatio=19
           -XX:NativeMemoryTracking=summary -Xss232k"
           -prof com.aws.iot.evergreen.jmh.profilers.ForcedGcMemoryProfiler

--- a/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -46,13 +46,13 @@ public class DependencyResolverBenchmark {
 
         private DependencyResolver resolver;
         private List<PackageIdentifier> result;
+        private Kernel kernel;
 
         @Setup
         public void setup() {
-            Kernel kernel = new Kernel();
+            kernel = new Kernel();
             kernel.parseArgs("-i", DependencyResolverBenchmark.class.getResource(getConfigFile()).toString());
-            // We don't need to launch kernel here. Only configuration parsing and main service loading are
-            // required for this benchmarking.
+            kernel.launch();
 
             // TODO: Update local package store accordingly when the new implementation is ready
             // TODO: Figure out if there's a better way to load resource directory in local package store
@@ -65,6 +65,11 @@ public class DependencyResolverBenchmark {
         @TearDown(Level.Invocation)
         public void doTeardown() {
             ForcedGcMemoryProfiler.recordUsedMemory();
+        }
+
+        @TearDown(Level.Trial)
+        public void doShutdown() {
+            kernel.shutdown();
         }
 
         @Benchmark


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Since 0c9a58a, our benchmark has been broken for dependency resolution. This was not found because JMH exits 0 even if there are failures. This changes add `-foe true` so that it will fail on error. This change also fixes the issue which caused the failure which is that `mainService` is only initialized by `kernel.launch()` now, which was not the case before.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
