### PR TITLE
Add tests for KernelCommandLine

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,6 +55,8 @@ jobs:
           show_branch: true
           # Use class names instead of the filename
           show_class_names: true
+          # Only show the files changed in the PR
+          only_changed_files: true
       - name: GitHub Actions Artifact Cleaner
         uses: glassechidna/artifact-cleaner@v2
         continue-on-error: true

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -100,14 +100,14 @@ class DeploymentTaskIntegrationTest {
         kernel.launch();
 
         // initialize packageStore and dependencyResolver
-        packageStore = new PackageStore(kernel.packageStorePath, new GreengrassPackageServiceHelper(),
+        packageStore = new PackageStore(kernel.getPackageStorePath(), new GreengrassPackageServiceHelper(),
                 new GreengrassRepositoryDownloader(), Executors.newSingleThreadExecutor(), kernel);
 
         Path localStoreContentPath = Paths.get(DeploymentTaskIntegrationTest.class.getResource(
                 "local_store_content").getPath());
 
         // pre-load contents to package store
-        copyFolderRecursively(localStoreContentPath, kernel.packageStorePath);
+        copyFolderRecursively(localStoreContentPath, kernel.getPackageStorePath());
 
         dependencyResolver = new DependencyResolver(packageStore, kernel);
         kernelConfigResolver = new KernelConfigResolver(packageStore, kernel);

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -84,7 +84,7 @@ class DeploymentE2ETest {
 
         Path localStoreContentPath = Paths.get(DeploymentE2ETest.class.getResource("local_store_content").getPath());
         // pre-load contents to package store
-        copyFolderRecursively(localStoreContentPath, kernel.packageStorePath);
+        copyFolderRecursively(localStoreContentPath, kernel.getPackageStorePath());
 
         // TODO: Without this sleep, DeploymentService sometimes is not able to pick up new IoT job created here,
         // causing these tests to fail. There may be a race condition between DeploymentService startup logic and
@@ -261,7 +261,7 @@ class DeploymentE2ETest {
             cf.write(thing.certificatePem.getBytes(StandardCharsets.UTF_8));
         }
 
-        Topics deploymentServiceTopics = kernel.config.lookupTopics(SERVICES_NAMESPACE_TOPIC, "DeploymentService");
+        Topics deploymentServiceTopics = kernel.getConfig().lookupTopics(SERVICES_NAMESPACE_TOPIC, "DeploymentService");
         deploymentServiceTopics.createLeafChild(DEVICE_PARAM_THING_NAME).withValue(thing.thingName);
         deploymentServiceTopics.createLeafChild(DEVICE_PARAM_MQTT_CLIENT_ENDPOINT).withValue(thing.endpoint);
         deploymentServiceTopics.createLeafChild(DEVICE_PARAM_PRIVATE_KEY_PATH).withValue(privateKeyFilePath);

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCAwareServicesTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCAwareServicesTest.java
@@ -46,7 +46,7 @@ class IPCAwareServicesTest extends BaseITCase {
                 serviceRunning.countDown();
             }
         };
-        kernel.context.addGlobalStateChangeListener(listener);
+        kernel.getContext().addGlobalStateChangeListener(listener);
         kernel.launch();
 
         // waiting for main to transition to running

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
@@ -59,7 +59,7 @@ class IPCServicesTest {
 
         // ensure awaitIpcServiceLatch starts
         CountDownLatch awaitIpcServiceLatch = new CountDownLatch(1);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("ServiceName") && newState.equals(State.RUNNING)) {
                 awaitIpcServiceLatch.countDown();
             }
@@ -70,7 +70,7 @@ class IPCServicesTest {
         assertTrue(awaitIpcServiceLatch.await(10, TimeUnit.SECONDS));
 
         Topic kernelUri =
-                kernel.config.lookup(EvergreenService.SERVICES_NAMESPACE_TOPIC, "setenv", KERNEL_URI_ENV_VARIABLE_NAME);
+                kernel.getConfig().lookup(EvergreenService.SERVICES_NAMESPACE_TOPIC, "setenv", KERNEL_URI_ENV_VARIABLE_NAME);
         URI serverUri = new URI((String) kernelUri.getOnce());
         port = serverUri.getPort();
         address = serverUri.getHost();

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
@@ -24,7 +24,7 @@ class GenericExternalServiceTest extends BaseITCase {
         kernel.parseArgs("-i", getClass().getResource("skipif_broken.yaml").toString());
 
         CountDownLatch testErrored = new CountDownLatch(1);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("test") && newState.equals(State.ERRORED)) {
                 testErrored.countDown();
             }
@@ -46,7 +46,7 @@ class GenericExternalServiceTest extends BaseITCase {
         CountDownLatch ServicesAErroredLatch = new CountDownLatch(1);
         CountDownLatch ServicesBErroredLatch = new CountDownLatch(1);
         // service sleeps for 120 seconds during startup and timeout is 5 seconds, service should transition to errored
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if("ServiceA".equals(service.getName()) && State.ERRORED.equals(newState)){
                 ServicesAErroredLatch.countDown();
             }

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelShutdownTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelShutdownTest.java
@@ -31,7 +31,7 @@ class KernelShutdownTest extends BaseITCase {
         AtomicBoolean sleeperAClosed = new AtomicBoolean(false);
         AtomicBoolean sleeperBClosed = new AtomicBoolean(false);
 
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if ("main".equals(service.getName()) && newState.isClosable()) {
                 mainClosed.set(true);
             }

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
@@ -58,7 +58,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         // GIVEN
         kernel.parseArgs("-i", getClass().getResource("single_service.yaml").toString());
         CountDownLatch mainRunning = new CountDownLatch(1);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
                 mainRunning.countDown();
             }
@@ -69,7 +69,7 @@ class ServiceConfigMergingTest extends BaseITCase {
 
         // WHEN
         CountDownLatch mainRestarted = new CountDownLatch(1);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("main") && newState.equals(State.RUNNING) && oldState
                     .equals(State.INSTALLED)) {
                 mainRestarted.countDown();
@@ -99,7 +99,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         kernel.parseArgs("-i", getClass().getResource("single_service.yaml").toString());
 
         CountDownLatch mainRunning = new CountDownLatch(1);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
                 mainRunning.countDown();
             }
@@ -112,7 +112,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         CountDownLatch newServiceStarted = new CountDownLatch(1);
 
         // Check that new_service starts and then main gets restarted
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("new_service") && newState.equals(State.RUNNING)) {
                 newServiceStarted.countDown();
             }
@@ -154,7 +154,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         kernel.parseArgs("-i", getClass().getResource("single_service.yaml").toString());
 
         CountDownLatch mainRunning = new CountDownLatch(1);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
                 mainRunning.countDown();
             }
@@ -169,7 +169,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         CountDownLatch newServiceStarted = new CountDownLatch(1);
 
         // Check that new_service2 starts, then new_service, and then main gets restarted
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("new_service2") && newState.equals(State.RUNNING)) {
                 newService2Started.countDown();
             }
@@ -247,7 +247,7 @@ class ServiceConfigMergingTest extends BaseITCase {
 
         // launch kernel
         CountDownLatch mainRunning = new CountDownLatch(1);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
                 mainRunning.countDown();
             }
@@ -273,7 +273,7 @@ class ServiceConfigMergingTest extends BaseITCase {
                 mainRestarted.set(true);
             }
         };
