### PR TITLE
Hardcode CMS endpoint during kernel startup

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -11,7 +11,6 @@ import com.aws.iot.evergreen.deployment.DeploymentTask;
 import com.aws.iot.evergreen.deployment.exceptions.ServiceUpdateException;
 import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
 import com.aws.iot.evergreen.deployment.model.DeploymentResult;
-import com.aws.iot.evergreen.easysetup.DeviceProvisioningHelper;
 import com.aws.iot.evergreen.kernel.GenericExternalService;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
@@ -112,8 +111,6 @@ class DeploymentTaskIntegrationTest {
         System.setProperty("root", rootDir.toAbsolutePath().toString());
         kernel = new Kernel();
         kernel.parseArgs("-i", DeploymentTaskIntegrationTest.class.getResource("onlyMain.yaml").toString());
-        DeviceProvisioningHelper deviceProvisioningHelper = new DeviceProvisioningHelper(BETA_REGION.toString());
-        deviceProvisioningHelper.updateKernelConfigWithCMSConfiguration(kernel, BETA_REGION.toString());
         kernel.launch();
         // get required instances from context
         packageManager = kernel.getContext().get(PackageManager.class);

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -62,7 +62,6 @@ class DeploymentE2ETest extends BaseE2ETestCase {
                         .toAbsolutePath().toString());
 
         deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, BETA_REGION.toString());
-        deviceProvisioningHelper.updateKernelConfigWithCMSConfiguration(kernel, BETA_REGION.toString());
         kernel.launch();
 
         Path localStoreContentPath = Paths.get(DeploymentE2ETest.class.getResource("local_store_content").getPath());

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MqttReconnectTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MqttReconnectTest.java
@@ -72,7 +72,6 @@ public class MqttReconnectTest extends BaseE2ETestCase {
                         .toAbsolutePath().toString());
 
         deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, BETA_REGION.toString());
-        deviceProvisioningHelper.updateKernelConfigWithCMSConfiguration(kernel, BETA_REGION.toString());
 
         Path localStoreContentPath = Paths.get(DeploymentE2ETest.class.getResource("local_store_content").getPath());
         // pre-load contents to package store

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MultipleDeploymentsTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MultipleDeploymentsTest.java
@@ -52,7 +52,6 @@ class MultipleDeploymentsTest extends BaseE2ETestCase {
                 .toString(), "-r", tempRootDir.toAbsolutePath().toString());
 
         deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, BETA_REGION.toString());
-        deviceProvisioningHelper.updateKernelConfigWithCMSConfiguration(kernel, BETA_REGION.toString());
 
         Path localStoreContentPath = Paths
                 .get(MultipleDeploymentsTest.class.getResource("local_store_content").getPath());

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/packagemanager/PackageManagerE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/packagemanager/PackageManagerE2ETest.java
@@ -67,7 +67,6 @@ class PackageManagerE2ETest extends BaseE2ETestCase {
         kernel = new Kernel();
         kernel.parseArgs("-i", PackageManagerE2ETest.class.getResource("onlyMain.yaml").toString());
         deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, BETA_REGION.toString());
-        deviceProvisioningHelper.updateKernelConfigWithCMSConfiguration(kernel, BETA_REGION.toString());
 
         // The integration test will pick up credentials from the default provider chain
         // In automated testing, the device environment should ideally have credentials for all tests

