### PR TITLE
Fix test failures in BeforeAll

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
     </dependencies>
     <pluginRepositories>
         <pluginRepository>
+            <id>maven-snapshots</id>
+            <name>Maven snapshots</name>
+            <layout>default</layout>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+        </pluginRepository>
+        <pluginRepository>
             <id>yle-public</id>
             <name>Yle public repository</name>
             <url>https://d2x444wtt5plvm.cloudfront.net/release</url>
@@ -239,7 +245,9 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.0.0-SNAPSHOT</version> <!-- Use snapshot until M5 is released because M4 has a bug which
+                doesn't report errors from @BeforeAll
+                 -->
                 <configuration>
                     <skipTests>true</skipTests>
                     <trimStackTrace>false</trimStackTrace>

--- a/src/test/java/com/aws/iot/evergreen/kernel/RequestLifecycleChangeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/RequestLifecycleChangeTest.java
@@ -24,7 +24,7 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
 
     @BeforeAll
     public static void setup() throws Exception {
-        desiredStateListField = EvergreenService.class.getDeclaredField("desiredStateList");
+        desiredStateListField = Lifecycle.class.getDeclaredField("desiredStateList");
         desiredStateListField.setAccessible(true);
     }
 
@@ -32,7 +32,9 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
     void beforeEach() throws Exception {
         Topics config = initializeMockedConfig();
         evergreenService = new EvergreenService(config);
-        desiredStateList = (List<State>) desiredStateListField.get(evergreenService);
+        Field lifecycleField = EvergreenService.class.getDeclaredField("lifecycle");
+        lifecycleField.setAccessible(true);
+        desiredStateList = (List<State>) desiredStateListField.get(lifecycleField.get(evergreenService));
     }
 
     @Test
@@ -41,7 +43,7 @@ public class RequestLifecycleChangeTest extends EGServiceTestUtil {
         evergreenService.requestStart();
         assertDesiredState(State.RUNNING);
 
-        // calling requestRetart() multiple times doesn't result in duplication
+        // calling requestRestart() multiple times doesn't result in duplication
         evergreenService.requestStart();
         assertDesiredState(State.RUNNING);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix test failures in BeforeAll. Surefire 3.0.0-M4 has a known issue that failures occurring during `BeforeAll` are not reported as a test failure (https://github.com/junit-team/junit5/issues/2178). This change moves us to the surefire snapshot which has it fixed. It also fixes the test failure.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
