### PR TITLE
Add integration with Package Management Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,21 @@
             <version>0.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws.services</groupId>
+            <artifactId>greengrasspackagemanagement</artifactId>
+            <version>1.11.1-SNAPSHOT</version>
+        </dependency>
+        <!-- TODO: This is temporary, adding because there is some confusion about which version
+        of core should be used for the AWS SDK (2.x or 1.x). Will be removed once the pom file for
+        service SDK is updated
+        -->
+        <dependency>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <groupId>com.amazonaws</groupId>
+            <optional>false</optional>
+            <version>1.11.766</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.10</version>

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceClientFactory.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceClientFactory.java
@@ -1,0 +1,56 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+package com.aws.iot.evergreen.packagemanager;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.greengrasspackagemanagement.AWSGreengrassPackageManagement;
+import com.amazonaws.services.greengrasspackagemanagement.AWSGreengrassPackageManagementClientBuilder;
+import com.aws.iot.evergreen.logging.api.Logger;
+import com.aws.iot.evergreen.logging.impl.LogManager;
+import com.aws.iot.evergreen.util.Utils;
+import lombok.Getter;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Getter
+public class GreengrassPackageServiceClientFactory {
+
+    private static final Logger logger = LogManager.getLogger(GreengrassPackageServiceClientFactory.class);
+
+    private final AWSGreengrassPackageManagement pmsClient;
+
+    /**
+     * Constructor with custom endpoint/region configuration.
+     *
+     * @param greengrassServiceEndpoint String containing service endpoint
+     * @param greengrassServiceRegion String containing service region
+     */
+    @Inject
+    public GreengrassPackageServiceClientFactory(
+            @Named("greengrassServiceEndpoint") String greengrassServiceEndpoint,
+            @Named("greengrassServiceRegion") String greengrassServiceRegion) {
+
+        if (Utils.isEmpty(greengrassServiceEndpoint) || Utils.isEmpty(greengrassServiceRegion)) {
+            // Initialize default client, client builder determines endpoint configuration
+            // Will try to use default credential provider and environment region configuration
+            logger.atInfo("initialize-pms-client")
+                  .addKeyValue("service-endpoint", "default")
+                  .addKeyValue("service-region", "default")
+                  .log();
+            this.pmsClient = AWSGreengrassPackageManagementClientBuilder.defaultClient();
+        } else {
+            AWSGreengrassPackageManagementClientBuilder clientBuilder
+                    = AWSGreengrassPackageManagementClientBuilder.standard();
+            logger.atInfo("initialize-pms-client")
+                  .addKeyValue("service-endpoint", greengrassServiceEndpoint)
+                  .addKeyValue("service-region", greengrassServiceRegion)
+                  .log();
+            clientBuilder.withEndpointConfiguration(
+                    new AwsClientBuilder.EndpointConfiguration(greengrassServiceEndpoint, greengrassServiceRegion));
+            this.pmsClient = clientBuilder.build();
+        }
+        // TODO: Might need to retrieve AWS credentials from custom credential provider
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
@@ -1,15 +1,73 @@
 package com.aws.iot.evergreen.packagemanager;
 
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.greengrasspackagemanagement.AWSGreengrassPackageManagement;
+import com.amazonaws.services.greengrasspackagemanagement.model.GetPackageRequest;
+import com.amazonaws.services.greengrasspackagemanagement.model.GetPackageResult;
+import com.amazonaws.services.greengrasspackagemanagement.model.RecipeFormatType;
+import com.aws.iot.evergreen.logging.api.Logger;
+import com.aws.iot.evergreen.logging.impl.LogManager;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackageLoadingException;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
+import com.aws.iot.evergreen.util.SerializerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import javax.inject.Inject;
 
 public class GreengrassPackageServiceHelper {
 
-    //TODO connect to cloud service
-    @SuppressWarnings({"PMD.UnusedLocalVariable"})
-    PackageRecipe downloadPackageRecipe(PackageIdentifier packageIdentifier) throws PackageDownloadException {
-        // TODO: to be implemented.
-        return null;
+    private static String PACKAGE_RECIPE_PARSING_EXCEPTION_FMT = "Error parsing downloaded recipe for package %s";
+    private static String PACKAGE_RECIPE_DOWNLOAD_EXCEPTION_FMT = "Error downloading recipe for package %s";
+
+    private static final ObjectMapper RECIPE_SERIALIZER = SerializerFactory.getRecipeSerializer();
+
+    // Service logger instance
+    protected final Logger logger = LogManager.getLogger(GreengrassPackageServiceHelper.class);
+
+    private final AWSGreengrassPackageManagement evgPmsClient;
+
+    @Inject
+    public GreengrassPackageServiceHelper(GreengrassPackageServiceClientFactory clientFactory) {
+        this.evgPmsClient = clientFactory.getPmsClient();
+    }
+
+    PackageRecipe downloadPackageRecipe(PackageIdentifier packageIdentifier)
+            throws PackageDownloadException, PackageLoadingException {
+        GetPackageRequest getPackageRequest =
+                new GetPackageRequest().withPackageARN(packageIdentifier.getArn())
+                                       .withType(RecipeFormatType.YAML);
+
+        GetPackageResult getPackageResult;
+        try {
+            getPackageResult = evgPmsClient.getPackage(getPackageRequest);
+        } catch (AmazonClientException e) {
+            // TODO: This should be expanded to handle various types of retryable/non-retryable exceptions
+            String errorMsg = String.format(PACKAGE_RECIPE_DOWNLOAD_EXCEPTION_FMT,
+                                            packageIdentifier.getArn());
+            logger.atError("download-package-from-greengrass-repo", e)
+                  .addKeyValue("packageIdentifier", packageIdentifier)
+                  .addKeyValue("errorMessage", errorMsg)
+                  .log();
+            throw new PackageDownloadException(errorMsg, e);
+        }
+
+        try {
+            ByteBuffer recipeBuf = getPackageResult.getRecipe();
+            return RECIPE_SERIALIZER.readValue(new ByteBufferBackedInputStream(recipeBuf),
+                                               PackageRecipe.class);
+        } catch (IOException e) {
+            String errorMsg = String.format(PACKAGE_RECIPE_PARSING_EXCEPTION_FMT,
+                                            packageIdentifier.getArn());
+            logger.atError("download-package-from-greengrass-repo", e)
+                  .addKeyValue("packageIdentifier", packageIdentifier)
+                  .addKeyValue("errorMessage", errorMsg)
+                  .log();
+            throw new PackageLoadingException(errorMsg, e);
+        }
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/plugins/ArtifactDownloader.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/plugins/ArtifactDownloader.java
@@ -1,5 +1,6 @@
 package com.aws.iot.evergreen.packagemanager.plugins;
 
+import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 
 import java.io.IOException;
@@ -9,5 +10,5 @@ import java.nio.file.Path;
 public interface ArtifactDownloader {
 
     void downloadToPath(PackageIdentifier packageIdentifier, URI artifactUri, Path saveToPath)
-            throws IOException;
+            throws IOException, PackageDownloadException;
 }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloader.java
@@ -1,7 +1,14 @@
 package com.aws.iot.evergreen.packagemanager.plugins;
 
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.greengrasspackagemanagement.AWSGreengrassPackageManagement;
+import com.amazonaws.services.greengrasspackagemanagement.model.GetArtifactRequest;
+import com.amazonaws.services.greengrasspackagemanagement.model.GetArtifactResult;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.logging.impl.LogManager;
+import com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceClientFactory;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 
 import java.io.IOException;
@@ -12,22 +19,35 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import javax.inject.Inject;
 
 public class GreengrassRepositoryDownloader implements ArtifactDownloader {
     private static final Logger logger = LogManager.getLogger(GreengrassRepositoryDownloader.class);
     private static final String CONTENT_DISPOSITION = "Content-Disposition";
+    private static final String HTTP_HEADER_LOCATION = "Location";
+    private static final String ARTIFACT_DOWNLOAD_EXCEPTION_PMS_FMT
+            = "Failed to download artifact %s for package %s, http response from server was %d";
 
-    @SuppressWarnings({"PMD.AssignmentInOperand", "AvoidFileStream"})
+    private final AWSGreengrassPackageManagement evgPmsClient;
+
+    @Inject
+    public GreengrassRepositoryDownloader(GreengrassPackageServiceClientFactory clientFactory) {
+        this.evgPmsClient = clientFactory.getPmsClient();
+    }
+
     @Override
     public void downloadToPath(PackageIdentifier packageIdentifier, URI artifactUri, Path saveToPath)
-            throws IOException {
+            throws IOException, PackageDownloadException {
         logger.atInfo().setEventType("download-artifact-from-greengrass-repo")
                 .addKeyValue("packageIdentifier", packageIdentifier).addKeyValue("artifactUri", artifactUri).log();
-        String preSignedUrl = getArtifactDownloadURL(packageIdentifier.getArn(), artifactUri.getSchemeSpecificPart());
+
+        String preSignedUrl = getArtifactDownloadURL(packageIdentifier.getArn(),
+                                                     artifactUri.getSchemeSpecificPart());
         URL url = new URL(preSignedUrl);
-        HttpURLConnection httpConn = null;
+        HttpURLConnection httpConn = connect(url);
+
         try {
-            httpConn = connect(url);
             int responseCode = httpConn.getResponseCode();
 
             if (responseCode == HttpURLConnection.HTTP_OK) {
@@ -50,9 +70,45 @@ public class GreengrassRepositoryDownloader implements ArtifactDownloader {
         return (HttpURLConnection) url.openConnection();
     }
 
-    String getArtifactDownloadURL(String packageArn, String artifactName) {
-        //TODO retrieve artifact presigned download URL from cloud as redirection
-        return "placeholder";
+    String getArtifactDownloadURL(String packageArn, String artifactName) throws PackageDownloadException {
+        GetArtifactRequest getArtifactRequest = new GetArtifactRequest().withArtifactName(artifactName)
+                                                                        .withPackageARN(packageArn);
+
+        GetArtifactResult getArtifactResult = null;
+        // TODO: This is horribly bad code, but unfortunately, the service is configured to return 302 redirect and
+        // the auto-generated SDK does NOT like that. The only way to handle this at the moment is to catch the
+        // exception for the redirect. This response code needs a revisit from the service side either to change the
+        // response code or to gracefully respond instead of throwing exception
+        try {
+            getArtifactResult = evgPmsClient.getArtifact(getArtifactRequest);
+        } catch (AmazonServiceException ase) {
+            // TODO: This should be expanded to handle various types of retryable/non-retryable exceptions
+            // Ideally service side response is fixed and this can be merged with the Client Exception handling
+            // section below
+            int responseStatus = ase.getStatusCode();
+            Map<String, String> headers = ase.getHttpHeaders();
+            if (responseStatus != HttpURLConnection.HTTP_MOVED_TEMP || !headers.containsKey(HTTP_HEADER_LOCATION)) {
+                logger.atError("download-artifact-from-greengrass-repo", ase)
+                      .addKeyValue("packageArn", packageArn)
+                      .addKeyValue("artifactName", artifactName)
+                      .addKeyValue("failureCode", responseStatus)
+                      .log();
+                throw new PackageDownloadException(String.format(ARTIFACT_DOWNLOAD_EXCEPTION_PMS_FMT,
+                                                                 packageArn, artifactName, responseStatus), ase);
+            }
+            return headers.get(HTTP_HEADER_LOCATION);
+        } catch (AmazonClientException ace) {
+            // TODO: This should be expanded to handle various types of retryable/non-retryable exceptions
+            logger.atError("download-artifact-from-greengrass-repo", ace)
+                  .addKeyValue("packageArn", packageArn)
+                  .addKeyValue("artifactName", artifactName)
+                  .log();
+            throw new PackageDownloadException(String.format(ARTIFACT_DOWNLOAD_EXCEPTION_PMS_FMT,
+                                                             packageArn, artifactName), ace);
+        }
+
+        // This should be expected behavior
+        return (getArtifactResult == null) ? null : getArtifactResult.getRedirectUrl();
     }
 
     String extractFilename(URL preSignedUrl, String contentDisposition) {

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelperTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelperTest.java
@@ -1,0 +1,68 @@
+package com.aws.iot.evergreen.packagemanager;
+
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
+import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
+
+import com.vdurmont.semver4j.Semver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+
+import com.amazonaws.services.greengrasspackagemanagement.AWSGreengrassPackageManagement;
+import com.amazonaws.services.greengrasspackagemanagement.model.GetPackageRequest;
+import com.amazonaws.services.greengrasspackagemanagement.model.GetPackageResult;
+
+@ExtendWith({MockitoExtension.class, EGExtension.class})
+class GreengrassPackageServiceHelperTest {
+
+    @Mock
+    private AWSGreengrassPackageManagement client;
+
+    @Mock
+    private GreengrassPackageServiceClientFactory clientFactory;
+
+    private GreengrassPackageServiceHelper helper;
+
+    @Captor
+    private ArgumentCaptor<GetPackageRequest> getPackageRequestArgumentCaptor;
+
+    @BeforeEach
+    void beforeEach() {
+        when(clientFactory.getPmsClient()).thenReturn(client);
+        this.helper = spy(new GreengrassPackageServiceHelper(clientFactory));
+    }
+
+    @Test
+    void GIVEN_artifact_url_WHEN_attempt_download_THEN_task_succeed() throws Exception {
+        String recipeContents =
+                TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
+        ByteBuffer testRecipeBytes = ByteBuffer.wrap(recipeContents.getBytes());
+        GetPackageResult testResult = new GetPackageResult().withRecipe(testRecipeBytes);
+        doReturn(testResult).when(client).getPackage(getPackageRequestArgumentCaptor.capture());
+        PackageRecipe testPackage =
+                helper.downloadPackageRecipe(new PackageIdentifier(TestHelper.MONITORING_SERVICE_PACKAGE_NAME,
+                                                                   new Semver("1.0.0")));
+
+        GetPackageRequest generatedRequest = getPackageRequestArgumentCaptor.getValue();
+        final String expectedArn = String.format("%s-1.0.0", TestHelper.MONITORING_SERVICE_PACKAGE_NAME);
+        assertEquals(expectedArn, generatedRequest.getPackageARN());
+        assertEquals("YAML", generatedRequest.getType());
+        assertEquals(testPackage.getPackageName(), TestHelper.MONITORING_SERVICE_PACKAGE_NAME);
+        assertTrue(testPackage.getVersion().isEqualTo("1.0.0"));
+    }
+
+    // TODO: Add test cases for failure status codes once the SDK model is updated to return proper http responses
+}

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloaderTest.java
@@ -1,13 +1,17 @@
 package com.aws.iot.evergreen.packagemanager.plugins;
 
+import com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceClientFactory;
 import com.aws.iot.evergreen.packagemanager.TestHelper;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
 import com.vdurmont.semver4j.Semver;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
@@ -17,28 +21,54 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.greengrasspackagemanagement.AWSGreengrassPackageManagement;
+import com.amazonaws.services.greengrasspackagemanagement.model.GetArtifactRequest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, EGExtension.class})
 class GreengrassRepositoryDownloaderTest {
 
-    @Spy
-    private GreengrassRepositoryDownloader downloader;
-
     @Mock
     private HttpURLConnection connection;
 
+    @Mock
+    private AWSGreengrassPackageManagement client;
+
+    @Mock
+    private GreengrassPackageServiceClientFactory clientFactory;
+
+    private GreengrassRepositoryDownloader downloader;
+
+    @Captor
+    ArgumentCaptor<GetArtifactRequest> getArtifactRequestArgumentCaptor;
+
+    @BeforeEach
+    void beforeEach() {
+        when(clientFactory.getPmsClient()).thenReturn(client);
+        this.downloader = spy(new GreengrassRepositoryDownloader(clientFactory));
+    }
+
     @Test
     void GIVEN_artifact_url_WHEN_attempt_download_THEN_task_succeed() throws Exception {
-        doReturn("https://www.amazon.com/artifact.txt").when(downloader)
-                .getArtifactDownloadURL(anyString(), anyString());
+        AmazonServiceException ase = new AmazonServiceException("Redirect");
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", "https://www.amazon.com/artifact.txt");
+        ase.setStatusCode(HttpStatus.SC_MOVED_TEMPORARILY);
+        ase.setHttpHeaders(headers);
+        when(client.getArtifact(getArtifactRequestArgumentCaptor.capture())).thenThrow(ase);
+
         doReturn(connection).when(downloader).connect(any());
         when(connection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         Path mockArtifactPath = TestHelper.getPathForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0")
@@ -49,7 +79,11 @@ class GreengrassRepositoryDownloaderTest {
         Path testCache = TestHelper.getPathForLocalTestCache();
         Path saveToPath = testCache.resolve("CoolService").resolve("1.0.0");
         Files.createDirectories(saveToPath);
-        downloader.downloadToPath(pkgId, new URI("greengrass:binary"), saveToPath);
+        downloader.downloadToPath(pkgId, new URI("greengrass:artifactName"), saveToPath);
+
+        GetArtifactRequest generatedRequest = getArtifactRequestArgumentCaptor.getValue();
+        assertEquals("CoolServiceARN", generatedRequest.getPackageARN());
+        assertEquals("artifactName", generatedRequest.getArtifactName());
 
         byte[] originalFile = Files.readAllBytes(mockArtifactPath);
         byte[] downloadFile = Files.readAllBytes(saveToPath.resolve("artifact.txt"));
@@ -60,8 +94,13 @@ class GreengrassRepositoryDownloaderTest {
 
     @Test
     void GIVEN_http_connection_error_WHEN_attempt_download_THEN_return_exception() throws Exception {
-        doReturn("https://www.amazon.com/artifact.txt").when(downloader)
-                .getArtifactDownloadURL(anyString(), anyString());
+        AmazonServiceException ase = new AmazonServiceException("Redirect");
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", "https://www.amazon.com/artifact.txt");
+        ase.setStatusCode(HttpStatus.SC_MOVED_TEMPORARILY);
+        ase.setHttpHeaders(headers);
+        when(client.getArtifact(any())).thenThrow(ase);
+
         doReturn(connection).when(downloader).connect(any());
         when(connection.getResponseCode()).thenThrow(IOException.class);
 


### PR DESCRIPTION
**Description of changes:**
- Add integration with Package Manager Service using SDK client

THINGS TO NOTE:
- Currently the SDK client uses default configuration and environment credentials. I will update that further as I try to get the integ tests to work, current plan is to pick up the endpoint and credentials from the kernel context but open to a discussion.
- The default behavior for package manager is to look in the local package store for available recipes before calling the service. If files are found locally, the package manager service is NOT called. This has implications on implementation of integ tests, if you want to use package service as source for E2E tests, you will need to upload your test artifacts to the service. An alternative method is to follow the DeploymentTaskIntegration test where the artifacts need are just copied to a local store and the call to PMS is skipped.
- The Evergreen Service SDK has been manually uploaded to the same account as distribution as the Evergreen IPC SDK

**How was this change tested:**
- Unit tested
- Integration test to follow in separate PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.