### PR TITLE
Refactor: Split EvergreenService and Lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
                 <version>3.13.0</version>
                 <configuration>
                     <!-- Current violations should not be exceeded. Try to decrease these over time -->
-                    <maxAllowedViolations>15</maxAllowedViolations>
+                    <maxAllowedViolations>13</maxAllowedViolations>
                     <printFailingErrors>true</printFailingErrors>
                     <rulesets>
                         <ruleset>codestyle/pmd-eg-ruleset.xml</ruleset>

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCAwareServicesTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCAwareServicesTest.java
@@ -5,7 +5,7 @@ package com.aws.iot.evergreen.integrationtests.ipc;
 
 import com.aws.iot.evergreen.dependency.State;
 import com.aws.iot.evergreen.integrationtests.BaseITCase;
-import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.GlobalStateChangeListener;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.util.Exec;
 import org.junit.jupiter.api.AfterEach;
@@ -41,7 +41,7 @@ class IPCAwareServicesTest extends BaseITCase {
     @Test
     void GIVEN_ipc_aware_service_WHEN_report_state_as_running_THEN_kernel_updates_state_as_running() throws Exception {
         CountDownLatch serviceRunning = new CountDownLatch(1);
-        EvergreenService.GlobalStateChangeListener listener = (service, oldState, newState) -> {
+        GlobalStateChangeListener listener = (service, oldState, newState) -> {
             if (SAMPLE_IPC_AWARE_SERVICE_NAME.equals(service.getName()) && State.RUNNING.equals(newState)) {
                 serviceRunning.countDown();
             }

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
@@ -9,6 +9,7 @@ import com.aws.iot.evergreen.dependency.State;
 import com.aws.iot.evergreen.integrationtests.BaseITCase;
 import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.GenericExternalService;
+import com.aws.iot.evergreen.kernel.GlobalStateChangeListener;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
 import org.junit.jupiter.api.AfterEach;
@@ -258,7 +259,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         AtomicBoolean mainRestarted = new AtomicBoolean(false);
         AtomicBoolean newService2Started = new AtomicBoolean(false);
         AtomicBoolean newServiceStarted = new AtomicBoolean(false);
-        EvergreenService.GlobalStateChangeListener listener = (service, oldState, newState) -> {
+        GlobalStateChangeListener listener = (service, oldState, newState) -> {
             if (service.getName().equals("new_service2") && newState.equals(State.RUNNING)) {
                 newService2Started.set(true);
             }

--- a/src/main/java/com/aws/iot/evergreen/builtin/services/lifecycle/LifecycleIPCAgent.java
+++ b/src/main/java/com/aws/iot/evergreen/builtin/services/lifecycle/LifecycleIPCAgent.java
@@ -15,6 +15,7 @@ import com.aws.iot.evergreen.ipc.services.lifecycle.LifecycleResponseStatus;
 import com.aws.iot.evergreen.ipc.services.lifecycle.StateChangeRequest;
 import com.aws.iot.evergreen.ipc.services.lifecycle.StateTransitionEvent;
 import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.GlobalStateChangeListener;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.logging.impl.LogManager;
@@ -44,7 +45,7 @@ public class LifecycleIPCAgent implements InjectionActions {
 
     private static final Logger log = LogManager.getLogger(LifecycleIPCAgent.class);
 
-    private final EvergreenService.GlobalStateChangeListener onServiceChange = (service, oldState, newState) -> {
+    private final GlobalStateChangeListener onServiceChange = (service, oldState, newState) -> {
         Map<ConnectionContext, BiConsumer<State, State>> callbacks = listeners.get(service.getName());
         if (callbacks != null) {
             callbacks.values().forEach(x -> x.accept(oldState, newState));

--- a/src/main/java/com/aws/iot/evergreen/config/Topic.java
+++ b/src/main/java/com/aws/iot/evergreen/config/Topic.java
@@ -115,16 +115,8 @@ public class Topic extends Node {
                 .addKeyValue("reason", what.name()).log();
         if (watchers != null) {
             for (Watcher s : watchers) {
-                try {
-                    if (s instanceof Subscriber) {
-                        ((Subscriber) s).published(what, this);
-                    }
-                } catch (Throwable ex) {
-                    /* TODO if a subscriber fails, we should do more than just log a
-                       message.  Possibly unsubscribe it if the fault is persistent */
-                    logger.atError().setCause(ex).setEventType("config-node-update-error")
-                            .addKeyValue("configNode", getFullName()).addKeyValue("subscriber", s.toString())
-                            .addKeyValue("reason", what.name()).log();
+                if (s instanceof Subscriber) {
+                    ((Subscriber) s).published(what, this);
                 }
             }
         }

--- a/src/main/java/com/aws/iot/evergreen/dependency/Context.java
+++ b/src/main/java/com/aws/iot/evergreen/dependency/Context.java
@@ -8,6 +8,7 @@ import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.config.Topics;
 import com.aws.iot.evergreen.config.WhatHappened;
 import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.GlobalStateChangeListener;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.logging.impl.LogManager;
 import com.aws.iot.evergreen.util.Coerce;
@@ -49,7 +50,7 @@ public class Context implements Closeable {
     // magical
     private boolean shuttingDown = false;
     // global state change notification
-    private CopyOnWriteArrayList<EvergreenService.GlobalStateChangeListener> listeners;
+    private CopyOnWriteArrayList<GlobalStateChangeListener> listeners;
     private final BlockingDeque<Runnable> serialized = new LinkedBlockingDeque<>();
     private final Thread publishThread = new Thread() {
         {
@@ -232,7 +233,7 @@ public class Context implements Closeable {
      *
      * @param l listener to add
      */
-    public synchronized void addGlobalStateChangeListener(EvergreenService.GlobalStateChangeListener l) {
+    public synchronized void addGlobalStateChangeListener(GlobalStateChangeListener l) {
         if (listeners == null) {
             listeners = new CopyOnWriteArrayList<>();
         }
@@ -244,7 +245,7 @@ public class Context implements Closeable {
      *
      * @param l listener to remove
      */
-    public synchronized void removeGlobalStateChangeListener(EvergreenService.GlobalStateChangeListener l) {
+    public synchronized void removeGlobalStateChangeListener(GlobalStateChangeListener l) {
         if (listeners != null) {
             listeners.remove(l);
         }

--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -21,6 +21,7 @@ import java.util.function.IntConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.aws.iot.evergreen.kernel.Lifecycle.TIMEOUT_NAMESPACE_TOPIC;
 import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 
 @SuppressWarnings("PMD.NullAssignment")
@@ -86,7 +87,7 @@ public class GenericExternalService extends EvergreenService {
 
     @Override
     public void startup() throws InterruptedException {
-        RunStatus result = run(LIFECYCLE_STARTUP_NAMESPACE_TOPIC, exit -> {
+        RunStatus result = run(Lifecycle.LIFECYCLE_STARTUP_NAMESPACE_TOPIC, exit -> {
             runScript = null;
             if (getState() == State.INSTALLED) {
                 if (exit == 0) {
@@ -158,7 +159,6 @@ public class GenericExternalService extends EvergreenService {
         }
     }
 
-
     @Override
     @SuppressWarnings("PMD.CloseResource")
     public void shutdown() {
@@ -196,7 +196,7 @@ public class GenericExternalService extends EvergreenService {
      * @return the status of the run.
      */
     protected RunStatus run(String name, IntConsumer background) throws InterruptedException {
-        Node n = (getLifeCycleTopic() == null) ? null : getLifeCycleTopic().getChild(name);
+        Node n = (getLifecycleTopic() == null) ? null : getLifecycleTopic().getChild(name);
         return n == null ? RunStatus.NothingDone : run(n, background);
     }
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/GlobalStateChangeListener.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GlobalStateChangeListener.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.kernel;
+
+import com.aws.iot.evergreen.dependency.State;
+
+public interface GlobalStateChangeListener {
+    void globalServiceStateChanged(EvergreenService l, State oldState, State newState);
+}

--- a/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
@@ -1,0 +1,633 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.kernel;
+
+import com.aws.iot.evergreen.config.Topic;
+import com.aws.iot.evergreen.config.Topics;
+import com.aws.iot.evergreen.dependency.State;
+import com.aws.iot.evergreen.logging.api.Logger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+
+@SuppressFBWarnings(value = "JLM_JSR166_UTILCONCURRENT_MONITORENTER",
+        justification = "We're synchronizing on the desired state list which is fine")
+public class Lifecycle {
+    public static final String LIFECYCLE_INSTALL_NAMESPACE_TOPIC = "install";
+    public static final String LIFECYCLE_STARTUP_NAMESPACE_TOPIC = "startup";
+    public static final String TIMEOUT_NAMESPACE_TOPIC = "timeout";
+
+    private static final Integer DEFAULT_INSTALL_STAGE_TIMEOUT_IN_SEC = 120;
+    private static final Integer DEFAULT_STARTUP_STAGE_TIMEOUT_IN_SEC = 120;
+    private static final String CURRENT_STATE_METRIC_NAME = "currentState";
+    private static final String INVALID_STATE_ERROR_EVENT = "service-invalid-state-error";
+    // The maximum number of ERRORED before transitioning the service state to BROKEN.
+    private static final int MAXIMUM_CONTINUAL_ERROR = 3;
+
+    private final EvergreenService evergreenService;
+    private final Topic stateTopic;
+    private final Logger logger;
+    private Future backingTask = CompletableFuture.completedFuture(null);
+    private String backingTaskName;
+    private State prevState;
+    @Getter
+    private Future<?> lifecycleFuture;
+    // A state event can be a state transition event, or a desired state updated notification.
+    // TODO: make class of StateEvent instead of generic object.
+    private final BlockingQueue<Object> stateEventQueue = new ArrayBlockingQueue<>(1);
+    private final Object stateEventLock = new Object();
+    // DesiredStateList is used to set desired path of state transition.
+    // Eg. Start a service will need DesiredStateList to be <RUNNING>
+    // ReInstall a service will set DesiredStateList to <FINISHED->NEW->RUNNING>
+    private final List<State> desiredStateList = new CopyOnWriteArrayList<>();
+    private static final Set<State> ALLOWED_STATES_FOR_REPORTING =
+            new HashSet<>(Arrays.asList(State.RUNNING, State.ERRORED, State.FINISHED));
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+    // The number of continual occurrences from a state to ERRORED.
+    // This is not thread safe and should only be used inside reportState().
+    private final Map<State, Integer> stateToErroredCount = new HashMap<>();
+    // We only need to track the ERROR for the state transition starting from NEW, INSTALLED and RUNNING because
+    // these states impact whether the service can function as expected.
+    private static final Set<State> STATES_TO_ERRORED = new HashSet<>(Arrays.asList(State.NEW, State.INSTALLED,
+            State.RUNNING));
+
+    /**
+     * Constructor for lifecycle.
+     *
+     * @param evergreenService service that this is the lifecycle for
+     * @param state            service's state topic
+     * @param logger           service's logger
+     */
+    public Lifecycle(EvergreenService evergreenService, Topic state, Logger logger) {
+        this.evergreenService = evergreenService;
+        this.prevState = State.NEW;
+        this.stateTopic = state;
+        this.logger = logger;
+    }
+
+    private void updateStateAndBroadcast(State newState) {
+        final State currentState = evergreenService.getState();
+
+        if (newState.equals(currentState)) {
+            return;
+        }
+
+        // TODO: Add validation
+        logger.atInfo().setEventType("service-set-state").kv(CURRENT_STATE_METRIC_NAME, currentState)
+                .kv("newState", newState).log();
+
+        // Sync on State.class to make sure the order of setValue and globalNotifyStateChanged are consistent
+        // across different services.
+        synchronized (State.class) {
+            prevState = currentState;
+            stateTopic.withValue(newState);
+            evergreenService.getContext().globalNotifyStateChanged(evergreenService, prevState, newState);
+        }
+    }
+
+    /**
+     * public API for service to report state. Allowed state are RUNNING, FINISHED, ERRORED.
+     *
+     * @param newState reported state from the service which should eventually be set as the service's
+     *                 actual state
+     */
+    synchronized void reportState(State newState) {
+        logger.atInfo().setEventType("service-report-state").kv("newState", newState).log();
+        if (!ALLOWED_STATES_FOR_REPORTING.contains(newState)) {
+            logger.atError().setEventType(INVALID_STATE_ERROR_EVENT).kv("newState", newState)
+                    .log("Invalid report state");
+        }
+        // TODO: Add more validations
+
+        if (evergreenService.getState().equals(State.INSTALLED) && newState.equals(State.FINISHED)) {
+            // if a service doesn't have any run logic, request stop on service to clean up DesiredStateList
+            requestStop();
+        }
+
+        State currentState = evergreenService.getState();
+
+        if (State.ERRORED.equals(newState) && STATES_TO_ERRORED.contains(currentState)) {
+            // If the reported state is ERRORED, we'll increase the ERROR counter for the current state.
+            stateToErroredCount.compute(currentState, (k, v) -> (v == null) ? 1 : v + 1);
+        } else {
+            // If the reported state is a non-ERRORED state, we would like to reset the ERROR counter for the current
+            // state. This is to avoid putting the service to BROKEN state because of transient issues.
+            stateToErroredCount.put(currentState, 0);
+        }
+        if (stateToErroredCount.get(currentState) > MAXIMUM_CONTINUAL_ERROR) {
+            enqueueStateEvent(State.BROKEN);
+        } else {
+            enqueueStateEvent(newState);
+        }
+    }
+
+    private Optional<State> getReportState() {
+        Object top = stateEventQueue.poll();
+        if (top instanceof State) {
+            return Optional.of((State) top);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns true if the service has reached its desired state.
+     *
+     * @return
+     */
+    public boolean reachedDesiredState() {
+        synchronized (desiredStateList) {
+            return desiredStateList.isEmpty()
+                    // when reachedDesiredState() is called in global state listener,
+                    // service lifecycle thread hasn't drained the desiredStateList yet.
+                    // Therefore adding this check.
+                    || desiredStateList.stream().allMatch(s -> s == evergreenService.getState());
+        }
+    }
+
+    private Optional<State> peekOrRemoveFirstDesiredState(State activeState) {
+        synchronized (desiredStateList) {
+            if (desiredStateList.isEmpty()) {
+                return Optional.empty();
+            }
+
+            State first = desiredStateList.get(0);
+            if (first.equals(activeState)) {
+                desiredStateList.remove(first);
+                // ignore remove() return value as it's possible that desiredStateList update
+            }
+            return Optional.ofNullable(first);
+        }
+    }
+
+    void setDesiredState(State... state) {
+        // Set desiredStateList and override existing desiredStateList.
+        synchronized (desiredStateList) {
+            List<State> newStateList = Arrays.asList(state);
+            if (newStateList.equals(desiredStateList)) {
+                return;
+            }
+            desiredStateList.clear();
+            desiredStateList.addAll(newStateList);
+            // try insert to the queue, if queue full doesn't block.
+            enqueueStateEvent("DesiredStateUpdated");
+        }
+    }
+
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+    private void enqueueStateEvent(Object event) {
+        synchronized (stateEventLock) {
+            if (event instanceof State) {
+                // override existing reportState
+                stateEventQueue.clear();
+                stateEventQueue.offer(event);
+            } else {
+                stateEventQueue.offer(event);
+
+                // Ignore returned value of offer().
+                // If enqueue isn't successful, the event queue has contents and there is no need to send another
+                // trigger to process state transition.
+            }
+        }
+    }
+
+    void startStateTransition() throws InterruptedException {
+        while (!(isClosed.get() && evergreenService.getState().isClosable())) {
+            Optional<State> desiredState;
+            State current = evergreenService.getState();
+            logger.atInfo().setEventType("service-state-transition-start")
+                    .kv(CURRENT_STATE_METRIC_NAME, current).log();
+
+            // if already in desired state, remove the head of desired state list.
+            desiredState = peekOrRemoveFirstDesiredState(current);
+            while (desiredState.isPresent() && desiredState.get().equals(current)) {
+                desiredState = peekOrRemoveFirstDesiredState(current);
+            }
+            AtomicReference<Future> triggerTimeOutReference = new AtomicReference<>();
+            switch (current) {
+                case BROKEN:
+                    if (handleCurrentStateBroken(desiredState)) {
+                        break;
+                    }
+                    continue;
+                case NEW:
+                    if (handleCurrentStateNew(desiredState)) {
+                        break;
+                    }
+                    continue;
+                case INSTALLED:
+                    if (handleCurrentStateInstalled(desiredState, triggerTimeOutReference)) {
+                        break;
+                    }
+                    continue;
+                case RUNNING:
+                    if (handleCurrentStateRunning(desiredState)) {
+                        break;
+                    }
+                    continue;
+                case STOPPING:
+                    handleCurrentStateStopping();
+                    continue;
+                case FINISHED:
+                    if (handleCurrentStateFinished(desiredState)) {
+                        break;
+                    }
+                    continue;
+                case ERRORED:
+                    handleCurrentStateErrored(desiredState);
+                    continue;
+                default:
+                    logger.atError(INVALID_STATE_ERROR_EVENT)
+                            .kv(CURRENT_STATE_METRIC_NAME, evergreenService.getState())
+                            .log("Unrecognized state");
+                    break;
+            }
+
+            // blocking on event queue.
+            // The state event can either be a report state transition event or a desired state updated event.
+            // TODO: check if it's possible to move this blocking logic to the beginning of while loop.
+            Object stateEvent = stateEventQueue.take();
+            if (stateEvent instanceof State) {
+                State toState = (State) stateEvent;
+                logger.atInfo().setEventType("service-report-state").kv("state", toState).log();
+                updateStateAndBroadcast(toState);
+            }
+            // service transitioning to another state, cancelling task monitoring the timeout for startup
+            Future triggerTimeOutFuture = triggerTimeOutReference.get();
+            if (triggerTimeOutFuture != null) {
+                triggerTimeOutFuture.cancel(true);
+            }
+        }
+    }
+
+    private boolean handleCurrentStateBroken(Optional<State> desiredState) {
+        if (!desiredState.isPresent()) {
+            return true;
+        }
+        // Having State.NEW as the desired state indicates the service is requested to reinstall, so here
+        // we'll transition out of BROKEN state to give it a new chance.
+        if (State.NEW.equals(desiredState.get())) {
+            updateStateAndBroadcast(State.NEW);
+        } else {
+            logger.atError().setEventType("service-broken")
+                    .log("service is broken. Deployment is needed");
+        }
+        return false;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    private boolean handleCurrentStateNew(Optional<State> desiredState) throws InterruptedException {
+        // if no desired state is set, don't do anything.
+        if (!desiredState.isPresent()) {
+            return true;
+        }
+        CountDownLatch installLatch = new CountDownLatch(1);
+        setBackingTask(() -> {
+            try {
+                evergreenService.install();
+            } catch (InterruptedException t) {
+                logger.atWarn("service-install-interrupted").log("Service interrupted while running install");
+            } catch (Throwable t) {
+                reportState(State.ERRORED);
+                logger.atError().setEventType("service-install-error").setCause(t).log();
+            } finally {
+                installLatch.countDown();
+            }
+        }, "install");
+
+        Topic installTimeOutTopic = evergreenService.config.find(EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC,
+                LIFECYCLE_INSTALL_NAMESPACE_TOPIC, TIMEOUT_NAMESPACE_TOPIC);
+        Integer installTimeOut = installTimeOutTopic == null ? DEFAULT_INSTALL_STAGE_TIMEOUT_IN_SEC
+                : (Integer) installTimeOutTopic.getOnce();
+        boolean ok = installLatch.await(installTimeOut, TimeUnit.SECONDS);
+        State reportState = getReportState().orElse(null);
+        if (State.ERRORED.equals(reportState) || !ok) {
+            updateStateAndBroadcast(State.ERRORED);
+        } else if (State.BROKEN.equals(reportState)) {
+            updateStateAndBroadcast(State.BROKEN);
+        } else {
+            updateStateAndBroadcast(State.INSTALLED);
+        }
+        return false;
+    }
+
+    private boolean handleCurrentStateInstalled(Optional<State> desiredState,
+                                                AtomicReference<Future> triggerTimeOutReference) {
+        stopBackingTask();
+        if (!desiredState.isPresent()) {
+            return true;
+        }
+
+        switch (desiredState.get()) {
+            case FINISHED:
+                updateStateAndBroadcast(State.FINISHED);
+                return false;
+            case NEW:
+                // This happens if a restart is requested while we're currently INSTALLED
+                updateStateAndBroadcast(State.NEW);
+                return false;
+            case RUNNING:
+                handleStateTransitionInstalledToRunning(triggerTimeOutReference);
+                break;
+            default:
+                // not allowed for NEW, STOPPING, ERRORED, BROKEN
+                logger.atError().setEventType(INVALID_STATE_ERROR_EVENT).kv("desiredState", desiredState)
+                        .log("Unexpected desired state");
+                break;
+        }
+        return true;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    private void handleStateTransitionInstalledToRunning(AtomicReference<Future> triggerTimeOutReference) {
+        setBackingTask(() -> {
+            try {
+                logger.atInfo().setEventType("service-awaiting-start").log("waiting for dependencies to start");
+                evergreenService.waitForDependencyReady();
+                logger.atInfo().setEventType("service-starting").log();
+            } catch (InterruptedException e) {
+                logger.atWarn().setEventType("service-dependency-error")
+                        .log("Got interrupted while waiting for dependency ready");
+                return;
+            }
+            try {
+                Topics startupTopics = evergreenService.config
+                        .findTopics(EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC,
+                                LIFECYCLE_STARTUP_NAMESPACE_TOPIC);
+                // only schedule task to report error for services with startup stage
+                // timeout for run stage is handled in generic external service
+                if (startupTopics != null) {
+                    Topic timeOutTopic = startupTopics.findLeafChild(TIMEOUT_NAMESPACE_TOPIC);
+                    // default time out is 120 seconds
+                    Integer timeout = timeOutTopic == null ? DEFAULT_STARTUP_STAGE_TIMEOUT_IN_SEC
+                            : (Integer) timeOutTopic.getOnce();
+
+
+                    Future<?> schedule =
+                            evergreenService.getContext().get(ScheduledExecutorService.class).schedule(() -> {
+                                if (!State.RUNNING.equals(evergreenService.getState())) {
+                                    logger.atWarn("service-startup-timed-out")
+                                            .log("Service failed to startup within timeout");
+                                    reportState(State.ERRORED);
+                                }
+                            }, timeout, TimeUnit.SECONDS);
+                    triggerTimeOutReference.set(schedule);
+                }
+                // TODO: rename to  initiateStartup. Service need to report state to RUNNING.
+                evergreenService.startup();
+            } catch (InterruptedException i) {
+                logger.atWarn("service-run-interrupted").log("Service interrupted while running startup");
+            } catch (Throwable t) {
+                reportState(State.ERRORED);
+                logger.atError().setEventType("service-runtime-error").setCause(t).log();
+            }
+        }, "start");
+    }
+
+    private boolean handleCurrentStateRunning(Optional<State> desiredState) {
+        if (!desiredState.isPresent()) {
+            return true;
+        }
+        // desired state is different, let's transition to stopping state first.
+        updateStateAndBroadcast(State.STOPPING);
+        return false;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    private void handleCurrentStateStopping() throws InterruptedException {
+        // does not handle desiredState in STOPPING because we must stop first.
+        // does not use setBackingTask because it will cancel the existing task.
+        CountDownLatch stopping = new CountDownLatch(1);
+        Future<?> shutdownFuture = evergreenService.getContext().get(ExecutorService.class).submit(() -> {
+            try {
+                evergreenService.shutdown();
+            } catch (InterruptedException i) {
+                logger.atWarn("service-shutdown-interrupted").log("Service interrupted while running shutdown");
+            } catch (Throwable t) {
+                reportState(State.ERRORED);
+                logger.atError().setEventType("service-shutdown-error").setCause(t).log();
+            } finally {
+                stopping.countDown();
+            }
+        });
+
+        boolean stopSucceed = stopping.await(15, TimeUnit.SECONDS);
+
+        stopBackingTask();
+        if (State.ERRORED.equals(getReportState().orElse(null)) || !stopSucceed) {
+            updateStateAndBroadcast(State.ERRORED);
+            // If the thread is still running, then kill it
+            if (!shutdownFuture.isDone()) {
+                shutdownFuture.cancel(true);
+            }
+        } else {
+            Optional<State> desiredState = peekOrRemoveFirstDesiredState(State.FINISHED);
+            serviceTerminatedMoveToDesiredState(desiredState.orElse(State.FINISHED));
+        }
+    }
+
+    private boolean handleCurrentStateFinished(Optional<State> desiredState) {
+        if (!desiredState.isPresent()) {
+            return true;
+        }
+
+        logger.atInfo().setEventType("service-state-transition")
+                .kv(CURRENT_STATE_METRIC_NAME, evergreenService.getState())
+                .kv("desiredState", desiredState).log();
+        serviceTerminatedMoveToDesiredState(desiredState.get());
+        return false;
+    }
+
+    private void handleCurrentStateErrored(Optional<State> desiredState) throws InterruptedException {
+        try {
+            evergreenService.handleError();
+        } catch (InterruptedException e) {
+            logger.atWarn("service-errorhandler-interrupted").log("Service interrupted while running error handler");
+            // Since we run the error handler in this thread, that means we should rethrow
+            // in order to shutdown this thread since we were requested to stop
+            throw e;
+        }
+
+        if (!desiredState.isPresent()) {
+            // Reset the desired state to RUNNING to retry the ERROR.
+            requestStart();
+        }
+
+        switch (prevState) {
+            case RUNNING:
+                updateStateAndBroadcast(State.STOPPING);
+                break;
+            case NEW: // error in installing.
+                updateStateAndBroadcast(State.NEW);
+                break;
+            case INSTALLED: // error in starting
+                updateStateAndBroadcast(State.INSTALLED);
+                break;
+            case STOPPING:
+                // not handled;
+                desiredState = peekOrRemoveFirstDesiredState(State.FINISHED);
+                serviceTerminatedMoveToDesiredState(desiredState.orElse(State.FINISHED));
+                break;
+            default:
+                logger.atError().setEventType(INVALID_STATE_ERROR_EVENT).kv("previousState", prevState)
+                        .log("Unexpected previous state");
+                updateStateAndBroadcast(State.FINISHED);
+                break;
+        }
+    }
+
+    /**
+     * Given the service is terminated, move to desired state.
+     * Only use in service lifecycle thread.
+     *
+     * @param desiredState the desiredState to go, not null
+     */
+    @SuppressWarnings("PMD.MissingBreakInSwitch")
+    private void serviceTerminatedMoveToDesiredState(@Nonnull State desiredState) {
+        switch (desiredState) {
+            case NEW:
+                updateStateAndBroadcast(State.NEW);
+                break;
+            case INSTALLED:
+            case RUNNING:
+                updateStateAndBroadcast(State.INSTALLED);
+                break;
+            case FINISHED:
+                updateStateAndBroadcast(State.FINISHED);
+                break;
+            default:
+                // not allowed to set desired state to STOPPING, ERRORED, BROKEN
+                logger.atError().setEventType(INVALID_STATE_ERROR_EVENT).addKeyValue("desiredState", desiredState)
+                        .log("Unexpected desired state");
+        }
+    }
+
+    private synchronized void setBackingTask(Runnable r, String action) {
+        Future bt = backingTask;
+        String btName = backingTaskName;
+
+        if (!bt.isDone()) {
+            backingTask = CompletableFuture.completedFuture(null);
+            logger.info("Stopping backingTask {}", btName);
+            bt.cancel(true);
+        }
+
+        if (r != null) {
+            backingTaskName = action;
+            logger.debug("Scheduling backingTask {}", backingTaskName);
+            backingTask = evergreenService.getContext().get(ExecutorService.class).submit(r);
+        }
+    }
+
+    private void stopBackingTask() {
+        setBackingTask(null, null);
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    void initLifecycleThread() {
+        lifecycleFuture = evergreenService.getContext().get(ExecutorService.class).submit(() -> {
+            while (!isClosed.get()) {
+                try {
+                    startStateTransition();
+                    return;
+                } catch (InterruptedException i) {
+                    logger.atWarn().setEventType("service-state-transition-interrupted")
+                            .log("Service lifecycle thread interrupted. Thread will exit now");
+                    return;
+                } catch (Throwable e) {
+                    logger.atError().setEventType("service-state-transition-error")
+                            .kv(CURRENT_STATE_METRIC_NAME, evergreenService.getState()).setCause(e)
+                            .log();
+                    logger.atInfo().setEventType("service-state-transition-retry")
+                            .kv(CURRENT_STATE_METRIC_NAME, evergreenService.getState()).log();
+                }
+            }
+        });
+    }
+
+    void setClosed(boolean b) {
+        isClosed.set(b);
+    }
+
+    /**
+     * Start Service.
+     */
+    final void requestStart() {
+        synchronized (desiredStateList) {
+            if (desiredStateList.isEmpty()) {
+                setDesiredState(State.RUNNING);
+                return;
+            }
+            State lastState = desiredStateList.get(desiredStateList.size() - 1);
+            if (lastState == State.RUNNING) {
+                return;
+            } else if (lastState == State.FINISHED) {
+                desiredStateList.set(desiredStateList.size() - 1, State.RUNNING);
+            } else {
+                desiredStateList.add(State.RUNNING);
+            }
+        }
+    }
+
+    /**
+     * ReInstall Service.
+     */
+    final void requestReinstall() {
+        synchronized (desiredStateList) {
+            setDesiredState(State.NEW, State.RUNNING);
+        }
+    }
+
+    /**
+     * Restart Service.
+     */
+    final void requestRestart() {
+        synchronized (desiredStateList) {
+            // don't override in the case of re-install
+            int index = desiredStateList.indexOf(State.NEW);
+            if (index == -1) {
+                setDesiredState(State.INSTALLED, State.RUNNING);
+                return;
+            }
+            desiredStateList.subList(index + 1, desiredStateList.size()).clear();
+            desiredStateList.add(State.RUNNING);
+        }
+    }
+
+    /**
+     * Stop Service.
+     */
+    final void requestStop() {
+        synchronized (desiredStateList) {
+            // don't override in the case of re-install
+            int index = desiredStateList.indexOf(State.NEW);
+            if (index == -1) {
+                setDesiredState(State.FINISHED);
+                return;
+            }
+            desiredStateList.subList(index + 1, desiredStateList.size()).clear();
+            desiredStateList.add(State.FINISHED);
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactored `EvergreenService` by splitting out state machine (lifecycle) related functionality into a separate class: `Lifecycle`. That class was then further refactored by extracting methods from the large nested mess of switch statements. Each method is now named as `handleCurrentState<STATE>` and `handleStateTransition<STATE>To<STATE>` so it is very clear exactly what is happening just by the method names. Both classes are still pretty big (each over 500 lines), but this is certainly an improvement from 1 enormous class.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
