### PR TITLE
Flaky Test: Slow down error service so it doesn't go to broken

### DIFF
--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Analyze Test Run
         run: >-
           pip3 -q install agithub &&
-          python3 .github/scripts/flake.py --cmd "mvn -ntp -q verify" -i 10 --token "${{ github.token }}"
+          python3 .github/scripts/flake.py --cmd "mvn -ntp -q verify" -i 10 -ff --token "${{ github.token }}"
           --out-dir "failed_tests/"
       - name: Upload Errors
         uses: actions/upload-artifact@v1.0.0

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config_broken.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/config_broken.yaml
@@ -17,7 +17,7 @@ services:
   runErrorRetry:
     lifecycle:
       run: |-
-        sleep 2
+        sleep 5
         echo "RUN_BROKEN"
         exit 1
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`GIVEN_expected_state_transitions_WHEN_services_error_out_THEN_all_expectations_should_be_seen` is now flaky when run in CI. I ran it over 60 times locally and it never failed. After reviewing the logs from the failed runs on CI, I believe the problem is that the service is too quickly moved to `BROKEN` before giving the other services time to react, and thus produce the expected state transitions in this test. This PR simply extends the sleep time so that it would take 15 seconds for the service to be moved to `BROKEN`, by which time this test will have hopefully completed.

Additionally I'm enabling fail-fast mode for the flake finder so that if it finds a broken test it will hopefully be able to open an issue before the GitHub token expires in 1 hour.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
