### PR TITLE
Minor fix on DeploymentConfigMergerTest

### DIFF
--- a/src/test/java/com/aws/iot/evergreen/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/iot/evergreen/deployment/DeploymentConfigMergerTest.java
@@ -38,6 +38,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.aws.iot.evergreen.deployment.DeploymentConfigMerger.WAIT_SVC_START_POLL_INTERVAL_MILLISEC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -182,10 +185,15 @@ public class DeploymentConfigMergerTest {
             throws Exception {
         // GIVEN
         EvergreenService mockService = mock(EvergreenService.class);
+
         // service is in BROKEN state before merge
-        doReturn(State.BROKEN).when(mockService).getState();
+        final AtomicReference<State> mockState = new AtomicReference<>(State.BROKEN);
+        doAnswer((invocation) -> mockState.get()).when(mockService).getState();
         doReturn((long) 1).when(mockService).getStateModTime();
-        doReturn(false).when(mockService).reachedDesiredState();
+
+        final AtomicBoolean mockReachedDesiredState = new AtomicBoolean(false);
+        doAnswer((invocation) -> mockReachedDesiredState.get()).when(mockService).reachedDesiredState();
+
         CountDownLatch serviceStarted = new CountDownLatch(1);
         new Thread(() -> {
             try {
@@ -200,9 +208,8 @@ public class DeploymentConfigMergerTest {
         assertFalse(serviceStarted.await(3 * WAIT_SVC_START_POLL_INTERVAL_MILLISEC, TimeUnit.MILLISECONDS));
 
         // WHEN
-        // use doReturn() here: https://stackoverflow.com/questions/11121772
-        doReturn(State.RUNNING).when(mockService).getState();
-        doReturn(true).when(mockService).reachedDesiredState();
+        mockState.set(State.RUNNING);
+        mockReachedDesiredState.set(true);
 
         // THEN
         assertTrue(serviceStarted.await(3 * WAIT_SVC_START_POLL_INTERVAL_MILLISEC, TimeUnit.MILLISECONDS));


### PR DESCRIPTION
use AtomicReference to modify mock returned value to solve thread
issues.

**Issue #, if available:**
DeploymentConfigMergerTest fails intermittently on WrongTypeOfReturnValue Exception due to mockito mocked object isn't thread safe.

**Description of changes:**
Use AtomicReference to ensure threadsafe when modifying the returned value of a mocked object.

**Why is this change necessary:**
Fix flaky test

**How was this change tested:**
Run 20 times locally and passed.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
