### PR TITLE
Fix config update by passing changed node up through subscribers

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/config/Topics.java
+++ b/src/main/java/com/aws/iot/evergreen/config/Topics.java
@@ -258,7 +258,7 @@ public class Topics extends Node implements Iterable<Node> {
             }
         }
         if (parent != null && parentNeedsToKnow()) {
-            parent.childChanged(WhatHappened.childChanged, this);
+            parent.childChanged(WhatHappened.childChanged, child);
         }
     }
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -396,6 +396,10 @@ public class EvergreenService implements InjectionActions {
                         case FINISHED:
                             updateStateAndBroadcast(State.FINISHED);
                             continue;
+                        case NEW:
+                            // This happens if a restart is requested while we're currently INSTALLED
+                            updateStateAndBroadcast(State.NEW);
+                            continue;
                         case RUNNING:
                             setBackingTask(() -> {
                                 try {
@@ -444,7 +448,7 @@ public class EvergreenService implements InjectionActions {
 
                             break;
                         default:
-                            // not allowed for NEW, STOPPING, ERRORED, BROKEN
+                            // not allowed for STOPPING, ERRORED, BROKEN
                             logger.atError().setEventType(INVALID_STATE_ERROR_EVENT)
                                     .kv("desiredState", desiredState).log("Unexpected desired state");
                             break;

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -32,7 +32,7 @@ import javax.inject.Inject;
 public class KernelConfigResolver {
 
     private static final String SERVICE_DEPENDENCIES_CONFIG_KEY = "dependencies";
-    protected static final String VERSION_CONFIG_KEY = "version";
+    public static final String VERSION_CONFIG_KEY = "version";
     protected static final String PARAMETERS_CONFIG_KEY = "parameters";
     private static final String SERVICE_NAMESPACE_CONFIG_KEY = "services";
     private static final String PARAMETER_REFERENCE_FORMAT = "{{params:%s.value}}";


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes `GenericExternalService` listening to changes to `install`, etc by passing the changed node up through all of the subscribers. Additionally fixes the subscriber which was erroneously using the `c` variable instead of `child`.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
