### PR TITLE
Add Deployment safe namespace topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ coverage
 jmh-result.json
 work
 bin
-config
+/config
 evergreen.metrics

--- a/src/test/java/com/aws/iot/evergreen/config/ConfigurationReaderTest.java
+++ b/src/test/java/com/aws/iot/evergreen/config/ConfigurationReaderTest.java
@@ -1,0 +1,59 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+package com.aws.iot.evergreen.config;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.aws.iot.evergreen.dependency.Context;
+import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICES_NAMESPACE_TOPIC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(EGExtension.class)
+public class ConfigurationReaderTest {
+    // This is a generic test for configuration reader, hence declaring a namespace here
+    // Deployment Config Merge is tested separately in integration test
+    private static final String SKIP_MERGE_NAMESPACE_KEY = "notMerged";
+
+    Configuration config = new Configuration(new Context());
+
+    @AfterEach
+    void afterEach() throws IOException {
+        config.context.close();
+    }
+
+    @Test
+    public void GIVEN_tlog_with_ignored_namespace_WHEN_tlog_merged_to_config_with_condition_THEN_ignored_value_not_updated()
+            throws Exception {
+        // Create this topic with temp value
+        config.lookup(SERVICES_NAMESPACE_TOPIC, "YellowSignal",
+                      SKIP_MERGE_NAMESPACE_KEY, "testTopic").withValue("Test");
+        Path tlogPath = Paths.get(ConfigurationReaderTest.class.getResource("test.tlog").toURI());
+        ConfigurationReader.mergeTlogIntoConfig(config, tlogPath, true,
+                                                s -> !s.childOf(SKIP_MERGE_NAMESPACE_KEY));
+        // Test tlog file has value set to "TLogValue"
+        assertEquals("Test", config.lookup(SERVICES_NAMESPACE_TOPIC, "YellowSignal",
+                                           SKIP_MERGE_NAMESPACE_KEY, "testTopic").getOnce());
+    }
+
+    @Test
+    public void GIVEN_tlog_with_ignored_namespace_WHEN_tlog_merged_to_config_with_no_condition_THEN_all_values_updated()
+            throws Exception {
+        // Create this topic with temp value
+        config.lookup(SERVICES_NAMESPACE_TOPIC, "YellowSignal",
+                      SKIP_MERGE_NAMESPACE_KEY, "testTopic")
+                                .withValue("Test");
+        Path tlogPath = Paths.get(ConfigurationReaderTest.class.getResource("test.tlog").toURI());
+        ConfigurationReader.mergeTlogIntoConfig(config, tlogPath, true, null);
+        assertEquals("TLogValue", config.lookup(SERVICES_NAMESPACE_TOPIC, "YellowSignal",
+                                                SKIP_MERGE_NAMESPACE_KEY, "testTopic").getOnce());
+    }
+}

--- a/src/test/resources/com/aws/iot/evergreen/config/test.tlog
+++ b/src/test/resources/com/aws/iot/evergreen/config/test.tlog
@@ -1,0 +1,17 @@
+1,system.rootpath,"/tmp"
+1588872930086,setenv.AWS_GG_KERNEL_URI,"tcp://127.0.0.1:37743"
+1,services.servicediscovery.dependencies,[]
+1588872929914,services.YellowSignal.lifecycle.run,"echo proceed with caution This is not a test"
+1588872929914,services.YellowSignal.version,"1.0.0"
+1588872929914,services.YellowSignal.parameters.message,"This is not a test"
+1588872929914,services.YellowSignal.dependencies,[]
+1,services.IPCService.dependencies,[]
+1,services.SafeSystemUpdate.dependencies,[]
+1,services.DeploymentService.dependencies,[]
+1588872925144,services.main.lifecycle.install,"echo All installed"
+1588872925144,services.main.lifecycle.run,"echo $PATH\npwd\nprintenv\nwhile true; do\ndate; sleep 5; echo RUNNING\ndone"
+1588872929914,services.main.dependencies,[YellowSignal, DeploymentService, lifecycleipc, IPCService, servicediscovery, SafeSystemUpdate]
+1,services.lifecycleipc.dependencies,[]
+1588872928102,services._AUTH_TOKENS.FakeToken,"main"
+1588872930080,services._AUTH_TOKENS.FakeToken2,"YellowSignal"
+1588872931120,services.YellowSignal.notMerged.testTopic,"TLogValue"


### PR DESCRIPTION
**Description of changes:**
Adds a namespace that is safe from deployment rollbacks 

**How was this change tested:**
Manually verified the change. This namespace exists outside of the default parameters list at the moment. Trying to figure out a way to have a sensible integration test but in theory deployment should never modify this new namespace in the first place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
