### PR TITLE
Fix flaky integ test in DeploymentService mergeConfig

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/config/Topics.java
+++ b/src/main/java/com/aws/iot/evergreen/config/Topics.java
@@ -250,12 +250,12 @@ public class Topics extends Node implements Iterable<Node> {
      * @param n node to remove
      */
     public void remove(Node n) {
+        if (!children.remove(n.getName(), n)) {
+            logger.atError("config-node-child-remove-error").kv("thisNode", toString()).kv("childNode", n.getName())
+                    .log();
+            return;
+        }
         context.runOnPublishQueue(() -> {
-            if (!children.remove(n.getName(), n)) {
-                logger.atError("config-node-child-remove-error").kv("thisNode", toString()).kv("childNode", n.getName())
-                        .log();
-                return;
-            }
             n.fire(WhatHappened.removed);
             this.childChanged(WhatHappened.childRemoved, n);
         });

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
@@ -189,7 +189,7 @@ public class DeploymentConfigMerger {
             return;
         }
         // wait until topic listeners finished processing read changes.
-        kernel.getContext().runOnPublishQueueAndWait(() -> {
+        kernel.getContext().runOnPublishQueue(() -> {
             // polling to wait for all services to be started.
             kernel.getContext().get(ExecutorService.class).execute(() -> {
                 // TODO: Add timeout


### PR DESCRIPTION
**Issue #, if available:**
DeploymentTaskIntegrationTest failed occasionally due to obsolete service is removed asynchronously.

**Description of changes:**
In Topics.remove() , put the logic of 'remove the node from children' synchronous

**Why is this change necessary:**

**How was this change tested:**
Run DeploymentTaskIntegrationTest 10 times and all passed

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