-        kernel.context.addGlobalStateChangeListener(listener);
+        kernel.getContext().addGlobalStateChangeListener(listener);
 
         EvergreenService main = kernel.locate("main");
         kernel.mergeInNewConfig("id", System.currentTimeMillis(), newConfig).get(60, TimeUnit.SECONDS);
@@ -295,7 +295,7 @@ class ServiceConfigMergingTest extends BaseITCase {
             stateChanged.set(true);
         };
 
-        kernel.context.addGlobalStateChangeListener(listener);
+        kernel.getContext().addGlobalStateChangeListener(listener);
 
         // THEN
         // merge in the same config the second time
@@ -308,7 +308,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         assertFalse(stateChanged.get(), "State shouldn't change in merging the same config.");
 
         // remove listener
-        kernel.context.removeGlobalStateChangeListener(listener);
+        kernel.getContext().removeGlobalStateChangeListener(listener);
     }
 
     @Test
@@ -327,7 +327,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         //wait for main to run
         assertTrue(mainRunningLatch.await(60, TimeUnit.SECONDS));
 
-        Map<Object, Object> currentConfig = new HashMap<>(kernel.config.toPOJO());
+        Map<Object, Object> currentConfig = new HashMap<>(kernel.getConfig().toPOJO());
         Map<String, Map> servicesConfig =
                 (Map<String, Map>) currentConfig.get(SERVICES_NAMESPACE_TOPIC);
 
