### PR TITLE
Split coverage reports and checks for unit and integ tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Convert Jacoco interation test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco-it/jacoco.xml src/main/java > target/jacoco-report/cobertura-it.xml
       - name: cobertura-report-unit-test
-        uses: 5monkeys/cobertura-action@master
+        uses: shaguptashaikh/cobertura-action@master
         continue-on-error: true
         with:
           # The GITHUB_TOKEN for this repo
@@ -53,15 +53,17 @@ jobs:
           # If files with 100% should be skipped from report.
           skip_covered: false
           # Minimum allowed coverage percentage as an integer.
-          minimum_coverage: 60
+          minimum_coverage: 64
           # Show line rate as specific column.
           show_line: true
           # Show branch rate as specific column.
           show_branch: true
           # Use class names instead of the filename
           show_class_names: true
+          # Use a unique name for the report and comment
+          report_name: Unit Tests Coverage Report
       - name: cobertura-report-integration-test
-        uses: 5monkeys/cobertura-action@master
+        uses: shaguptashaikh/cobertura-action@master
         continue-on-error: true
         with:
           # The GITHUB_TOKEN for this repo
@@ -71,13 +73,15 @@ jobs:
           # If files with 100% should be skipped from report.
           skip_covered: false
           # Minimum allowed coverage percentage as an integer.
-          minimum_coverage: 60
+          minimum_coverage: 58
           # Show line rate as specific column.
           show_line: true
           # Show branch rate as specific column.
           show_branch: true
           # Use class names instead of the filename
           show_class_names: true
+          # Use a unique name for the report and comment
+          report_name: Integration Tests Coverage Report
       - name: Build benchmark with Maven
         # Changes can break the benchmark, so compile it now to make sure it is buildable
         run: mvn -ntp install -DskipTests && mvn -ntp -f src/test/evergreen-kernel-benchmark install

--- a/pom.xml
+++ b/pom.xml
@@ -415,11 +415,6 @@
                                             <minimum>0.66</minimum>
                                         </limit>
                                         <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
-                                        </limit>
-                                        <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.59</minimum>
@@ -447,9 +442,9 @@
                                             <minimum>0.58</minimum>
                                         </limit>
                                         <limit>
-                                            <counter>COMPLEXITY</counter>
+                                            <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.52</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                     </limits>
                                 </rule>


### PR DESCRIPTION
**Issue #, if available:**
https://issues.amazon.com/issues/P37008620

**Description of changes:**
Splitting coverage report generation, minimum coverage requirements and report uploading for unit and integration tests

**Why is this change necessary:**
Current aggregate coverage report and requirements don't give much idea on where we need more unit tests vs integ tests resulting in poor coverage in both areas individually. This change intends to encourage developers to write more tests of both kinds and assess our progress for the ongoing task to improve test coverage.

**How was this change tested:**
mvn -ntp clean verify

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
