### PR TITLE
Fix race condition between reported state and actual state

### DIFF
--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/ipc/ipc_aware_main.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/ipc/ipc_aware_main.yaml
@@ -4,6 +4,7 @@ services:
     dependencies:
       - IPCService
     lifecycle:
-      startup:
-        mvn -q exec:java -f "$POM_DIR/pom.xml" -Dexec.mainClass="com.aws.iot.evergreen.integrationtests.ipc.sample.SampleIpcAwareServiceMovesToRunning" -Dexec.classpathScope="test"
-
+      startup: >-
+        mvn -q exec:java -f "$POM_DIR/pom.xml"
+        -Dexec.mainClass="com.aws.iot.evergreen.integrationtests.ipc.sample.SampleIpcAwareServiceMovesToRunning"
+        -Dexec.classpathScope="test" -Dexec.args="-Xms1m"

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
@@ -128,7 +128,6 @@ public class DeploymentConfigMerger {
                             totallyCompleteFuture
                                     .complete(new DeploymentResult(DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED, e));
                         }
-                        return;
                     }
                 });
             });
@@ -140,8 +139,8 @@ public class DeploymentConfigMerger {
     /*
      * Rollback kernel to the state recorded before merging deployment config
      */
-    private void rollback(String deploymentId, CompletableFuture totallyCompleteFuture, Throwable failureCause,
-                          AggregateServicesChangeManager servicesChangeManager) {
+    private void rollback(String deploymentId, CompletableFuture<DeploymentResult> totallyCompleteFuture,
+                          Throwable failureCause, AggregateServicesChangeManager servicesChangeManager) {
 
         logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, deploymentId).log("Rolling back failed deployment");
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -103,6 +103,20 @@ public class EvergreenService implements InjectionActions {
         return (State) state.getOnce();
     }
 
+    /**
+     * Returns true if either the current or the very last reported state (if any)
+     * is equal to the provided state.
+     *
+     * @param state state to check against
+     */
+    public boolean currentOrReportedStateIs(State state) {
+        if (state.equals(getState())) {
+            return true;
+        }
+        Optional<State> reportedState = lifecycle.lastReportedState();
+        return reportedState.isPresent() && reportedState.get().equals(state);
+    }
+
     public long getStateModTime() {
         return state.getModtime();
     }

--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -126,7 +126,7 @@ public class GenericExternalService extends EvergreenService {
             // the reportStates outside of the callback
             synchronized (this) {
                 logger.atInfo().kv("exitCode", exit).log("Run script exited");
-                if (startingStateGeneration == getStateGeneration() && State.RUNNING.equals(getState())) {
+                if (startingStateGeneration == getStateGeneration() && currentOrReportedStateIs(State.RUNNING)) {
                     if (exit == 0) {
                         logger.atInfo().setEventType("generic-service-stopping").log("Service finished running");
                         this.requestStop();

--- a/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
@@ -672,4 +672,9 @@ public class Lifecycle {
             desiredStateList.add(State.FINISHED);
         }
     }
+
+    Optional<State> lastReportedState() {
+        return stateEventQueue.stream().filter(s -> s instanceof State).map(s -> (State) s)
+                .reduce((first, second) -> second);
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes a race condition in the `GenericExternalService`'s callbacks which check for the current state. There is a race between the reported state and the actual "processed" state. The service reports running, then exits very quickly which triggers the callback. The lifecycle thread hasn't yet processed the state change, so technically it is still "INSTALLED" and not yet "RUNNING", so the equality check would fail, causing the tick-tock service to be stuck "RUNNING" and never moves to "FINISHED". 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