@@ -343,7 +343,7 @@ class ServiceConfigMergingTest extends BaseITCase {
 
         Future<Void> future = kernel.mergeInNewConfig("id", System.currentTimeMillis(), currentConfig);
         AtomicBoolean isSleeperAClosed = new AtomicBoolean(false);
-        kernel.context.addGlobalStateChangeListener((service, oldState, newState) -> {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if ("sleeperA".equals(service.getName()) && newState.isClosable()) {
                 isSleeperAClosed.set(true);
             }
@@ -359,7 +359,7 @@ class ServiceConfigMergingTest extends BaseITCase {
         assertEquals(State.RUNNING, main.getState());
         assertEquals(State.RUNNING, sleeperB.getState());
         // ensuring config value for sleeperA is removed
-        assertFalse(kernel.config.findTopics(SERVICES_NAMESPACE_TOPIC).children.containsKey("sleeperA"));
+        assertFalse(kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC).children.containsKey("sleeperA"));
         // ensure kernel no longer holds a reference of sleeperA
         assertThrows(ServiceLoadException.class, () -> kernel.locate("sleeperA"));
 

--- a/src/main/java/com/aws/iot/evergreen/builtin/services/lifecycle/LifecycleIPCAgent.java
+++ b/src/main/java/com/aws/iot/evergreen/builtin/services/lifecycle/LifecycleIPCAgent.java
@@ -55,7 +55,7 @@ public class LifecycleIPCAgent implements InjectionActions {
 
     @Override
     public void postInject() {
-        kernel.context.addGlobalStateChangeListener(onServiceChange);
+        kernel.getContext().addGlobalStateChangeListener(onServiceChange);
     }
 
     /**
@@ -69,7 +69,7 @@ public class LifecycleIPCAgent implements InjectionActions {
 
         State s = State.valueOf(stateChangeRequest.getState());
         Optional<EvergreenService> service =
-                Optional.ofNullable(kernel.context.get(EvergreenService.class, context.getServiceName()));
+                Optional.ofNullable(kernel.getContext().get(EvergreenService.class, context.getServiceName()));
 
         LifecycleGenericResponse lifecycleGenericResponse = new LifecycleGenericResponse();
         if (service.isPresent()) {

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeviceConfigurationHelper.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeviceConfigurationHelper.java
@@ -53,7 +53,7 @@ public class DeviceConfigurationHelper {
     private String getStringParameterFromConfig(String parameterName) {
         String paramValue = "";
         //TODO: Update when device provisioning is implemented
-        Topic childTopic = kernel.config.lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
+        Topic childTopic = kernel.getConfig().lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
                 DeploymentService.DEPLOYMENT_SERVICE_TOPICS).findLeafChild(parameterName);
         if (childTopic != null && childTopic.getOnce() != null) {
             paramValue = childTopic.getOnce().toString();

--- a/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
@@ -17,6 +17,9 @@ import com.aws.iot.evergreen.util.CommitableWriter;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.jr.ob.JSON;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -42,14 +45,26 @@ import javax.inject.Singleton;
  */
 public class Kernel {
     private static final Logger logger = LogManager.getLogger(Kernel.class);
-    public final Context context;
-    public final Configuration config;
+    @Getter
+    private final Context context;
+    @Getter
+    private final Configuration config;
 
-    public Path rootPath;
-    public Path configPath;
-    public Path clitoolPath;
-    public Path workPath;
-    public Path packageStorePath;
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private Path rootPath;
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private Path configPath;
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private Path clitoolPath;
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private Path workPath;
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private Path packageStorePath;
 
     private final KernelCommandLine kernelCommandLine;
     private final KernelLifecycle kernelLifecycle;

--- a/src/main/java/com/aws/iot/evergreen/kernel/ShellRunner.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/ShellRunner.java
@@ -41,7 +41,7 @@ public interface ShellRunner {
                             .kv("stderr", ss).log();
                 }).setenv("SVCUID",
                         String.valueOf(onBehalfOf.getServiceConfig().findLeafChild(SERVICE_UNIQUE_ID_KEY).getOnce()))
-                        .cd(config.workPath.toFile());
+                        .cd(config.getWorkPath().toFile());
             }
             return null;
         }

--- a/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -68,14 +68,14 @@ public class DependencyResolverBenchmark {
             // For now, hardcode to be under root of kernel package
 
             // initialize packageStore, dependencyResolver, and kernelConfigResolver
-            PackageStore packageStore = new PackageStore(kernel.packageStorePath, new GreengrassPackageServiceHelper(),
+            PackageStore packageStore = new PackageStore(kernel.getPackageStorePath(), new GreengrassPackageServiceHelper(),
                     new GreengrassRepositoryDownloader(), Executors.newSingleThreadExecutor(), kernel);
 
             Path localStoreContentPath = Paths.get(System.getProperty("user.dir"))
                     .resolve("src/test/evergreen-kernel-benchmark/mock_artifact_source");
 
             // pre-load contents to package store
-            copyFolderRecursively(localStoreContentPath, kernel.packageStorePath);
+            copyFolderRecursively(localStoreContentPath, kernel.getPackageStorePath());
 
             resolver = new DependencyResolver(packageStore, kernel);
         }

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
@@ -110,7 +110,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
         @Test
         public void GIVEN_deployment_service_running_WHEN_connection_resumed_THEN_subscriptions_redone()
                 throws Exception {
-            deploymentService.setExecutorService(mockKernel.context.get(ExecutorService.class));
+            deploymentService.setExecutorService(mockKernel.getContext().get(ExecutorService.class));
             verify(mockIotJobsHelper).connect();
             MqttClientConnectionEvents callbacks = deploymentService.callbacks;
             callbacks.onConnectionResumed(true);
@@ -128,7 +128,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
         @BeforeEach
         public void setup() throws Exception {
             Topics processedDeploymentsTopics =
-                    mockKernel.config.lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
+                    mockKernel.getConfig().lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
                             DeploymentService.DEPLOYMENT_SERVICE_TOPICS,
                             DeploymentService.PROCESSED_DEPLOYMENTS_TOPICS);
             when(config.createInteriorChild(eq(DeploymentService.PROCESSED_DEPLOYMENTS_TOPICS)))
@@ -206,18 +206,18 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
                 MqttClientConnectionEvents callbacks = deploymentService.callbacks;
 
                 callbacks.onConnectionInterrupted(1);
-                Topics processedDeployments = mockKernel.config.lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
+                Topics processedDeployments = mockKernel.getConfig().lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
                         DeploymentService.DEPLOYMENT_SERVICE_TOPICS, DeploymentService.PROCESSED_DEPLOYMENTS_TOPICS);
                 assertEquals(1, processedDeployments.size());
 
                 //Using actual executor service for running the method in a separate thread
-                deploymentService.setExecutorService(mockKernel.context.get(ExecutorService.class));
+                deploymentService.setExecutorService(mockKernel.getContext().get(ExecutorService.class));
                 callbacks.onConnectionResumed(true);
                 //Wait for job statuses to be updated
                 Thread.sleep(Duration.ofSeconds(1).toMillis());
                 mockIotJobsHelperInOrder.verify(mockIotJobsHelper, times(2))
                         .updateJobStatus(eq(TEST_JOB_ID_1), eq(JobStatus.SUCCEEDED),  any());
-                processedDeployments = mockKernel.config.lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
+                processedDeployments = mockKernel.getConfig().lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
                         DeploymentService.DEPLOYMENT_SERVICE_TOPICS, DeploymentService.PROCESSED_DEPLOYMENTS_TOPICS);
                 assertEquals(0, processedDeployments.size());
             }
@@ -230,7 +230,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
                 startDeploymentServiceInAnotherThread();
                 Thread.sleep(Duration.ofSeconds(2).toMillis());
 
-                deploymentService.setExecutorService(mockKernel.context.get(ExecutorService.class));
+                deploymentService.setExecutorService(mockKernel.getContext().get(ExecutorService.class));
                 MqttClientConnectionEvents callbacks = deploymentService.callbacks;
 
                 callbacks.onConnectionInterrupted(1);
@@ -269,7 +269,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
                 //Wait for the enough time after which deployment service would have updated the status of job
                 Thread.sleep(Duration.ofSeconds(2).toMillis());
                 //Using actual executor service for running the method in a separate thread
-                deploymentService.setExecutorService(mockKernel.context.get(ExecutorService.class));
+                deploymentService.setExecutorService(mockKernel.getContext().get(ExecutorService.class));
                 MqttClientConnectionEvents callbacks = deploymentService.callbacks;
                 callbacks.onConnectionResumed(true);
                 //Wait for main thread to update the persisted deployment statuses
@@ -286,7 +286,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
                 mockIotJobsHelperInOrder.verify(mockIotJobsHelper, times(1))
                         .updateJobStatus(eq(TEST_JOB_ID_2), eq(JobStatus.FAILED),  any());
 
-                Topics processedDeployments = mockKernel.config.lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
+                Topics processedDeployments = mockKernel.getConfig().lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC,
                         DeploymentService.DEPLOYMENT_SERVICE_TOPICS, DeploymentService.PROCESSED_DEPLOYMENTS_TOPICS);
                 assertEquals(0, processedDeployments.size());
             }

