### PR TITLE
Fixed race condition during service close

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -143,7 +143,7 @@ class DeploymentE2ETest {
                         Arrays.asList(new DeploymentPackageConfiguration("CustomerApp", "1.0.0", null, null, null),
                                 new DeploymentPackageConfiguration("SomeService", "1.0.0", null, null, null))).build());
         String jobId1 = Utils.createJob(document1, targets);
-        Utils.waitForJobToComplete(jobId1, Duration.ofMinutes(5));
+        Utils.waitForJobToComplete(jobId1, Duration.ofMinutes(2));
 
         // Second deployment to remove some services deployed previously
         String document2 = new ObjectMapper().writeValueAsString(
@@ -152,7 +152,7 @@ class DeploymentE2ETest {
                         .deploymentPackageConfigurationList(Arrays.asList(
                                 new DeploymentPackageConfiguration("CustomerApp", "1.0.0", null, null, null))).build());
         String jobId2 = Utils.createJob(document2, targets);
-        Utils.waitForJobToComplete(jobId2, Duration.ofMinutes(5));
+        Utils.waitForJobToComplete(jobId2, Duration.ofMinutes(2));
 
         // Ensure that main is finished, which is its terminal state, so this means that all updates ought to be done
         assertEquals(State.FINISHED, kernel.getMain().getState());

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -256,8 +256,8 @@ public class EvergreenService implements InjectionActions {
                 } catch (InterruptedException e) {
                     logger.error("Interrupted waiting for dependers to exit");
                 }
-                requestStop();
                 lifecycle.setClosed(true);
+                requestStop();
                 lifecycle.getLifecycleFuture().get();
                 closeFuture.complete(null);
             } catch (Exception e) {


### PR DESCRIPTION
**Description of changes:**

For a service in FINISHED state, when close() is closed the  following happens
1. requeststop() -> pushes new desired state as "FINISHED" to stateEventQueue
2. lifecycle.setClosed(true) -> sets the closed flag in lifecycle 

Race condition:
When a new item is available in stateEventQueue the lifecycle thread is unblocked and proceeds to process the new event. Before proceeding with the new event the lifecycle thread checks if the 
service is closed and service is in a closable state. If both the conditions are true, the thread exits and service is marked as closed.

Due to race condition,  if the lifecycle thread performs the check before lifecycle.setClosed(true) can be executed, lifecycle thread enters the state transitioning logic. Since the service is already in the desired state, the lifecycle thread had nothing to do but wait for the next state event.  If there is no next event, the thread waits indefinitely and causes the tests to timeout.


**How was this change tested:**
1. Reproduced the bug using Thread.sleep() and the fix was verified. 
2. mvn verify 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
