### PR TITLE
Renamed all occurrences of auth to authentication

### DIFF
--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/tes/TESTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/e2e/tes/TESTest.java
@@ -129,7 +129,7 @@ class TESTest extends BaseITCase {
         URL url = new URL(urlString);
         // Get the first token from the token map
         String token =
-                kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC, AuthenticationHandler.AUTH_TOKEN_LOOKUP_KEY)
+                kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC, AuthenticationHandler.AUTHENTICATION_TOKEN_LOOKUP_KEY)
                         .iterator().next().getName();
         assertNotNull(token);
         String response = getResponseString(url, token);
@@ -167,7 +167,7 @@ class TESTest extends BaseITCase {
         deviceProvisioningHelper.setupIoTRoleForTes(roleName, newRoleAliasName, thingInfo.getCertificateArn());
         kernel.getConfig().lookupTopics(SERVICES_NAMESPACE_TOPIC, TOKEN_EXCHANGE_SERVICE_TOPICS)
                 .lookup(PARAMETERS_CONFIG_KEY, IOT_ROLE_ALIAS_TOPIC).withValue(newRoleAliasName);
-        token = kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC, AuthenticationHandler.AUTH_TOKEN_LOOKUP_KEY)
+        token = kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC, AuthenticationHandler.AUTHENTICATION_TOKEN_LOOKUP_KEY)
                 .iterator().next().getName();
         assertNotNull(token);
         while (!(new String(kernel.getContext().get(CredentialRequestHandler.class).getCredentialsBypassCache(),

--- a/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCAuthorizationTest.java
+++ b/src/integrationtests/java/com/aws/iot/evergreen/integrationtests/ipc/IPCAuthorizationTest.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 import static com.aws.iot.evergreen.integrationtests.ipc.IPCTestUtils.TEST_SERVICE_NAME;
 import static com.aws.iot.evergreen.integrationtests.ipc.IPCTestUtils.getIPCConfigForService;
 import static com.aws.iot.evergreen.integrationtests.ipc.IPCTestUtils.prepareKernelFromConfigFile;
-import static com.aws.iot.evergreen.ipc.AuthenticationHandler.AUTH_TOKEN_LOOKUP_KEY;
+import static com.aws.iot.evergreen.ipc.AuthenticationHandler.AUTHENTICATION_TOKEN_LOOKUP_KEY;
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
 import static com.aws.iot.evergreen.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
@@ -96,7 +96,7 @@ class IPCAuthorizationTest {
     @Test
     void GIVEN_authorizationClient_WHEN_valid_token_provided_THEN_succeeds() throws AuthorizationException {
         //Grab a real, randomly assigned auth token for an existing service
-        Topics authTokensArray = kernel.findServiceTopic(AUTH_TOKEN_LOOKUP_KEY);
+        Topics authTokensArray = kernel.findServiceTopic(AUTHENTICATION_TOKEN_LOOKUP_KEY);
         Topic authTokenTopic = (Topic) authTokensArray.children.values().toArray()[0];
 
         AuthorizationResponse response = authorizationClient.validateToken(authTokenTopic.getName());

--- a/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DeploymentConfigMerger.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 
-import static com.aws.iot.evergreen.ipc.AuthenticationHandler.AUTH_TOKEN_LOOKUP_KEY;
+import static com.aws.iot.evergreen.ipc.AuthenticationHandler.AUTHENTICATION_TOKEN_LOOKUP_KEY;
 import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICE_NAME_KEY;
 
@@ -298,7 +298,7 @@ public class DeploymentConfigMerger {
 
         rootMergeBehavior.getChildOverride().put(SERVICES_NAMESPACE_TOPIC, servicesMergeBehavior);
         servicesMergeBehavior.getChildOverride().put(UpdateBehaviorTree.WILDCARD, insideServiceMergeBehavior);
-        servicesMergeBehavior.getChildOverride().put(AUTH_TOKEN_LOOKUP_KEY,
+        servicesMergeBehavior.getChildOverride().put(AUTHENTICATION_TOKEN_LOOKUP_KEY,
                 new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE));
         insideServiceMergeBehavior.getChildOverride().put(
                 EvergreenService.RUNTIME_STORE_NAMESPACE_TOPIC, serviceRuntimeMergeBehavior);

--- a/src/main/java/com/aws/iot/evergreen/ipc/AuthenticationHandler.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/AuthenticationHandler.java
@@ -7,8 +7,8 @@ import com.aws.iot.evergreen.dependency.InjectionActions;
 import com.aws.iot.evergreen.ipc.common.BuiltInServiceDestinationCode;
 import com.aws.iot.evergreen.ipc.common.FrameReader;
 import com.aws.iot.evergreen.ipc.exceptions.UnauthenticatedException;
-import com.aws.iot.evergreen.ipc.services.auth.AuthRequest;
-import com.aws.iot.evergreen.ipc.services.auth.AuthResponse;
+import com.aws.iot.evergreen.ipc.services.authentication.AuthenticationRequest;
+import com.aws.iot.evergreen.ipc.services.authentication.AuthenticationResponse;
 import com.aws.iot.evergreen.ipc.services.common.ApplicationMessage;
 import com.aws.iot.evergreen.ipc.services.common.IPCUtil;
 import com.aws.iot.evergreen.kernel.EvergreenService;
@@ -29,9 +29,9 @@ import static com.aws.iot.evergreen.ipc.common.ResponseHelper.sendResponse;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AuthenticationHandler implements InjectionActions {
-    public static final String AUTH_TOKEN_LOOKUP_KEY = "_AUTH_TOKENS";
+    public static final String AUTHENTICATION_TOKEN_LOOKUP_KEY = "_AUTHENTICATION_TOKENS";
     public static final String SERVICE_UNIQUE_ID_KEY = "_UID";
-    public static final int AUTH_API_VERSION = 1;
+    public static final int AUTHENTICATION_API_VERSION = 1;
     private static final Logger logger = LogManager.getLogger(AuthenticationHandler.class);
 
     @Inject
@@ -40,25 +40,25 @@ public class AuthenticationHandler implements InjectionActions {
     private IPCRouter router;
 
     /**
-     * Register an auth token for the given service.
+     * Register an authentication token for the given service.
      *
-     * @param s service to generate an auth token for
+     * @param s service to generate an authentication token for
      */
-    public static void registerAuthToken(EvergreenService s) {
+    public static void registerAuthenticationToken(EvergreenService s) {
         Topic uid = s.getPrivateConfig().createLeafChild(SERVICE_UNIQUE_ID_KEY).withParentNeedsToKnow(false);
-        String authToken = Utils.generateRandomString(16).toUpperCase();
-        uid.withValue(authToken);
-        Topics tokenTopics = s.getServiceConfig().parent.lookupTopics(AUTH_TOKEN_LOOKUP_KEY);
+        String authenticationToken = Utils.generateRandomString(16).toUpperCase();
+        uid.withValue(authenticationToken);
+        Topics tokenTopics = s.getServiceConfig().parent.lookupTopics(AUTHENTICATION_TOKEN_LOOKUP_KEY);
         tokenTopics.withParentNeedsToKnow(false);
 
-        Topic tokenTopic = tokenTopics.createLeafChild(authToken);
+        Topic tokenTopic = tokenTopics.createLeafChild(authenticationToken);
 
-        // If the auth token was already registered, that's an issue, so we will retry
+        // If the authentication token was already registered, that's an issue, so we will retry
         // generating a new token in that case
         if (tokenTopic.getOnce() == null) {
             tokenTopic.withValue(s.getName());
         } else {
-            registerAuthToken(s);
+            registerAuthenticationToken(s);
         }
     }
 
@@ -74,72 +74,76 @@ public class AuthenticationHandler implements InjectionActions {
             throws UnauthenticatedException {
 
         ApplicationMessage applicationMessage = ApplicationMessage.fromBytes(message.getPayload());
-        AuthRequest authRequest;
+        AuthenticationRequest authenticationRequest;
         try {
-            authRequest = IPCUtil.decode(applicationMessage.getPayload(), AuthRequest.class);
+            authenticationRequest = IPCUtil.decode(applicationMessage.getPayload(), AuthenticationRequest.class);
         } catch (IOException e) {
-            throw new UnauthenticatedException("Fail to decode Auth message", e);
+            throw new UnauthenticatedException("Fail to decode Authentication message", e);
         }
 
-        String serviceName = doAuthentication(authRequest.getAuthToken());
+        String serviceName = doAuthentication(authenticationRequest.getAuthenticationToken());
         return new ConnectionContext(serviceName, remoteAddress, router);
     }
 
     /**
-     * Lookup the provided auth token to associate it with a service (or reject it).
-     * @param authToken token to be looked up.
+     * Lookup the provided authentication token to associate it with a service (or reject it).
+     * @param authenticationToken token to be looked up.
      * @return service name to which the token is associated.
      * @throws UnauthenticatedException if token is invalid or unassociated.
      */
-    public String doAuthentication(String authToken) throws UnauthenticatedException {
-        if (authToken == null) {
-            throw new UnauthenticatedException("Invalid auth token");
+    public String doAuthentication(String authenticationToken) throws UnauthenticatedException {
+        if (authenticationToken == null) {
+            throw new UnauthenticatedException("Invalid authentication token");
         }
         Topic service = config.find(EvergreenService.SERVICES_NAMESPACE_TOPIC,
-                AUTH_TOKEN_LOOKUP_KEY, authToken);
+                AUTHENTICATION_TOKEN_LOOKUP_KEY, authenticationToken);
         if (service == null) {
-            throw new UnauthenticatedException("Auth token not found");
+            throw new UnauthenticatedException("Authentication token not found");
         }
         return Coerce.toString(service.getOnce());
     }
 
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
-    void handleAuth(ChannelHandlerContext ctx, FrameReader.MessageFrame message) throws IOException {
-        if (message.destination == BuiltInServiceDestinationCode.AUTH.getValue()) {
+    void handleAuthentication(ChannelHandlerContext ctx, FrameReader.MessageFrame message) throws IOException {
+        if (message.destination == BuiltInServiceDestinationCode.AUTHENTICATION.getValue()) {
             try {
                 ConnectionContext context = doAuthentication(message.message, ctx.channel().remoteAddress());
                 ctx.channel().attr(IPCChannelHandler.CONNECTION_CONTEXT_KEY).set(context);
                 logger.atInfo().setEventType("ipc-client-authenticated").addKeyValue("clientContext", context).log();
 
                 router.clientConnected(context, ctx.channel());
-                AuthResponse authResponse =
-                        AuthResponse.builder().serviceName(context.getServiceName()).clientId(context.getClientId())
+                AuthenticationResponse authenticationResponse =
+                        AuthenticationResponse.builder().serviceName(context.getServiceName())
+                                .clientId(context.getClientId())
                                 .build();
                 ApplicationMessage applicationMessage =
-                        ApplicationMessage.builder().version(AUTH_API_VERSION).payload(IPCUtil.encode(authResponse))
+                        ApplicationMessage.builder().version(AUTHENTICATION_API_VERSION)
+                                .payload(IPCUtil.encode(authenticationResponse))
                                 .build();
                 sendResponse(new FrameReader.Message(applicationMessage.toByteArray()), message.requestId,
                         message.destination, ctx, false);
             } catch (Throwable t) {
-                logger.atError().setEventType("ipc-client-auth-error").setCause(t)
+                logger.atError().setEventType("ipc-client-authentication-error").setCause(t)
                         .addKeyValue("clientAddress", ctx.channel().remoteAddress()).log();
-                AuthResponse authResponse =
-                        AuthResponse.builder().errorMessage("Error while authenticating client").build();
+                AuthenticationResponse authenticationResponse =
+                        AuthenticationResponse.builder().errorMessage("Error while authenticating client").build();
                 ApplicationMessage applicationMessage =
-                        ApplicationMessage.builder().version(AUTH_API_VERSION).payload(IPCUtil.encode(authResponse))
+                        ApplicationMessage.builder().version(AUTHENTICATION_API_VERSION).payload(IPCUtil
+                                .encode(authenticationResponse))
                                 .build();
                 sendResponse(new FrameReader.Message(applicationMessage.toByteArray()), message.requestId,
                         message.destination, ctx, true);
             }
         } else {
-            logger.atError().setEventType("ipc-client-auth-error")
+            logger.atError().setEventType("ipc-client-authentication-error")
                     .addKeyValue("clientAddress", ctx.channel().remoteAddress())
                     .addKeyValue("destination", message.destination)
-                    .log("First request from client should be destined for Auth");
-            AuthResponse authResponse =
-                    AuthResponse.builder().errorMessage("Error while authenticating client").build();
+                    .log("First request from client should be destined for Authentication");
+            AuthenticationResponse authenticationResponse =
+                    AuthenticationResponse.builder().errorMessage("Error while authenticating client").build();
             ApplicationMessage applicationMessage =
-                    ApplicationMessage.builder().version(AUTH_API_VERSION).payload(IPCUtil.encode(authResponse))
+                    ApplicationMessage.builder().version(AUTHENTICATION_API_VERSION).payload(IPCUtil
+                            .encode(authenticationResponse))
                             .build();
             sendResponse(new FrameReader.Message(applicationMessage.toByteArray()), message.requestId,
                     message.destination, ctx, true);

--- a/src/main/java/com/aws/iot/evergreen/ipc/IPCChannelHandler.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/IPCChannelHandler.java
@@ -37,7 +37,7 @@ public class IPCChannelHandler extends ChannelInboundHandlerAdapter {
     private static final Logger logger = LogManager.getLogger(IPCChannelHandler.class);
 
     @Inject
-    private AuthenticationHandler auth;
+    private AuthenticationHandler authenticationHandler;
 
     @Inject
     private IPCRouter router;
@@ -77,7 +77,7 @@ public class IPCChannelHandler extends ChannelInboundHandlerAdapter {
 
         // When there isn't context yet, we expect a call to be authorized first
         if (ctx.channel().attr(CONNECTION_CONTEXT_KEY).get() == null) {
-            auth.handleAuth(ctx, message);
+            authenticationHandler.handleAuthentication(ctx, message);
             return;
         }
 

--- a/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/GenericExternalService.java
@@ -95,7 +95,7 @@ public class GenericExternalService extends EvergreenService {
     public void postInject() {
         // Register token before calling super so that the token is available when the lifecyle thread
         // starts running
-        AuthenticationHandler.registerAuthToken(this);
+        AuthenticationHandler.registerAuthenticationToken(this);
         super.postInject();
     }
 


### PR DESCRIPTION
**Description of changes:**
Renamed all existing instances of `auth` to be `authentication`. 
**Why is this change necessary:**
Now that we are adding in authorization, this refactoring is to clarify and reduce ambiguity whenever the term `auth` is used. 
**How was this change tested:**
`mvn clean package`, with the corresponding changes to the SDK in the same workspace
**Any additional information or context required to review the change:**
After the corresponding PR for `aws-greengrass-sdk-java` is merged in, this will be merged into avoid any breaking changes.

### ***Note: This PR is expected to FAIL the build, since the  corresponding SDK changes have not yet been built and merged in: https://github.com/aws/aws-greengrass-sdk-java/pull/49.***

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
