### PR TITLE
Add test failure for any logged exception

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/BaseITCase.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/BaseITCase.java
@@ -1,6 +1,7 @@
 package com.aws.iot.evergreen.integrationtests;
 
 
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -13,7 +14,7 @@ import java.nio.file.Path;
  *
  * However, individual integration test could override the setup or just set up without extending this.
  */
-public class BaseITCase {
+public class BaseITCase extends ExceptionLogProtector {
 
     @TempDir
     protected Path tempRootDir;

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -19,6 +19,7 @@ import com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceHelper;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
 import com.aws.iot.evergreen.packagemanager.PackageStore;
 import com.aws.iot.evergreen.packagemanager.plugins.GreengrassRepositoryDownloader;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
@@ -58,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class DeploymentTaskIntegrationTest {
+class DeploymentTaskIntegrationTest extends ExceptionLogProtector {
 
     private static final String TEST_CUSTOMER_APP_STRING = "Hello evergreen. This is a test";
 

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -12,6 +12,7 @@ import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
 import com.aws.iot.evergreen.integrationtests.e2e.util.Utils;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.aws.iot.evergreen.util.CommitableFile;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
@@ -51,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("E2E")
-class DeploymentE2ETest {
+class DeploymentE2ETest extends ExceptionLogProtector {
     @TempDir
     Path tempRootDir;
 
@@ -171,6 +172,8 @@ class DeploymentE2ETest {
     void GIVEN_blank_kernel_WHEN_deployment_has_conflicts_THEN_job_should_fail_and_return_error() throws Exception {
         launchKernel("blank_config.yaml");
 
+        ignoreExceptionUltimateCauseWithMessageSubstring("Conflicts in resolving package: Mosquitto");
+
         // Target our DUT for deployments
         // TODO: Eventually switch this to target using Thing Group instead of individual Thing
         String[] targets = {thing.thingArn};
@@ -201,8 +204,9 @@ class DeploymentE2ETest {
     @Test
     void GIVEN_deployment_fails_due_to_service_broken_WHEN_deploy_fix_THEN_service_run_and_job_is_successful()
             throws Exception {
-
         launchKernel("blank_config.yaml");
+
+        ignoreExceptionUltimateCauseWithMessage("Service CustomerApp in broken state after deployment");
 
         // Create first Job Doc with a faulty service (CustomerApp-0.9.0)
         String document = new ObjectMapper().writeValueAsString(

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
@@ -20,6 +20,7 @@ import com.aws.iot.evergreen.ipc.services.servicediscovery.exceptions.ResourceNo
 import com.aws.iot.evergreen.ipc.services.servicediscovery.exceptions.ResourceNotOwnedException;
 import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.aws.iot.evergreen.testcommons.testutilities.TestUtils;
 import com.aws.iot.evergreen.util.Pair;
 import org.junit.jupiter.api.AfterAll;
@@ -41,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class IPCServicesTest {
+class IPCServicesTest extends ExceptionLogProtector {
 
     @TempDir
     static Path tempRootDir;

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
@@ -49,6 +49,7 @@ class KernelTest extends BaseITCase {
     void GIVEN_config_missing_main_WHEN_kernel_launches_THEN_throw_RuntimeException() {
         kernel = new Kernel();
         kernel.parseArgs("-i", this.getClass().getResource("config_missing_main.yaml").toString());
+        ignoreExceptionWithMessage("Cannot load main service");
         assertThrows(RuntimeException.class, () -> kernel.launch());
     }
 

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/ServiceConfigMergingTest.java
@@ -48,7 +48,9 @@ class ServiceConfigMergingTest extends BaseITCase {
 
     @AfterEach
     void after() {
-        kernel.shutdown();
+        if (kernel != null) {
+            kernel.shutdown();
+        }
     }
 
     @Test

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -205,10 +205,11 @@ public class EvergreenService implements InjectionActions {
         e = getUltimateCause(e);
         error = e;
         logger.atError("service-errored", e).log();
-        serviceErrored();
+        reportState(State.ERRORED);
     }
 
-    public void serviceErrored() {
+    public void serviceErrored(String reason) {
+        logger.atError("service-errored").kv("reason", reason).log();
         reportState(State.ERRORED);
     }
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
@@ -423,6 +423,9 @@ public class Lifecycle {
 
         stopBackingTask();
         if (State.ERRORED.equals(getReportState().orElse(null)) || !stopSucceed) {
+            if (!stopSucceed) {
+                logger.atError("service-shutdown-error").log("Service stop timed out");
+            }
             updateStateAndBroadcast(State.ERRORED);
             // If the thread is still running, then kill it
             if (!shutdownFuture.isDone()) {

--- a/src/test/java/com/aws/iot/evergreen/config/ConfigurationTest.java
+++ b/src/test/java/com/aws/iot/evergreen/config/ConfigurationTest.java
@@ -4,6 +4,7 @@
 package com.aws.iot.evergreen.config;
 
 import com.aws.iot.evergreen.dependency.Context;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.jr.ob.JSON;
 import org.hamcrest.core.StringContains;
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({"PMD.DetachedTestCase", "PMD.UnusedLocalVariable"})
-public class ConfigurationTest {
+public class ConfigurationTest extends ExceptionLogProtector {
     final Configuration config = new Configuration(new Context());
 
     //    @Test

--- a/src/test/java/com/aws/iot/evergreen/config/PlatformResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/config/PlatformResolverTest.java
@@ -3,6 +3,7 @@
 
 package com.aws.iot.evergreen.config;
 
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -18,7 +19,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class PlatformResolverTest {
+public class PlatformResolverTest extends ExceptionLogProtector {
     ObjectMapper mapper = new ObjectMapper();
     private static Method platformResolveInternalMethod;
 

--- a/src/test/java/com/aws/iot/evergreen/dependency/LifecycleTest.java
+++ b/src/test/java/com/aws/iot/evergreen/dependency/LifecycleTest.java
@@ -5,6 +5,7 @@ package com.aws.iot.evergreen.dependency;
 
 import com.aws.iot.evergreen.config.Topics;
 import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -25,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings({"PMD.CloseResource", "PMD.NonStaticInitializer"})
-public class LifecycleTest {
+public class LifecycleTest extends ExceptionLogProtector {
     static int seq;
     static CountDownLatch cd;
 

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
@@ -13,6 +13,7 @@ import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
 import com.aws.iot.evergreen.packagemanager.PackageStore;
 import com.aws.iot.evergreen.testcommons.testutilities.EGServiceTestUtil;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -52,6 +53,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
 
     private static final String TEST_JOB_ID_1 = "TEST_JOB_1";
     private static final String TEST_JOB_ID_2 = "TEST_JOB_2";
+    private static final String CONNECTION_ERROR = "Connection error";
 
     @Mock
     IotJobsHelper mockIotJobsHelper;
@@ -89,7 +91,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
     }
 
     @Nested
-    public class ServiceStartup {
+    public class ServiceStartup extends ExceptionLogProtector {
 
         @BeforeEach
         public void startService() throws Exception {
@@ -121,7 +123,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
     }
 
     @Nested
-    class DeploymentInProgress {
+    class DeploymentInProgress extends ExceptionLogProtector {
 
         CompletableFuture<Void> mockFuture = new CompletableFuture<>();
 
@@ -178,7 +180,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
         }
 
         @Nested
-        public class MqttConnectionBreaks {
+        public class MqttConnectionBreaks extends ExceptionLogProtector {
 
             ArgumentCaptor<MqttClientConnectionEvents> mqttEventCaptor;
 
@@ -192,8 +194,8 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
             public void GIVEN_deployment_job_WHEN_mqtt_breaks_on_success_job_update_THEN_persist_deployment_update_later()
                     throws Exception {
                 when(mockExecutorService.submit(any(DeploymentTask.class))).thenReturn(mockFuture);
-                ignoreExceptionUltimateCauseWithMessage("Connection error");
-                ExecutionException e = new ExecutionException(new MqttException("Connection error"));
+                ignoreExceptionUltimateCauseWithMessage(CONNECTION_ERROR);
+                ExecutionException e = new ExecutionException(new MqttException(CONNECTION_ERROR));
                 doNothing().when(mockIotJobsHelper).updateJobStatus(eq(TEST_JOB_ID_1), eq(JobStatus.IN_PROGRESS),
                         any());
                 doThrow(e).doNothing().when(mockIotJobsHelper)
@@ -250,8 +252,8 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
                 Throwable t = new NonRetryableDeploymentTaskFailureException(null);
                 mockFutureWitException.completeExceptionally(t);
                 doReturn(mockFuture, mockFutureWitException).when(mockExecutorService).submit(any(DeploymentTask.class));
-                ignoreExceptionUltimateCauseWithMessage("Connection error");
-                ExecutionException executionException = new ExecutionException(new MqttException("Connection error"));
+                ignoreExceptionUltimateCauseWithMessage(CONNECTION_ERROR);
+                ExecutionException executionException = new ExecutionException(new MqttException(CONNECTION_ERROR));
                 doNothing().when(mockIotJobsHelper).updateJobStatus(eq(TEST_JOB_ID_1), eq(JobStatus.IN_PROGRESS),
                         any());
                 doNothing().when(mockIotJobsHelper).updateJobStatus(eq(TEST_JOB_ID_2), eq(JobStatus.IN_PROGRESS),

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentTaskTest.java
@@ -12,6 +12,7 @@ import com.aws.iot.evergreen.packagemanager.PackageStore;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageLoadingException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class DeploymentTaskTest {
+class DeploymentTaskTest extends ExceptionLogProtector {
     @Mock
     private DependencyResolver mockDependencyResolver;
     @Mock

--- a/src/test/java/com/aws/iot/evergreen/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/IotJobsHelperTest.java
@@ -5,6 +5,7 @@ package com.aws.iot.evergreen.deployment;
 
 import com.aws.iot.evergreen.deployment.model.Deployment;
 import com.aws.iot.evergreen.deployment.model.DeviceConfiguration;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class IotJobsHelperTest {
+public class IotJobsHelperTest extends ExceptionLogProtector {
 
     private static final String TEST_THING_NAME = "TEST_THING";
     private static final String TEST_JOB_ID = "TestJobId";

--- a/src/test/java/com/aws/iot/evergreen/ipc/AuthHandlerTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/AuthHandlerTest.java
@@ -13,6 +13,7 @@ import com.aws.iot.evergreen.ipc.services.auth.AuthResponse;
 import com.aws.iot.evergreen.ipc.services.common.ApplicationMessage;
 import com.aws.iot.evergreen.ipc.services.common.IPCUtil;
 import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -50,7 +51,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class AuthHandlerTest {
+class AuthHandlerTest extends ExceptionLogProtector {
     private static final String SERVICE_NAME = "ServiceName";
 
     AuthHandler mockAuth;
@@ -68,7 +69,7 @@ class AuthHandlerTest {
     ArgumentCaptor<FrameReader.MessageFrame> frameCaptor;
 
     @BeforeEach
-    public void setupMocks() throws Exception {
+    public void setupMocks() {
         lenient().when(mockCtx.channel()).thenReturn(mockChannel);
         lenient().when(mockChannel.attr(any())).thenReturn((Attribute) mockAttr);
         lenient().doAnswer((invocation) -> mockAttrValue = invocation.getArgument(0)).when(mockAttr).set(any());
@@ -158,7 +159,9 @@ class AuthHandlerTest {
         // GIVEN
         // done in setupMocks
 
-        doThrow(new IPCClientNotAuthorizedException("No Auth!")).when(mockAuth).doAuth(any(), any());
+        IPCClientNotAuthorizedException ex = new IPCClientNotAuthorizedException("No Auth!");
+        ignoreException(ex);
+        doThrow(ex).when(mockAuth).doAuth(any(), any());
 
         // WHEN
         FrameReader.MessageFrame requestFrame =

--- a/src/test/java/com/aws/iot/evergreen/ipc/IPCChannelHandlerTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/IPCChannelHandlerTest.java
@@ -6,6 +6,7 @@ package com.aws.iot.evergreen.ipc;
 import com.aws.iot.evergreen.ipc.common.BuiltInServiceDestinationCode;
 import com.aws.iot.evergreen.ipc.common.FrameReader;
 import com.aws.iot.evergreen.ipc.exceptions.IPCException;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
@@ -36,7 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class IPCChannelHandlerTest {
+public class IPCChannelHandlerTest extends ExceptionLogProtector {
     public static final String ERROR_MESSAGE = "AAAAAAH!";
     @Mock
     AuthHandler mockAuth;

--- a/src/test/java/com/aws/iot/evergreen/ipc/IPCRouterTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/IPCRouterTest.java
@@ -4,6 +4,7 @@
 package com.aws.iot.evergreen.ipc;
 
 import com.aws.iot.evergreen.ipc.exceptions.IPCException;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -15,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
-public class IPCRouterTest {
+public class IPCRouterTest extends ExceptionLogProtector {
 
     @Test
     public void GIVEN_function_WHEN_register_callback_THEN_callback_can_be_called() throws Throwable {

--- a/src/test/java/com/aws/iot/evergreen/kernel/KernelCommandLineTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/KernelCommandLineTest.java
@@ -6,6 +6,7 @@
 package com.aws.iot.evergreen.kernel;
 
 import com.aws.iot.evergreen.config.Configuration;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.aws.iot.evergreen.util.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,14 +25,13 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class KernelCommandLineTest {
+class KernelCommandLineTest extends ExceptionLogProtector {
     @TempDir
-    protected Path tempRootDir;
+    Path tempRootDir;
 
     @BeforeEach
     void setRootDir() {
@@ -48,9 +48,11 @@ class KernelCommandLineTest {
     @Test
     void GIVEN_invalid_command_line_argument_WHEN_parseArgs_THEN_throw_RuntimeException() {
         KernelCommandLine kernel = new KernelCommandLine(mock(Kernel.class));
+        String exceptionSubstring = "Undefined command line argument";
+        ignoreExceptionWithMessageSubstring(exceptionSubstring);
         RuntimeException thrown = assertThrows(RuntimeException.class,
                 () -> kernel.parseArgs("-xyznonsense", "nonsense"));
-        assertTrue(thrown.getMessage().contains("Undefined command line argument"));
+        assertThat(thrown.getMessage(), containsString(exceptionSubstring));
     }
 
     @Test
@@ -60,8 +62,10 @@ class KernelCommandLineTest {
 
         Kernel kernel = new Kernel();
         kernel.shutdown();
+        String exceptionMessage = "Cannot create all required directories";
+        ignoreExceptionWithMessage(exceptionMessage);
         RuntimeException thrown = assertThrows(RuntimeException.class, kernel::parseArgs);
-        assertTrue(thrown.getMessage().contains("Cannot create all required directories"));
+        assertThat(thrown.getMessage(), is(exceptionMessage));
     }
 
     @Test
@@ -72,8 +76,10 @@ class KernelCommandLineTest {
         when(mockConfig.read(anyString())).thenThrow(IOException.class);
 
         KernelCommandLine kcl = new KernelCommandLine(mockKernel);
+        String exceptionMessage = "Can't read the config file test.yaml";
+        ignoreExceptionWithMessage(exceptionMessage);
         RuntimeException ex = assertThrows(RuntimeException.class, () -> kcl.parseArgs("-i", "test.yaml"));
-        assertThat(ex.getMessage(), is("Can't read the config file test.yaml"));
+        assertThat(ex.getMessage(), is(exceptionMessage));
     }
 
     @Test

--- a/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
@@ -11,6 +11,7 @@ import com.aws.iot.evergreen.dependency.ImplementsService;
 import com.aws.iot.evergreen.dependency.State;
 import com.aws.iot.evergreen.kernel.exceptions.InputValidationException;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-class KernelTest {
+class KernelTest extends ExceptionLogProtector {
     private static final String EXPECTED_CONFIG_OUTPUT =
             "---\n"
             + "services:\n"
@@ -192,6 +193,7 @@ class KernelTest {
             throws Exception {
         // We need to launch the kernel here as this triggers EZPlugins to search the classpath for @ImplementsService
         // it complains that there's no main, but we don't care for this test
+        ignoreExceptionUltimateCauseWithMessage("No matching definition in system model for: main");
         try {
             kernel.parseArgs().launch();
         } catch (RuntimeException ignored) {

--- a/src/test/java/com/aws/iot/evergreen/kernel/MergeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/MergeTest.java
@@ -8,6 +8,7 @@ import com.aws.iot.evergreen.dependency.Context;
 import com.aws.iot.evergreen.dependency.State;
 import com.aws.iot.evergreen.deployment.DeploymentConfigMerger;
 import com.aws.iot.evergreen.deployment.exceptions.ServiceUpdateException;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class mergeTest {
+public class MergeTest extends ExceptionLogProtector {
 
     private EvergreenService mockMainService;
     private EvergreenService mockServiceA;

--- a/src/test/java/com/aws/iot/evergreen/kernel/PeriodicityTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/PeriodicityTest.java
@@ -3,6 +3,7 @@
 
 package com.aws.iot.evergreen.kernel;
 
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -13,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author jag
  */
-public class PeriodicityTest {
+public class PeriodicityTest extends ExceptionLogProtector {
 
     @Test
     public void testSomeMethod() {

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
@@ -14,6 +14,7 @@ import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictExc
 import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageMetadata;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,7 +48,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class DependencyResolverTest {
+class DependencyResolverTest extends ExceptionLogProtector {
     @InjectMocks
     private DependencyResolver resolver;
 
@@ -66,7 +67,7 @@ class DependencyResolverTest {
     }
 
     @Nested
-    class MergeSemverRequirementsTest {
+    class MergeSemverRequirementsTest extends ExceptionLogProtector {
         @Test
         void GIVEN_list_of_version_ranges_WHEN_get_union_THEN_get_version_range() {
             List<String> constraints = new LinkedList<>();
@@ -109,7 +110,7 @@ class DependencyResolverTest {
     }
 
     @Nested
-    class ResolveDependenciesTest {
+    class ResolveDependenciesTest extends ExceptionLogProtector {
         private final Semver v1_2_0 = new Semver("1.2.0");
         private final Semver v1_1_0 = new Semver("1.1.0");
         private final Semver v1_0_0 = new Semver("1.0.0");

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolverTest.java
@@ -15,6 +15,7 @@ import com.aws.iot.evergreen.packagemanager.models.Package;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageParameter;
 import com.aws.iot.evergreen.packagemanager.models.RecipeTemplateVersion;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class KernelConfigResolverTest {
+public class KernelConfigResolverTest extends ExceptionLogProtector {
     private static final String LIFECYCLE_CONFIG_ROOT_KEY = "lifecycle";
     private static final String LIFECYCLE_INSTALL_KEY = "install";
     private static final String LIFECYCLE_RUN_KEY = "run";

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/PackageStoreTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/PackageStoreTest.java
@@ -11,6 +11,7 @@ import com.aws.iot.evergreen.packagemanager.models.Package;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageMetadata;
 import com.aws.iot.evergreen.packagemanager.plugins.GreengrassRepositoryDownloader;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +50,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class PackageStoreTest {
+class PackageStoreTest extends ExceptionLogProtector {
 
     private Path testCache;
 
@@ -181,6 +182,7 @@ class PackageStoreTest {
     void GIVEN_package_service_error_out_WHEN_request_to_prepare_package_THEN_task_error_out() throws Exception {
         PackageIdentifier pkgId = new PackageIdentifier("SomeService", new Semver("1.0.0"), "PackageARN");
         when(packageServiceHelper.downloadPackageRecipe(any())).thenThrow(PackageDownloadException.class);
+        ignoreExceptionUltimateCauseOfType(PackageDownloadException.class);
 
         Future<Void> future = packageStore.preparePackages(Collections.singletonList(pkgId));
         assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
@@ -190,7 +192,7 @@ class PackageStoreTest {
 // TODO migrate the tests above over and remove "test_packages" and "mock_artifact_source".
 @Nested
 @ExtendWith(MockitoExtension.class)
-class NewPackageStoreTest {
+class NewPackageStoreTest extends ExceptionLogProtector {
     private static final String MONITORING_SERVICE_PKG_NAME = "MonitoringService";
     private static final Semver MONITORING_SERVICE_PKG_VERSION = new Semver("1.1.0", Semver.SemverType.NPM);
     private static final PackageIdentifier MONITORING_SERVICE_PKG_ID =

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageTest.java
@@ -5,6 +5,7 @@ package com.aws.iot.evergreen.packagemanager.models;
 
 import com.aws.iot.evergreen.config.PlatformResolver;
 import com.aws.iot.evergreen.packagemanager.TestHelper;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.jupiter.api.AfterAll;
@@ -24,7 +25,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PackageTest {
+public class PackageTest extends ExceptionLogProtector {
     private static Map<String, Integer> backupRanks;
     private static Field ranksField;
 

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloaderTest.java
@@ -2,6 +2,7 @@ package com.aws.iot.evergreen.packagemanager.plugins;
 
 import com.aws.iot.evergreen.packagemanager.TestHelper;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +27,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class GreengrassRepositoryDownloaderTest {
+class GreengrassRepositoryDownloaderTest extends ExceptionLogProtector {
 
     @Spy
     private GreengrassRepositoryDownloader downloader;

--- a/src/test/java/com/aws/iot/evergreen/testcommons/testutilities/EGServiceTestUtil.java
+++ b/src/test/java/com/aws/iot/evergreen/testcommons/testutilities/EGServiceTestUtil.java
@@ -15,7 +15,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-public class EGServiceTestUtil extends TestBase {
+public class EGServiceTestUtil extends ExceptionLogProtector {
 
     public static final String STATE_TOPIC_NAME = "_State";
     protected String serviceFullName = "EvergreenServiceFullName";

--- a/src/test/java/com/aws/iot/evergreen/testcommons/testutilities/ExceptionLogProtector.java
+++ b/src/test/java/com/aws/iot/evergreen/testcommons/testutilities/ExceptionLogProtector.java
@@ -5,6 +5,7 @@
 
 package com.aws.iot.evergreen.testcommons.testutilities;
 
+import com.aws.iot.evergreen.ipc.IPCService;
 import com.aws.iot.evergreen.logging.impl.EvergreenStructuredLogMessage;
 import com.aws.iot.evergreen.logging.impl.Log4jLogEventBuilder;
 import com.aws.iot.evergreen.util.Utils;
@@ -12,16 +13,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-public class TestBase {
+@SuppressWarnings("PMD.SystemPrintln")
+public class ExceptionLogProtector {
     // Predicate which returns TRUE if the exception should be ignored as expected
-    protected Collection<Predicate<Throwable>> throwablePredicates = new LinkedList<>();
-    private List<Throwable> exceptions = new LinkedList<>();
+    protected final Collection<Predicate<Throwable>> throwablePredicates = new CopyOnWriteArraySet<>();
+    private final List<Throwable> exceptions = new CopyOnWriteArrayList<>();
     private final Consumer<EvergreenStructuredLogMessage> listener = (m) -> {
         if (m.getCause() != null) {
             boolean ignored = false;
@@ -40,6 +43,15 @@ public class TestBase {
     @BeforeEach
     protected void testBaseBefore() {
         Log4jLogEventBuilder.addGlobalListener(listener);
+
+        // Default ignores:
+
+        // Ignore IPCService being interrupted while starting which can happen if we call shutdown() too quickly
+        // after launch()
+        ignoreExceptionWithStackTraceContaining(InterruptedException.class, IPCService.class.getName() + ".listen");
+
+        // Ignore error from MQTT not being configured
+        ignoreExceptionWithMessage("[thingName cannot be empty, certificateFilePath cannot be empty, privateKeyPath cannot be empty, rootCAPath cannot be empty, clientEndpoint cannot be empty]");
     }
 
     @AfterEach
@@ -47,13 +59,8 @@ public class TestBase {
         Log4jLogEventBuilder.removeGlobalListener(listener);
         try {
             if (!exceptions.isEmpty()) {
-                if (exceptions.size() == 1) {
-                    System.err.println("1 non-ignored exception occurred during test run. Failing test");
-                    exceptions.get(0).printStackTrace(System.err);
-                    throw exceptions.get(0);
-                }
-
-                System.err.println("Multiple non-ignored exceptions occurred during test run. Failing test");
+                System.err.println((exceptions.size() == 1 ? "1" : "Multiple") +
+                        " non-ignored exceptions occurred during test run. Failing test");
                 for (Throwable ex : exceptions) {
                     ex.printStackTrace(System.err);
                 }
@@ -61,25 +68,27 @@ public class TestBase {
                 throw exceptions.get(0);
             }
         } finally {
+            // clear exceptions and predicates so that we start clean on the next run
+            // do this in the finally so that it happens after we have thrown/printed the exceptions
             exceptions.clear();
             throwablePredicates.clear();
         }
     }
 
     protected void ignoreExceptionWithMessage(String message) {
-        throwablePredicates.add((t) -> t.getMessage().equals(message));
+        throwablePredicates.add((t) -> Objects.equals(t.getMessage(), message));
     }
 
     protected void ignoreExceptionWithMessageSubstring(String substring) {
-        throwablePredicates.add((t) -> t.getMessage().contains(substring));
+        throwablePredicates.add((t) -> t.getMessage() != null && t.getMessage().contains(substring));
     }
 
     protected void ignoreExceptionUltimateCauseWithMessage(String message) {
-        throwablePredicates.add((t) -> Utils.getUltimateMessage(t).equals(message));
+        throwablePredicates.add((t) -> Objects.equals(Utils.getUltimateMessage(t), message));
     }
 
     protected void ignoreExceptionUltimateCauseWithMessageSubstring(String substring) {
-        throwablePredicates.add((t) -> Utils.getUltimateMessage(t).contains(substring));
+        throwablePredicates.add((t) -> Utils.getUltimateMessage(t) != null && Utils.getUltimateMessage(t).contains(substring));
     }
 
     protected void ignoreExceptionOfType(Class<? extends Throwable> clazz) {
@@ -88,5 +97,23 @@ public class TestBase {
 
     protected void ignoreExceptionUltimateCauseOfType(Class<? extends Throwable> clazz) {
         throwablePredicates.add((t) -> Objects.equals(Utils.getUltimateCause(t).getClass(), clazz));
+    }
+
+    protected void ignoreException(Throwable expected) {
+        throwablePredicates.add(t -> Objects.equals(expected, t));
+    }
+
+    protected void ignoreExceptionWithStackTraceContaining(Class<? extends Throwable> clazz, String trace) {
+        throwablePredicates.add(t -> {
+            if (!Objects.equals(t.getClass(), clazz)) {
+                return false;
+            }
+            for (StackTraceElement e : t.getStackTrace()) {
+                if (e.toString().contains(trace)) {
+                    return true;
+                }
+            }
+            return false;
+        });
     }
 }

--- a/src/test/java/com/aws/iot/evergreen/util/CoerceTest.java
+++ b/src/test/java/com/aws/iot/evergreen/util/CoerceTest.java
@@ -3,6 +3,7 @@
 
 package com.aws.iot.evergreen.util;
 
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.Test;
 
 import static com.aws.iot.evergreen.util.Coerce.toBoolean;
@@ -13,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CoerceTest {
+public class CoerceTest extends ExceptionLogProtector {
 
     @Test
     public void T1() {

--- a/src/test/java/com/aws/iot/evergreen/util/EZPluginsTest.java
+++ b/src/test/java/com/aws/iot/evergreen/util/EZPluginsTest.java
@@ -4,6 +4,7 @@
 package com.aws.iot.evergreen.util;
 
 import com.aws.iot.evergreen.dependency.EZPlugins;
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -12,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("PMD.AvoidCatchingThrowable")
-public class EZPluginsTest {
+public class EZPluginsTest extends ExceptionLogProtector {
     int hits;
 
     private static Throwable cause(Throwable t) {

--- a/src/test/java/com/aws/iot/evergreen/util/UtilsTest.java
+++ b/src/test/java/com/aws/iot/evergreen/util/UtilsTest.java
@@ -3,6 +3,7 @@
 
 package com.aws.iot.evergreen.util;
 
+import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.Test;
 
 import java.nio.CharBuffer;
@@ -19,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"PMD.AvoidUsingOctalValues", "PMD.MethodNamingConventions"})
-public class UtilsTest {
+public class UtilsTest extends ExceptionLogProtector {
 
     private static void testLparse1(String s, long expecting, String remaining) {
         CharBuffer cb = CharBuffer.wrap(s);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
As mentioned in our error handling meeting today, I had been thinking about something like this, so here it is. If we have any programming errors which don't trigger an exception in the main thread then this will be able to handle them, assuming that they are logged at some point.

Adds new `ExceptionLogProtector` for **all** our tests to inherit from. This class has a before and after which registers a log listener to find all log messages that have a cause set. If there is a cause set, then it checks to see if we should ignore the cause. If it is not ignored, then it is added into a list which is printed and then thrown in the after so that the test case will fail.

In working on this I found an issue with how we close the `Exec`. I believe I have fixed the issue, but I'd strongly consider using this 58K library: https://github.com/zeroturnaround/zt-exec which properly handles processes, redirecting outputs, timeouts, getting PIDs, closing the exec when the JVM exits, and works with Windows processes gracefully (when paired with https://github.com/zeroturnaround/zt-process-killer).

As a result of my fix, the `kernel.shutdown()` is now much, much faster, as previously it was timing out a lot when waiting for some processes to exit (when they had actually already exited).

**Why is this change necessary:**

**How was this change tested:**
Ran all tests locally and made required changes to make them pass with the new protection.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
