### PR TITLE
Modularize PackageStore and separate out from PackageManager

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentService.java
@@ -18,7 +18,7 @@ import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.util.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -68,7 +68,7 @@ public class DeploymentService extends EvergreenService {
     @Inject
     private DependencyResolver dependencyResolver;
     @Inject
-    private PackageStore packageStore;
+    private PackageManager packageManager;
     @Inject
     private KernelConfigResolver kernelConfigResolver;
     @Inject
@@ -125,18 +125,18 @@ public class DeploymentService extends EvergreenService {
      * @param executorService      Executor service coming from kernel
      * @param kernel               The evergreen kernel
      * @param dependencyResolver   {@link DependencyResolver}
-     * @param packageStore         {@link PackageStore}
+     * @param packageManager         {@link PackageManager}
      * @param kernelConfigResolver {@link KernelConfigResolver}
      */
 
     DeploymentService(Topics topics, ExecutorService executorService, Kernel kernel,
-                      DependencyResolver dependencyResolver, PackageStore packageStore,
+                      DependencyResolver dependencyResolver, PackageManager packageManager,
                       KernelConfigResolver kernelConfigResolver, IotJobsHelper iotJobsHelper) {
         super(topics);
         this.executorService = executorService;
         this.kernel = kernel;
         this.dependencyResolver = dependencyResolver;
-        this.packageStore = packageStore;
+        this.packageManager = packageManager;
         this.kernelConfigResolver = kernelConfigResolver;
         this.iotJobsHelper = iotJobsHelper;
     }
@@ -272,7 +272,7 @@ public class DeploymentService extends EvergreenService {
             return;
         }
         DeploymentTask deploymentTask =
-                new DeploymentTask(dependencyResolver, packageStore, kernelConfigResolver, kernel, logger,
+                new DeploymentTask(dependencyResolver, packageManager, kernelConfigResolver, kernel, logger,
                         deploymentDocument);
         storeDeploymentStatusInConfig(deployment.getId(), JobStatus.IN_PROGRESS, new HashMap<>());
         updateStatusOfPersistedDeployments();

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
@@ -7,7 +7,7 @@ import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
 import com.aws.iot.evergreen.packagemanager.exceptions.UnexpectedPackagingException;
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
 @AllArgsConstructor
 public class DeploymentTask implements Callable<Void> {
     private final DependencyResolver dependencyResolver;
-    private final PackageStore packageStore;
+    private final PackageManager packageManager;
     private final KernelConfigResolver kernelConfigResolver;
     private final Kernel kernel;
     private final Logger logger;
@@ -49,7 +49,7 @@ public class DeploymentTask implements Callable<Void> {
                     .resolveDependencies(deploymentDocument, rootPackages);
             // Block this without timeout because a device can be offline and it can take quite a long time
             // to download a package.
-            packageStore.preparePackages(desiredPackages).get();
+            packageManager.preparePackages(desiredPackages).get();
 
             Map<Object, Object> newConfig = kernelConfigResolver.resolve(desiredPackages, deploymentDocument,
                     rootPackages);

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -40,7 +40,7 @@ public class DependencyResolver {
     private static final String PACKAGE_NAME_KEY = "packageName";
 
     @Inject
-    private PackageStore packageStore;
+    private PackageManager packageManager;
 
     @Inject
     private Kernel kernel;
@@ -141,7 +141,7 @@ public class DependencyResolver {
 
         Requirement req = Requirement.buildNPM(mergeSemverRequirements(versionConstraints.values()));
 
-        Iterator<PackageMetadata> versionsToExplore = packageStore.listAvailablePackageMetadata(pkgName, req);
+        Iterator<PackageMetadata> versionsToExplore = packageManager.listAvailablePackageMetadata(pkgName, req);
 
         if (!versionsToExplore.hasNext()) {
             errorMessage = Optional.of(buildErrorMessage(pkgName, resolvedPackageNameToVersion,
@@ -256,7 +256,7 @@ public class DependencyResolver {
             // add active service in device but the version constraints not in the deployment document
             if (rootPackagesToResolve.contains(serviceName) && !packageNameToVersionConstraints.keySet()
                     .contains(serviceName)) {
-                Semver version = packageStore.getPackageVersionFromService(evergreenService);
+                Semver version = packageManager.getPackageVersionFromService(evergreenService);
                 packageNameToVersionConstraints.putIfAbsent(serviceName, new HashMap<>());
                 packageNameToVersionConstraints.get(serviceName).putIfAbsent(ROOT_REQUIREMENT_KEY, version.getValue());
                 logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, serviceName).addKeyValue(VERSION_KEY, version)
@@ -277,7 +277,7 @@ public class DependencyResolver {
     }
 
     private String buildErrorMessage(PackageIdentifier pkg, PackageIdentifier dependingPkg, String requirement) {
-        return String.format("Package version %s does not satisfy requirements of %s, which is: %s", pkg, dependingPkg,
+        return String.format("PackageRecipe version %s does not satisfy requirements of %s, which is: %s", pkg, dependingPkg,
                 requirement);
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
@@ -1,14 +1,14 @@
 package com.aws.iot.evergreen.packagemanager;
 
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
-import com.aws.iot.evergreen.packagemanager.models.Package;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 
 public class GreengrassPackageServiceHelper {
 
     //TODO connect to cloud service
     @SuppressWarnings({"PMD.UnusedLocalVariable"})
-    Package downloadPackageRecipe(PackageIdentifier packageIdentifier) throws PackageDownloadException {
+    PackageRecipe downloadPackageRecipe(PackageIdentifier packageIdentifier) throws PackageDownloadException {
         // TODO: to be implemented.
         return null;
     }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/PackageManager.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/PackageManager.java
@@ -1,0 +1,267 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+package com.aws.iot.evergreen.packagemanager;
+
+import com.aws.iot.evergreen.config.Topic;
+import com.aws.iot.evergreen.dependency.InjectionActions;
+import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
+import com.aws.iot.evergreen.logging.api.Logger;
+import com.aws.iot.evergreen.logging.impl.LogManager;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackageLoadingException;
+import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
+import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+import com.aws.iot.evergreen.packagemanager.models.PackageMetadata;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
+import com.aws.iot.evergreen.packagemanager.plugins.ArtifactDownloader;
+import com.aws.iot.evergreen.packagemanager.plugins.GreengrassRepositoryDownloader;
+import com.aws.iot.evergreen.util.Coerce;
+import com.aws.iot.evergreen.util.SerializerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vdurmont.semver4j.Requirement;
+import com.vdurmont.semver4j.Semver;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+@NoArgsConstructor // for dependency injection
+public class PackageManager implements InjectionActions {
+    private static final Logger logger = LogManager.getLogger(PackageManager.class);
+    private static final String GREENGRASS_SCHEME = "GREENGRASS";
+    private static final String VERSION_KEY = "version";
+    private static final String PACKAGE_NAME_KEY = "packageName";
+
+    private static final ObjectMapper OBJECT_MAPPER = SerializerFactory.getRecipeSerializer();
+
+    @Inject
+    private GreengrassRepositoryDownloader greengrassArtifactDownloader;
+
+    @Inject
+    private GreengrassPackageServiceHelper greengrassPackageServiceHelper;
+
+    @Inject
+    private ExecutorService executorService;
+
+    @Inject
+    private PackageStore packageStore;
+
+    @Inject
+    private Kernel kernel;
+
+    /**
+     * List the package metadata for available package versions that satisfy the requirement.
+     * It is ordered by the active version first if found, followed by available versions locally.
+     *
+     * @param packageName        the package name
+     * @param versionRequirement the version requirement for this package
+     * @return an iterator of PackageMetadata, with the active version first if found, followed by available versions
+     * locally.
+     * @throws PackagingException if fails when trying to list available package metadata
+     */
+    Iterator<PackageMetadata> listAvailablePackageMetadata(String packageName, Requirement versionRequirement)
+            throws PackagingException {
+        // TODO Switch to customized Iterator to enable lazy iteration
+
+        // 1. Find the version if this package is currently active with some version and it is satisfied by requirement
+        Optional<PackageMetadata> optionalActivePackageMetadata =
+                findActiveAndSatisfiedPackageMetadata(packageName, versionRequirement);
+
+        // 2. list available packages locally
+        List<PackageMetadata> packageMetadataList =
+                packageStore.listAvailablePackageMetadata(packageName, versionRequirement);
+
+        // 3. If the active satisfied version presents, set it as the head of list.
+        if (optionalActivePackageMetadata.isPresent()) {
+            PackageMetadata activePackageMetadata = optionalActivePackageMetadata.get();
+
+            logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, packageName)
+                    .addKeyValue(VERSION_KEY, activePackageMetadata.getPackageIdentifier().getVersion())
+                    .log("Found active version for dependency package and it is satisfied by the version requirement."
+                            + " Setting it as the head of the available package list.");
+
+            packageMetadataList.remove(activePackageMetadata);
+            packageMetadataList.add(0, activePackageMetadata);
+
+        }
+
+        // TODO 4. list available packages from cloud when cloud SDK is ready.
+
+        logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, packageName)
+                .addKeyValue("packageMetadataList", packageMetadataList)
+                .log("Found possible versions for dependency package");
+        return packageMetadataList.iterator();
+    }
+
+    /**
+     * Make sure all the specified packages exist in the package cache. Download them from remote repository if
+     * they don't exist.
+     *
+     * @param pkgIds a list of packages.
+     * @return a future to notify once this is finished.
+     */
+    public Future<Void> preparePackages(List<PackageIdentifier> pkgIds) {
+        return executorService.submit(() -> {
+            for (PackageIdentifier packageIdentifier : pkgIds) {
+                preparePackage(packageIdentifier);
+            }
+            return null;
+        });
+    }
+
+    private void preparePackage(PackageIdentifier packageIdentifier)
+            throws PackageLoadingException, PackageDownloadException {
+        logger.atInfo().setEventType("prepare-package-start").addKeyValue("packageIdentifier", packageIdentifier).log();
+        try {
+            PackageRecipe pkg = findRecipeDownloadIfNotExisted(packageIdentifier);
+            List<URI> artifactURIList = pkg.getArtifacts().stream().map(artifactStr -> {
+                try {
+                    return new URI(artifactStr);
+                } catch (URISyntaxException e) {
+                    String message = String.format("artifact URI %s is invalid", artifactStr);
+                    logger.atError().setCause(e).log(message);
+                    throw new RuntimeException(message, e);
+                }
+            }).collect(Collectors.toList());
+            downloadArtifactsIfNecessary(packageIdentifier, artifactURIList);
+            logger.atInfo().setEventType("prepare-package-finished").addKeyValue("packageIdentifier", packageIdentifier)
+                    .log();
+        } catch (PackageLoadingException | PackageDownloadException e) {
+            logger.atError().setCause(e).log(String.format("Failed to prepare package %s", packageIdentifier));
+            throw e;
+        }
+    }
+
+    private PackageRecipe findRecipeDownloadIfNotExisted(PackageIdentifier packageIdentifier)
+            throws PackageDownloadException, PackageLoadingException {
+        Optional<PackageRecipe> packageOptional = Optional.empty();
+        try {
+            packageOptional = packageStore.findPackageRecipe(packageIdentifier);
+        } catch (PackageLoadingException e) {
+            logger.atWarn().log(String.format("Failed to load package recipe for %s", packageIdentifier), e);
+        }
+        if (packageOptional.isPresent()) {
+            return packageOptional.get();
+        } else {
+            PackageRecipe packageRecipe = greengrassPackageServiceHelper.downloadPackageRecipe(packageIdentifier);
+            packageStore.createPackageRecipe(packageRecipe);
+            return packageRecipe;
+        }
+    }
+
+    void downloadArtifactsIfNecessary(PackageIdentifier packageIdentifier, List<URI> artifactList)
+            throws PackageLoadingException, PackageDownloadException {
+        Path packageArtifactDirectory =
+                packageStore.resolveArtifactDirectoryPath(packageIdentifier);
+        if (!Files.exists(packageArtifactDirectory) || !Files.isDirectory(packageArtifactDirectory)) {
+            try {
+                Files.createDirectories(packageArtifactDirectory);
+            } catch (IOException e) {
+                throw new PackageLoadingException(
+                        String.format("Failed to create package artifact cache directory %s", packageArtifactDirectory),
+                        e);
+            }
+        }
+
+        List<URI> artifactsNeedToDownload = determineArtifactsNeedToDownload(packageArtifactDirectory, artifactList);
+        logger.atDebug().setEventType("downloading-package-artifacts")
+                .addKeyValue("packageIdentifier", packageIdentifier)
+                .addKeyValue("artifactsNeedToDownload", artifactsNeedToDownload).log();
+
+        for (URI artifact : artifactsNeedToDownload) {
+            ArtifactDownloader downloader = selectArtifactDownloader(artifact);
+            try {
+                downloader.downloadToPath(packageIdentifier, artifact, packageArtifactDirectory);
+            } catch (IOException e) {
+                throw new PackageDownloadException(
+                        String.format("Failed to download package %s artifact %s", packageIdentifier, artifact), e);
+            }
+        }
+    }
+
+    @SuppressWarnings("PMD.UnusedFormalParameter")
+    private List<URI> determineArtifactsNeedToDownload(Path packageArtifactDirectory, List<URI> artifacts) {
+        //TODO implement proper idempotency logic to determine what artifacts need to download
+        return artifacts;
+    }
+
+    private ArtifactDownloader selectArtifactDownloader(URI artifactUri) throws PackageLoadingException {
+        String scheme = artifactUri.getScheme() == null ? null : artifactUri.getScheme().toUpperCase();
+        if (GREENGRASS_SCHEME.equals(scheme)) {
+            return greengrassArtifactDownloader;
+        }
+
+        throw new PackageLoadingException(String.format("artifact URI scheme %s is not supported yet", scheme));
+    }
+
+    /**
+     * Find the active version for a package.
+     *
+     * @param packageName the package name
+     * @return Optional of version; Empty if no active version for this package found.
+     */
+    private Optional<Semver> findActiveVersion(final String packageName) {
+        EvergreenService service;
+        try {
+            service = kernel.locate(packageName);
+        } catch (ServiceLoadException e) {
+            logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, packageName)
+                    .log("Didn't find a active service for this package running in the kernel.");
+            return Optional.empty();
+        }
+        return Optional.of(getPackageVersionFromService(service));
+    }
+
+    /**
+     * Get the package version from the active Evergreen service.
+     *
+     * @param service the active evergreen service
+     * @return the package version from the active Evergreen service
+     */
+    Semver getPackageVersionFromService(final EvergreenService service) {
+        Topic versionTopic = service.getServiceConfig().findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY);
+        //TODO handle null case
+        return new Semver(Coerce.toString(versionTopic));
+    }
+
+    /**
+     * Find the package metadata for a package if it's active version satisfies the requirement.
+     *
+     * @param packageName the package name
+     * @param requirement the version requirement
+     * @return Optional of the package metadata for the package; empty if this package doesn't have active version or
+     * the active version doesn't satisfy the requirement.
+     * @throws PackagingException if fails to find the target recipe or parse the recipe
+     */
+    private Optional<PackageMetadata> findActiveAndSatisfiedPackageMetadata(String packageName, Requirement requirement)
+            throws PackagingException {
+        Optional<Semver> activeVersionOptional = findActiveVersion(packageName);
+
+        if (!activeVersionOptional.isPresent()) {
+            return Optional.empty();
+        }
+
+        Semver activeVersion = activeVersionOptional.get();
+
+        if (!requirement.isSatisfiedBy(activeVersion)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(packageStore.getPackageMetadata(new PackageIdentifier(packageName, activeVersion)));
+    }
+
+
+}

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/PackageStore.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/PackageStore.java
@@ -3,23 +3,15 @@
 
 package com.aws.iot.evergreen.packagemanager;
 
-import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.dependency.InjectionActions;
-import com.aws.iot.evergreen.kernel.EvergreenService;
-import com.aws.iot.evergreen.kernel.Kernel;
-import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.logging.impl.LogManager;
-import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageLoadingException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
 import com.aws.iot.evergreen.packagemanager.exceptions.UnexpectedPackagingException;
-import com.aws.iot.evergreen.packagemanager.models.Package;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageMetadata;
-import com.aws.iot.evergreen.packagemanager.plugins.ArtifactDownloader;
-import com.aws.iot.evergreen.packagemanager.plugins.GreengrassRepositoryDownloader;
-import com.aws.iot.evergreen.util.Coerce;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 import com.aws.iot.evergreen.util.SerializerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vdurmont.semver4j.Requirement;
@@ -29,19 +21,13 @@ import lombok.NoArgsConstructor;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -50,9 +36,7 @@ public class PackageStore implements InjectionActions {
     private static final Logger logger = LogManager.getLogger(PackageStore.class);
     private static final String RECIPE_DIRECTORY = "recipe";
     private static final String ARTIFACT_DIRECTORY = "artifact";
-    private static final String GREENGRASS_SCHEME = "GREENGRASS";
-    private static final String VERSION_KEY = "version";
-    private static final String PACKAGE_NAME_KEY = "packageName";
+    private static final String RECIPE_FILE_NAME_FORMAT = "%s-%s.yaml";
 
     private static final ObjectMapper OBJECT_MAPPER = SerializerFactory.getRecipeSerializer();
 
@@ -61,42 +45,9 @@ public class PackageStore implements InjectionActions {
     private Path artifactDirectory;
 
     @Inject
-    private GreengrassRepositoryDownloader greengrassArtifactDownloader;
-
-    @Inject
-    private GreengrassPackageServiceHelper greengrassPackageServiceHelper;
-
-    @Inject
-    private ExecutorService executorService;
-
-    @Inject
     @Named("packageStoreDirectory")
     private Path packageStoreDirectory;
 
-    @Inject
-    private Kernel kernel;
-
-    /**
-     * PackageStore constructor.
-     *
-     * @param packageStoreDirectory directory for caching package recipes and artifacts
-     * @param packageServiceHelper  greengrass package service client helper
-     * @param artifactDownloader    artifact downloader
-     * @param executorService       executor service
-     * @param kernel                kernel
-     */
-    public PackageStore(Path packageStoreDirectory, GreengrassPackageServiceHelper packageServiceHelper,
-                        GreengrassRepositoryDownloader artifactDownloader, ExecutorService executorService,
-                        Kernel kernel) {
-        this.packageStoreDirectory = packageStoreDirectory;
-        initializeSubDirectories(packageStoreDirectory);
-        this.greengrassPackageServiceHelper = packageServiceHelper;
-        this.greengrassArtifactDownloader = artifactDownloader;
-        this.executorService = executorService;
-        this.kernel = kernel;
-    }
-
-    // Workaround using InjectionActions since constructor named pattern injection is not supported yet
     @Override
     public void postInject() {
         initializeSubDirectories(packageStoreDirectory);
@@ -123,129 +74,34 @@ public class PackageStore implements InjectionActions {
     }
 
     /**
-     * List the package metadata for available package versions that satisfy the requirement.
-     * It is ordered by the active version first if found, followed by available versions locally.
+     * Creates a package recipe in the package store on the disk.
      *
-     * @param packageName        the package name
-     * @param versionRequirement the version requirement for this package
-     * @return an iterator of PackageMetadata, with the active version first if found, followed by available versions
-     *     locally.
-     * @throws PackagingException if fails when trying to list available package metadata
-     *
+     * @param packageRecipe package recipe to be create.
+     * @throws PackageLoadingException if fails to write the package recipe to disk.
      */
-    public Iterator<PackageMetadata> listAvailablePackageMetadata(String packageName, Requirement versionRequirement)
-            throws PackagingException {
-        // TODO Switch to customized Iterator to enable lazy iteration
+    void createPackageRecipe(PackageRecipe packageRecipe) throws PackageLoadingException {
+        Path recipePath = resolveRecipePath(packageRecipe.getPackageName(), packageRecipe.getVersion());
 
-        // 1. Find the version if this package is currently active with some version and it is satisfied by requirement
-        Optional<PackageMetadata> optionalActivePackageMetadata =
-                findActiveAndSatisfiedPackageMetadata(packageName, versionRequirement);
-
-        // 2. list available packages locally
-        List<PackageMetadata> packageMetadataList =
-                listAvailablePackageMetadataFromLocal(packageName, versionRequirement);
-
-        // 3. If the active satisfied version presents, set it as the head of list.
-        if (optionalActivePackageMetadata.isPresent()) {
-            PackageMetadata activePackageMetadata = optionalActivePackageMetadata.get();
-
-            logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, packageName)
-                    .addKeyValue(VERSION_KEY, activePackageMetadata.getPackageIdentifier().getVersion())
-                    .log("Found active version for dependency package and it is satisfied by the version requirement."
-                            + " Setting it as the head of the available package list.");
-
-            packageMetadataList.remove(activePackageMetadata);
-            packageMetadataList.add(0, activePackageMetadata);
-
-        }
-
-        // TODO 4. list available packages from cloud when cloud SDK is ready.
-
-
-        logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, packageName)
-                .addKeyValue("packageMetadataList", packageMetadataList)
-                .log("Found possible versions for dependency package");
-        return packageMetadataList.iterator();
-    }
-
-    /**
-     * Make sure all the specified packages exist in the package cache. Download them from remote repository if
-     * they don't exist.
-     *
-     * @param pkgIds a list of packages.
-     * @return a future to notify once this is finished.
-     */
-    public Future<Void> preparePackages(List<PackageIdentifier> pkgIds) {
-        return executorService.submit(() -> {
-            for (PackageIdentifier packageIdentifier : pkgIds) {
-                preparePackage(packageIdentifier);
-            }
-            return null;
-        });
-    }
-
-    private void preparePackage(PackageIdentifier packageIdentifier)
-            throws PackageLoadingException, PackageDownloadException {
-        logger.atInfo().setEventType("prepare-package-start").addKeyValue("packageIdentifier", packageIdentifier).log();
         try {
-            Package pkg = findRecipeDownloadIfNotExisted(packageIdentifier);
-            List<URI> artifactURIList = pkg.getArtifacts().stream().map(artifactStr -> {
-                try {
-                    return new URI(artifactStr);
-                } catch (URISyntaxException e) {
-                    String message = String.format("artifact URI %s is invalid", artifactStr);
-                    logger.atError().setCause(e).log(message);
-                    throw new RuntimeException(message, e);
-                }
-            }).collect(Collectors.toList());
-            downloadArtifactsIfNecessary(packageIdentifier, artifactURIList);
-            logger.atInfo().setEventType("prepare-package-finished").addKeyValue("packageIdentifier", packageIdentifier)
-                    .log();
-        } catch (PackageLoadingException | PackageDownloadException e) {
-            logger.atError().setCause(e).log(String.format("Failed to prepare package %s", packageIdentifier));
-            throw e;
-        }
-    }
-
-    private Package findRecipeDownloadIfNotExisted(PackageIdentifier packageIdentifier)
-            throws PackageDownloadException, PackageLoadingException {
-        Path recipePath = resolveRecipePath(packageIdentifier.getName(), packageIdentifier.getVersion());
-        Optional<Package> packageOptional = Optional.empty();
-        try {
-            packageOptional = findPackageRecipe(recipePath);
-        } catch (PackageLoadingException e) {
-            logger.atWarn().log(String.format("Failed to load package from %s", recipePath), e);
-        }
-        if (packageOptional.isPresent()) {
-            return packageOptional.get();
-        } else {
-            Package pkg = greengrassPackageServiceHelper.downloadPackageRecipe(packageIdentifier);
-            savePackageRecipeToFile(pkg, recipePath);
-            return pkg;
+            OBJECT_MAPPER.writeValue(recipePath.toFile(), packageRecipe);
+        } catch (IOException e) {
+            // TODO refine exception
+            throw new PackageLoadingException(String.format("Failed to save package recipe to %s", recipePath), e);
         }
     }
 
     /**
-     * Get the package recipe with given package identifier.
+     * Find the target package recipe from package store on the disk.
      *
      * @param pkgId package identifier
-     * @return retrieved package recipe.
-     * @throws PackageLoadingException if fails to find the target package recipe or failed to load recipe
+     * @return Optional of package recipe; empty if not found.
+     * @throws PackageLoadingException if fails to parse the recipe file.
      */
-    public Package getPackageRecipe(PackageIdentifier pkgId) throws PackageLoadingException {
-        Optional<Package> optionalPackage = findPackageRecipe(resolveRecipePath(pkgId.getName(), pkgId.getVersion()));
+    Optional<PackageRecipe> findPackageRecipe(PackageIdentifier pkgId) throws PackageLoadingException {
+        Path recipePath = resolveRecipePath(pkgId.getName(), pkgId.getVersion());
 
-        if (!optionalPackage.isPresent()) {
-            // TODO refine exception and logs
-            throw new PackageLoadingException(
-                    String.format("The recipe for package: '%s' doesn't exist in the local package store.", pkgId));
-        }
-
-        return optionalPackage.get();
-    }
-
-    Optional<Package> findPackageRecipe(Path recipePath) throws PackageLoadingException {
         logger.atDebug().setEventType("finding-package-recipe").addKeyValue("packageRecipePath", recipePath).log();
+
         if (!Files.exists(recipePath) || !Files.isRegularFile(recipePath)) {
             return Optional.empty();
         }
@@ -258,128 +114,44 @@ public class PackageStore implements InjectionActions {
         }
 
         try {
-            return Optional.of(OBJECT_MAPPER.readValue(recipeContent, Package.class));
+            return Optional.of(OBJECT_MAPPER.readValue(recipeContent, PackageRecipe.class));
         } catch (IOException e) {
             throw new PackageLoadingException(String.format("Failed to parse package recipe at %s", recipePath), e);
         }
     }
 
-    void savePackageRecipeToFile(Package pkg, Path saveToFile) throws PackageLoadingException {
-        try {
-            OBJECT_MAPPER.writeValue(saveToFile.toFile(), pkg);
-        } catch (IOException e) {
-            throw new PackageLoadingException(String.format("Failed to save package recipe to %s", saveToFile), e);
-        }
-    }
-
-    private Path resolveRecipePath(String packageName, Semver packageVersion) {
-        return recipeDirectory.resolve(String.format("%s-%s.yaml", packageName, packageVersion.getValue()));
-    }
-
-    void downloadArtifactsIfNecessary(PackageIdentifier packageIdentifier, List<URI> artifactList)
-            throws PackageLoadingException, PackageDownloadException {
-        Path packageArtifactDirectory =
-                resolveArtifactDirectoryPath(packageIdentifier.getName(), packageIdentifier.getVersion());
-        if (!Files.exists(packageArtifactDirectory) || !Files.isDirectory(packageArtifactDirectory)) {
-            try {
-                Files.createDirectories(packageArtifactDirectory);
-            } catch (IOException e) {
-                throw new PackageLoadingException(
-                        String.format("Failed to create package artifact cache directory %s", packageArtifactDirectory),
-                        e);
-            }
-        }
-
-        List<URI> artifactsNeedToDownload = determineArtifactsNeedToDownload(packageArtifactDirectory, artifactList);
-        logger.atDebug().setEventType("downloading-package-artifacts")
-                .addKeyValue("packageIdentifier", packageIdentifier)
-                .addKeyValue("artifactsNeedToDownload", artifactsNeedToDownload).log();
-
-        for (URI artifact : artifactsNeedToDownload) {
-            ArtifactDownloader downloader = selectArtifactDownloader(artifact);
-            try {
-                downloader.downloadToPath(packageIdentifier, artifact, packageArtifactDirectory);
-            } catch (IOException e) {
-                throw new PackageDownloadException(
-                        String.format("Failed to download package %s artifact %s", packageIdentifier, artifact), e);
-            }
-        }
-    }
-
-    @SuppressWarnings("PMD.UnusedFormalParameter")
-    private List<URI> determineArtifactsNeedToDownload(Path packageArtifactDirectory, List<URI> artifacts) {
-        //TODO implement proper idempotency logic to determine what artifacts need to download
-        return artifacts;
-    }
-
-    private Path resolveArtifactDirectoryPath(String packageName, Semver packageVersion) {
-        return artifactDirectory.resolve(packageName).resolve(packageVersion.getValue());
-    }
-
-    private ArtifactDownloader selectArtifactDownloader(URI artifactUri) throws PackageLoadingException {
-        String scheme = artifactUri.getScheme() == null ? null : artifactUri.getScheme().toUpperCase();
-        if (GREENGRASS_SCHEME.equals(scheme)) {
-            return greengrassArtifactDownloader;
-        }
-
-        throw new PackageLoadingException(String.format("artifact URI scheme %s is not supported yet", scheme));
-    }
-
-
     /**
-     * Find the active version for a package.
+     * Get the package recipe from package store on the disk.
      *
-     * @param packageName the package name
-     * @return Optional of version; Empty if no active version for this package found.
+     * @param pkgId package identifier
+     * @return retrieved package recipe.
+     * @throws PackageLoadingException if fails to find the target package recipe or fails to parse the recipe file.
      */
-    private Optional<Semver> findActiveVersion(final String packageName) {
-        EvergreenService service;
-        try {
-            service = kernel.locate(packageName);
-        } catch (ServiceLoadException e) {
-            logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, packageName)
-                    .log("Didn't find a active service for this package running in the kernel.");
-            return Optional.empty();
+    PackageRecipe getPackageRecipe(PackageIdentifier pkgId) throws PackageLoadingException {
+        Optional<PackageRecipe> optionalPackage = findPackageRecipe(pkgId);
+
+        if (!optionalPackage.isPresent()) {
+            // TODO refine exception and logs
+            throw new PackageLoadingException(
+                    String.format("The recipe for package: '%s' doesn't exist in the local package store.", pkgId));
         }
-        return Optional.of(getPackageVersionFromService(service));
+
+        return optionalPackage.get();
     }
 
     /**
-     * Get the package version from the active Evergreen service.
+     * Get package metadata for given package name and version.
      *
-     * @param service the active evergreen service
-     * @return the package version from the active Evergreen service
+     * @param pkgId package id
+     * @return PackageMetadata; non-null
+     * @throws PackagingException if fails to find or parse the recipe
      */
-    Semver getPackageVersionFromService(final EvergreenService service) {
-        Topic versionTopic = service.getServiceConfig().findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY);
-        //TODO handle null case
-        return new Semver(Coerce.toString(versionTopic));
-    }
+    PackageMetadata getPackageMetadata(PackageIdentifier pkgId) throws PackagingException {
+        PackageRecipe retrievedPackageRecipe = getPackageRecipe(pkgId);
 
-    /**
-     * Find the package metadata for a package if it's active version satisfies the requirement.
-     *
-     * @param packageName the package name
-     * @param requirement the version requirement
-     * @return Optional of the package metadata for the package; empty if this package doesn't have active version or
-     *     the active version doesn't satisfy the requirement.
-     * @throws PackagingException if fails to find the target recipe or parse the recipe
-     */
-    private Optional<PackageMetadata> findActiveAndSatisfiedPackageMetadata(String packageName, Requirement requirement)
-            throws PackagingException {
-        Optional<Semver> activeVersionOptional = findActiveVersion(packageName);
-
-        if (!activeVersionOptional.isPresent()) {
-            return Optional.empty();
-        }
-
-        Semver activeVersion = activeVersionOptional.get();
-
-        if (!requirement.isSatisfiedBy(activeVersion)) {
-            return Optional.empty();
-        }
-
-        return Optional.of(getPackageMetadata(new PackageIdentifier(packageName, activeVersion)));
+        return new PackageMetadata(
+                new PackageIdentifier(retrievedPackageRecipe.getPackageName(), retrievedPackageRecipe.getVersion()),
+                retrievedPackageRecipe.getDependencies());
     }
 
     /**
@@ -390,8 +162,7 @@ public class PackageStore implements InjectionActions {
      * @return a list of PackageMetadata that satisfies the requirement.
      * @throws UnexpectedPackagingException if fails to parse version directory to Semver
      */
-    private List<PackageMetadata> listAvailablePackageMetadataFromLocal(final String packageName,
-                                                                        Requirement requirement)
+    List<PackageMetadata> listAvailablePackageMetadata(final String packageName, Requirement requirement)
             throws PackagingException {
         File[] recipeFiles = recipeDirectory.toFile().listFiles();
 
@@ -419,19 +190,19 @@ public class PackageStore implements InjectionActions {
         return packageMetadataList;
     }
 
-    /**
-     * Get package metadata for given package name and version.
-     *
-     * @param pkgId package id
-     * @return PackageMetadata; non-null
-     * @throws PackagingException if fails to find or parse the recipe
-     */
-    PackageMetadata getPackageMetadata(PackageIdentifier pkgId) throws PackagingException {
-        Package retrievedPackage = getPackageRecipe(pkgId);
 
-        return new PackageMetadata(
-                new PackageIdentifier(retrievedPackage.getPackageName(), retrievedPackage.getVersion()),
-                retrievedPackage.getDependencies());
+    /**
+     * Resolve the artifact directory path for a target package id.
+     *
+     * @param packageIdentifier packageIdentifier
+     * @return the artifact directory path for target package.
+     */
+    Path resolveArtifactDirectoryPath(PackageIdentifier packageIdentifier) {
+        return artifactDirectory.resolve(packageIdentifier.getName()).resolve(packageIdentifier.getVersion().getValue());
+    }
+
+    private Path resolveRecipePath(String packageName, Semver packageVersion) {
+        return recipeDirectory.resolve(String.format(RECIPE_FILE_NAME_FORMAT, packageName, packageVersion.getValue()));
     }
 
     private static String parsePackageNameFromFileName(String filename) {
@@ -451,14 +222,14 @@ public class PackageStore implements InjectionActions {
         String suffix = ".yaml";
         String[] packageNameAndVersionParts = filename.split(suffix)[0].split("-");
 
-        // Package name could have '-'. Pick the last part since the version is always after the package name.
+        // PackageRecipe name could have '-'. Pick the last part since the version is always after the package name.
         String versionStr = packageNameAndVersionParts[packageNameAndVersionParts.length - 1];
 
         try {
             return new Semver(versionStr);
         } catch (SemverException e) {
             throw new UnexpectedPackagingException(
-                    String.format("Package recipe file name: '%s' is corrupted!", filename), e);
+                    String.format("PackageRecipe recipe file name: '%s' is corrupted!", filename), e);
         }
     }
 

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageParameter.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageParameter.java
@@ -20,7 +20,7 @@ public class PackageParameter {
     private final ParameterType type;
 
     /**
-     * Create a Package Param object.
+     * Create a PackageRecipe Param object.
      *
      * @param name  Name of the parameter
      * @param value Default value for the parameter
@@ -34,7 +34,7 @@ public class PackageParameter {
     }
 
     /**
-     * Create a Package Param object.
+     * Create a PackageRecipe Param object.
      *
      * @param name  Name of the parameter
      * @param value Default value for the parameter

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
@@ -30,7 +30,7 @@ import java.util.Set;
 @Getter
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class Package {
+public class PackageRecipe {
 
     // TODO: Will be used for schema versioning in the future
     private final RecipeTemplateVersion recipeTemplateVersion;
@@ -60,7 +60,7 @@ public class Package {
     // TODO: clean up this field
     @Deprecated
     @JsonIgnore
-    private Set<Package> dependencyPackages;
+    private Set<PackageRecipe> dependencyPackageRecipes;
 
     /**
      * Constructor for Jackson to deserialize.
@@ -74,20 +74,20 @@ public class Package {
      * @param lifecycle             Lifecycle definitions
      * @param artifacts             Artifact definitions
      * @param dependencies          List of dependencies
-     * @param requires              Package Requires
+     * @param requires              PackageRecipe Requires
      * @throws SemverException if the semver fails to be created
      */
     @JsonCreator
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    public Package(@JsonProperty("RecipeTemplateVersion") RecipeTemplateVersion recipeTemplateVersion,
-                   @JsonProperty("PackageName") String packageName, @JsonProperty("Version") Semver version,
-                   @JsonProperty("Description") String description, @JsonProperty("Publisher") String publisher,
-                   @JsonProperty("Parameters") Set<PackageParameter> packageParameters,
-                   @JsonProperty("Lifecycle") @JsonDeserialize(
+    public PackageRecipe(@JsonProperty("RecipeTemplateVersion") RecipeTemplateVersion recipeTemplateVersion,
+                         @JsonProperty("PackageName") String packageName, @JsonProperty("Version") Semver version,
+                         @JsonProperty("Description") String description, @JsonProperty("Publisher") String publisher,
+                         @JsonProperty("Parameters") Set<PackageParameter> packageParameters,
+                         @JsonProperty("Lifecycle") @JsonDeserialize(
                            using = MapFieldDeserializer.class) Map<String, Object> lifecycle,
-                   @JsonProperty("Artifacts") List<String> artifacts, @JsonProperty("Dependencies") @JsonDeserialize(
+                         @JsonProperty("Artifacts") List<String> artifacts, @JsonProperty("Dependencies") @JsonDeserialize(
             using = MapFieldDeserializer.class) Map<String, String> dependencies,
-                   @JsonProperty("Requires") List<String> requires) {
+                         @JsonProperty("Requires") List<String> requires) {
         this.recipeTemplateVersion = recipeTemplateVersion;
         this.packageName = packageName;
         //TODO: Figure out how to do this in deserialize (only option so far seems to be custom deserializer)
@@ -100,7 +100,7 @@ public class Package {
         this.artifacts = artifacts == null ? Collections.emptyList() : artifacts;
         this.dependencies = dependencies == null ? Collections.emptyMap() : dependencies;
         this.requires = requires == null ? Collections.emptyList() : requires;
-        this.dependencyPackages = new HashSet<>();
+        this.dependencyPackageRecipes = new HashSet<>();
     }
 
     @JsonSerialize(using = SemverSerializer.class)

--- a/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/evergreen-kernel-benchmark/src/main/java/com/aws/iot/evergreen/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -11,7 +11,7 @@ import com.aws.iot.evergreen.jmh.profilers.ForcedGcMemoryProfiler;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceHelper;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.plugins.GreengrassRepositoryDownloader;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -67,8 +67,8 @@ public class DependencyResolverBenchmark {
             // TODO: Figure out if there's a better way to load resource directory in local package store
             // For now, hardcode to be under root of kernel package
 
-            // initialize packageStore, dependencyResolver, and kernelConfigResolver
-            PackageStore packageStore = new PackageStore(kernel.getPackageStorePath(), new GreengrassPackageServiceHelper(),
+            // initialize packageManager, dependencyResolver, and kernelConfigResolver
+            PackageManager packageManager = new PackageManager(kernel.getPackageStorePath(), new GreengrassPackageServiceHelper(),
                     new GreengrassRepositoryDownloader(), Executors.newSingleThreadExecutor(), kernel);
 
             Path localStoreContentPath = Paths.get(System.getProperty("user.dir"))
@@ -77,7 +77,7 @@ public class DependencyResolverBenchmark {
             // pre-load contents to package store
             copyFolderRecursively(localStoreContentPath, kernel.getPackageStorePath());
 
-            resolver = new DependencyResolver(packageStore, kernel);
+            resolver = new DependencyResolver(packageManager, kernel);
         }
 
         @TearDown(Level.Invocation)

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
@@ -11,7 +11,7 @@ import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.testcommons.testutilities.EGServiceTestUtil;
 import com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector;
 import org.junit.jupiter.api.AfterEach;
@@ -71,7 +71,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
     private DependencyResolver dependencyResolver;
 
     @Mock
-    private PackageStore packageStore;
+    private PackageManager packageManager;
 
     @Mock
     private KernelConfigResolver kernelConfigResolver;
@@ -88,7 +88,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
         //Creating the class to be tested
         deploymentService =
                 new DeploymentService(config, mockExecutorService, mockKernel,
-                        dependencyResolver, packageStore, kernelConfigResolver, mockIotJobsHelper);
+                        dependencyResolver, packageManager, kernelConfigResolver, mockIotJobsHelper);
         deploymentsQueue = new LinkedBlockingQueue<>();
         deploymentService.setDeploymentsQueue(deploymentsQueue);
     }

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
@@ -53,7 +53,7 @@ class DependencyResolverTest {
     private DependencyResolver resolver;
 
     @Mock
-    private PackageStore mockPackageStore;
+    private PackageManager mockPackageManager;
 
     @Mock
     private Kernel kernel;
@@ -150,7 +150,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -159,7 +159,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_0_0), dependenciesB1_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -169,13 +169,13 @@ class DependencyResolverTest {
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_1_0), Collections.emptyMap());
             PackageMetadata packageB2_1_2_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_2_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Arrays.asList(packageB2_1_1_0, packageB2_1_2_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_0_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_0_0).iterator());
 
             when(kernel.getMain()).thenReturn(mainService);
@@ -212,7 +212,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -221,7 +221,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_0_0), dependenciesB1_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -230,13 +230,13 @@ class DependencyResolverTest {
 
             PackageMetadata packageB2_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_1_0), dependenciesB2_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_0_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_0_0).iterator());
 
             when(kernel.getMain()).thenReturn(mainService);
@@ -253,17 +253,17 @@ class DependencyResolverTest {
             assertThat(result,
                     containsInAnyOrder(new PackageIdentifier(pkgA, v1_0_0), new PackageIdentifier(pkgB1, v1_0_0),
                             new PackageIdentifier(pkgB2, v1_1_0), new PackageIdentifier(pkgC1, v1_0_0)));
-            verify(mockPackageStore).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
+            verify(mockPackageManager).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
 
             // top-level package order: B2, A
             // refresh iterator
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_0_0).iterator());
 
             doc = new DeploymentDocument("mockJob2", Arrays.asList(pkgB2, pkgA), Arrays.asList(
@@ -271,7 +271,7 @@ class DependencyResolverTest {
                     new DeploymentPackageConfiguration(pkgB2, v1_1_0.toString(), "", new HashSet<>(),
                             new ArrayList<>())), "mockGroup1", 1L);
             result = resolver.resolveDependencies(doc, Arrays.asList(pkgB2, pkgA));
-            verify(mockPackageStore).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
+            verify(mockPackageManager).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
 
 
             assertEquals(4, result.size());
@@ -302,7 +302,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -311,7 +311,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_0_0), dependenciesB1_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -320,11 +320,11 @@ class DependencyResolverTest {
 
             PackageMetadata packageB2_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_1_0), dependenciesB2_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
-            lenient().when(mockPackageStore
+            lenient().when(mockPackageManager
                     .listAvailablePackageMetadata(eq(pkgC1), eq(Requirement.buildNPM(">1.1.0 <1.0.0"))))
                     .thenReturn(Collections.emptyIterator());
 
@@ -344,17 +344,17 @@ class DependencyResolverTest {
 
             // top-level package order: B2, A
             // refresh iterator for A B1 and B2
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_2_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_2_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), eq(Requirement.buildNPM(">1.1.0"))))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), eq(Requirement.buildNPM(">1.1.0"))))
                     .thenReturn(Collections.singletonList(packageC_1_2_0).iterator());
 
             DeploymentDocument doc2 = new DeploymentDocument("mockJob2", Arrays.asList(pkgB2, pkgA), Arrays.asList(
@@ -364,7 +364,7 @@ class DependencyResolverTest {
 
             thrown = assertThrows(PackageVersionConflictException.class,
                     () -> resolver.resolveDependencies(doc2, Arrays.asList(pkgB2, pkgA)));
-            assertEquals("Package version C1-v1.2.0 does not satisfy requirements of B1-v1.0.0, which is: <1.0.0",
+            assertEquals("PackageRecipe version C1-v1.2.0 does not satisfy requirements of B1-v1.0.0, which is: <1.0.0",
                     thrown.getMessage());
         }
 
@@ -384,7 +384,7 @@ class DependencyResolverTest {
             dependenciesA_1_x.put(pkgC1, ">=1.0.0");
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -393,7 +393,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_1_0), dependenciesB1_1_0);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -402,13 +402,13 @@ class DependencyResolverTest {
 
             PackageMetadata packageB2_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_0_0), dependenciesB2_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_1_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_1_0).iterator());
 
             when(kernel.getMain()).thenReturn(mainService);
@@ -423,7 +423,7 @@ class DependencyResolverTest {
 
 
             // B2 is currently running as as root of another group
-            when(mockPackageStore.getPackageVersionFromService(mockServiceB2)).thenReturn(v1_0_0);
+            when(mockPackageManager.getPackageVersionFromService(mockServiceB2)).thenReturn(v1_0_0);
 
             // New deployment: A, B1
             DeploymentDocument doc = new DeploymentDocument("mockJob1", Arrays.asList(pkgA, pkgB1), Arrays.asList(

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/TestHelper.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/TestHelper.java
@@ -3,7 +3,7 @@
 
 package com.aws.iot.evergreen.packagemanager;
 
-import com.aws.iot.evergreen.packagemanager.models.Package;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -63,8 +63,8 @@ public final class TestHelper {
         return rootPath.resolve(testPackageName + "-" + testPackageVersion);
     }
 
-    public static Package getPackageObject(String recipe) throws IOException {
-        return OBJECT_MAPPER.readValue(recipe, Package.class);
+    public static PackageRecipe getPackageObject(String recipe) throws IOException {
+        return OBJECT_MAPPER.readValue(recipe, PackageRecipe.class);
     }
 
     public static String getPackageRecipeForTestPackage(String testPackageName, String testPackageVersion)

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(ExceptionLogProtector.class)
-public class PackageTest {
+public class PackageRecipeTest {
     private static Map<String, Integer> backupRanks;
     private static Field ranksField;
 
@@ -57,7 +57,7 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String recipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package testPkg = TestHelper.getPackageObject(recipeContents);
+        PackageRecipe testPkg = TestHelper.getPackageObject(recipeContents);
         assertThat(testPkg.getPackageName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
         assertThat(testPkg.getVersion().getValue(), is("1.0.0"));
         assertThat(testPkg.getPublisher(), is("Me"));
@@ -87,7 +87,7 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String recipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "2.0.0");
-        Package testPkg = TestHelper.getPackageObject(recipeContents);
+        PackageRecipe testPkg = TestHelper.getPackageObject(recipeContents);
         assertThat(testPkg.getPackageName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
         assertThat(testPkg.getVersion().getValue(), is("2.0.0"));
         assertThat(testPkg.getPublisher(), is("Me"));
@@ -108,8 +108,8 @@ public class PackageTest {
         // Packages are same
         String monitorServiceRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
-        Package monitorServicePkgCopy = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkgCopy = TestHelper.getPackageObject(monitorServiceRecipeContents);
 
         assertThat(monitorServicePkgCopy, is(monitorServicePkg));
         assertThat(monitorServicePkgCopy.hashCode(), is(monitorServicePkg.hashCode()));
@@ -120,12 +120,12 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String monitorServiceRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
 
         // Same package different versions
         String monitorService11RecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.1.0");
-        Package monitorService11Pkg = TestHelper.getPackageObject(monitorService11RecipeContents);
+        PackageRecipe monitorService11Pkg = TestHelper.getPackageObject(monitorService11RecipeContents);
 
         assertThat(monitorService11Pkg, not(monitorServicePkg));
         assertThat(monitorService11Pkg.hashCode(), not(monitorServicePkg.hashCode()));
@@ -136,12 +136,12 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String monitorServiceRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
 
         // Different packages
         String conveyorBeltRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.CONVEYOR_BELT_PACKAGE_NAME, "1.0.0");
-        Package conveyorBeltPkg = TestHelper.getPackageObject(conveyorBeltRecipeContents);
+        PackageRecipe conveyorBeltPkg = TestHelper.getPackageObject(conveyorBeltRecipeContents);
 
         assertThat(conveyorBeltPkg, not(monitorServicePkg));
         assertThat(conveyorBeltPkg.hashCode(), not(monitorServicePkg.hashCode()));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This is a draft PR - because I think this is too big, even without the test.

So I'm planning to break this down into 3 smaller PRs to make our reviewers life much easier, per our action item from last retro.

1. `PackageStore` -> `PackageManager`
1. `Package` -> `PackageRecipe`
1. Adding new `PackageStore` with CRUD, file name and folder handling logic, including:
    1. createPackageRecipe
    1. findPackageRecipe
    1. getPackageRecipe
and other additional methods.

1. Change the PackageManager to use the new PackageStore. All file handling logic should now be encapsulated.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
