### PR TITLE
post-inject auth token

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -93,12 +93,17 @@ public class GenericExternalService extends EvergreenService {
             }
         });
 
-        AuthenticationHandler.registerAuthToken(this);
     }
 
     public static String exit2String(int exitCode) {
         return exitCode > 128 && exitCode < 129 + sigCodes.length ? sigCodes[exitCode - 129]
                 : "exit(" + ((exitCode << 24) >> 24) + ")";
+    }
+
+    @Override
+    public void postInject() {
+        super.postInject();
+        AuthenticationHandler.registerAuthToken(this);
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move `registerAuthToken` to postInject

**Why is this change necessary:**
`registerAuthToken` accesses class instance variables that have not been initialized yet in constructor.
**How was this change tested:**
`mvn clean verify`

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
