### PR TITLE
Cleanup service logging, address ignored InterruptedExceptions

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.aws.iot.evergreen.util.Utils.getUltimateCause;
@@ -40,6 +41,8 @@ public class EvergreenService implements InjectionActions {
     public static final String SERVICES_NAMESPACE_TOPIC = "services";
     public static final String SERVICE_LIFECYCLE_NAMESPACE_TOPIC = "lifecycle";
     public static final String SERVICE_NAME_KEY = "serviceName";
+
+    private static final String CURRENT_STATE_METRIC_NAME = "currentState";
 
     protected final Topics config;
     public Context context;
@@ -73,7 +76,8 @@ public class EvergreenService implements InjectionActions {
         // skipif will require validation for onpath/exists etc. keywords
 
         this.logger = LogManager.getLogger(getName());
-        logger.addDefaultKeyValue(SERVICE_NAME_KEY, getName());
+        logger.dfltKv(SERVICE_NAME_KEY, getName());
+        logger.dfltKv(CURRENT_STATE_METRIC_NAME, (Supplier<State>) this::getState);
         this.state = initStateTopic(topics);
 
         this.externalDependenciesTopic = topics.createLeafChild("dependencies").dflt(new ArrayList<String>());
@@ -107,24 +111,23 @@ public class EvergreenService implements InjectionActions {
         return state;
     }
 
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private synchronized void initDependenciesTopic() {
         externalDependenciesTopic.subscribe((what, node) -> {
             if (!WhatHappened.changed.equals(what)) {
                 return;
             }
             Iterable<String> depList = (Iterable<String>) node.getOnce();
-            logger.atInfo().log("Setting up dependencies again", String.join(",", depList));
+            logger.atInfo().log("Setting up dependencies again {}", String.join(",", depList));
             try {
                 setupDependencies(depList);
-            } catch (Exception e) {
+            } catch (ServiceLoadException | InputValidationException e) {
                 logger.atError().log("Error while setting up dependencies from subscription", e);
             }
         });
 
         try {
             setupDependencies((Iterable<String>) externalDependenciesTopic.getOnce());
-        } catch (Exception e) {
+        } catch (ServiceLoadException | InputValidationException e) {
             serviceErrored(e);
         }
     }
@@ -305,7 +308,8 @@ public class EvergreenService implements InjectionActions {
             if ((State.INSTALLED.equals(getState()) || State.RUNNING.equals(getState()))
                     && !dependencyReady(dependentEvergreenService, startWhenState)) {
                 requestRestart();
-                logger.atInfo().setEventType("service-restart").log("Restart service because of dependencies");
+                logger.atInfo("service-restart").log("Restarting service because dependency {} was in a bad state",
+                        dependentEvergreenService.getName());
             }
             synchronized (dependencyReadyLock) {
                 if (dependencyReady()) {
@@ -343,7 +347,7 @@ public class EvergreenService implements InjectionActions {
 
         synchronized (dependersExitedLock) {
             while (!dependersExited(dependers)) {
-                logger.atDebug().setEventType("service-waiting-for-depender-to-finish").log();
+                logger.atDebug("service-waiting-for-depender-to-finish").log();
                 dependersExitedLock.wait();
             }
         }
@@ -356,8 +360,7 @@ public class EvergreenService implements InjectionActions {
         Optional<EvergreenService> dependerService =
                 dependers.stream().filter(d -> !d.getState().isClosable()).findAny();
         if (dependerService.isPresent()) {
-            logger.atDebug().setEventType("continue-waiting-for-dependencies")
-                    .kv("waitingFor", dependerService.get().getName()).log();
+            logger.atDebug("continue-waiting-for-dependencies").kv("waitingFor", dependerService.get().getName()).log();
             return false;
         }
         return true;
@@ -371,7 +374,7 @@ public class EvergreenService implements InjectionActions {
                         .map(Map.Entry::getKey)
                         .collect(Collectors.toList());
         if (!ret.isEmpty()) {
-            logger.atDebug().setEventType("continue-waiting-for-dependencies").kv("waitingFor", ret).log();
+            logger.atDebug("continue-waiting-for-dependencies").kv("waitingFor", ret).log();
         }
         return ret.isEmpty();
     }
@@ -384,7 +387,7 @@ public class EvergreenService implements InjectionActions {
     void waitForDependencyReady() throws InterruptedException {
         synchronized (dependencyReadyLock) {
             while (!dependencyReady()) {
-                logger.atDebug().setEventType("service-waiting-for-dependency").log();
+                logger.atDebug("service-waiting-for-dependency").log();
                 dependencyReadyLock.wait();
             }
         }
@@ -458,8 +461,7 @@ public class EvergreenService implements InjectionActions {
                 .filter(e -> !keptDependencies.containsKey(e.getKey()) && !e.getValue().isDefaultDependency)
                 .map(Map.Entry::getKey).collect(Collectors.toSet());
         if (!removedDependencies.isEmpty()) {
-            logger.atInfo().setEventType("removing-unused-dependencies")
-                    .addKeyValue("removedDependencies", removedDependencies).log();
+            logger.atInfo("removing-unused-dependencies").kv("removedDependencies", removedDependencies).log();
 
             removedDependencies.forEach(dependency -> {
                 DependencyInfo dependencyInfo = dependencies.remove(dependency);
@@ -476,8 +478,8 @@ public class EvergreenService implements InjectionActions {
                 }
                 addOrUpdateDependency(dependentEvergreenService, startWhen, false);
             } catch (InputValidationException e) {
-                logger.atWarn().setCause(e).setEventType("add-dependency")
-                        .log("Unable to add dependency {}", dependentEvergreenService);
+                logger.atWarn("add-dependency")
+                        .log("Unable to add dependency {}", dependentEvergreenService, e);
             }
         });
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/UpdateSystemSafelyService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/UpdateSystemSafelyService.java
@@ -82,9 +82,9 @@ public class UpdateSystemSafelyService extends EvergreenService {
         }
     }
 
-    @SuppressWarnings({"SleepWhileInLoop", "checkstyle:emptycatchblock"})
+    @SuppressWarnings({"SleepWhileInLoop"})
     @Override
-    public void startup() {
+    public void startup() throws InterruptedException {
         // startup() is invoked on it's own thread
         reportState(State.RUNNING);
 
@@ -114,11 +114,8 @@ public class UpdateSystemSafelyService extends EvergreenService {
                 }
             }
             if (maxt > now) {
-                try {
-                    logger.atDebug().setEventType("service-update-pending").addKeyValue("waitInMS", maxt - now).log();
-                    Thread.sleep(maxt - now);
-                } catch (InterruptedException ignored) {
-                }
+                logger.atDebug().setEventType("service-update-pending").addKeyValue("waitInMS", maxt - now).log();
+                Thread.sleep(maxt - now);
             } else {
                 logger.atDebug().setEventType("service-update-scheduled").log();
                 context.runOnPublishQueueAndWait(() -> {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Cleans up service logging to use short versions of APIs when possible. Sets "currentState" default key to `getState` so that with every log that is output, the state is automatically included and is up to date.

Also fixes a loop when the service is `BROKEN` which was due to the lifecycle thread `continue`ing instead of `break`ing and thus waiting for an event. Before, it would print the error log continuously until the service was shutdown or was updated.

Also addresses 2 place where we were ignoring `InterruptedException` to pass them up or handle them more appropriately.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
