### PR TITLE
Make Flake Finder more debuggable, fix PMD running multiple times

### DIFF
--- a/.github/scripts/flake.py
+++ b/.github/scripts/flake.py
@@ -30,10 +30,16 @@ def main():
 
     for i in range(0, iterations):
         print(f"Running iteration {i + 1} of {iterations}", flush=True)
-        process = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+        process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         # If the tests failed, then we should check which test(s) failed in order to report it
         if process.returncode != 0:
             print(f"Iteration {i + 1} failed, saving and parsing results now", flush=True)
+            os.makedirs(args.out_dir, exist_ok=True)
+            with open(f'{args.out_dir}{i+1}-full-stdout.txt', 'w') as f:
+                f.write(process.stdout.decode('utf-8'))
+            with open(f'{args.out_dir}{i+1}-full-stderr.txt', 'w') as f:
+                f.write(process.stderr.decode('utf-8'))
+
             parse_test_results(i, results, args.out_dir)
             if args.ff:
                 break
@@ -93,7 +99,6 @@ def parse_test_results(iteration, previous_results, failed_test_dir):
 
             previous_results[testcase.get("classname")][testcase.get("name")] \
                 .append({"iteration": iteration, "failure": failure})
-            os.makedirs(failed_test_dir, exist_ok=True)
             # Save test stdout and stderr
             file_path_prefix = f'{failed_test_dir}{iteration}-{testcase.get("classname")}.{testcase.get("name")}-'
             if testcase.find("system-out") is not None:

--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Analyze Test Run
         run: >-
           pip3 -q install agithub &&
-          python3 .github/scripts/flake.py --cmd "mvn -ntp -q verify" -i 10 -ff --token "${{ github.token }}"
+          python3 .github/scripts/flake.py --cmd "mvn -ntp verify" -i 10 -ff --token "${{ github.token }}"
           --out-dir "failed_tests/"
       - name: Upload Errors
         uses: actions/upload-artifact@v1.0.0

--- a/codestyle/pmd-eg-ruleset.xml
+++ b/codestyle/pmd-eg-ruleset.xml
@@ -93,7 +93,7 @@
             <property name="xpath">
                 <value>
                     <![CDATA[
-//PrimaryExpression[pmd-java:typeIs("java.util.concurrent.Future")and (PrimaryPrefix/Name[contains(@Image, "get")] and PrimarySuffix[@ArgumentCount=0]) or (PrimarySuffix/MemberSelector/MethodReference[@Image="get"])]
+//PrimaryExpression[pmd-java:typeIs("java.util.concurrent.Future") and (PrimaryPrefix/Name[contains(@Image, "get")] and PrimarySuffix[@ArgumentCount=0]) or (PrimarySuffix/MemberSelector/MethodReference[@Image="get"])]
 ]]>
                 </value>
             </property>

--- a/codestyle/pmd-eg-tests-ruleset.xml
+++ b/codestyle/pmd-eg-tests-ruleset.xml
@@ -88,7 +88,7 @@
     </rule>
     <rule name="AvoidGettingFutureWithoutTimeout"
           language="java"
-          message="Calls to 'get' on Futures must have a timeout"
+          message="Calls to 'get()' on Futures must have a timeout"
           class="net.sourceforge.pmd.lang.rule.XPathRule">
         <description>
             Calls to Future.get() will block forever. This is almost always undesirable.

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,55 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.0.0</version>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                    <effort>Max</effort>
+                    <!-- Reports all bugs (other values are medium and max) -->
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <excludeFilterFile>codestyle/findbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>analyze-compile</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.29</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <configLocation>codestyle/checkstyle.xml</configLocation>
+                    <violationSeverity>warning</violationSeverity>
+                    <maxAllowedViolations>0</maxAllowedViolations>
+                    <skip>${skipTests}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
                         <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
@@ -236,55 +285,6 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M4</version>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.0</version>
-                <configuration>
-                    <skip>${skipTests}</skip>
-                    <effort>Max</effort>
-                    <!-- Reports all bugs (other values are medium and max) -->
-                    <threshold>Low</threshold>
-                    <xmlOutput>true</xmlOutput>
-                    <excludeFilterFile>codestyle/findbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>analyze-compile</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <logViolationsToConsole>true</logViolationsToConsole>
-                    <configLocation>codestyle/checkstyle.xml</configLocation>
-                    <violationSeverity>warning</violationSeverity>
-                    <maxAllowedViolations>0</maxAllowedViolations>
-                    <skip>${skipTests}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -34,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.Arrays;

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
@@ -101,6 +101,7 @@ class KernelTest extends BaseITCase {
         kernel.shutdown();
     }
 
+    @SuppressWarnings("PMD.AssignmentInOperand")
     private Consumer<EvergreenStructuredLogMessage> getLogListener() {
         return evergreenStructuredLogMessage -> {
             String stdoutStr = evergreenStructuredLogMessage.getContexts().get("stdout");

--- a/src/main/java/com/aws/iot/evergreen/deployment/exceptions/ServiceUpdateException.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/exceptions/ServiceUpdateException.java
@@ -1,6 +1,7 @@
 package com.aws.iot.evergreen.deployment.exceptions;
 
 public class ServiceUpdateException extends DeploymentException {
+    static final long serialVersionUID = -3387516993124229948L;
 
     public ServiceUpdateException(String message) {
         super(message);

--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -106,6 +106,7 @@ public class GenericExternalService extends EvergreenService {
         }
     }
 
+    @SuppressWarnings("PMD.CloseResource")
     private void handleRunScript() throws InterruptedException {
         // sync block will ensure that the call back can execute only after
         // the service transition state based on RunStatus result


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Flake finder was failing because PMD was finding more than the allowed 1 issue when run a second time. This is due to PMD executing on the newly compile integration test classes which it had not seen before. This change fixes or suppresses PMD warnings, it also changes the execution order so that we have checkstyle, compile source, compile tests, pmd, spotbugs, run unit, run integration.

This change also makes flake finder much easier to debug when our command fails, but does not result in test result XML files (like when PMD fails). It does this by writing stdout and stderr to files in the `failed_tests` directory.

**Why is this change necessary:**

**How was this change tested:**
Tested locally and by setting flake finder to run on pull requests. I ran it when this PR was a draft and saw that it was able to run more than twice (due to previous PMD failures it would always fail on the second run).

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
