### PR TITLE
[Bug fix]Get rid of validation error message when initializing DeviceConfiguration object, fix arg names between setup and kernel command line

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,7 +25,7 @@ targets for each of the projects
 
 ## Running the Kernel
 Once built, in order to run the kernel, you can create a run configuration in your IDE or just use the command line.
-What you want is to run `java -jar <kernel-jar-path>.jar -root <config-root-dir-path>`. The config directory
+What you want is to run `java -jar <kernel-jar-path>.jar --root <config-root-dir-path>`. The config directory
 needs to have a `config.yaml` file in it.
 
 ### Config YAML

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/KernelTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -72,6 +73,18 @@ class KernelTest extends BaseITCase {
         kernel.parseArgs("-i", this.getClass().getResource("config_missing_main.yaml").toString());
         ignoreExceptionWithMessage(context, "Cannot load main service");
         assertThrows(RuntimeException.class, () -> kernel.launch());
+    }
+
+    @Test
+    void GIVEN_config_path_not_given_WHEN_kernel_launches_THEN_load_empty_main_service() throws Exception {
+        // launch kernel without config arg
+        kernel = new Kernel();
+        kernel.parseArgs().toString();
+        kernel.launch();
+
+        // verify
+        EvergreenService mainService = kernel.locate("main");
+        assertNotNull(mainService);
     }
 
     @SuppressWarnings("PMD.AssignmentInOperand")

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeviceConfiguration.java
@@ -46,16 +46,55 @@ public class DeviceConfiguration {
     private final Validator regionValidator;
 
     /**
-     * Constructor.
+     * Constructor used to read device cinfiguration from the config store.
      *
      * @param kernel Kernel to get config from
      */
     @Inject
-    @SuppressWarnings("PMD.NullAssignment")
     public DeviceConfiguration(Kernel kernel) {
         this.kernel = kernel;
-        deTildeValidator = (newV, old) -> kernel.deTilde(Coerce.toString(newV));
-        regionValidator = (newV, old) -> {
+        deTildeValidator = getDeTildeValidator(kernel);
+        regionValidator = getRegionValidator();
+        validate();
+    }
+
+    /**
+     * Constructor to use when setting the device configuration to kernel config.
+     *
+     * @param kernel              kernel to set config for
+     * @param thingName           IoT thing name
+     * @param iotDataEndpoint     IoT data endpoint
+     * @param iotCredEndpoint     IoT cert endpoint
+     * @param privateKeyPath      private key location on device
+     * @param certificateFilePath certificate location on device
+     * @param rootCaFilePath      downloaded RootCA location on device
+     * @param awsRegion           aws region for the device
+     */
+    public DeviceConfiguration(Kernel kernel, String thingName, String iotDataEndpoint, String iotCredEndpoint,
+                               String privateKeyPath, String certificateFilePath, String rootCaFilePath,
+                               String awsRegion) {
+        this.kernel = kernel;
+        deTildeValidator = getDeTildeValidator(kernel);
+        regionValidator = getRegionValidator();
+
+        getThingName().withValue(thingName);
+        getIotDataEndpoint().withValue(iotDataEndpoint);
+        getIotCredentialEndpoint().withValue(iotCredEndpoint);
+        getPrivateKeyFilePath().withValue(privateKeyPath);
+        getCertificateFilePath().withValue(certificateFilePath);
+        getRootCAFilePath().withValue(rootCaFilePath);
+        getAWSRegion().withValue(awsRegion);
+
+        validate();
+    }
+
+    private Validator getDeTildeValidator(Kernel kernel) {
+        return (newV, old) -> kernel.deTilde(Coerce.toString(newV));
+    }
+
+    @SuppressWarnings("PMD.NullAssignment")
+    private Validator getRegionValidator() {
+        return (newV, old) -> {
             // If the region value is empty/null, then try to get the region from the SDK lookup path
             if (!(newV instanceof String) || Utils.isEmpty((String) newV)) {
                 try {
@@ -71,7 +110,6 @@ public class DeviceConfiguration {
             }
             return newV;
         };
-        validate();
     }
 
     public Topic getThingName() {

--- a/src/main/java/com/aws/iot/evergreen/easysetup/EvergreenSetup.java
+++ b/src/main/java/com/aws/iot/evergreen/easysetup/EvergreenSetup.java
@@ -215,16 +215,20 @@ public class EvergreenSetup {
     }
 
     void provision(Kernel kernel) throws IOException {
+        logger.atInfo().log("Provisioning AWS IoT resources for the device...");
         ThingInfo thingInfo =
                 deviceProvisioningHelper.createThing(deviceProvisioningHelper.getIotClient(), policyName, thingName);
+        logger.atInfo().log("Configuring kernel with provisioning details...");
         deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, awsRegion);
 
         if (setupTes) {
+            logger.atInfo().log("Setting up resources for TokenExchangeService...");
             deviceProvisioningHelper.setupIoTRoleForTes(tesRoleName, tesRoleAliasName, thingInfo.getCertificateArn());
+            logger.atInfo().log("Configuring kernel with TokenExchangeService role details...");
             deviceProvisioningHelper.updateKernelConfigWithTesRoleInfo(kernel, tesRoleAliasName);
+            logger.atInfo().log("Creating an empty component for TokenExchangeService...");
+            deviceProvisioningHelper.setUpEmptyPackagesForFirstPartyServices();
         }
-
-        deviceProvisioningHelper.setUpEmptyPackagesForFirstPartyServices();
     }
 
 }

--- a/src/main/java/com/aws/iot/evergreen/easysetup/README.md
+++ b/src/main/java/com/aws/iot/evergreen/easysetup/README.md
@@ -1,0 +1,35 @@
+# Easy setup script
+The setup script is intended to give a brand new user of Evergreen to get started with Evergreen device quickly.
+As part of that experience the user can get an fat jar for the Evergreen kernel, the script can launch the kernel
+ with the customer's provided config if desired, optionally provision the test device as an AWS IoT Thing, create and
+ attach policies and certificates to it, optionally create TES role and role alias or uses existing ones and attaches
+ them to the IoT thing certificate.
+
+
+## Getting the jar
+Eventually we want to distribute the jar over CDN but while that strategy is being worked on currently a user needs
+ to check out the repository and build it, use the following command for that
+```
+mvn clean package
+```
+Check the build logs to see where the jar lives
+
+## Using the script
+OPTIONS
+```
+	--config, -i			Path to the configuration file to start Evergreen kernel with
+	--root, -r			Path to the directory to use as the root for Evergreen
+	--thing-name, -tn		Desired thing name to register the device with in AWS IoT cloud, ignored if --provision option is false/not specified
+	--policy-name, -pn 		Desired name for IoT thing policy, ignored if --provision option is false/not specified
+	—-tes-role-name, -trn 	        Name of the IAM role to use for TokenExchangeService for the device to talk to
+                                        AWS services, if the role does not exist then it will be created in your AWS
+                                        account, ignored if --setup-tes option is false/not specified
+	--tes-role-alias-name, -r	Name of the RoleAlias to attach to the IAM role for TES in the AWS IoT cloud, if the role alias does not exist then it will be created in your AWS account, ignored if --setup-tes option is false/not specified
+	--provision, -p 		Y/N Indicate if you want to register the device as an AWS IoT thing, ignored if
+                                        --provision option is false/not specified
+	--aws-region, -ar		AWS region where the resources should be looked for/created
+	--setup-tes, -t 		Y/N Indicate if you want to use Token Exchange Service to talk toAWS services using the
+                                        device certificate, ignored if --provision option is false/not specified
+	--install-cli, -ic 		Y/N Indicate if you want to install Evergreen device CLI. {}
+```
+

--- a/src/main/java/com/aws/iot/evergreen/kernel/KernelCommandLine.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/KernelCommandLine.java
@@ -73,7 +73,7 @@ public class KernelCommandLine {
                 case "-i":
                     try {
                         String configArg = getArg();
-                        Objects.requireNonNull(configArg, "-i or -config requires an argument");
+                        Objects.requireNonNull(configArg, "-i or --config requires an argument");
                         kernel.getConfig().read(deTilde(configArg));
                         haveRead = true;
                     } catch (IOException ex) {
@@ -89,7 +89,7 @@ public class KernelCommandLine {
                 case "--root":
                 case "-r":
                     rootAbsolutePath = getArg();
-                    Objects.requireNonNull(rootAbsolutePath, "-r or -root requires an argument");
+                    Objects.requireNonNull(rootAbsolutePath, "-r or --root requires an argument");
                     break;
                 default:
                     RuntimeException rte =

--- a/src/main/java/com/aws/iot/evergreen/kernel/KernelLifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/KernelLifecycle.java
@@ -74,7 +74,8 @@ public class KernelLifecycle {
                 }
                 if (!Files.exists(transactionLogPath) && !Files.exists(configurationFile)) {
                     kernel.getConfig()
-                            .lookup(EvergreenService.SERVICES_NAMESPACE_TOPIC, kernelCommandLine.mainServiceName);
+                            .lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC, kernelCommandLine.mainServiceName,
+                                    EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC);
                 }
             }
             tlog = ConfigurationWriter.logTransactionsTo(kernel.getConfig(), transactionLogPath);

--- a/src/test/java/com/aws/iot/evergreen/easysetup/EvergreenSetupTest.java
+++ b/src/test/java/com/aws/iot/evergreen/easysetup/EvergreenSetupTest.java
@@ -80,7 +80,7 @@ public class EvergreenSetupTest {
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any());
         verify(deviceProvisioningHelper, times(0)).setupIoTRoleForTes(any(), any(), any());
         verify(deviceProvisioningHelper, times(0)).updateKernelConfigWithTesRoleInfo(any(), any());
-        verify(deviceProvisioningHelper, times(1)).setUpEmptyPackagesForFirstPartyServices();
+        verify(deviceProvisioningHelper, times(0)).setUpEmptyPackagesForFirstPartyServices();
     }
 
 }

--- a/src/test/java/com/aws/iot/evergreen/kernel/KernelCommandLineTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/KernelCommandLineTest.java
@@ -47,7 +47,7 @@ class KernelCommandLineTest {
     void GIVEN_missing_parameter_to_argument_WHEN_parseArgs_THEN_throw_RuntimeException() {
         KernelCommandLine kcl = new KernelCommandLine(mock(Kernel.class));
         RuntimeException ex = assertThrows(RuntimeException.class, () -> kcl.parseArgs("-i"));
-        assertThat(ex.getMessage(), is("-i or -config requires an argument"));
+        assertThat(ex.getMessage(), is("-i or --config requires an argument"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**
1] When setting up DeviceConfiguration, due to the way the DeviceConfiguration utility is written, it used to lookup the config in Kernel context and immediately invoke validate method, even before any config values were set. This was due to the fact that it was originally intended to 'read' the config from kernel so it assumed that the config would already be set. But the setup script cannot use it as it is to set configuration because it tries to validate on constructor invocation.
2] Setup script expects long arg names with two hyphens e.g. --thing-name, --root, --config etc vs KernelCommandLine expects long arg names with 1 hyphen e.g. -config, -root, this causes a mismatch between these two classes and the root and config args if specified with the long name were not being passed on to the kernel command line as intended, to fix it, all args are changed to have two hyphens for long arg names
3] Add log statements for conveying the progress made by the script to the user
4] Fix bug for the case when config is not specified, added integ test to verify it works
5] Changed the TES role policy name to include roleAliasName as suffix so that if the role alias for the policy is being changed it can be accepted and a new role policy will be created and role alias will be attached to it.
6] Create empty TES package only if the customer opts in for TES
7] Added readme for script
**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
New/modified/existing tests passed

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
