### PR TITLE
Update cloud SDK and fix recipe format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,13 +87,8 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws.services</groupId>
-            <artifactId>greengrassfleetconfiguration</artifactId>
+            <artifactId>evergreen</artifactId>
             <version>1.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws.services</groupId>
-            <artifactId>greengrasscomponentmanagement</artifactId>
-            <version>1.11.1-SNAPSHOT</version>
         </dependency>
         <!-- TODO: This is temporary, adding because there is some confusion about which version
         of core should be used for the AWS SDK (2.x or 1.x). Will be removed once the pom file for

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/BaseE2ETestCase.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/BaseE2ETestCase.java
@@ -6,18 +6,16 @@
 package com.aws.iot.evergreen.integrationtests.e2e;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagementClientBuilder;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.DeleteComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.InvalidInputException;
-import com.amazonaws.services.greengrasscomponentmanagement.model.ResourceAlreadyExistException;
-import com.amazonaws.services.greengrassfleetconfiguration.AWSGreengrassFleetConfiguration;
-import com.amazonaws.services.greengrassfleetconfiguration.AWSGreengrassFleetConfigurationClientBuilder;
-import com.amazonaws.services.greengrassfleetconfiguration.model.PublishConfigurationRequest;
-import com.amazonaws.services.greengrassfleetconfiguration.model.PublishConfigurationResult;
-import com.amazonaws.services.greengrassfleetconfiguration.model.SetConfigurationRequest;
-import com.amazonaws.services.greengrassfleetconfiguration.model.SetConfigurationResult;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.AWSEvergreenClientBuilder;
+import com.amazonaws.services.evergreen.model.CreateComponentResult;
+import com.amazonaws.services.evergreen.model.DeleteComponentResult;
+import com.amazonaws.services.evergreen.model.InvalidInputException;
+import com.amazonaws.services.evergreen.model.PublishConfigurationRequest;
+import com.amazonaws.services.evergreen.model.PublishConfigurationResult;
+import com.amazonaws.services.evergreen.model.ResourceAlreadyExistException;
+import com.amazonaws.services.evergreen.model.SetConfigurationRequest;
+import com.amazonaws.services.evergreen.model.SetConfigurationResult;
 import com.aws.iot.evergreen.easysetup.DeviceProvisioningHelper;
 import com.aws.iot.evergreen.integrationtests.e2e.util.IotJobsUtils;
 import com.aws.iot.evergreen.kernel.Kernel;
