### PR TITLE
Handle internal service not having a version

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/packagemanager/PackageManager.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/PackageManager.java
@@ -230,7 +230,7 @@ public class PackageManager implements InjectionActions {
                     .log("Didn't find a active service for this package running in the kernel.");
             return Optional.empty();
         }
-        return Optional.of(getPackageVersionFromService(service));
+        return Optional.ofNullable(getPackageVersionFromService(service));
     }
 
     /**
@@ -241,7 +241,11 @@ public class PackageManager implements InjectionActions {
      */
     Semver getPackageVersionFromService(final EvergreenService service) {
         Topic versionTopic = service.getServiceConfig().findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY);
-        //TODO handle null case
+
+        if (versionTopic == null) {
+            return null;
+        }
+
         return new Semver(Coerce.toString(versionTopic));
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Internal services (such as TES) do not have versions defined. If such a service is a dependency of another service (such as Stream Manager), during package resolution, it will result a NPE because of the missing version. This PR is to fix the NPE problem.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
