### PR TITLE
Revert minimizeJar so EG will work when run from the jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,6 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <minimizeJar>true</minimizeJar>
                             <finalName>${evergreenjar.name}</finalName>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Revert minimizeJar so EG will work when run from the jar. Minimize jar was wrongly stripping log4j classes, so just reverting this for now until we have a better packaging and testing story.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
