### PR TITLE
Manually call Log4J shutdown hook after we complete our shutdown

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
@@ -94,7 +94,11 @@ public class Kernel {
         context.put(Executor.class, executorService);
         context.put(ExecutorService.class, executorService);
         context.put(ThreadPoolExecutor.class, ses);
-        Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            shutdown();
+            // Shutdown Log4j because we disabled it's shutdown hook
+            org.apache.logging.log4j.LogManager.shutdown();
+        }));
         kernelCommandLine = new KernelCommandLine(this);
         kernelLifecycle = new KernelLifecycle(this, kernelCommandLine);
         context.put(KernelCommandLine.class, kernelCommandLine);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Based on https://github.com/aws/aws-greengrass-sdk-java/pull/37, this change manually calls the Log4J shutdown handler after the kernel's shutdown logic is done.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