--- a/src/test/java/com/aws/iot/evergreen/kernel/KernelCommandLineTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/KernelCommandLineTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.kernel;
+
+import com.aws.iot.evergreen.config.Configuration;
+import com.aws.iot.evergreen.util.Utils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class KernelCommandLineTest {
+    public static final String TMP_NEW_ROOT = "/tmp/new_root";
+    @TempDir
+    protected Path tempRootDir;
+
+    @BeforeEach
+    void setRootDir() {
+        System.setProperty("root", tempRootDir.toAbsolutePath().toString());
+    }
+
+    @Test
+    void GIVEN_missing_parameter_to_argument_WHEN_parseArgs_THEN_throw_RuntimeException() {
+        KernelCommandLine kcl = new KernelCommandLine(mock(Kernel.class));
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> kcl.parseArgs("-i"));
+        assertThat(ex.getMessage(), is("-i or -config requires an argument"));
+    }
+
+    @Test
+    void GIVEN_invalid_command_line_argument_WHEN_parseArgs_THEN_throw_RuntimeException() {
+        KernelCommandLine kernel = new KernelCommandLine(mock(Kernel.class));
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> kernel.parseArgs("-xyznonsense", "nonsense"));
+        assertTrue(thrown.getMessage().contains("Undefined command line argument"));
+    }
+
+    @Test
+    void GIVEN_create_path_fail_WHEN_parseArgs_THEN_throw_RuntimeException() throws Exception {
+        // Make the root path not writeable so the create path method will fail
+        Files.setPosixFilePermissions(tempRootDir, PosixFilePermissions.fromString("r-x------"));
+
+        Kernel kernel = new Kernel();
+        RuntimeException thrown = assertThrows(RuntimeException.class, kernel::parseArgs);
+        assertTrue(thrown.getMessage().contains("Cannot create all required directories"));
+    }
+
+    @Test
+    void GIVEN_unable_to_read_config_WHEN_parseArgs_THEN_throw_RuntimeException() throws IOException {
+        Kernel mockKernel = mock(Kernel.class);
+        Configuration mockConfig = mock(Configuration.class);
+        when(mockKernel.getConfig()).thenReturn(mockConfig);
+        when(mockConfig.read(anyString())).thenThrow(IOException.class);
+
+        KernelCommandLine kcl = new KernelCommandLine(mockKernel);
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> kcl.parseArgs("-i", "test.yaml"));
+        assertThat(ex.getMessage(), is("Can't read the config file test.yaml"));
+    }
+
+    @Test
+    void GIVEN_root_argument_THEN_default_root_is_overridden() {
+        Kernel kernel = new Kernel();
+
+        Path newDir = tempRootDir.resolve("new/under/dir");
+        kernel.parseArgs("-r", newDir.toString());
+        assertEquals(newDir.toString(), kernel.getConfig().find("system", "rootpath").getOnce());
+    }
+
+    @Test
+    void GIVEN_kernel_WHEN_deTilde_THEN_proper_path_is_returned() {
+        Kernel mockKernel = mock(Kernel.class);
+        when(mockKernel.getClitoolPath()).thenReturn(tempRootDir.resolve("bin"));
+        when(mockKernel.getConfigPath()).thenReturn(tempRootDir.resolve("config"));
+        when(mockKernel.getPackageStorePath()).thenReturn(tempRootDir.resolve("packages"));
+        when(mockKernel.getRootPath()).thenReturn(tempRootDir.resolve("root"));
+
+        KernelCommandLine kcl = new KernelCommandLine(mockKernel);
+
+        assertThat(kcl.deTilde("~/test"), containsString(System.getProperty("user.name")+ "/test"));
+        assertThat(kcl.deTilde("~bin/test"), is(tempRootDir.toString()+ "/bin/test"));
+        assertThat(kcl.deTilde("~config/test"), is(tempRootDir.toString()+ "/config/test"));
+        assertThat(kcl.deTilde("~packages/test"), is(tempRootDir.toString()+ "/packages/test"));
+        assertThat(kcl.deTilde("~root/test"), is(tempRootDir.toString()+ "/root/test"));
+    }
+
+    @Test
+    void GIVEN_resource_to_install_WHEN_installCliTool_THEN_resource_is_copied_to_bin() throws IOException {
+        Kernel mockKernel = mock(Kernel.class);
+        when(mockKernel.getClitoolPath()).thenReturn(tempRootDir.resolve("bin"));
+
+        KernelCommandLine kcl = new KernelCommandLine(mockKernel);
+        Utils.createPaths(tempRootDir.resolve("bin"));
+        File f = tempRootDir.resolve("bin/config.yaml").toFile();
+        assertThat(f, not(anExistingFile()));
+
+        kcl.installCliTool(getClass().getResource("config.yaml"));
+        assertThat(f, anExistingFile());
+    }
+
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Requires #185. Adds tests for `KernelCommandLine` and makes `Kernel` more mockable by adding getters instead of public fields. Fixed the `installCliTool` function which was completely broken as it did not actually copy the file to the new location.


Test coverage for KernelCommandLine is now 92%+.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
