### PR TITLE
Switch back to master brach for sdk dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.aws.iot</groupId>
             <artifactId>evergreen-java-sdk</artifactId>
-            <version>0.0.0-shared_config-SNAPSHOT</version>
+            <version>0.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws.services</groupId>


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws/aws-greengrass-kernel/pull/346 - Config store PR used the shared-config branch of the java sdk dependency temporarily for passing builds since the SDK change had breaking changes. Now that both of those PRs are closed, switching back to the correct SDK dependency

**Description of changes:**
N/A
**Why is this change necessary:**
N/A
**How was this change tested:**
Will test with github action workflow, when it starts passing, we should be good to go
**Any additional information or context required to review the change:**
N/A
**Checklist:**  N/A
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
