### PR TITLE
S3 Upload during Publish

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -112,3 +112,6 @@ jobs:
           aws-region: us-west-2
       - name: Publish with Maven
         run: mvn -ntp --settings settings.xml deploy -DskipTests -Dstargate-snapshot-repository-url=${{ secrets.stargate_dev_snapshot_repository_url }}
+      - run: sudo apt-get install -y awscli
+      - name: Upload to S3
+        run: aws s3 cp target/Evergreen.jar s3://gg-evergreen-releases/${{github.repository}}/${{github.ref}}/evergreen-${{github.sha}}.jar


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Uploads our fully built evergreen jar to s3://gg-evergreen-releases/aws/aws-greengrass-kernel/<branch>/evergreen-<commit-sha>.jar.

**Why is this change necessary:**
Enables Rafe to E2E test our code by downloading the built jar from s3.

**How was this change tested:**
Created draft pull request which ran the s3 upload and verified that the file was uploaded to s3.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
