### PR TITLE
Fix tlog appending and add test

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/config/Configuration.java
+++ b/src/main/java/com/aws/iot/evergreen/config/Configuration.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import static com.aws.iot.evergreen.util.Utils.extension;
@@ -75,6 +76,7 @@ public class Configuration {
      *
      * @param path String[] of node names to traverse to find the Topic
      */
+    @Nullable
     public Topic find(String... path) {
         return root.find(path);
     }
@@ -85,6 +87,7 @@ public class Configuration {
      *
      * @param path String[] of node names to traverse to find the Topics
      */
+    @Nullable
     public Topics findTopics(String... path) {
         return root.findTopics(path);
     }

--- a/src/main/java/com/aws/iot/evergreen/config/ConfigurationWriter.java
+++ b/src/main/java/com/aws/iot/evergreen/config/ConfigurationWriter.java
@@ -21,7 +21,7 @@ import java.nio.file.StandardOpenOption;
 import static com.aws.iot.evergreen.util.Utils.appendLong;
 import static com.aws.iot.evergreen.util.Utils.flush;
 
-public class ConfigurationWriter implements Closeable, Subscriber {
+public class ConfigurationWriter implements Closeable, ChildChanged {
     private final Writer out;
     private final Configuration conf;
     @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "No need for flush immediately to be sync")
@@ -93,17 +93,18 @@ public class ConfigurationWriter implements Closeable, Subscriber {
     }
 
     @Override
-    public synchronized void published(WhatHappened what, Topic n) {
-        if (what == WhatHappened.childChanged) {
+    public synchronized void childChanged(WhatHappened what, Node n) {
+        if (what == WhatHappened.childChanged && n instanceof Topic) {
+            Topic t = (Topic) n;
             try {
                 if (n.getName().startsWith("_")) {
                     return;  // Don't log entries whose name starts in '_'
                 }
-                appendLong(n.getModtime(), out);
+                appendLong(t.getModtime(), out);
                 out.append(',');
                 n.appendNameTo(out);
                 out.append(',');
-                Coerce.appendParseableString(n.getOnce(), out);
+                Coerce.appendParseableString(t.getOnce(), out);
                 out.append('\n');
             } catch (IOException ex) {
                 logger.atError().setEventType("config-dump-error").addKeyValue("configNode", n.getFullName())
@@ -116,6 +117,6 @@ public class ConfigurationWriter implements Closeable, Subscriber {
     }
 
     public void writeAll() { //TODO double check this
-        conf.deepForEachTopic(n -> published(WhatHappened.childChanged, n));
+        conf.deepForEachTopic(n -> childChanged(WhatHappened.childChanged, n));
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/config/Node.java
+++ b/src/main/java/com/aws/iot/evergreen/config/Node.java
@@ -108,7 +108,7 @@ public abstract class Node {
      *
      * @param s subscriber to remove
      */
-    public void remove(Subscriber s) {
+    public void remove(Watcher s) {
         if (watchers != null) {
             watchers.remove(s);
         }

--- a/src/main/java/com/aws/iot/evergreen/kernel/KernelLifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/KernelLifecycle.java
@@ -89,11 +89,12 @@ public class KernelLifecycle {
                 kernel.writeEffectiveConfig(configurationFile);
                 Files.deleteIfExists(transactionLogPath);
             } else {
-                if (Files.exists(configurationFile)) {
-                    kernel.getConfig().read(configurationFile);
-                }
+                // Prefer the tlog because the yaml config file will not be up to date
                 if (Files.exists(transactionLogPath)) {
                     kernel.getConfig().read(transactionLogPath);
+                }
+                if (Files.exists(configurationFile)) {
+                    kernel.getConfig().read(configurationFile);
                 }
             }
             tlog = ConfigurationWriter.logTransactionsTo(kernel.getConfig(), transactionLogPath);

--- a/src/test/java/com/aws/iot/evergreen/config/ConfigurationWriterTest.java
+++ b/src/test/java/com/aws/iot/evergreen/config/ConfigurationWriterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.config;
+
+import com.aws.iot.evergreen.dependency.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ConfigurationWriterTest {
+    @TempDir
+    protected Path tempDir;
+
+    private Context context;
+
+    @BeforeEach
+    void beforeEach() {
+        context = new Context();
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    void GIVEN_config_with_configuration_writer_WHEN_config_changes_made_THEN_written_to_tlog() throws IOException {
+        Path tlog = tempDir.resolve("c.tlog");
+        Configuration config = new Configuration(context);
+
+        try (ConfigurationWriter writer = ConfigurationWriter.logTransactionsTo(config, tlog)) {
+            writer.flushImmediately(true);
+
+            // Create a Topic somewhere in the hierarchy
+            config.lookup("a", "b", "c", "d", "e").withValue("Some Val");
+            // Create another Topic and use a different data type as the value (number)
+            config.lookup("a", "b", "c", "d", "e2").withValue(2);
+            context.runOnPublishQueueAndWait(() -> {
+            }); // Block until publish queue is empty to ensure all changes have
+            // been processed
+
+            // Update the first Topic to show that the tlog can have multiple values over time
+            config.lookup("a", "b", "c", "d", "e").withValue("New Val");
+            // Create another Topic and use yet another data type (list)
+            config.lookup("a", "b", "c", "d", "e3").withValue(Arrays.asList("1", "2", "3"));
+            context.runOnPublishQueueAndWait(() -> {
+            });
+
+            // Assert that we can get back to the current in-memory state by reading the tlog
+            Configuration readConfig = ConfigurationReader.createFromTLog(context, tlog);
+            assertThat(readConfig.toPOJO(), is(config.toPOJO()));
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes the `ConfigurationWriter` which was broken because it implemented the `Subscriber` interface instead of the `ChildChanged` interface. Because of that it was not receiving any of the updates which happened to the config.

I also added a basic test which verifies that the config can be recreated from the tlog.

Additionally, I set the kernel to read from the tlog first if it exists, instead of reading from the yaml file because the yaml file is never updated, so it won't have the most recent state.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
