### PR TITLE
Use component parameters/configuration directly for dynamic config

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
@@ -49,8 +49,8 @@ import java.util.function.Consumer;
 
 import static com.aws.iot.evergreen.ipc.AuthHandler.SERVICE_UNIQUE_ID_KEY;
 import static com.aws.iot.evergreen.ipc.IPCService.KERNEL_URI_ENV_VARIABLE_NAME;
-import static com.aws.iot.evergreen.kernel.EvergreenService.CUSTOM_CONFIG_NAMESPACE;
 import static com.aws.iot.evergreen.kernel.EvergreenService.SETENV_CONFIG_NAMESPACE;
+import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.PARAMETERS_CONFIG_KEY;
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -215,7 +215,7 @@ class IPCServicesTest {
         client = new IPCClientImpl(config);
         ConfigStore c = new ConfigStoreImpl(client);
 
-        Topics custom = kernel.findServiceTopic("ServiceName").createInteriorChild(CUSTOM_CONFIG_NAMESPACE);
+        Topics custom = kernel.findServiceTopic("ServiceName").createInteriorChild(PARAMETERS_CONFIG_KEY);
 
         AtomicInteger numCalls = new AtomicInteger();
         Pair<CompletableFuture<Void>, Consumer<String>> p = TestUtils.asyncAssertOnConsumer((a) -> {
@@ -248,7 +248,7 @@ class IPCServicesTest {
         client = new IPCClientImpl(config);
         ConfigStore c = new ConfigStoreImpl(client);
 
-        Topics custom = kernel.findServiceTopic("ServiceName").createInteriorChild(CUSTOM_CONFIG_NAMESPACE);
+        Topics custom = kernel.findServiceTopic("ServiceName").createInteriorChild(PARAMETERS_CONFIG_KEY);
         custom.createLeafChild("abc").withValue("ABC");
         custom.createInteriorChild("DDF").createLeafChild("A").withValue("C");
 

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/kernel/GenericExternalServiceTest.java
@@ -20,9 +20,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.aws.iot.evergreen.kernel.EvergreenService.CUSTOM_CONFIG_NAMESPACE;
 import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
 import static com.aws.iot.evergreen.kernel.EvergreenService.SETENV_CONFIG_NAMESPACE;
+import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.PARAMETERS_CONFIG_KEY;
 import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -123,7 +123,7 @@ class GenericExternalServiceTest extends BaseITCase {
         Subscriber customConfigWatcher = (WhatHappened what, Topic t) -> {
             topicUpdateProcessedFuture.complete(null);
         };
-        Topic customConfigTopic = service.getServiceConfig().find(CUSTOM_CONFIG_NAMESPACE, "my_custom_key");
+        Topic customConfigTopic = service.getServiceConfig().find(PARAMETERS_CONFIG_KEY, "my_custom_key");
         customConfigTopic.subscribe(customConfigWatcher);
 
         customConfigTopic.withValue("my_custom_initial_value");

--- a/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/service_with_dynamic_config.yaml
+++ b/src/integrationtests/resources/com/aws/iot/evergreen/integrationtests/kernel/service_with_dynamic_config.yaml
@@ -14,5 +14,5 @@ services:
     version: 1.0.0
     setenv:
       my_env_var: var1
-    custom:
+    parameters:
       my_custom_key: 'my_custom_initial_value'

--- a/src/main/java/com/aws/iot/evergreen/builtin/services/configstore/ConfigStoreIPCAgent.java
+++ b/src/main/java/com/aws/iot/evergreen/builtin/services/configstore/ConfigStoreIPCAgent.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 
-import static com.aws.iot.evergreen.kernel.EvergreenService.CUSTOM_CONFIG_NAMESPACE;
+import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.PARAMETERS_CONFIG_KEY;
 
 /**
  * Class to handle business logic for all ConfigStore requests over IPC.
@@ -68,7 +68,7 @@ public class ConfigStoreIPCAgent implements InjectionActions {
         }
         // Ensure that the node which changed was part of the custom config
         int customConfigIndex = nodePath.size() - 4;
-        if (!nodePath.get(customConfigIndex).equals(CUSTOM_CONFIG_NAMESPACE)) {
+        if (!nodePath.get(customConfigIndex).equals(PARAMETERS_CONFIG_KEY)) {
             return;
         }
 
@@ -148,7 +148,7 @@ public class ConfigStoreIPCAgent implements InjectionActions {
                     .build();
         }
 
-        Topics configTopics = serviceTopic.findInteriorChild(CUSTOM_CONFIG_NAMESPACE);
+        Topics configTopics = serviceTopic.findInteriorChild(PARAMETERS_CONFIG_KEY);
         if (configTopics == null) {
             return response.responseStatus(ConfigStoreResponseStatus.NoDynamicConfig)
                     .errorMessage("Service has no dynamic config").build();

--- a/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/EvergreenService.java
@@ -42,7 +42,6 @@ public class EvergreenService implements InjectionActions, DisruptableCheck {
     public static final String SERVICE_LIFECYCLE_NAMESPACE_TOPIC = "lifecycle";
     public static final String SERVICE_DEPENDENCIES_NAMESPACE_TOPIC = "dependencies";
     public static final String SERVICE_NAME_KEY = "serviceName";
-    public static final String CUSTOM_CONFIG_NAMESPACE = "custom";
     public static final String SETENV_CONFIG_NAMESPACE = "setenv";
 
     private static final String CURRENT_STATE_METRIC_NAME = "currentState";

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -26,10 +26,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 
-import static com.aws.iot.evergreen.kernel.EvergreenService.CUSTOM_CONFIG_NAMESPACE;
 import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
-import static com.aws.iot.evergreen.kernel.EvergreenService.SETENV_CONFIG_NAMESPACE;
 
 public class KernelConfigResolver {
 
@@ -104,20 +102,6 @@ public class KernelConfigResolver {
                     interpolate(configKVPair.getValue(), resolvedParams, packageIdentifier));
         }
         resolvedServiceConfig.put(EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC, resolvedLifecycleConfig);
-
-        Map<Object, Object> resolvedCustomConfig = new HashMap<>();
-        for (Map.Entry<String, Object> configKVPair : packageRecipe.getCustomConfig().entrySet()) {
-            resolvedCustomConfig.put(configKVPair.getKey(),
-                    interpolate(configKVPair.getValue(), resolvedParams, packageIdentifier));
-        }
-        resolvedServiceConfig.put(CUSTOM_CONFIG_NAMESPACE, resolvedCustomConfig);
-
-        Map<String, String> resolvedSetEnvConfig = new HashMap<>();
-        for (Map.Entry<String, String> configKVPair : packageRecipe.getEnvironmentVariables().entrySet()) {
-            resolvedSetEnvConfig.put(configKVPair.getKey(),
-                    (String) interpolate(configKVPair.getValue(), resolvedParams, packageIdentifier));
-        }
-        resolvedServiceConfig.put(SETENV_CONFIG_NAMESPACE, resolvedSetEnvConfig);
 
         // Generate dependencies
         List<String> dependencyConfig = new ArrayList<>();

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageRecipe.java
@@ -58,10 +58,6 @@ public class PackageRecipe {
 
     private final Map<String, RecipeDependencyProperties> dependencies;
 
-    private final Map<String, Object> customConfig;
-
-    private final Map<String, String> environmentVariables;
-
     /**
      * Constructor for Jackson to deserialize.
      *
@@ -75,8 +71,6 @@ public class PackageRecipe {
      * @param lifecycle             Lifecycle definitions
      * @param artifacts             Artifact definitions
      * @param dependencies          List of dependencies
-     * @param customConfig          Custom config to store in kernel config store
-     * @param environmentVariables  Environment variables for the service
      * @throws SemverException if the semver fails to be created
      */
     @JsonCreator
@@ -91,11 +85,7 @@ public class PackageRecipe {
                          @JsonProperty("Artifacts") Map<String, List<URI>> artifacts,
                          @JsonProperty("Dependencies") @JsonDeserialize(
                                  using = DependencyMapDeserializer.class)
-                                     Map<String, RecipeDependencyProperties> dependencies,
-                         @JsonProperty("CustomConfig") @JsonDeserialize(
-                                 using = MapFieldDeserializer.class) Map<String, Object> customConfig,
-                         @JsonProperty("EnvironmentVariables") @JsonDeserialize(
-                                 using = MapFieldDeserializer.class) Map<String, String> environmentVariables) {
+                                     Map<String, RecipeDependencyProperties> dependencies) {
 
         this.recipeTemplateVersion = recipeTemplateVersion;
         this.componentName = componentName;
@@ -109,8 +99,6 @@ public class PackageRecipe {
         this.lifecycle = lifecycle == null ? Collections.emptyMap() : lifecycle;
         this.artifacts = artifacts == null ? Collections.emptyMap() : artifacts;
         this.dependencies = dependencies == null ? Collections.emptyMap() : dependencies;
-        this.customConfig = customConfig == null ? Collections.emptyMap() : customConfig;
-        this.environmentVariables = environmentVariables == null ? Collections.emptyMap() : environmentVariables;
     }
 
     @JsonSerialize(using = SemverSerializer.class)


### PR DESCRIPTION
**Issue #, if available:**
Reuse parameters directly for dynamic config instead of using a dedicated custom config key in component recipe

This change does not include renaming of parameters -> configuration in code or parameters -> defaults in recipe model since that needs a lot more changes and an agreement on other changes like independent schema for configuration etc 

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
