### PR TITLE
Fix flakiness in IPC lifecycle test

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCServicesTest.java
@@ -79,6 +79,8 @@ class IPCServicesTest {
     @BeforeEach
     void beforeEach(ExtensionContext context) {
         ignoreExceptionWithMessage(context, "Connection reset by peer");
+        // Ignore if IPC can't send us more lifecycle updates because the test is already done.
+        ignoreExceptionUltimateCauseWithMessage(context, "Channel not found for given connection context");
     }
 
     @BeforeAll
@@ -187,7 +189,7 @@ class IPCServicesTest {
     }
 
     @Test
-    void lifecycleTest(ExtensionContext context) throws Exception {
+    void lifecycleTest() throws Exception {
         KernelIPCClientConfig config = getIPCConfigForService("ServiceName");
         client = new IPCClientImpl(config);
         LifecycleImpl c = new LifecycleImpl(client);
@@ -200,8 +202,6 @@ class IPCServicesTest {
         c.listenToStateChanges("ServiceName", p.getRight());
         c.reportState("ERRORED");
         p.getLeft().get(500, TimeUnit.MILLISECONDS);
-        // Ignore if IPC can't send us more lifecycle updates because the test is already done.
-        ignoreExceptionUltimateCauseWithMessage(context, "Channel not found for given connection context");
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Ignore channel not found which causes flakiness due to race between lifecycle update and test ending.
Error is carrying over from previous test, causing `registerResources` test to fail, even though the issue is actually coming from the `lifecycleTest`. This error was already ignored in the lifecycle test, it is now ignored for this whole test class. It is safe to ignore because test assertions will still fail if it is a true failure.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [x] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [x] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
