### PR TITLE
Rename PackageStore -> PackageManager; Rename Package -> PackageRecipe

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -16,7 +16,7 @@ import com.aws.iot.evergreen.logging.impl.Log4jLogEventBuilder;
 import com.aws.iot.evergreen.logging.impl.LogManager;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -75,7 +75,7 @@ class DeploymentTaskIntegrationTest {
     private static Logger logger;
 
     private static DependencyResolver dependencyResolver;
-    private static PackageStore packageStore;
+    private static PackageManager packageManager;
     private static KernelConfigResolver kernelConfigResolver;
 
     private DeploymentDocument sampleJobDocument;
@@ -101,7 +101,7 @@ class DeploymentTaskIntegrationTest {
         kernel.launch();
 
         // get required instances from context
-        packageStore = kernel.getContext().get(PackageStore.class);
+        packageManager = kernel.getContext().get(PackageManager.class);
         dependencyResolver = kernel.getContext().get(DependencyResolver.class);
         kernelConfigResolver = kernel.getContext().get(KernelConfigResolver.class);
 
@@ -226,7 +226,7 @@ class DeploymentTaskIntegrationTest {
         sampleJobDocument = OBJECT_MAPPER.readValue(new File(uri), DeploymentDocument.class);
         sampleJobDocument.setTimestamp(timestamp);
         DeploymentTask deploymentTask =
-                new DeploymentTask(dependencyResolver, packageStore, kernelConfigResolver, kernel, logger,
+                new DeploymentTask(dependencyResolver, packageManager, kernelConfigResolver, kernel, logger,
                         sampleJobDocument);
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         return executorService.submit(deploymentTask);

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentService.java
@@ -18,7 +18,7 @@ import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.util.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -68,7 +68,7 @@ public class DeploymentService extends EvergreenService {
     @Inject
     private DependencyResolver dependencyResolver;
     @Inject
-    private PackageStore packageStore;
+    private PackageManager packageManager;
     @Inject
     private KernelConfigResolver kernelConfigResolver;
     @Inject
@@ -125,18 +125,18 @@ public class DeploymentService extends EvergreenService {
      * @param executorService      Executor service coming from kernel
      * @param kernel               The evergreen kernel
      * @param dependencyResolver   {@link DependencyResolver}
-     * @param packageStore         {@link PackageStore}
+     * @param packageManager         {@link PackageManager}
      * @param kernelConfigResolver {@link KernelConfigResolver}
      */
 
     DeploymentService(Topics topics, ExecutorService executorService, Kernel kernel,
-                      DependencyResolver dependencyResolver, PackageStore packageStore,
+                      DependencyResolver dependencyResolver, PackageManager packageManager,
                       KernelConfigResolver kernelConfigResolver, IotJobsHelper iotJobsHelper) {
         super(topics);
         this.executorService = executorService;
         this.kernel = kernel;
         this.dependencyResolver = dependencyResolver;
-        this.packageStore = packageStore;
+        this.packageManager = packageManager;
         this.kernelConfigResolver = kernelConfigResolver;
         this.iotJobsHelper = iotJobsHelper;
     }
@@ -272,7 +272,7 @@ public class DeploymentService extends EvergreenService {
             return;
         }
         DeploymentTask deploymentTask =
-                new DeploymentTask(dependencyResolver, packageStore, kernelConfigResolver, kernel, logger,
+                new DeploymentTask(dependencyResolver, packageManager, kernelConfigResolver, kernel, logger,
                         deploymentDocument);
         storeDeploymentStatusInConfig(deployment.getId(), JobStatus.IN_PROGRESS, new HashMap<>());
         updateStatusOfPersistedDeployments();

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentTask.java
@@ -7,7 +7,7 @@ import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageVersionConflictException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackagingException;
 import com.aws.iot.evergreen.packagemanager.exceptions.UnexpectedPackagingException;
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
 @AllArgsConstructor
 public class DeploymentTask implements Callable<Void> {
     private final DependencyResolver dependencyResolver;
-    private final PackageStore packageStore;
+    private final PackageManager packageManager;
     private final KernelConfigResolver kernelConfigResolver;
     private final Kernel kernel;
     private final Logger logger;
@@ -49,7 +49,7 @@ public class DeploymentTask implements Callable<Void> {
                     .resolveDependencies(deploymentDocument, rootPackages);
             // Block this without timeout because a device can be offline and it can take quite a long time
             // to download a package.
-            packageStore.preparePackages(desiredPackages).get();
+            packageManager.preparePackages(desiredPackages).get();
 
             Map<Object, Object> newConfig = kernelConfigResolver.resolve(desiredPackages, deploymentDocument,
                     rootPackages);

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/DependencyResolver.java
@@ -40,7 +40,7 @@ public class DependencyResolver {
     private static final String PACKAGE_NAME_KEY = "packageName";
 
     @Inject
-    private PackageStore packageStore;
+    private PackageManager packageManager;
 
     @Inject
     private Kernel kernel;
@@ -141,7 +141,7 @@ public class DependencyResolver {
 
         Requirement req = Requirement.buildNPM(mergeSemverRequirements(versionConstraints.values()));
 
-        Iterator<PackageMetadata> versionsToExplore = packageStore.listAvailablePackageMetadata(pkgName, req);
+        Iterator<PackageMetadata> versionsToExplore = packageManager.listAvailablePackageMetadata(pkgName, req);
 
         if (!versionsToExplore.hasNext()) {
             errorMessage = Optional.of(buildErrorMessage(pkgName, resolvedPackageNameToVersion,
@@ -256,7 +256,7 @@ public class DependencyResolver {
             // add active service in device but the version constraints not in the deployment document
             if (rootPackagesToResolve.contains(serviceName) && !packageNameToVersionConstraints.keySet()
                     .contains(serviceName)) {
-                Semver version = packageStore.getPackageVersionFromService(evergreenService);
+                Semver version = packageManager.getPackageVersionFromService(evergreenService);
                 packageNameToVersionConstraints.putIfAbsent(serviceName, new HashMap<>());
                 packageNameToVersionConstraints.get(serviceName).putIfAbsent(ROOT_REQUIREMENT_KEY, version.getValue());
                 logger.atDebug().addKeyValue(PACKAGE_NAME_KEY, serviceName).addKeyValue(VERSION_KEY, version)

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
@@ -1,14 +1,14 @@
 package com.aws.iot.evergreen.packagemanager;
 
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
-import com.aws.iot.evergreen.packagemanager.models.Package;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 
 public class GreengrassPackageServiceHelper {
 
     //TODO connect to cloud service
     @SuppressWarnings({"PMD.UnusedLocalVariable"})
-    Package downloadPackageRecipe(PackageIdentifier packageIdentifier) throws PackageDownloadException {
+    PackageRecipe downloadPackageRecipe(PackageIdentifier packageIdentifier) throws PackageDownloadException {
         // TODO: to be implemented.
         return null;
     }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
@@ -30,7 +30,7 @@ import java.util.Set;
 @Getter
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class Package {
+public class PackageRecipe {
 
     // TODO: Will be used for schema versioning in the future
     private final RecipeTemplateVersion recipeTemplateVersion;
@@ -60,7 +60,7 @@ public class Package {
     // TODO: clean up this field
     @Deprecated
     @JsonIgnore
-    private Set<Package> dependencyPackages;
+    private Set<PackageRecipe> dependencyPackageRecipes;
 
     /**
      * Constructor for Jackson to deserialize.
@@ -79,15 +79,16 @@ public class Package {
      */
     @JsonCreator
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    public Package(@JsonProperty("RecipeTemplateVersion") RecipeTemplateVersion recipeTemplateVersion,
-                   @JsonProperty("PackageName") String packageName, @JsonProperty("Version") Semver version,
-                   @JsonProperty("Description") String description, @JsonProperty("Publisher") String publisher,
-                   @JsonProperty("Parameters") Set<PackageParameter> packageParameters,
-                   @JsonProperty("Lifecycle") @JsonDeserialize(
-                           using = MapFieldDeserializer.class) Map<String, Object> lifecycle,
-                   @JsonProperty("Artifacts") List<String> artifacts, @JsonProperty("Dependencies") @JsonDeserialize(
-            using = MapFieldDeserializer.class) Map<String, String> dependencies,
-                   @JsonProperty("Requires") List<String> requires) {
+    public PackageRecipe(@JsonProperty("RecipeTemplateVersion") RecipeTemplateVersion recipeTemplateVersion,
+                         @JsonProperty("PackageName") String packageName, @JsonProperty("Version") Semver version,
+                         @JsonProperty("Description") String description, @JsonProperty("Publisher") String publisher,
+                         @JsonProperty("Parameters") Set<PackageParameter> packageParameters,
+                         @JsonProperty("Lifecycle") @JsonDeserialize(
+                                 using = MapFieldDeserializer.class) Map<String, Object> lifecycle,
+                         @JsonProperty("Artifacts") List<String> artifacts,
+                         @JsonProperty("Dependencies") @JsonDeserialize(
+                                 using = MapFieldDeserializer.class) Map<String, String> dependencies,
+                         @JsonProperty("Requires") List<String> requires) {
         this.recipeTemplateVersion = recipeTemplateVersion;
         this.packageName = packageName;
         //TODO: Figure out how to do this in deserialize (only option so far seems to be custom deserializer)
@@ -100,7 +101,7 @@ public class Package {
         this.artifacts = artifacts == null ? Collections.emptyList() : artifacts;
         this.dependencies = dependencies == null ? Collections.emptyMap() : dependencies;
         this.requires = requires == null ? Collections.emptyList() : requires;
-        this.dependencyPackages = new HashSet<>();
+        this.dependencyPackageRecipes = new HashSet<>();
     }
 
     @JsonSerialize(using = SemverSerializer.class)

--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentServiceTest.java
@@ -13,7 +13,7 @@ import com.aws.iot.evergreen.logging.impl.EvergreenStructuredLogMessage;
 import com.aws.iot.evergreen.logging.impl.Log4jLogEventBuilder;
 import com.aws.iot.evergreen.packagemanager.DependencyResolver;
 import com.aws.iot.evergreen.packagemanager.KernelConfigResolver;
-import com.aws.iot.evergreen.packagemanager.PackageStore;
+import com.aws.iot.evergreen.packagemanager.PackageManager;
 import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
 import com.aws.iot.evergreen.testcommons.testutilities.EGServiceTestUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -77,7 +77,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
     private DependencyResolver dependencyResolver;
 
     @Mock
-    private PackageStore packageStore;
+    private PackageManager packageManager;
 
     @Mock
     private KernelConfigResolver kernelConfigResolver;
@@ -95,7 +95,7 @@ public class DeploymentServiceTest extends EGServiceTestUtil {
         // Creating the class to be tested
         deploymentService =
                 new DeploymentService(config, mockExecutorService, mockKernel,
-                        dependencyResolver, packageStore, kernelConfigResolver, mockIotJobsHelper);
+                        dependencyResolver, packageManager, kernelConfigResolver, mockIotJobsHelper);
         deploymentsQueue = new LinkedBlockingQueue<>();
         deploymentService.setDeploymentsQueue(deploymentsQueue);
     }

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/DependencyResolverTest.java
@@ -53,7 +53,7 @@ class DependencyResolverTest {
     private DependencyResolver resolver;
 
     @Mock
-    private PackageStore mockPackageStore;
+    private PackageManager mockPackageManager;
 
     @Mock
     private Kernel kernel;
@@ -150,7 +150,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -159,7 +159,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_0_0), dependenciesB1_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -169,13 +169,13 @@ class DependencyResolverTest {
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_1_0), Collections.emptyMap());
             PackageMetadata packageB2_1_2_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_2_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Arrays.asList(packageB2_1_1_0, packageB2_1_2_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_0_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_0_0).iterator());
 
             when(kernel.getMain()).thenReturn(mainService);
@@ -212,7 +212,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -221,7 +221,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_0_0), dependenciesB1_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -230,13 +230,13 @@ class DependencyResolverTest {
 
             PackageMetadata packageB2_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_1_0), dependenciesB2_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_0_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_0_0).iterator());
 
             when(kernel.getMain()).thenReturn(mainService);
@@ -253,17 +253,17 @@ class DependencyResolverTest {
             assertThat(result,
                     containsInAnyOrder(new PackageIdentifier(pkgA, v1_0_0), new PackageIdentifier(pkgB1, v1_0_0),
                             new PackageIdentifier(pkgB2, v1_1_0), new PackageIdentifier(pkgC1, v1_0_0)));
-            verify(mockPackageStore).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
+            verify(mockPackageManager).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
 
             // top-level package order: B2, A
             // refresh iterator
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_0_0).iterator());
 
             doc = new DeploymentDocument("mockJob2", Arrays.asList(pkgB2, pkgA), Arrays.asList(
@@ -271,7 +271,7 @@ class DependencyResolverTest {
                     new DeploymentPackageConfiguration(pkgB2, v1_1_0.toString(), "", new HashSet<>(),
                             new ArrayList<>())), "mockGroup1", 1L);
             result = resolver.resolveDependencies(doc, Arrays.asList(pkgB2, pkgA));
-            verify(mockPackageStore).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
+            verify(mockPackageManager).listAvailablePackageMetadata(pkgC1, Requirement.buildNPM(">=1.0.0 <1.1.0"));
 
 
             assertEquals(4, result.size());
@@ -302,7 +302,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -311,7 +311,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_0_0), dependenciesB1_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -320,11 +320,11 @@ class DependencyResolverTest {
 
             PackageMetadata packageB2_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_1_0), dependenciesB2_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
-            lenient().when(mockPackageStore
+            lenient().when(mockPackageManager
                     .listAvailablePackageMetadata(eq(pkgC1), eq(Requirement.buildNPM(">1.1.0 <1.0.0"))))
                     .thenReturn(Collections.emptyIterator());
 
@@ -344,17 +344,17 @@ class DependencyResolverTest {
 
             // top-level package order: B2, A
             // refresh iterator for A B1 and B2
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_2_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_2_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), eq(Requirement.buildNPM(">1.1.0"))))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), eq(Requirement.buildNPM(">1.1.0"))))
                     .thenReturn(Collections.singletonList(packageC_1_2_0).iterator());
 
             DeploymentDocument doc2 = new DeploymentDocument("mockJob2", Arrays.asList(pkgB2, pkgA), Arrays.asList(
@@ -384,7 +384,7 @@ class DependencyResolverTest {
             dependenciesA_1_x.put(pkgC1, ">=1.0.0");
             PackageMetadata packageA_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgA, v1_0_0), dependenciesA_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgA), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageA_1_0_0).iterator());
 
             // prepare B1
@@ -393,7 +393,7 @@ class DependencyResolverTest {
 
             PackageMetadata packageB1_1_0_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB1, v1_1_0), dependenciesB1_1_0);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB1_1_0_0).iterator());
 
             // prepare B2
@@ -402,13 +402,13 @@ class DependencyResolverTest {
 
             PackageMetadata packageB2_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgB2, v1_0_0), dependenciesB2_1_x);
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgB2), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageB2_1_1_0).iterator());
 
             // prepare C1
             PackageMetadata packageC_1_1_0 =
                     new PackageMetadata(new PackageIdentifier(pkgC1, v1_1_0), Collections.emptyMap());
-            when(mockPackageStore.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
+            when(mockPackageManager.listAvailablePackageMetadata(eq(pkgC1), Mockito.any()))
                     .thenReturn(Collections.singletonList(packageC_1_1_0).iterator());
 
             when(kernel.getMain()).thenReturn(mainService);
@@ -423,7 +423,7 @@ class DependencyResolverTest {
 
 
             // B2 is currently running as as root of another group
-            when(mockPackageStore.getPackageVersionFromService(mockServiceB2)).thenReturn(v1_0_0);
+            when(mockPackageManager.getPackageVersionFromService(mockServiceB2)).thenReturn(v1_0_0);
 
             // New deployment: A, B1
             DeploymentDocument doc = new DeploymentDocument("mockJob1", Arrays.asList(pkgA, pkgB1), Arrays.asList(

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolverTest.java
@@ -11,7 +11,7 @@ import com.aws.iot.evergreen.deployment.model.DeploymentPackageConfiguration;
 import com.aws.iot.evergreen.kernel.EvergreenService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
-import com.aws.iot.evergreen.packagemanager.models.Package;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageParameter;
 import com.aws.iot.evergreen.packagemanager.models.RecipeTemplateVersion;
@@ -55,7 +55,7 @@ public class KernelConfigResolverTest {
     @Mock
     private Kernel kernel;
     @Mock
-    private PackageStore packageStore;
+    private PackageManager packageManager;
     @Mock
     private EvergreenService mainService;
     @Mock
@@ -75,10 +75,10 @@ public class KernelConfigResolverTest {
                 new PackageIdentifier(TEST_INPUT_PACKAGE_B, new Semver("2.3", Semver.SemverType.NPM));
         List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier, dependencyPackageIdentifier);
 
-        Package rootPackage =
+        PackageRecipe rootPackageRecipe =
                 getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.singletonMap(TEST_INPUT_PACKAGE_B, "2.3"),
                         Collections.emptyMap());
-        Package dependencyPackage =
+        PackageRecipe dependencyPackageRecipe =
                 getPackage(TEST_INPUT_PACKAGE_B, "2.3", Collections.emptyMap(), Collections.emptyMap());
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig =
@@ -91,8 +91,8 @@ public class KernelConfigResolverTest {
                 .deploymentPackageConfigurationList(
                         Arrays.asList(rootPackageDeploymentConfig, dependencyPackageDeploymentConfig)).build();
 
-        when(packageStore.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackage);
-        when(packageStore.getPackageRecipe(dependencyPackageIdentifier)).thenReturn(dependencyPackage);
+        when(packageManager.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackageRecipe);
+        when(packageManager.getPackageRecipe(dependencyPackageIdentifier)).thenReturn(dependencyPackageRecipe);
         when(kernel.getMain()).thenReturn(mainService);
         when(kernel.locate(any())).thenThrow(new ServiceLoadException("Service not found"));
         when(mainService.getName()).thenReturn("main");
@@ -100,7 +100,7 @@ public class KernelConfigResolverTest {
         when(alreadyRunningService.getName()).thenReturn("IpcService");
 
         // WHEN
-        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageStore, kernel);
+        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageManager, kernel);
         Map<Object, Object> resolvedConfig =
                 kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
 
@@ -129,7 +129,7 @@ public class KernelConfigResolverTest {
                 new PackageIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2", Semver.SemverType.NPM));
         List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier);
 
-        Package rootPackage = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(), Collections.emptyMap());
+        PackageRecipe rootPackageRecipe = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(), Collections.emptyMap());
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig =
                 new DeploymentPackageConfiguration(TEST_INPUT_PACKAGE_A, "1.2", ">1.0", Collections.emptySet(),
@@ -137,7 +137,7 @@ public class KernelConfigResolverTest {
         DeploymentDocument document = DeploymentDocument.builder().rootPackages(Arrays.asList(TEST_INPUT_PACKAGE_A))
                 .deploymentPackageConfigurationList(Arrays.asList(rootPackageDeploymentConfig)).build();
 
-        when(packageStore.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackage);
+        when(packageManager.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackageRecipe);
         when(kernel.getMain()).thenReturn(mainService);
         when(kernel.locate(TEST_INPUT_PACKAGE_A)).thenReturn(alreadyRunningService);
         when(mainService.getName()).thenReturn("main");
@@ -145,7 +145,7 @@ public class KernelConfigResolverTest {
         when(alreadyRunningService.getName()).thenReturn(TEST_INPUT_PACKAGE_A);
 
         // WHEN
-        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageStore, kernel);
+        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageManager, kernel);
         Map<Object, Object> resolvedConfig =
                 kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
 
@@ -168,7 +168,7 @@ public class KernelConfigResolverTest {
                 new PackageIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2", Semver.SemverType.NPM));
         List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier);
 
-        Package rootPackage = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(),
+        PackageRecipe rootPackageRecipe = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(),
                 getSimpleParameterMap(TEST_INPUT_PACKAGE_A));
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig =
@@ -178,14 +178,14 @@ public class KernelConfigResolverTest {
         DeploymentDocument document = DeploymentDocument.builder().rootPackages(Arrays.asList(TEST_INPUT_PACKAGE_A))
                 .deploymentPackageConfigurationList(Arrays.asList(rootPackageDeploymentConfig)).build();
 
-        when(packageStore.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackage);
+        when(packageManager.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackageRecipe);
         when(kernel.getMain()).thenReturn(mainService);
         when(kernel.locate(any())).thenThrow(new ServiceLoadException("Service not found"));
         when(mainService.getName()).thenReturn("main");
         when(mainService.getDependencies()).thenReturn(Collections.emptyMap());
 
         // WHEN
-        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageStore, kernel);
+        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageManager, kernel);
         Map<Object, Object> resolvedConfig =
                 kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
 
@@ -217,7 +217,7 @@ public class KernelConfigResolverTest {
                 new PackageIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2", Semver.SemverType.NPM));
         List<PackageIdentifier> packagesToDeploy = Arrays.asList(rootPackageIdentifier);
 
-        Package rootPackage = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(),
+        PackageRecipe rootPackageRecipe = getPackage(TEST_INPUT_PACKAGE_A, "1.2", Collections.emptyMap(),
                 getSimpleParameterMap(TEST_INPUT_PACKAGE_A));
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig =
@@ -226,7 +226,7 @@ public class KernelConfigResolverTest {
         DeploymentDocument document = DeploymentDocument.builder().rootPackages(Arrays.asList(TEST_INPUT_PACKAGE_A))
                 .deploymentPackageConfigurationList(Arrays.asList(rootPackageDeploymentConfig)).build();
 
-        when(packageStore.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackage);
+        when(packageManager.getPackageRecipe(rootPackageIdentifier)).thenReturn(rootPackageRecipe);
         when(kernel.getMain()).thenReturn(mainService);
         when(kernel.locate(TEST_INPUT_PACKAGE_A)).thenReturn(alreadyRunningService);
         when(mainService.getName()).thenReturn("main");
@@ -240,7 +240,7 @@ public class KernelConfigResolverTest {
                 .thenReturn(null);
 
         // WHEN
-        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageStore, kernel);
+        KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(packageManager, kernel);
         Map<Object, Object> resolvedConfig =
                 kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
 
@@ -265,15 +265,15 @@ public class KernelConfigResolverTest {
     }
 
     // utilities for mocking input
-    private Package getPackage(String packageName, String packageVersion, Map<String, String> dependencies,
-                               Map<String, String> packageParamsWithDefaultsRaw) {
+    private PackageRecipe getPackage(String packageName, String packageVersion, Map<String, String> dependencies,
+                                     Map<String, String> packageParamsWithDefaultsRaw) {
 
         Set<PackageParameter> parameters = packageParamsWithDefaultsRaw.entrySet().stream()
                 .map(entry -> new PackageParameter(entry.getKey(), entry.getValue(), "STRING"))
                 .collect(Collectors.toSet());
 
         Semver version = new Semver(packageVersion, Semver.SemverType.NPM);
-        return new Package(RecipeTemplateVersion.JAN_25_2020, packageName, version, "Test package", "Publisher",
+        return new PackageRecipe(RecipeTemplateVersion.JAN_25_2020, packageName, version, "Test package", "Publisher",
                 parameters, getSimplePackageLifecycle(packageName), Collections.emptyList(), dependencies,
                 Collections.emptyList());
     }

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/PackageManagerTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/PackageManagerTest.java
@@ -7,7 +7,7 @@ import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageDownloadException;
 import com.aws.iot.evergreen.packagemanager.exceptions.PackageLoadingException;
-import com.aws.iot.evergreen.packagemanager.models.Package;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageMetadata;
 import com.aws.iot.evergreen.packagemanager.plugins.GreengrassRepositoryDownloader;
@@ -52,11 +52,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, EGExtension.class})
-class PackageStoreTest {
+class PackageManagerTest {
 
     private Path testCache;
 
-    private PackageStore packageStore;
+    private PackageManager packageManager;
 
     @Mock
     private GreengrassRepositoryDownloader artifactDownloader;
@@ -70,7 +70,7 @@ class PackageStoreTest {
     @BeforeEach
     void beforeEach() {
         testCache = TestHelper.getPathForLocalTestCache();
-        packageStore = new PackageStore(testCache, packageServiceHelper, artifactDownloader,
+        packageManager = new PackageManager(testCache, packageServiceHelper, artifactDownloader,
                 Executors.newSingleThreadExecutor(), kernel);
     }
 
@@ -84,8 +84,8 @@ class PackageStoreTest {
             throws Exception {
         Path recipePath = TestHelper.getPathForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.1.0")
                 .resolve("recipe.yaml");
-        Optional<Package> pkg = packageStore.findPackageRecipe(recipePath);
-        assertThat(pkg.isPresent(), is(true));
+        Optional<PackageRecipe> packageRecipe = packageManager.findPackageRecipe(recipePath);
+        assertThat(packageRecipe.isPresent(), is(true));
     }
 
     @Test
@@ -94,7 +94,7 @@ class PackageStoreTest {
                 .resolve("bad_recipe.yaml");
 
         Exception exception =
-                assertThrows(PackageLoadingException.class, () -> packageStore.findPackageRecipe(recipePath));
+                assertThrows(PackageLoadingException.class, () -> packageManager.findPackageRecipe(recipePath));
         assertThat(exception.getMessage().startsWith("Failed to parse package recipe"), is(true));
     }
 
@@ -103,29 +103,29 @@ class PackageStoreTest {
         Path recipePath = TestHelper.getPathForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.1.0")
                 .resolve("not_exist_recipe.yaml");
 
-        Optional<Package> pkg = packageStore.findPackageRecipe(recipePath);
-        assertThat(pkg.isPresent(), is(false));
+        Optional<PackageRecipe> packageRecipe = packageManager.findPackageRecipe(recipePath);
+        assertThat(packageRecipe.isPresent(), is(false));
     }
 
     @Test
     void GIVEN_package_in_memory_WHEN_attempt_save_package_THEN_successfully_save_to_file() throws Exception {
         Path recipePath = TestHelper.getPathForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.1.0")
                 .resolve("recipe.yaml");
-        Package pkg = packageStore.findPackageRecipe(recipePath).get();
+        PackageRecipe packageRecipe = packageManager.findPackageRecipe(recipePath).get();
 
         Path saveToFile =
                 testCache.resolve(String.format("%s-%s.yaml", TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.1.0"));
-        packageStore.savePackageRecipeToFile(pkg, saveToFile);
+        packageManager.savePackageRecipeToFile(packageRecipe, saveToFile);
 
-        Package savedPackage = packageStore.findPackageRecipe(saveToFile).get();
-        assertThat(savedPackage, is(pkg));
+        PackageRecipe savedPackageRecipe = packageManager.findPackageRecipe(saveToFile).get();
+        assertThat(savedPackageRecipe, is(packageRecipe));
     }
 
     @Test
     void GIVEN_artifact_list_empty_WHEN_attempt_download_artifact_THEN_do_nothing() throws Exception {
         PackageIdentifier pkgId = new PackageIdentifier("CoolService", new Semver("1.0.0"), "CoolServiceARN");
 
-        packageStore.downloadArtifactsIfNecessary(pkgId, Collections.emptyList());
+        packageManager.downloadArtifactsIfNecessary(pkgId, Collections.emptyList());
 
         verify(artifactDownloader, never()).downloadToPath(any(), any(), any());
     }
@@ -134,7 +134,7 @@ class PackageStoreTest {
     void GIVEN_artifact_list_WHEN_attempt_download_artifact_THEN_invoke_downloader() throws Exception {
         PackageIdentifier pkgId = new PackageIdentifier("CoolService", new Semver("1.0.0"), "CoolServiceARN");
 
-        packageStore.downloadArtifactsIfNecessary(pkgId,
+        packageManager.downloadArtifactsIfNecessary(pkgId,
                 Arrays.asList(new URI("greengrass:binary1"), new URI("greengrass:binary2")));
 
         ArgumentCaptor<URI> uriArgumentCaptor = ArgumentCaptor.forClass(URI.class);
@@ -151,7 +151,7 @@ class PackageStoreTest {
     void GIVEN_artifact_provider_not_supported_WHEN_attempt_download_THEN_throw_package_exception() {
         PackageIdentifier pkgId = new PackageIdentifier("CoolService", new Semver("1.0.0"), "CoolServiceARN");
 
-        Exception exception = assertThrows(PackageLoadingException.class, () -> packageStore
+        Exception exception = assertThrows(PackageLoadingException.class, () -> packageManager
                 .downloadArtifactsIfNecessary(pkgId, Collections.singletonList(new URI("docker:image1"))));
         assertThat(exception.getMessage(), is("artifact URI scheme DOCKER is not supported yet"));
     }
@@ -161,7 +161,7 @@ class PackageStoreTest {
         PackageIdentifier pkgId = new PackageIdentifier("CoolService", new Semver("1.0" + ".0"), "CoolServiceARN");
 
         Exception exception = assertThrows(PackageLoadingException.class,
-                () -> packageStore.downloadArtifactsIfNecessary(pkgId, Collections.singletonList(new URI("binary1"))));
+                () -> packageManager.downloadArtifactsIfNecessary(pkgId, Collections.singletonList(new URI("binary1"))));
         assertThat(exception.getMessage(), is("artifact URI scheme null is not supported yet"));
     }
 
@@ -170,9 +170,9 @@ class PackageStoreTest {
         PackageIdentifier pkgId = new PackageIdentifier("SomeService", new Semver("1.0.0"), "PackageARN");
         Path recipePath = TestHelper.getPathForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.1.0")
                 .resolve("recipe.yaml");
-        Package pkg = packageStore.findPackageRecipe(recipePath).get();
-        when(packageServiceHelper.downloadPackageRecipe(any())).thenReturn(pkg);
-        Future<Void> future = packageStore.preparePackages(Collections.singletonList(pkgId));
+        PackageRecipe packageRecipe = packageManager.findPackageRecipe(recipePath).get();
+        when(packageServiceHelper.downloadPackageRecipe(any())).thenReturn(packageRecipe);
+        Future<Void> future = packageManager.preparePackages(Collections.singletonList(pkgId));
         future.get(5, TimeUnit.SECONDS);
 
         assertThat(future.isDone(), is(true));
@@ -186,7 +186,7 @@ class PackageStoreTest {
         when(packageServiceHelper.downloadPackageRecipe(any())).thenThrow(PackageDownloadException.class);
         ignoreExceptionUltimateCauseOfType(context, PackageDownloadException.class);
 
-        Future<Void> future = packageStore.preparePackages(Collections.singletonList(pkgId));
+        Future<Void> future = packageManager.preparePackages(Collections.singletonList(pkgId));
         assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     }
 }
@@ -201,7 +201,7 @@ class NewPackageStoreTest {
             new PackageIdentifier(MONITORING_SERVICE_PKG_NAME, MONITORING_SERVICE_PKG_VERSION);
 
     private static final Path TEST_ROOT_PATH =
-            Paths.get(PackageStoreTest.class.getResource("test_store_root").getPath());
+            Paths.get(PackageManagerTest.class.getResource("test_store_root").getPath());
 
     private static final String ACTIVE_VERSION_STR = "2.0.0";
     private static final Semver ACTIVE_VERSION = new Semver(ACTIVE_VERSION_STR);
@@ -218,11 +218,11 @@ class NewPackageStoreTest {
     @Mock
     private EvergreenService mockService;
 
-    private PackageStore packageStore;
+    private PackageManager packageManager;
 
     @BeforeEach
     void beforeEach() {
-        packageStore = new PackageStore(TEST_ROOT_PATH, packageServiceHelper, artifactDownloader,
+        packageManager = new PackageManager(TEST_ROOT_PATH, packageServiceHelper, artifactDownloader,
                 Executors.newSingleThreadExecutor(), kernel);
     }
 
@@ -242,7 +242,7 @@ class NewPackageStoreTest {
         // WHEN
         Requirement requirement = Requirement.buildNPM(">=1.0.0 <3.0.0");
         Iterator<PackageMetadata> iterator =
-                packageStore.listAvailablePackageMetadata(MONITORING_SERVICE_PKG_NAME, requirement);
+                packageManager.listAvailablePackageMetadata(MONITORING_SERVICE_PKG_NAME, requirement);
 
         // THEN
 
@@ -279,7 +279,7 @@ class NewPackageStoreTest {
         // WHEN
         Requirement requirement = Requirement.buildNPM(">=1.0.0 <3.0.0");
         Iterator<PackageMetadata> iterator =
-                packageStore.listAvailablePackageMetadata(MONITORING_SERVICE_PKG_NAME, requirement);
+                packageManager.listAvailablePackageMetadata(MONITORING_SERVICE_PKG_NAME, requirement);
 
         // THEN
 
@@ -322,7 +322,7 @@ class NewPackageStoreTest {
         // WHEN
         Requirement requirement = Requirement.buildNPM(">=1.0.0 <2.0.0");
         Iterator<PackageMetadata> iterator =
-                packageStore.listAvailablePackageMetadata(MONITORING_SERVICE_PKG_NAME, requirement);
+                packageManager.listAvailablePackageMetadata(MONITORING_SERVICE_PKG_NAME, requirement);
 
         // THEN
 
@@ -353,12 +353,12 @@ class NewPackageStoreTest {
         when(serviceConfigTopics.findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY)).thenReturn(versionTopic);
         when(versionTopic.getOnce()).thenReturn(ACTIVE_VERSION_STR);
 
-        assertThat(packageStore.getPackageVersionFromService(mockService), is(ACTIVE_VERSION));
+        assertThat(packageManager.getPackageVersionFromService(mockService), is(ACTIVE_VERSION));
     }
 
     @Test
     void GIVEN_recipe_exists_WHEN_getPackageMetadata_THEN_returnIt() throws Exception {
-        PackageMetadata packageMetadata = packageStore.getPackageMetadata(MONITORING_SERVICE_PKG_ID);
+        PackageMetadata packageMetadata = packageManager.getPackageMetadata(MONITORING_SERVICE_PKG_ID);
 
         assertThat(packageMetadata.getPackageIdentifier(), is(MONITORING_SERVICE_PKG_ID));
         assertThat(packageMetadata.getDependencies(), is(getExpectedDependencies(MONITORING_SERVICE_PKG_VERSION)));

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/TestHelper.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/TestHelper.java
@@ -3,7 +3,7 @@
 
 package com.aws.iot.evergreen.packagemanager;
 
-import com.aws.iot.evergreen.packagemanager.models.Package;
+import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -63,8 +63,8 @@ public final class TestHelper {
         return rootPath.resolve(testPackageName + "-" + testPackageVersion);
     }
 
-    public static Package getPackageObject(String recipe) throws IOException {
-        return OBJECT_MAPPER.readValue(recipe, Package.class);
+    public static PackageRecipe getPackageObject(String recipe) throws IOException {
+        return OBJECT_MAPPER.readValue(recipe, PackageRecipe.class);
     }
 
     public static String getPackageRecipeForTestPackage(String testPackageName, String testPackageVersion)

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(EGExtension.class)
-public class PackageTest {
+public class PackageRecipeTest {
     private static Map<String, Integer> backupRanks;
     private static Field ranksField;
 
@@ -57,7 +57,7 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String recipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package testPkg = TestHelper.getPackageObject(recipeContents);
+        PackageRecipe testPkg = TestHelper.getPackageObject(recipeContents);
         assertThat(testPkg.getPackageName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
         assertThat(testPkg.getVersion().getValue(), is("1.0.0"));
         assertThat(testPkg.getPublisher(), is("Me"));
@@ -87,7 +87,7 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String recipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "2.0.0");
-        Package testPkg = TestHelper.getPackageObject(recipeContents);
+        PackageRecipe testPkg = TestHelper.getPackageObject(recipeContents);
         assertThat(testPkg.getPackageName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
         assertThat(testPkg.getVersion().getValue(), is("2.0.0"));
         assertThat(testPkg.getPublisher(), is("Me"));
@@ -108,8 +108,8 @@ public class PackageTest {
         // Packages are same
         String monitorServiceRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
-        Package monitorServicePkgCopy = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkgCopy = TestHelper.getPackageObject(monitorServiceRecipeContents);
 
         assertThat(monitorServicePkgCopy, is(monitorServicePkg));
         assertThat(monitorServicePkgCopy.hashCode(), is(monitorServicePkg.hashCode()));
@@ -120,12 +120,12 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String monitorServiceRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
 
         // Same package different versions
         String monitorService11RecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.1.0");
-        Package monitorService11Pkg = TestHelper.getPackageObject(monitorService11RecipeContents);
+        PackageRecipe monitorService11Pkg = TestHelper.getPackageObject(monitorService11RecipeContents);
 
         assertThat(monitorService11Pkg, not(monitorServicePkg));
         assertThat(monitorService11Pkg.hashCode(), not(monitorServicePkg.hashCode()));
@@ -136,12 +136,12 @@ public class PackageTest {
             throws IOException, URISyntaxException {
         String monitorServiceRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
-        Package monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
+        PackageRecipe monitorServicePkg = TestHelper.getPackageObject(monitorServiceRecipeContents);
 
         // Different packages
         String conveyorBeltRecipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.CONVEYOR_BELT_PACKAGE_NAME, "1.0.0");
-        Package conveyorBeltPkg = TestHelper.getPackageObject(conveyorBeltRecipeContents);
+        PackageRecipe conveyorBeltPkg = TestHelper.getPackageObject(conveyorBeltRecipeContents);
 
         assertThat(conveyorBeltPkg, not(monitorServicePkg));
         assertThat(conveyorBeltPkg.hashCode(), not(monitorServicePkg.hashCode()));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Part 1 of #201 

This PR is purely renaming.

**Why is this change necessary:**
`Package` was confusing - It is actually representing `PackageRecipe`.

Renaming current `PackageStore` -> `PackageManager`  and leave the name for real storage operations.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
