### PR TITLE
Fix requestRestart() behavior in dependency state change.

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -346,7 +346,7 @@ public class EvergreenService implements InjectionActions, DisruptableCheck {
 
     private Subscriber createDependencySubscriber(EvergreenService dependentEvergreenService, State startWhenState) {
         return (WhatHappened what, Topic t) -> {
-            if ((State.INSTALLED.equals(getState()) || State.RUNNING.equals(getState()))
+            if ((State.STARTING.equals(getState()) || State.RUNNING.equals(getState()))
                     && !dependencyReady(dependentEvergreenService, startWhenState)) {
                 requestRestart();
                 logger.atInfo("service-restart").log("Restarting service because dependency {} was in a bad state",


### PR DESCRIPTION
**Issue #, if available:**
As STARTING state is added, the criteria to restart a service is changed. 
**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