--- a/src/main/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelper.java
@@ -67,7 +67,7 @@ public class DeviceProvisioningHelper {
     private static final String E2E_TESTS_POLICY_NAME_PREFIX = "E2ETestsIotPolicy";
     private static final String E2E_TESTS_THING_NAME_PREFIX = "E2ETestsIotThing";
     // TODO : Remove once global components are implemented
-    private static final String GREENGRASS_SERVICE_ENDPOINT =
+    public static final String GREENGRASS_SERVICE_ENDPOINT =
             "https://3w5ajog718.execute-api.us-east-1.amazonaws.com/Beta/";
     private static final Map<String, String> FIRST_PARTY_COMPONENT_RECIPES = Collections
             .singletonMap(TOKEN_EXCHANGE_SERVICE_TOPICS, "{\n" + "\t\"RecipeTemplateVersion\": \"2020-01-25\",\n"
@@ -321,21 +321,6 @@ public class DeviceProvisioningHelper {
             logger.atInfo().kv("component name", componentName)
                     .log("Component already exists, skipping re-creating " + "component");
         }
-    }
-
-    /**
-     * Update the kernel config with iot thing info, in specific CA, private Key and cert path.
-     *
-     * @param kernel Kernel object to update
-     * @param awsRegion Target AWS Region
-     */
-    public void updateKernelConfigWithCMSConfiguration(Kernel kernel, String awsRegion) {
-        // Endpoint for Beta CMS in us-east-1
-        // TODO: Once service is available in multiple regions, this should not be a static config and
-        // use the region value to determine endpoint
-        kernel.getContext().put("greengrassServiceEndpoint", GREENGRASS_SERVICE_ENDPOINT);
-        DeviceConfiguration deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
-        deviceConfiguration.getAWSRegion().withValue(awsRegion);
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/aws/iot/evergreen/kernel/KernelCommandLine.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/KernelCommandLine.java
@@ -23,6 +23,9 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Objects;
 
+import static com.aws.iot.evergreen.easysetup.DeviceProvisioningHelper.GREENGRASS_SERVICE_ENDPOINT;
+import static com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceClientFactory.CONTEXT_COMPONENT_SERVICE_ENDPOINT;
+import static com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceClientFactory.CONTEXT_SERVICE_CRED_PROVIDER;
 import static com.aws.iot.evergreen.util.Utils.HOME_PATH;
 
 public class KernelCommandLine {
@@ -106,7 +109,11 @@ public class KernelCommandLine {
         // Always initialize default credential provider, can be overridden before launch if needed
         // TODO: This should be replaced by a Token Exchange Service credential provider
         AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-        kernel.getContext().put("greengrassServiceCredentialProvider", credentialsProvider);
+        kernel.getContext().put(CONTEXT_SERVICE_CRED_PROVIDER, credentialsProvider);
+        // Endpoint for Beta CMS in us-east-1
+        // TODO: Once service is available in multiple regions, this should not be a static config and
+        // use the region value to determine endpoint
+        kernel.getContext().put(CONTEXT_COMPONENT_SERVICE_ENDPOINT, GREENGRASS_SERVICE_ENDPOINT);
     }
 
     private void initPaths(String rootAbsolutePath) {

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceClientFactory.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceClientFactory.java
@@ -21,6 +21,8 @@ import javax.inject.Named;
 @SuppressWarnings("PMD.ConfusingTernary")
 public class GreengrassPackageServiceClientFactory {
 
+    public static final String CONTEXT_COMPONENT_SERVICE_ENDPOINT = "greengrassServiceEndpoint";
+    public static final String CONTEXT_SERVICE_CRED_PROVIDER = "greengrassServiceCredentialProvider";
     private static final Logger logger = LogManager.getLogger(GreengrassPackageServiceClientFactory.class);
 
     private final AWSGreengrassComponentManagement cmsClient;
@@ -33,9 +35,10 @@ public class GreengrassPackageServiceClientFactory {
      * @param credentialsProvider       AWS Credentials provider for device credentials
      */
     @Inject
-    public GreengrassPackageServiceClientFactory(@Named("greengrassServiceEndpoint") String greengrassServiceEndpoint,
-             DeviceConfiguration deviceConfiguration,
-             @Named("greengrassServiceCredentialProvider") AWSCredentialsProvider credentialsProvider) {
+    public GreengrassPackageServiceClientFactory(
+            @Named(CONTEXT_COMPONENT_SERVICE_ENDPOINT) String greengrassServiceEndpoint,
+            DeviceConfiguration deviceConfiguration,
+            @Named(CONTEXT_SERVICE_CRED_PROVIDER) AWSCredentialsProvider credentialsProvider) {
         AWSGreengrassComponentManagementClientBuilder clientBuilder =
                 AWSGreengrassComponentManagementClientBuilder.standard();
         String region = Coerce.toString(deviceConfiguration.getAWSRegion());

--- a/src/test/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelperTest.java
@@ -169,7 +169,7 @@ public class DeviceProvisioningHelperTest {
     }
 
     @Test
-    public void GIVEN_test_tes_role_config_WHEN_role_info_provided_THEN_add_config_to_config_store() throws Exception {
+    public void GIVEN_test_tes_role_config_WHEN_role_info_provided_THEN_add_config_to_config_store() {
         Kernel kernel = new Kernel()
                 .parseArgs("-i", getClass().getResource("blank_config.yaml").toString(), "-r", tempRootDir.toString());
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Hardcode CMS endpoint during kernel startup.

Next steps:
1. Ability to override the endpoint in easysetup and kernel config. Ability to persist the endpoint information in the device configuration.
1. E2E tests integrating CMS, FCS, and maybe easysetup

**Why is this change necessary:**
Required for cloud deployments to work properly with kernel easy setup.

**How was this change tested:**
PackageManagerE2ETest

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
