### PR TITLE
Dynamic config changes in deployments

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentConfigMergingTest.java
@@ -39,6 +39,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICES_NAMESPACE_TOPIC;
+import static com.aws.iot.evergreen.kernel.EvergreenService.SETENV_CONFIG_NAMESPACE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
@@ -123,7 +124,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         deploymentConfigMerger.mergeInNewConfig(testDeploymentDocument(), new HashMap<Object, Object>() {{
             put(SERVICES_NAMESPACE_TOPIC, new HashMap<Object, Object>() {{
                 put("main", new HashMap<Object, Object>() {{
-                    put("setenv", new HashMap<Object, Object>() {{
+                    put(SETENV_CONFIG_NAMESPACE, new HashMap<Object, Object>() {{
                         put("HELLO", "redefined");
                     }});
                 }});
@@ -132,7 +133,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
 
         // THEN
         assertTrue(mainRestarted.await(60, TimeUnit.SECONDS));
-        assertEquals("redefined", kernel.findServiceTopic("main").find("setenv", "HELLO").getOnce());
+        assertEquals("redefined", kernel.findServiceTopic("main").find(SETENV_CONFIG_NAMESPACE, "HELLO").getOnce());
         assertThat((String) kernel.findServiceTopic("main").find("lifecycle", "run").getOnce(),
                 containsString("echo \"Running main\""));
     }

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
@@ -50,6 +50,7 @@ import java.util.function.Consumer;
 import static com.aws.iot.evergreen.ipc.AuthHandler.SERVICE_UNIQUE_ID_KEY;
 import static com.aws.iot.evergreen.ipc.IPCService.KERNEL_URI_ENV_VARIABLE_NAME;
 import static com.aws.iot.evergreen.kernel.EvergreenService.CUSTOM_CONFIG_NAMESPACE;
+import static com.aws.iot.evergreen.kernel.EvergreenService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -95,7 +96,7 @@ class IPCServicesTest {
         assertTrue(awaitIpcServiceLatch.await(10, TimeUnit.SECONDS));
 
         Topic kernelUri =
-                kernel.getConfig().getRoot().lookup("setenv", KERNEL_URI_ENV_VARIABLE_NAME);
+                kernel.getConfig().getRoot().lookup(SETENV_CONFIG_NAMESPACE, KERNEL_URI_ENV_VARIABLE_NAME);
         URI serverUri = new URI((String) kernelUri.getOnce());
         port = serverUri.getPort();
         address = serverUri.getHost();

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
@@ -3,16 +3,30 @@
 
 package com.aws.iot.evergreen.integrationtests.kernel;
 
+import com.aws.iot.evergreen.config.Subscriber;
+import com.aws.iot.evergreen.config.Topic;
+import com.aws.iot.evergreen.config.WhatHappened;
 import com.aws.iot.evergreen.dependency.State;
 import com.aws.iot.evergreen.integrationtests.BaseITCase;
+import com.aws.iot.evergreen.kernel.GenericExternalService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.aws.iot.evergreen.kernel.EvergreenService.CUSTOM_CONFIG_NAMESPACE;
+import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
+import static com.aws.iot.evergreen.kernel.EvergreenService.SETENV_CONFIG_NAMESPACE;
+import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.VERSION_CONFIG_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 
 class GenericExternalServiceTest extends BaseITCase {
 
@@ -63,5 +77,153 @@ class GenericExternalServiceTest extends BaseITCase {
 
         assertTrue(ServicesAErroredLatch.await(5, TimeUnit.SECONDS));
         assertTrue(ServicesBErroredLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_service_with_dynamically_loaded_config_WHEN_dynamic_config_changes_THEN_service_does_not_restart()
+            throws Exception {
+        kernel = new Kernel();
+        kernel.parseArgs("-i", getClass().getResource("service_with_dynamic_config.yaml").toString());
+        CountDownLatch mainRunning = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
+                mainRunning.countDown();
+            }
+        });
+        kernel.launch();
+
+        assertTrue(mainRunning.await(5, TimeUnit.SECONDS));
+
+        GenericExternalService service = spy((GenericExternalService) kernel.locate("service_with_dynamic_config"));
+        assertEquals(State.RUNNING, service.getState());
+
+        CompletableFuture<Void> topicUpdateProcessedFuture = new CompletableFuture<>();
+        Subscriber customConfigWatcher = (WhatHappened what, Topic t) -> {
+            topicUpdateProcessedFuture.complete(null);
+        };
+        Topic customConfigTopic = service.getServiceConfig().find(CUSTOM_CONFIG_NAMESPACE, "my_custom_key");
+        customConfigTopic.subscribe(customConfigWatcher);
+
+        customConfigTopic.withValue("my_custom_initial_value");
+        topicUpdateProcessedFuture.get();
+
+        assertEquals(State.RUNNING, service.getState());
+
+        verify(service, times(0)).requestReinstall();
+        verify(service, times(0)).requestRestart();
+    }
+
+    @Test
+    void GIVEN_running_service_WHEN_install_config_changes_THEN_service_reinstalls() throws Exception {
+        kernel = new Kernel();
+        kernel.parseArgs("-i", getClass().getResource("service_with_dynamic_config.yaml").toString());
+        CountDownLatch mainRunning = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
+                mainRunning.countDown();
+            }
+        });
+        kernel.launch();
+
+        assertTrue(mainRunning.await(5, TimeUnit.SECONDS));
+
+        GenericExternalService service = spy((GenericExternalService) kernel.locate("service_with_dynamic_config"));
+        assertEquals(State.RUNNING, service.getState());
+
+        CountDownLatch serviceReinstalled = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((serviceToListenTo, oldState, newState) -> {
+            if ("service_with_dynamic_config".equals(serviceToListenTo.getName()) && State.NEW.equals(newState)) {
+                serviceReinstalled.countDown();
+            }
+        });
+        service.getServiceConfig().find(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, "install")
+                .withValue("echo \"Reinstalling service_with_dynamic_config\"");
+
+        assertTrue(serviceReinstalled.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_running_service_WHEN_version_config_changes_THEN_service_reinstalls() throws Exception {
+        kernel = new Kernel();
+        kernel.parseArgs("-i", getClass().getResource("service_with_dynamic_config.yaml").toString());
+        CountDownLatch mainRunning = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
+                mainRunning.countDown();
+            }
+        });
+        kernel.launch();
+
+        assertTrue(mainRunning.await(5, TimeUnit.SECONDS));
+
+        GenericExternalService service = spy((GenericExternalService) kernel.locate("service_with_dynamic_config"));
+        assertEquals(State.RUNNING, service.getState());
+
+        CountDownLatch serviceReinstalled = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((serviceToListenTo, oldState, newState) -> {
+            if ("service_with_dynamic_config".equals(serviceToListenTo.getName()) && State.NEW.equals(newState)) {
+                serviceReinstalled.countDown();
+            }
+        });
+        service.getServiceConfig().find(VERSION_CONFIG_KEY).withValue("1.0.1");
+
+        assertTrue(serviceReinstalled.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_running_service_WHEN_run_config_changes_THEN_service_restarts() throws Exception {
+        kernel = new Kernel();
+        kernel.parseArgs("-i", getClass().getResource("service_with_dynamic_config.yaml").toString());
+        CountDownLatch mainRunning = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
+                mainRunning.countDown();
+            }
+        });
+        kernel.launch();
+
+        assertTrue(mainRunning.await(5, TimeUnit.SECONDS));
+
+        GenericExternalService service = spy((GenericExternalService) kernel.locate("service_with_dynamic_config"));
+        assertEquals(State.RUNNING, service.getState());
+
+        CountDownLatch serviceRestarted = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((serviceToListenTo, oldState, newState) -> {
+            if ("service_with_dynamic_config".equals(serviceToListenTo.getName()) && State.INSTALLED.equals(newState)) {
+                serviceRestarted.countDown();
+            }
+        });
+        service.getServiceConfig().find(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, "run")
+                .withValue("echo \"Rerunning " + "service_with_dynamic_config\" && sleep 100");
+
+        assertTrue(serviceRestarted.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_running_service_WHEN_setenv_config_changes_THEN_service_restarts() throws Exception {
+        kernel = new Kernel();
+        kernel.parseArgs("-i", getClass().getResource("service_with_dynamic_config.yaml").toString());
+        CountDownLatch mainRunning = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals("main") && newState.equals(State.RUNNING)) {
+                mainRunning.countDown();
+            }
+        });
+        kernel.launch();
+
+        assertTrue(mainRunning.await(5, TimeUnit.SECONDS));
+
+        GenericExternalService service = spy((GenericExternalService) kernel.locate("service_with_dynamic_config"));
+        assertEquals(State.RUNNING, service.getState());
+
+        CountDownLatch serviceRestarted = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((serviceToListenTo, oldState, newState) -> {
+            if ("service_with_dynamic_config".equals(serviceToListenTo.getName()) && State.INSTALLED.equals(newState)) {
+                serviceRestarted.countDown();
+            }
+        });
+        service.getServiceConfig().find(SETENV_CONFIG_NAMESPACE, "my_env_var").withValue("var2");
+
+        assertTrue(serviceRestarted.await(5, TimeUnit.SECONDS));
     }
 }

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/service_with_dynamic_config.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/service_with_dynamic_config.yaml
@@ -1,0 +1,18 @@
+services:
+  main:
+    dependencies:
+      - service_with_dynamic_config
+    lifecycle:
+      run:
+        echo "Running main" && sleep 100
+  service_with_dynamic_config:
+    lifecycle:
+      install:
+        echo "Installing service_with_dynamic_config"
+      run:
+        echo "Running service_with_dynamic_config" && sleep 1000
+    version: 1.0.0
+    setenv:
+      my_env_var: var1
+    custom:
+      my_custom_key: 'my_custom_initial_value'

--- a/src/main/java/com/aws/iot/evergreen/ipc/IPCService.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/IPCService.java
@@ -73,7 +73,7 @@ public class IPCService extends EvergreenService {
             String serverUri = "tcp://" + LOCAL_IP + ":" + port;
             // adding KERNEL_URI under setenv of the root topic. All subsequent processes will have KERNEL_URI
             // set via environment variables
-            Topic kernelUri = config.getRoot().lookup("setenv", KERNEL_URI_ENV_VARIABLE_NAME);
+            Topic kernelUri = config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, KERNEL_URI_ENV_VARIABLE_NAME);
             kernelUri.withValue(serverUri);
 
             super.startup();

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -41,6 +41,7 @@ public class EvergreenService implements InjectionActions, DisruptableCheck {
     public static final String SERVICE_LIFECYCLE_NAMESPACE_TOPIC = "lifecycle";
     public static final String SERVICE_NAME_KEY = "serviceName";
     public static final String CUSTOM_CONFIG_NAMESPACE = "custom";
+    public static final String SETENV_CONFIG_NAMESPACE = "setenv";
 
     private static final String CURRENT_STATE_METRIC_NAME = "currentState";
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -75,8 +75,11 @@ public class GenericExternalService extends EvergreenService {
                 requestReinstall();
                 return;
             }
-            // By default for any change, just restart the service
-            requestRestart();
+
+            // Restart service for changes to the lifecycle config or if environment variables changed
+            if (child.childOf(SERVICE_LIFECYCLE_NAMESPACE_TOPIC) || child.childOf(SETENV_CONFIG_NAMESPACE)) {
+                requestRestart();
+            }
         });
 
         AuthHandler.registerAuthToken(this);
@@ -400,7 +403,7 @@ public class GenericExternalService extends EvergreenService {
         }
 
         addEnv(exec, src.parent); // add parents contributions first
-        Node env = src.getChild("setenv");
+        Node env = src.getChild(SETENV_CONFIG_NAMESPACE);
         if (env instanceof Topics) {
             ((Topics) env).forEach(n -> {
                 if (n instanceof Topic) {

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
@@ -6,7 +6,6 @@ package com.aws.iot.evergreen.packagemanager.models;
 import com.aws.iot.evergreen.config.PlatformResolver;
 import com.aws.iot.evergreen.util.SerializerFactory;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -22,7 +21,6 @@ import lombok.NoArgsConstructor;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,13 +52,9 @@ public class PackageRecipe {
 
     private final Map<String, String> dependencies;
 
-    // TODO: Needs discussion, this should probably be removed after integration demo
-    private final List<String> requires;
+    private final Map<String, Object> customConfig;
 
-    // TODO: clean up this field
-    @Deprecated
-    @JsonIgnore
-    private Set<PackageRecipe> dependencyPackageRecipes;
+    private final Map<String, String> environmentVariables;
 
     /**
      * Constructor for Jackson to deserialize.
@@ -74,7 +68,8 @@ public class PackageRecipe {
      * @param lifecycle             Lifecycle definitions
      * @param artifacts             Artifact definitions
      * @param dependencies          List of dependencies
-     * @param requires              Package Requires
+     * @param customConfig          Custom config to store in kernel config store
+     * @param environmentVariables  Environment variables for the service
      * @throws SemverException if the semver fails to be created
      */
     @JsonCreator
@@ -88,7 +83,10 @@ public class PackageRecipe {
                          @JsonProperty("Artifacts") List<String> artifacts,
                          @JsonProperty("Dependencies") @JsonDeserialize(
                                  using = MapFieldDeserializer.class) Map<String, String> dependencies,
-                         @JsonProperty("Requires") List<String> requires) {
+                         @JsonProperty("CustomConfig") @JsonDeserialize(
+                                 using = MapFieldDeserializer.class) Map<String, Object> customConfig,
+                         @JsonProperty("EnvironmentVariables") @JsonDeserialize(
+                                 using = MapFieldDeserializer.class) Map<String, String> environmentVariables) {
         this.recipeTemplateVersion = recipeTemplateVersion;
         this.packageName = packageName;
         //TODO: Figure out how to do this in deserialize (only option so far seems to be custom deserializer)
@@ -100,8 +98,8 @@ public class PackageRecipe {
         this.lifecycle = lifecycle == null ? Collections.emptyMap() : lifecycle;
         this.artifacts = artifacts == null ? Collections.emptyList() : artifacts;
         this.dependencies = dependencies == null ? Collections.emptyMap() : dependencies;
-        this.requires = requires == null ? Collections.emptyList() : requires;
-        this.dependencyPackageRecipes = new HashSet<>();
+        this.customConfig = customConfig == null ? Collections.emptyMap() : customConfig;
+        this.environmentVariables = environmentVariables == null ? Collections.emptyMap() : environmentVariables;
     }
 
     @JsonSerialize(using = SemverSerializer.class)

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
@@ -73,9 +73,6 @@ public class PackageRecipeTest {
         assertThat(testPkg.getDependencies().size(), is(1));
         assertThat(testPkg.getDependencies(), IsMapContaining.hasEntry("mac-log", "1.0"));
 
-        assertThat(testPkg.getRequires(), IsCollectionWithSize.hasSize(1));
-        assertThat(testPkg.getRequires().get(0), is("homebrew"));
-
         Set<PackageParameter> paramList = testPkg.getPackageParameters();
         assertThat(paramList.isEmpty(), is(false));
         PackageParameter parameter = new PackageParameter("TestParam", "TestVal", "String");

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.0.0.yaml
@@ -20,5 +20,3 @@ Artifacts:
 Dependencies:
   Log: '2.0'
   Cool-Database: '1.0'
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.1.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.1.0.yaml
@@ -21,5 +21,3 @@ Artifacts:
 Dependencies:
   Log: '>1.0'
   Cool-Database: '1.0'
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Cool-Database-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Cool-Database-1.0.0.yaml
@@ -15,5 +15,3 @@ Lifecycle:
     macos:
       skipif: onpath git
       script: brew install git
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/InvalidRecipe-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/InvalidRecipe-1.0.0.yaml
@@ -21,5 +21,3 @@ Config:
   Dependencies:
     Log: '2.0'
     Cool-Database: '1.0'
-  Requires:
-    - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.0.0.yaml
@@ -15,5 +15,3 @@ Lifecycle:
     macos:
       skipif: onpath git
       script: brew install git
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.5.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.5.0.yaml
@@ -15,5 +15,3 @@ Lifecycle:
     macos:
       skipif: onpath git
       script: brew install git
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-2.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-2.0.0.yaml
@@ -15,5 +15,3 @@ Lifecycle:
     macos:
       skipif: onpath git
       script: brew install git
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-1.1.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-1.1.0.yaml
@@ -20,5 +20,3 @@ Artifacts:
 Dependencies:
   Log: '1.1.0'
   Cool-Database: '1.1.0'
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.0.0/recipe.yaml
@@ -20,5 +20,3 @@ Artifacts:
 Dependencies:
   Log: '2.0'
   Cool-Database: '1.0'
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.1.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.1.0/recipe.yaml
@@ -21,5 +21,3 @@ Artifacts:
 Dependencies:
   Log: '>1.0'
   Cool-Database: '1.0'
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/InvalidRecipeVersion-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/InvalidRecipeVersion-1.0.0/recipe.yaml
@@ -21,5 +21,3 @@ Config:
   Dependencies:
     Log: '2.0'
     Cool-Database: '1.0'
-  Requires:
-    - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.0.0/recipe.yaml
@@ -30,5 +30,4 @@ Dependencies:
     Cool-Database: '1.0'
   macos:
     mac-log: '1.0'
-Requires:
-  - homebrew
+

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/bad_recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/bad_recipe.yaml
@@ -31,5 +31,3 @@ Dependencies:
     Cool-Database: '1.0'
   macos:
     mac-log: '1.0'
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/recipe.yaml
@@ -20,5 +20,3 @@ Artifacts:
 Dependencies:
   Log: '2.0'
   Cool-Database: '1.0'
-Requires:
-  - homebrew

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-2.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-2.0.0/recipe.yaml
@@ -9,5 +9,4 @@ Lifecycle:
     skipif: onpath git
     script: sudo apt-get install git
   run: /path/to/run
-Requires:
-  - homebrew
+


### PR DESCRIPTION
**Issue #, if available:**
https://sim.amazon.com/issues/P35314981
**Description of changes:**
Change default behavior for service config changes from always restarting service to restarting only when needed
**Why is this change necessary:**
To support deployments that change service config without restarting deployments
https://quip-amazon.com/mld0ATVx17YK/Dynamically-reload-config-without-restarting-Evergreen-service
**How was this change tested:**
Integ tests
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
