### PR TITLE
Subclass IotConnectionManager for easier DI

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/iot/IotCredentialConnectionManager.java
+++ b/src/main/java/com/aws/iot/evergreen/iot/IotCredentialConnectionManager.java
@@ -1,0 +1,17 @@
+package com.aws.iot.evergreen.iot;
+
+import com.aws.iot.evergreen.deployment.DeviceConfiguration;
+import com.aws.iot.evergreen.deployment.exceptions.DeviceConfigurationException;
+import com.aws.iot.evergreen.util.Coerce;
+
+public class IotCredentialConnectionManager extends IotConnectionManager {
+    /**
+     * Constructor.
+     *
+     * @param deviceConfiguration Device configuration helper getting cert and keys for mTLS
+     * @throws DeviceConfigurationException When unable to initialize this manager.
+     */
+    public IotCredentialConnectionManager(DeviceConfiguration deviceConfiguration) throws DeviceConfigurationException {
+        super(deviceConfiguration, Coerce.toString(deviceConfiguration.getIotCredentialEndpoint()));
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/iot/IotDataConnectionManager.java
+++ b/src/main/java/com/aws/iot/evergreen/iot/IotDataConnectionManager.java
@@ -1,0 +1,17 @@
+package com.aws.iot.evergreen.iot;
+
+import com.aws.iot.evergreen.deployment.DeviceConfiguration;
+import com.aws.iot.evergreen.deployment.exceptions.DeviceConfigurationException;
+import com.aws.iot.evergreen.util.Coerce;
+
+public class IotDataConnectionManager extends IotConnectionManager {
+    /**
+     * Constructor.
+     *
+     * @param deviceConfiguration Device configuration helper getting cert and keys for mTLS
+     * @throws DeviceConfigurationException When unable to initialize this manager.
+     */
+    public IotDataConnectionManager(DeviceConfiguration deviceConfiguration) throws DeviceConfigurationException {
+        super(deviceConfiguration, Coerce.toString(deviceConfiguration.getIotDataEndpoint()));
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/iot/evergreen/tes/CredentialRequestHandler.java
@@ -8,7 +8,7 @@ import com.aws.iot.evergreen.auth.Permission;
 import com.aws.iot.evergreen.auth.exceptions.AuthorizationException;
 import com.aws.iot.evergreen.deployment.exceptions.AWSIotException;
 import com.aws.iot.evergreen.iot.IotCloudHelper;
-import com.aws.iot.evergreen.iot.IotConnectionManager;
+import com.aws.iot.evergreen.iot.IotCredentialConnectionManager;
 import com.aws.iot.evergreen.iot.model.IotCloudResponse;
 import com.aws.iot.evergreen.ipc.AuthenticationHandler;
 import com.aws.iot.evergreen.ipc.exceptions.UnauthenticatedException;
@@ -64,7 +64,7 @@ public class CredentialRequestHandler implements HttpHandler {
 
     private final AuthorizationHandler authZHandler;
 
-    private final IotConnectionManager iotConnectionManager;
+    private final IotCredentialConnectionManager iotConnectionManager;
 
     private Clock clock = Clock.systemUTC();
 
@@ -84,12 +84,13 @@ public class CredentialRequestHandler implements HttpHandler {
      * Constructor.
      *
      * @param cloudHelper           {@link IotCloudHelper} for making http requests to cloud.
-     * @param connectionManager     {@link IotConnectionManager} underlying connection manager for cloud.
+     * @param connectionManager     {@link IotCredentialConnectionManager} underlying connection manager for cloud.
      * @param authenticationHandler {@link AuthenticationHandler} authN module for authenticating requests.
      * @param authZHandler          {@link AuthorizationHandler} authZ module for authorizing requests.
      */
     @Inject
-    public CredentialRequestHandler(final IotCloudHelper cloudHelper, final IotConnectionManager connectionManager,
+    public CredentialRequestHandler(final IotCloudHelper cloudHelper,
+                                    final IotCredentialConnectionManager connectionManager,
                                     final AuthenticationHandler authenticationHandler,
                                     final AuthorizationHandler authZHandler) {
         this.iotCloudHelper = cloudHelper;

--- a/src/test/java/com/aws/iot/evergreen/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/iot/evergreen/tes/CredentialRequestHandlerTest.java
@@ -7,7 +7,7 @@ import com.aws.iot.evergreen.auth.AuthorizationHandler;
 import com.aws.iot.evergreen.auth.exceptions.AuthorizationException;
 import com.aws.iot.evergreen.deployment.exceptions.AWSIotException;
 import com.aws.iot.evergreen.iot.IotCloudHelper;
-import com.aws.iot.evergreen.iot.IotConnectionManager;
+import com.aws.iot.evergreen.iot.IotCredentialConnectionManager;
 import com.aws.iot.evergreen.iot.model.IotCloudResponse;
 import com.aws.iot.evergreen.ipc.AuthenticationHandler;
 import com.aws.iot.evergreen.ipc.exceptions.UnauthenticatedException;
@@ -65,7 +65,7 @@ public class CredentialRequestHandlerTest {
     private static final IotCloudResponse CLOUD_RESPONSE =
             new IotCloudResponse(String.format(RESPONSE_STR, EXPIRATION).getBytes(StandardCharsets.UTF_8), 200);
     @Mock
-    IotConnectionManager mockConnectionManager;
+    IotCredentialConnectionManager mockConnectionManager;
 
     @Mock
     IotCloudHelper mockCloudHelper;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
IotConnectionManager defaults to the IoT credentials endpoint, which doesn't work for general dataplane operations. Subclass IotConnectionManager to make both credential and data endpoint managers easily injectable.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