@@ -77,9 +75,9 @@ public class BaseE2ETestCase implements AutoCloseable {
     protected Kernel kernel;
 
     protected static final IotClient iotClient = IotSdkClientFactory.getIotClient(BETA_REGION.toString());
-    private static AWSGreengrassFleetConfiguration fcsClient;
-    protected static final AWSGreengrassComponentManagement cmsClient =
-            AWSGreengrassComponentManagementClientBuilder.standard().withEndpointConfiguration(
+    private static AWSEvergreen fcsClient;
+    protected static final AWSEvergreen cmsClient =
+            AWSEvergreenClientBuilder.standard().withEndpointConfiguration(
             new AwsClientBuilder.EndpointConfiguration(CMS_BETA_ENDPOINT, BETA_REGION.toString())).build();
     private static final PackageIdentifier[] testComponents = {
             new PackageIdentifier("CustomerApp", new Semver("1.0.0")),
@@ -188,11 +186,11 @@ public class BaseE2ETestCase implements AutoCloseable {
         }
     }
 
-    protected static synchronized AWSGreengrassFleetConfiguration getFcsClient() {
+    protected static synchronized AWSEvergreen getFcsClient() {
         if (fcsClient == null) {
             AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(
                     FCS_BETA_ENDPOINT, BETA_REGION.toString());
-            fcsClient = AWSGreengrassFleetConfigurationClientBuilder.standard()
+            fcsClient = AWSEvergreenClientBuilder.standard()
                     .withEndpointConfiguration(endpointConfiguration).build();
         }
         return fcsClient;
@@ -200,7 +198,7 @@ public class BaseE2ETestCase implements AutoCloseable {
 
     @SuppressWarnings("PMD.LinguisticNaming")
     protected PublishConfigurationResult setAndPublishFleetConfiguration(SetConfigurationRequest setRequest) {
-        AWSGreengrassFleetConfiguration client = getFcsClient();
+        AWSEvergreen client = getFcsClient();
         logger.atInfo().kv("setRequest", setRequest).log();
         SetConfigurationResult setResult = client.setConfiguration(setRequest);
         logger.atInfo().kv("setResult", setResult).log();

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -5,10 +5,10 @@
 
 package com.aws.iot.evergreen.integrationtests.e2e.deployment;
 
-import com.amazonaws.services.greengrassfleetconfiguration.model.FailureHandlingPolicy;
-import com.amazonaws.services.greengrassfleetconfiguration.model.PackageMetaData;
-import com.amazonaws.services.greengrassfleetconfiguration.model.PublishConfigurationResult;
-import com.amazonaws.services.greengrassfleetconfiguration.model.SetConfigurationRequest;
+import com.amazonaws.services.evergreen.model.FailureHandlingPolicy;
+import com.amazonaws.services.evergreen.model.PackageMetaData;
+import com.amazonaws.services.evergreen.model.PublishConfigurationResult;
+import com.amazonaws.services.evergreen.model.SetConfigurationRequest;
 import com.aws.iot.evergreen.dependency.State;
 import com.aws.iot.evergreen.deployment.model.DeploymentResult;
 import com.aws.iot.evergreen.integrationtests.e2e.BaseE2ETestCase;

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MqttReconnectTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MqttReconnectTest.java
@@ -5,10 +5,10 @@
 
 package com.aws.iot.evergreen.integrationtests.e2e.deployment;
 
-import com.amazonaws.services.greengrassfleetconfiguration.model.FailureHandlingPolicy;
-import com.amazonaws.services.greengrassfleetconfiguration.model.PackageMetaData;
-import com.amazonaws.services.greengrassfleetconfiguration.model.PublishConfigurationResult;
-import com.amazonaws.services.greengrassfleetconfiguration.model.SetConfigurationRequest;
+import com.amazonaws.services.evergreen.model.FailureHandlingPolicy;
+import com.amazonaws.services.evergreen.model.PackageMetaData;
+import com.amazonaws.services.evergreen.model.PublishConfigurationResult;
+import com.amazonaws.services.evergreen.model.SetConfigurationRequest;
 import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.config.Topics;
 import com.aws.iot.evergreen.integrationtests.e2e.BaseE2ETestCase;

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MultipleDeploymentsTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/deployment/MultipleDeploymentsTest.java
@@ -5,9 +5,9 @@
 
 package com.aws.iot.evergreen.integrationtests.e2e.deployment;
 
-import com.amazonaws.services.greengrassfleetconfiguration.model.PackageMetaData;
-import com.amazonaws.services.greengrassfleetconfiguration.model.PublishConfigurationResult;
-import com.amazonaws.services.greengrassfleetconfiguration.model.SetConfigurationRequest;
+import com.amazonaws.services.evergreen.model.PackageMetaData;
+import com.amazonaws.services.evergreen.model.PublishConfigurationResult;
+import com.amazonaws.services.evergreen.model.SetConfigurationRequest;
 import com.aws.iot.evergreen.config.Topic;
 import com.aws.iot.evergreen.config.Topics;
 import com.aws.iot.evergreen.integrationtests.e2e.BaseE2ETestCase;
@@ -106,7 +106,7 @@ class MultipleDeploymentsTest extends BaseE2ETestCase {
             SetConfigurationRequest setRequest = new SetConfigurationRequest()
                     .withTargetName(thingGroupName)
                     .withTargetType(THING_GROUP_TARGET_TYPE)
-                    .withFailureHandlingPolicy(com.amazonaws.services.greengrassfleetconfiguration.model.FailureHandlingPolicy.DO_NOTHING)
+                    .withFailureHandlingPolicy(com.amazonaws.services.evergreen.model.FailureHandlingPolicy.DO_NOTHING)
                     .addPackagesEntry(helper.targetPkgName, new PackageMetaData().withRootComponent(true).withVersion("1.0.0"));
 
             PublishConfigurationResult publishResult = setAndPublishFleetConfiguration(setRequest);

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/BreakingService-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/BreakingService-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: BreakingService
+ComponentName: BreakingService
 Description: A service that just can't run
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/CustomerApp-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/CustomerApp-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: CustomerApp
+ComponentName: CustomerApp
 Description: A customer app
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/GreenSignal-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/GreenSignal-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: GreenSignal
+ComponentName: GreenSignal
 Description: A service indicating approval to proceed
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/Mosquitto-0.9.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/Mosquitto-0.9.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Mosquitto
+ComponentName: Mosquitto
 Description: Mosquitto MQTT Server
 Publisher: Eclipse Foundation
 Version: '0.9.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/Mosquitto-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/Mosquitto-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Mosquitto
+ComponentName: Mosquitto
 Description: Mosquitto MQTT Server
 Publisher: Eclipse Foundation
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/RedSignal-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/RedSignal-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: RedSignal
+ComponentName: RedSignal
 Description: A service revoking approval to proceed
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/SomeOldService-0.9.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/SomeOldService-0.9.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: SomeOldService
+ComponentName: SomeOldService
 Description: A random service to run in Evergreen
 Publisher: Me
 Version: '0.9.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/SomeService-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/SomeService-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: SomeService
+ComponentName: SomeService
 Description: A random service to run in Evergreen
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/YellowSignal-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/deployment/local_store_content/recipes/YellowSignal-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: YellowSignal
+ComponentName: YellowSignal
 Description: A service signalling proceed with caution
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/CustomerApp-0.9.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/CustomerApp-0.9.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: CustomerApp
+ComponentName: CustomerApp
 Description: A customer app
 Publisher: Me
 Version: '0.9.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/CustomerApp-0.9.1.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/CustomerApp-0.9.1.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: CustomerApp
+ComponentName: CustomerApp
 Description: A customer app
 Publisher: Me
 Version: '0.9.1'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/CustomerApp-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/CustomerApp-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: CustomerApp
+ComponentName: CustomerApp
 Description: A customer app
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/GreenSignal-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/GreenSignal-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: GreenSignal
+ComponentName: GreenSignal
 Description: A service indicating approval to proceed
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/KernelIntegTest-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/KernelIntegTest-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: KernelIntegTest
+ComponentName: KernelIntegTest
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/KernelIntegTestDependency-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/KernelIntegTestDependency-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: KernelIntegTestDependency
+ComponentName: KernelIntegTestDependency
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/Log-2.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/Log-2.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Log
+ComponentName: Log
 Description: A test app
 Publisher: Me
 Version: '2.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/Mosquitto-0.9.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/Mosquitto-0.9.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Mosquitto
+ComponentName: Mosquitto
 Description: Mosquitto MQTT Server
 Publisher: Eclipse Foundation
 Version: '0.9.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/Mosquitto-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/Mosquitto-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Mosquitto
+ComponentName: Mosquitto
 Description: Mosquitto MQTT Server
 Publisher: Eclipse Foundation
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/RedSignal-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/RedSignal-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: RedSignal
+ComponentName: RedSignal
 Description: A service revoking approval to proceed
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/SlowToDeployApp-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/SlowToDeployApp-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: SlowToDeployApp
+ComponentName: SlowToDeployApp
 Description: An app that takes some time to install so as to slow down deployments
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/SomeOldService-0.9.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/SomeOldService-0.9.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: SomeOldService
+ComponentName: SomeOldService
 Description: A random service to run in Evergreen
 Publisher: Me
 Version: '0.9.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/SomeService-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/SomeService-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: SomeService
+ComponentName: SomeService
 Description: A random service to run in Evergreen
 Publisher: Me
 Version: '1.0.0'

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/YellowSignal-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/e2e/local_store_content/recipes/YellowSignal-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: YellowSignal
+ComponentName: YellowSignal
 Description: A service signalling proceed with caution
 Publisher: Me
 Version: '1.0.0'

--- a/src/main/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelper.java
@@ -1,11 +1,11 @@
 package com.aws.iot.evergreen.easysetup;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagementClientBuilder;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CommitComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.ResourceAlreadyExistException;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.AWSEvergreenClientBuilder;
+import com.amazonaws.services.evergreen.model.CommitComponentRequest;
+import com.amazonaws.services.evergreen.model.CreateComponentRequest;
+import com.amazonaws.services.evergreen.model.ResourceAlreadyExistException;
 import com.aws.iot.evergreen.config.Topics;
 import com.aws.iot.evergreen.deployment.DeviceConfiguration;
 import com.aws.iot.evergreen.kernel.Kernel;
@@ -76,7 +76,7 @@ public class DeviceProvisioningHelper {
 
     private IotClient iotClient;
     private IamClient iamClient;
-    private AWSGreengrassComponentManagement cmsClient;
+    private AWSEvergreen cmsClient;
 
     /**
      * Constructor for a desired region.
@@ -87,7 +87,7 @@ public class DeviceProvisioningHelper {
     public DeviceProvisioningHelper(String awsRegion, PrintStream outStream) {
         this.iotClient = IotSdkClientFactory.getIotClient(awsRegion);
         this.iamClient = IamSdkClientFactory.getIamClient();
-        this.cmsClient = AWSGreengrassComponentManagementClientBuilder.standard().withEndpointConfiguration(
+        this.cmsClient = AWSEvergreenClientBuilder.standard().withEndpointConfiguration(
                 new AwsClientBuilder.EndpointConfiguration(GREENGRASS_SERVICE_ENDPOINT, awsRegion)).build();
         this.outStream = outStream;
     }
@@ -101,7 +101,7 @@ public class DeviceProvisioningHelper {
      * @param cmsClient cms client
      */
     DeviceProvisioningHelper(PrintStream outStream, IotClient iotClient, IamClient iamClient,
-                             AWSGreengrassComponentManagement cmsClient) {
+                             AWSEvergreen cmsClient) {
         this.outStream = outStream;
         this.iotClient = iotClient;
         this.iamClient = iamClient;
@@ -314,7 +314,7 @@ public class DeviceProvisioningHelper {
     /*
      * Create and commit an empty component.
      */
-    private void createEmptyComponent(AWSGreengrassComponentManagement cmsClient, String componentName) {
+    private void createEmptyComponent(AWSEvergreen cmsClient, String componentName) {
         outStream.println("Creating empty component " + componentName);
         ByteBuffer recipe =
                 ByteBuffer.wrap(FIRST_PARTY_COMPONENT_RECIPES.get(componentName).getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceClientFactory.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceClientFactory.java
@@ -5,8 +5,8 @@ package com.aws.iot.evergreen.packagemanager;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagementClientBuilder;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.AWSEvergreenClientBuilder;
 import com.aws.iot.evergreen.deployment.DeviceConfiguration;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.logging.impl.LogManager;
@@ -25,7 +25,7 @@ public class GreengrassPackageServiceClientFactory {
     public static final String CONTEXT_SERVICE_CRED_PROVIDER = "greengrassServiceCredentialProvider";
     private static final Logger logger = LogManager.getLogger(GreengrassPackageServiceClientFactory.class);
 
-    private final AWSGreengrassComponentManagement cmsClient;
+    private final AWSEvergreen cmsClient;
 
     /**
      * Constructor with custom endpoint/region configuration.
@@ -39,8 +39,8 @@ public class GreengrassPackageServiceClientFactory {
             @Named(CONTEXT_COMPONENT_SERVICE_ENDPOINT) String greengrassServiceEndpoint,
             DeviceConfiguration deviceConfiguration,
             @Named(CONTEXT_SERVICE_CRED_PROVIDER) AWSCredentialsProvider credentialsProvider) {
-        AWSGreengrassComponentManagementClientBuilder clientBuilder =
-                AWSGreengrassComponentManagementClientBuilder.standard();
+        AWSEvergreenClientBuilder clientBuilder =
+                AWSEvergreenClientBuilder.standard();
         String region = Coerce.toString(deviceConfiguration.getAWSRegion());
 
         if (!Utils.isEmpty(region)) {

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelper.java
@@ -1,22 +1,22 @@
 package com.aws.iot.evergreen.packagemanager;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CommitComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CommitComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.ComponentNameVersion;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentArtifactUploadUrlRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentArtifactUploadUrlResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.DeleteComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.DeleteComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.FindComponentVersionsByPlatformRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.FindComponentVersionsByPlatformResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.GetComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.GetComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.RecipeFormatType;
-import com.amazonaws.services.greengrasscomponentmanagement.model.ResolvedComponent;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.model.CommitComponentRequest;
+import com.amazonaws.services.evergreen.model.CommitComponentResult;
+import com.amazonaws.services.evergreen.model.ComponentNameVersion;
+import com.amazonaws.services.evergreen.model.CreateComponentArtifactUploadUrlRequest;
+import com.amazonaws.services.evergreen.model.CreateComponentArtifactUploadUrlResult;
+import com.amazonaws.services.evergreen.model.CreateComponentRequest;
+import com.amazonaws.services.evergreen.model.CreateComponentResult;
+import com.amazonaws.services.evergreen.model.DeleteComponentRequest;
+import com.amazonaws.services.evergreen.model.DeleteComponentResult;
+import com.amazonaws.services.evergreen.model.FindComponentVersionsByPlatformRequest;
+import com.amazonaws.services.evergreen.model.FindComponentVersionsByPlatformResult;
+import com.amazonaws.services.evergreen.model.GetComponentRequest;
+import com.amazonaws.services.evergreen.model.GetComponentResult;
+import com.amazonaws.services.evergreen.model.RecipeFormatType;
+import com.amazonaws.services.evergreen.model.ResolvedComponent;
 import com.aws.iot.evergreen.config.PlatformResolver;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.logging.impl.LogManager;
@@ -51,7 +51,7 @@ public class GreengrassPackageServiceHelper {
     // Service logger instance
     protected static final Logger logger = LogManager.getLogger(GreengrassPackageServiceHelper.class);
 
-    private final AWSGreengrassComponentManagement evgCmsClient;
+    private final AWSEvergreen evgCmsClient;
 
     @Inject
     public GreengrassPackageServiceHelper(GreengrassPackageServiceClientFactory clientFactory) {
@@ -74,8 +74,7 @@ public class GreengrassPackageServiceHelper {
             return componentSelectedMetadataList.stream().map(componentMetadata -> {
                 PackageIdentifier packageIdentifier
                         = new PackageIdentifier(componentMetadata.getComponentName(),
-                                                new Semver(componentMetadata.getComponentVersion()),
-                                                componentMetadata.getComponentARN());
+                                                new Semver(componentMetadata.getComponentVersion()));
                 return new PackageMetadata(packageIdentifier, componentMetadata.getDependencies().stream().collect(
                         Collectors.toMap(ComponentNameVersion::getComponentName,
                                          ComponentNameVersion::getComponentVersionConstraint)));
@@ -117,10 +116,10 @@ public class GreengrassPackageServiceHelper {
      *
      * @param cmsClient client of Component Management Service
      * @param recipeFilePath the path to the component recipe file
-     * @return {@Link CreateComponentResult}
+     * @return {@link CreateComponentResult}
      * @throws IOException if file reading fails
      */
-    public static CreateComponentResult createComponent(AWSGreengrassComponentManagement cmsClient,
+    public static CreateComponentResult createComponent(AWSEvergreen cmsClient,
                                                         Path recipeFilePath) throws IOException {
         ByteBuffer recipeBuf = ByteBuffer.wrap(Files.readAllBytes(recipeFilePath));
 
@@ -140,7 +139,7 @@ public class GreengrassPackageServiceHelper {
      * @param componentVersion version of the component that requires the artifact
      * @throws IOException if file upload fails
      */
-    public static void createAndUploadComponentArtifact(AWSGreengrassComponentManagement cmsClient, File artifact,
+    public static void createAndUploadComponentArtifact(AWSEvergreen cmsClient, File artifact,
                                                         String componentName, String componentVersion)
             throws IOException {
         if (skipComponentArtifactUpload(artifact)) {
@@ -156,7 +155,7 @@ public class GreengrassPackageServiceHelper {
     }
 
     protected static CreateComponentArtifactUploadUrlResult createComponentArtifactUploadUrl(
-            AWSGreengrassComponentManagement cmsClient, String componentName,
+            AWSEvergreen cmsClient, String componentName,
             String componentVersion, String artifactName) {
         CreateComponentArtifactUploadUrlRequest artifactUploadUrlRequest = new CreateComponentArtifactUploadUrlRequest()
                 .withComponentName(componentName).withComponentVersion(componentVersion)
@@ -188,9 +187,9 @@ public class GreengrassPackageServiceHelper {
      * @param cmsClient client of Component Management Service
      * @param componentName name of the component to commit
      * @param componentVersion version of the component to commit
-     * @return {@Link CommitComponentResult}
+     * @return {@link CommitComponentResult}
      */
-    public static CommitComponentResult commitComponent(AWSGreengrassComponentManagement cmsClient,
+    public static CommitComponentResult commitComponent(AWSEvergreen cmsClient,
                                                         String componentName, String componentVersion) {
         CommitComponentRequest commitComponentRequest = new CommitComponentRequest().withComponentName(componentName)
                 .withComponentVersion(componentVersion);
@@ -206,9 +205,9 @@ public class GreengrassPackageServiceHelper {
      * @param cmsClient client of Component Management Service
      * @param componentName name of the component to delete
      * @param componentVersion version of the component to delete
-     * @return {@Link DeleteComponentResult}
+     * @return {@link DeleteComponentResult}
      */
-    public static DeleteComponentResult deleteComponent(AWSGreengrassComponentManagement cmsClient,
+    public static DeleteComponentResult deleteComponent(AWSEvergreen cmsClient,
                                                         String componentName, String componentVersion) {
         DeleteComponentRequest deleteComponentRequest = new DeleteComponentRequest()
                 .withComponentName(componentName).withComponentVersion(componentVersion);

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -232,7 +232,7 @@ public class KernelConfigResolver {
     private Set<PackageParameter> getParametersFromDeployment(DeploymentDocument document,
                                                               PackageRecipe packageRecipe) {
         Optional<DeploymentPackageConfiguration> packageConfigInDeployment =
-                getMatchingPackageConfigFromDeployment(document, packageRecipe.getPackageName(),
+                getMatchingPackageConfigFromDeployment(document, packageRecipe.getComponentName(),
                         packageRecipe.getVersion().toString());
         return packageConfigInDeployment.map(deploymentPackageConfiguration -> PackageParameter
                 .fromMap(deploymentPackageConfiguration.getConfiguration())).orElse(Collections.emptySet());
@@ -243,7 +243,7 @@ public class KernelConfigResolver {
      */
     private Set<PackageParameter> getParametersStoredInConfig(PackageRecipe packageRecipe) {
         try {
-            EvergreenService service = kernel.locate(packageRecipe.getPackageName());
+            EvergreenService service = kernel.locate(packageRecipe.getComponentName());
             Set<PackageParameter> parametersStoredInConfig = new HashSet<>();
 
             // Get only those parameters which are still valid for the current version of the package

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/PackageStore.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/PackageStore.java
@@ -81,7 +81,7 @@ public class PackageStore {
      * @throws PackageLoadingException if fails to write the package recipe to disk.
      */
     void savePackageRecipe(@NonNull PackageRecipe packageRecipe) throws PackageLoadingException {
-        Path recipePath = resolveRecipePath(packageRecipe.getPackageName(), packageRecipe.getVersion());
+        Path recipePath = resolveRecipePath(packageRecipe.getComponentName(), packageRecipe.getVersion());
 
         try {
             RECIPE_SERIALIZER.writeValue(recipePath.toFile(), packageRecipe);

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
@@ -38,7 +38,7 @@ public class PackageRecipe {
     private final RecipeTemplateVersion recipeTemplateVersion;
 
     @EqualsAndHashCode.Include
-    private final String packageName;
+    private final String componentName;
 
     @EqualsAndHashCode.Include
     private Semver version;
@@ -66,7 +66,7 @@ public class PackageRecipe {
      * Constructor for Jackson to deserialize.
      *
      * @param recipeTemplateVersion Template version found in the Recipe file
-     * @param packageName           Name of the package
+     * @param componentName           Name of the component
      * @param version               Version of the package
      * @param description           Description metadata
      * @param publisher             Name of the publisher
@@ -82,7 +82,7 @@ public class PackageRecipe {
     @JsonCreator
     @SuppressWarnings("PMD.ExcessiveParameterList")
     public PackageRecipe(@JsonProperty("RecipeTemplateVersion") RecipeTemplateVersion recipeTemplateVersion,
-                         @JsonProperty("PackageName") String packageName, @JsonProperty("Version") Semver version,
+                         @JsonProperty("ComponentName") String componentName, @JsonProperty("Version") Semver version,
                          @JsonProperty("Description") String description, @JsonProperty("Publisher") String publisher,
                          @JsonProperty("Parameters") Set<PackageParameter> packageParameters,
                          @JsonProperty("Platforms") List<String> platforms,
@@ -98,7 +98,7 @@ public class PackageRecipe {
                                  using = MapFieldDeserializer.class) Map<String, String> environmentVariables) {
 
         this.recipeTemplateVersion = recipeTemplateVersion;
-        this.packageName = packageName;
+        this.componentName = componentName;
         //TODO: Figure out how to do this in deserialize (only option so far seems to be custom deserializer)
         //TODO: Validate SemverType.STRICT before creating this
         this.version = new Semver(version.toString(), Semver.SemverType.NPM);

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloader.java
@@ -2,9 +2,9 @@ package com.aws.iot.evergreen.packagemanager.plugins;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.model.GetComponentArtifactRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.GetComponentArtifactResult;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.model.GetComponentArtifactRequest;
+import com.amazonaws.services.evergreen.model.GetComponentArtifactResult;
 import com.aws.iot.evergreen.logging.api.Logger;
 import com.aws.iot.evergreen.logging.impl.LogManager;
 import com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceClientFactory;
@@ -29,7 +29,7 @@ public class GreengrassRepositoryDownloader implements ArtifactDownloader {
     private static final String ARTIFACT_DOWNLOAD_EXCEPTION_PMS_FMT
             = "Failed to download artifact %s for package %s-%s, http response from server was %d";
 
-    private final AWSGreengrassComponentManagement evgCmsClient;
+    private final AWSEvergreen evgCmsClient;
 
     @Inject
     public GreengrassRepositoryDownloader(GreengrassPackageServiceClientFactory clientFactory) {

--- a/src/main/java/com/aws/iot/evergreen/util/Exec.java
+++ b/src/main/java/com/aws/iot/evergreen/util/Exec.java
@@ -378,7 +378,6 @@ public final class Exec implements Closeable {
             if (wd != null) {
                 wd.accept(exit);
             }
-            notifyAll();
         }
     }
 

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/PyYAML-3.10.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/PyYAML-3.10.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: PyYAML
+ComponentName: PyYAML
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '3.10.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/PyYAML-3.13.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/PyYAML-3.13.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: PyYAML
+ComponentName: PyYAML
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '3.13.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/awscli-1.16.144.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/awscli-1.16.144.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: awscli
+ComponentName: awscli
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.16.144'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/boto3-1.9.128.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/boto3-1.9.128.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: boto3
+ComponentName: boto3
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.9.128'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/botocore-1.12.128.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/botocore-1.12.128.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: botocore
+ComponentName: botocore
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.12.128'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/botocore-1.12.134.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/botocore-1.12.134.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: botocore
+ComponentName: botocore
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.12.134'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/colorama-0.2.5.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/colorama-0.2.5.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: colorama
+ComponentName: colorama
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.2.5'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/colorama-0.3.9.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/colorama-0.3.9.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: colorama
+ComponentName: colorama
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.3.9'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/docutils-0.10.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/docutils-0.10.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: docutils
+ComponentName: docutils
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.10.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/docutils-0.12.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/docutils-0.12.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: docutils
+ComponentName: docutils
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.12.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/docutils-0.14.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/docutils-0.14.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: docutils
+ComponentName: docutils
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.14.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/jmespath-0.7.1.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/jmespath-0.7.1.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: jmespath
+ComponentName: jmespath
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.7.1'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/jmespath-0.8.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/jmespath-0.8.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: jmespath
+ComponentName: jmespath
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.8.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/jmespath-0.9.5.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/jmespath-0.9.5.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: jmespath
+ComponentName: jmespath
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.9.5'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/pyasn1-0.1.3.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/pyasn1-0.1.3.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: pyasn1
+ComponentName: pyasn1
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.1.3'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/pyasn1-0.4.8.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/pyasn1-0.4.8.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: pyasn1
+ComponentName: pyasn1
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.4.8'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/python-dateutil-2.3.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/python-dateutil-2.3.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: python-dateutil
+ComponentName: python-dateutil
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '2.3.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/python-dateutil-2.8.1.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/python-dateutil-2.8.1.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: python-dateutil
+ComponentName: python-dateutil
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '2.8.1'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/rsa-3.1.4.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/rsa-3.1.4.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: rsa
+ComponentName: rsa
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '3.1.4'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/rsa-3.4.2.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/rsa-3.4.2.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: rsa
+ComponentName: rsa
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '3.4.2'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.1.13.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.1.13.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: s3transfer
+ComponentName: s3transfer
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.1.13'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.2.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.2.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: s3transfer
+ComponentName: s3transfer
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.2.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.2.1.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.2.1.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: s3transfer
+ComponentName: s3transfer
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.2.1'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.3.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/s3transfer-0.3.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: s3transfer
+ComponentName: s3transfer
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '0.3.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/six-1.14.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/six-1.14.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: six
+ComponentName: six
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.14.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/six-1.5.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/six-1.5.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: six
+ComponentName: six
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.5.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.20.0.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.20.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: urllib3
+ComponentName: urllib3
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.20.0'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.21.1.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.21.1.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: urllib3
+ComponentName: urllib3
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.21.1'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.24.3.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.24.3.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: urllib3
+ComponentName: urllib3
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.24.3'

--- a/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.25.8.yaml
+++ b/src/test/evergreen-kernel-benchmark/mock_artifact_source/recipes/urllib3-1.25.8.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: urllib3
+ComponentName: urllib3
 Description: Test recipe for Evergreen packages
 Publisher: EvergreenBenchmarkTest
 Version: '1.25.8'

--- a/src/test/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/iot/evergreen/easysetup/DeviceProvisioningHelperTest.java
@@ -1,8 +1,8 @@
 package com.aws.iot.evergreen.easysetup;
 
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.ResourceAlreadyExistException;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.model.CreateComponentResult;
+import com.amazonaws.services.evergreen.model.ResourceAlreadyExistException;
 import com.aws.iot.evergreen.kernel.Kernel;
 import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
 import com.aws.iot.evergreen.util.IamSdkClientFactory;
@@ -70,7 +70,7 @@ public class DeviceProvisioningHelperTest {
     @Mock
     private IamClient iamClient;
     @Mock
-    private AWSGreengrassComponentManagement cmsClient;
+    private AWSEvergreen cmsClient;
     @Mock
     private GetPolicyResponse getPolicyResponse;
     @Mock

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelperTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/GreengrassPackageServiceHelperTest.java
@@ -1,13 +1,13 @@
 package com.aws.iot.evergreen.packagemanager;
 
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CommitComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentArtifactUploadUrlRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.CreateComponentResult;
-import com.amazonaws.services.greengrasscomponentmanagement.model.DeleteComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.GetComponentRequest;
-import com.amazonaws.services.greengrasscomponentmanagement.model.GetComponentResult;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.model.CommitComponentRequest;
+import com.amazonaws.services.evergreen.model.CreateComponentArtifactUploadUrlRequest;
+import com.amazonaws.services.evergreen.model.CreateComponentRequest;
+import com.amazonaws.services.evergreen.model.CreateComponentResult;
+import com.amazonaws.services.evergreen.model.DeleteComponentRequest;
+import com.amazonaws.services.evergreen.model.GetComponentRequest;
+import com.amazonaws.services.evergreen.model.GetComponentResult;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
 import com.aws.iot.evergreen.packagemanager.models.PackageRecipe;
 import com.aws.iot.evergreen.testcommons.testutilities.EGExtension;
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 class GreengrassPackageServiceHelperTest {
 
     @Mock
-    private AWSGreengrassComponentManagement client;
+    private AWSEvergreen client;
 
     @Mock
     private GreengrassPackageServiceClientFactory clientFactory;
@@ -74,7 +74,7 @@ class GreengrassPackageServiceHelperTest {
         assertEquals(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, generatedRequest.getComponentName());
         assertEquals("1.0.0", generatedRequest.getComponentVersion());
         assertEquals("YAML", generatedRequest.getType());
-        assertEquals(testPackage.getPackageName(), TestHelper.MONITORING_SERVICE_PACKAGE_NAME);
+        assertEquals(testPackage.getComponentName(), TestHelper.MONITORING_SERVICE_PACKAGE_NAME);
         assertTrue(testPackage.getVersion().isEqualTo("1.0.0"));
     }
 

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipeTest.java
@@ -51,7 +51,7 @@ public class PackageRecipeTest {
         String recipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "1.0.0");
         PackageRecipe testPkg = TestHelper.getPackageObject(recipeContents);
-        assertThat(testPkg.getPackageName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
+        assertThat(testPkg.getComponentName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
         assertThat(testPkg.getVersion().getValue(), is("1.0.0"));
         assertThat(testPkg.getPublisher(), is("Me"));
         assertThat(testPkg.getRecipeTemplateVersion(), is(RecipeTemplateVersion.JAN_25_2020));
@@ -79,7 +79,7 @@ public class PackageRecipeTest {
         String recipeContents =
                 TestHelper.getPackageRecipeForTestPackage(TestHelper.MONITORING_SERVICE_PACKAGE_NAME, "2.0.0");
         PackageRecipe testPkg = TestHelper.getPackageObject(recipeContents);
-        assertThat(testPkg.getPackageName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
+        assertThat(testPkg.getComponentName(), is(TestHelper.MONITORING_SERVICE_PACKAGE_NAME));
         assertThat(testPkg.getVersion().getValue(), is("2.0.0"));
         assertThat(testPkg.getPublisher(), is("Me"));
 

--- a/src/test/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/iot/evergreen/packagemanager/plugins/GreengrassRepositoryDownloaderTest.java
@@ -1,5 +1,8 @@
 package com.aws.iot.evergreen.packagemanager.plugins;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.evergreen.AWSEvergreen;
+import com.amazonaws.services.evergreen.model.GetComponentArtifactRequest;
 import com.aws.iot.evergreen.packagemanager.GreengrassPackageServiceClientFactory;
 import com.aws.iot.evergreen.packagemanager.TestHelper;
 import com.aws.iot.evergreen.packagemanager.models.PackageIdentifier;
@@ -24,10 +27,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.greengrasscomponentmanagement.AWSGreengrassComponentManagement;
-import com.amazonaws.services.greengrasscomponentmanagement.model.GetComponentArtifactRequest;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +43,7 @@ class GreengrassRepositoryDownloaderTest {
     private HttpURLConnection connection;
 
     @Mock
-    private AWSGreengrassComponentManagement client;
+    private AWSEvergreen client;
 
     @Mock
     private GreengrassPackageServiceClientFactory clientFactory;

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: ConveyorBelt
+ComponentName: ConveyorBelt
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.1.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/ConveyorBelt-1.1.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: ConveyorBelt
+ComponentName: ConveyorBelt
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.1.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Cool-Database-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Cool-Database-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Cool-Database
+ComponentName: Cool-Database
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/InvalidRecipe-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/InvalidRecipe-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: 'Invalid'
-PackageName: InvalidRecipeVersion
+ComponentName: InvalidRecipeVersion
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Log
+ComponentName: Log
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.5.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-1.5.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Log
+ComponentName: Log
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.5.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-2.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/Log-2.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: Log
+ComponentName: Log
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '2.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-1.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-1.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-1.1.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-1.1.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.1.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-2.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-2.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '2.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-3.0.0.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/recipes/MonitoringService-3.0.0.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '3.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.0.0/conveyor_artifact.txt
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.0.0/conveyor_artifact.txt
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitorService
+ComponentName: MonitorService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.0.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: ConveyorBelt
+ComponentName: ConveyorBelt
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.1.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/ConveyorBelt-1.1.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: ConveyorBelt
+ComponentName: ConveyorBelt
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.1.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/DependencyNotMap-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/DependencyNotMap-1.0.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: DependencyMissingVersion
+ComponentName: DependencyMissingVersion
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/DependencyUnknownKeyword-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/DependencyUnknownKeyword-1.0.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: DependencyUnknownKeyword
+ComponentName: DependencyUnknownKeyword
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/InvalidRecipeVersion-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/InvalidRecipeVersion-1.0.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: 'Invalid'
-PackageName: InvalidRecipeVersion
+ComponentName: InvalidRecipeVersion
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.0.0/monitor_artifact_100.txt
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.0.0/monitor_artifact_100.txt
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitorService
+ComponentName: MonitorService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.0.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/bad_recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/bad_recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/monitor_artifact_110.txt
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/monitor_artifact_110.txt
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitorService
+ComponentName: MonitorService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.0.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-1.1.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '1.1.0'

--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-2.0.0/recipe.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/test_packages/MonitoringService-2.0.0/recipe.yaml
@@ -1,6 +1,6 @@
 ---
 RecipeTemplateVersion: '2020-01-25'
-PackageName: MonitoringService
+ComponentName: MonitoringService
 Description: Test recipe for Evergreen packages
 Publisher: Me
 Version: '2.0.0'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Cloud renamed PackageName to ComponentName, which causes our E2E tests to fail. This change does the rename on our side, as well as switches us to their newest combined SDK.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
