### PR TITLE
[Draft] modify autoStart to isSystem

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/dependency/ImplementsService.java
+++ b/src/main/java/com/aws/iot/evergreen/dependency/ImplementsService.java
@@ -19,7 +19,7 @@ public @interface ImplementsService {
     /**
      * True if the service should start immediately when Kernel starts.
      */
-    boolean autostart() default false;
+    boolean isSystem() default false;
 
     /**
      * Version of the service. By default it is 0.0.0. Must be in the form of a.b.c.

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
@@ -365,12 +365,6 @@ public class DeploymentConfigMerger {
                 try {
                     EvergreenService eg = kernel.locate(serviceName);
 
-                    // If the service is an autostart service, then do not close it and do not
-                    // remove it from the config
-                    if (eg.isAutostart()) {
-                        return false;
-                    }
-
                     serviceClosedFutures.add(eg.close());
                 } catch (ServiceLoadException e) {
                     logger.atError().setCause(e).addKeyValue("serviceName", serviceName)

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentService.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-@ImplementsService(name = "DeploymentService", autostart = true)
+@ImplementsService(name = "DeploymentService", isSystem = true)
 public class DeploymentService extends EvergreenService {
 
     public static final String DEPLOYMENT_SERVICE_TOPICS = "DeploymentService";

--- a/src/main/java/com/aws/iot/evergreen/ipc/IPCService.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/IPCService.java
@@ -42,7 +42,7 @@ import static com.aws.iot.evergreen.ipc.codec.MessageFrameEncoder.MAX_PAYLOAD_SI
  * the service will receive a pointer to the channel that they will then be able to use to push messages
  * to the client at any time in the future.
  */
-@ImplementsService(name = "IPCService", autostart = true)
+@ImplementsService(name = "IPCService", isSystem = true)
 public class IPCService extends EvergreenService {
     public static final String KERNEL_URI_ENV_VARIABLE_NAME = "AWS_GG_KERNEL_URI";
     private static final int MAX_SO_BACKLOG = 128;

--- a/src/main/java/com/aws/iot/evergreen/ipc/modules/ConfigStoreIPCService.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/modules/ConfigStoreIPCService.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Future;
 import javax.inject.Inject;
 
 //TODO: see if this needs to be a GGService
-@ImplementsService(name = "configstoreipc", autostart = true)
+@ImplementsService(name = "configstoreipc", isSystem = true)
 public class ConfigStoreIPCService extends EvergreenService {
     private static final ObjectMapper CBOR_MAPPER = new CBORMapper();
 

--- a/src/main/java/com/aws/iot/evergreen/ipc/modules/LifecycleIPCService.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/modules/LifecycleIPCService.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
 import javax.inject.Inject;
 
 //TODO: see if this needs to be a GGService
-@ImplementsService(name = "lifecycleipc", autostart = true)
+@ImplementsService(name = "lifecycleipc", isSystem = true)
 public class LifecycleIPCService extends EvergreenService {
     private static final ObjectMapper CBOR_MAPPER = new CBORMapper();
 

--- a/src/main/java/com/aws/iot/evergreen/ipc/modules/ServiceDiscoveryService.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/modules/ServiceDiscoveryService.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
 import static com.aws.iot.evergreen.ipc.services.servicediscovery.ServiceDiscoveryOpCodes.values;
 
 //TODO: see if this needs to be a GGService
-@ImplementsService(name = "servicediscovery", autostart = true)
+@ImplementsService(name = "servicediscovery", isSystem = true)
 public class ServiceDiscoveryService extends EvergreenService {
     private final ObjectMapper mapper = new CBORMapper();
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -335,6 +335,7 @@ public class EvergreenService implements InjectionActions, DisruptableCheck {
             Subscriber subscriber = createDependencySubscriber(dependentEvergreenService, dependencyType);
             dependentEvergreenService.addStateSubscriber(subscriber);
             context.get(Kernel.class).clearODcache();
+            // TODO : remove isDefault field
             return new DependencyInfo(dependencyType, isDefault, subscriber);
         });
     }
@@ -555,9 +556,10 @@ public class EvergreenService implements InjectionActions, DisruptableCheck {
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().dependencyType));
     }
 
+    // TODO: remove isAutoStart
     public boolean isAutostart() {
         ImplementsService serviceAnnotation = getClass().getAnnotation(ImplementsService.class);
-        return serviceAnnotation != null && serviceAnnotation.autostart();
+        return serviceAnnotation != null && serviceAnnotation.isSystem();
     }
 
     protected final long getStateGeneration() {
@@ -577,6 +579,7 @@ public class EvergreenService implements InjectionActions, DisruptableCheck {
         // dependency type. Default to be HARD.
         DependencyType dependencyType;
         // true if the dependency isn't explicitly declared in config
+        // TODO: remove isDefault
         boolean isDefaultDependency;
         Subscriber stateTopicSubscriber;
     }

--- a/src/main/java/com/aws/iot/evergreen/kernel/UpdateSystemSafelyService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/UpdateSystemSafelyService.java
@@ -25,7 +25,7 @@ import javax.inject.Singleton;
  * Otherwise, it the update will be processed immediately, assuming that all disruptability
  * checks pass.
  */
-@ImplementsService(name = "SafeSystemUpdate", autostart = true)
+@ImplementsService(name = "SafeSystemUpdate", isSystem = true)
 @Singleton
 public class UpdateSystemSafelyService extends EvergreenService {
     private final Map<String, Crashable> pendingActions = new LinkedHashMap<>();

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -187,12 +187,6 @@ public class KernelConfigResolver {
     private Map<Object, Object> getMainConfig(List<String> rootPackages) {
         Map<Object, Object> mainServiceConfig = new HashMap<>();
         ArrayList<String> mainDependencies = new ArrayList<>(rootPackages);
-        kernel.getMain().getDependencies().forEach((evergreenService, dependencyType) -> {
-            // Add all autostart dependencies
-            if (evergreenService.isAutostart()) {
-                mainDependencies.add(evergreenService.getName() + ":" + dependencyType);
-            }
-        });
         mainServiceConfig.put(SERVICE_DEPENDENCIES_NAMESPACE_TOPIC, mainDependencies);
         return mainServiceConfig;
     }


### PR DESCRIPTION
Currently, evergreen start 'autoStart' services by adding them as 'main'
dependency. However, this causes unnecessary complexity in our code
that:
1. Although main depends on 'autoStart' services, Evergreen does not
guarantee that 'autoStart' services starts before every evergreen
service. Currently Kernel has a hack in getMain() to add 'autostart'
services to main's dependency services' dependency.
1. MergeConfig need to skip existing 'autoStart' services to not remove
them.
1. services need to keep track of it's dependencies in
isDefaultDependency.

This draft commit rename autoStart to isSystem. Evergreen will start
'isSystem' services as a system initialization process, before starting
any other services. 'isSystem' services also don't have config root
under 'services' , so that mergeConfig doesn't need to check 'autoStart'

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
