### PR TITLE
Use AWS_DEFAULT_REGION in cloudwatch upload script

### DIFF
--- a/.github/scripts/cwJMHUpload.py
+++ b/.github/scripts/cwJMHUpload.py
@@ -144,7 +144,7 @@ def main():
 
         width = 12
         height = 8
-        region = os.getenv("AWS_REGION")
+        region = os.getenv("AWS_DEFAULT_REGION")
         period = 300
         dashboard_data = {
             "start": "-P7D",  # Set default time range to 1 week


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Benchmark is still failing, now because the script was looking for AWS_REGION environment variable instead of AWS_DEFAULT_REGION variable. This change fixes it so it looks for the default region.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
