### PR TITLE
JDK 9 fix, fix version field being string/semver

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/deployment/LocalDeploymentListener.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/LocalDeploymentListener.java
@@ -12,7 +12,6 @@ import com.aws.iot.evergreen.logging.impl.LogManager;
 import com.aws.iot.evergreen.util.Coerce;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.vdurmont.semver4j.Semver;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -94,7 +93,7 @@ public class LocalDeploymentListener {
                         ComponentInfo.ComponentInfoBuilder componentInfoBuilder =
                                 ComponentInfo.builder().packageName(service.getName());
                         if (version != null) {
-                            componentInfoBuilder.version(((Semver) version.getOnce()).getValue());
+                            componentInfoBuilder.version(Coerce.toString(version));
                         }
                         if (parameters != null) {
                             componentInfoBuilder.runtimeParameters(parameters.children.entrySet().stream()

--- a/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
@@ -20,7 +20,6 @@ import com.aws.iot.evergreen.util.CommitableWriter;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.vdurmont.semver4j.Semver;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -302,8 +301,8 @@ public class Kernel {
                         context.put(ret.getClass(), v);
                     }
                     if (clazz.getAnnotation(ImplementsService.class) != null) {
-                        Semver version = new Semver(clazz.getAnnotation(ImplementsService.class).version());
-                        topics.createLeafChild(VERSION_CONFIG_KEY).withValue(version);
+                        topics.createLeafChild(VERSION_CONFIG_KEY)
+                                .withValue(clazz.getAnnotation(ImplementsService.class).version());
                     }
 
                     logger.atInfo("evergreen-service-loaded").kv(EvergreenService.SERVICE_NAME_KEY, ret.getName())
@@ -346,7 +345,7 @@ public class Kernel {
             if (service.isAutostart()) {
                 continue;
             }
-            rootPackageNameAndVersionMap.put(service.getName(), ((Semver) version.getOnce()).getValue());
+            rootPackageNameAndVersionMap.put(service.getName(), Coerce.toString(version));
         }
         return rootPackageNameAndVersionMap;
     }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -126,7 +126,7 @@ public class KernelConfigResolver {
         resolvedServiceConfig.put(SERVICE_DEPENDENCIES_NAMESPACE_TOPIC, dependencyConfig);
 
         // State information for deployments
-        resolvedServiceConfig.put(VERSION_CONFIG_KEY, packageRecipe.getVersion());
+        resolvedServiceConfig.put(VERSION_CONFIG_KEY, packageRecipe.getVersion().getValue());
         resolvedServiceConfig.put(PARAMETERS_CONFIG_KEY, resolvedParams.stream()
                 .collect(Collectors.toMap(PackageParameter::getName, PackageParameter::getValue)));
 

--- a/src/main/java/com/aws/iot/evergreen/util/Utils.java
+++ b/src/main/java/com/aws/iot/evergreen/util/Utils.java
@@ -7,6 +7,7 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -483,11 +484,13 @@ public final class Utils {
                                 radix = 2;
                                 break;
                             default:
-                                str.position(str.position() - 1);
+                                // Stupid cast for jdk 9+
+                                ((Buffer) str).position(str.position() - 1);
                                 break;
                         }
                     } else {
-                        str.position(str.position() - 1);
+                        // Stupid cast for jdk 9+
+                        ((Buffer) str).position(str.position() - 1);
                     }
                     break scanPrefix;
             }

--- a/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
@@ -12,7 +12,6 @@ import com.aws.iot.evergreen.dependency.ImplementsService;
 import com.aws.iot.evergreen.kernel.exceptions.InputValidationException;
 import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
 import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
-import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -245,8 +244,8 @@ class KernelTest {
                         .lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC, "service1"));
         EvergreenService service2 = new EvergreenService(kernel.getConfig()
                 .lookupTopics(EvergreenService.SERVICES_NAMESPACE_TOPIC, "service2"));
-        service1.getConfig().lookup(VERSION_CONFIG_KEY).dflt(new Semver("1.0.0"));
-        service2.getConfig().lookup(VERSION_CONFIG_KEY).dflt(new Semver("1.1.0"));
+        service1.getConfig().lookup(VERSION_CONFIG_KEY).dflt("1.0.0");
+        service2.getConfig().lookup(VERSION_CONFIG_KEY).dflt("1.1.0");
 
         EvergreenService mockMain = mock(EvergreenService.class);
         Map<EvergreenService, DependencyType> mainsDependency = new HashMap<>();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes version being saved in config so that it is consistently just a string and not a semver (which didn't serialize nicely).

Also fixes JDK 9+ compatibility in a utility function.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
