### PR TITLE
[Bug fix] When config path not given, initialize main service config …

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/kernel/KernelCommandLine.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/KernelCommandLine.java
@@ -23,8 +23,6 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Objects;
 
-import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICES_NAMESPACE_TOPIC;
-import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
 import static com.aws.iot.evergreen.util.Utils.HOME_PATH;
 
 public class KernelCommandLine {
@@ -96,12 +94,6 @@ public class KernelCommandLine {
                     logger.atError().setEventType("parse-args-error").setCause(rte).log();
                     throw rte;
             }
-        }
-        // If no config path was given then initialize with default blank config
-        if (!haveRead) {
-            kernel.getConfig()
-                    .lookup(SERVICES_NAMESPACE_TOPIC, mainServiceName, SERVICE_LIFECYCLE_NAMESPACE_TOPIC, "run")
-                    .withValue("echo \"Main Running\"");
         }
         if (Utils.isEmpty(rootAbsolutePath)) {
             rootAbsolutePath = "~/.evergreen";  // Default to hidden subdirectory of home.


### PR DESCRIPTION
When config path not given, initialize with default main service config, this allows the KernelLifeCycle class to launch main service with this default config when customer hasn't provided a config path, so that it doesn't error out, initializes plugins and then can look for config in alternate places like the tlog path etc

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
