### PR TITLE
clean stateToErroredCount when service get out of BROKEN state

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Lifecycle.java
@@ -380,6 +380,7 @@ public class Lifecycle {
         // we'll transition out of BROKEN state to give it a new chance.
         if (State.NEW.equals(desiredState.get())) {
             internalReportState(State.NEW);
+            stateToErroredCount.clear();
         } else {
             logger.atError("service-broken").log("service is broken. Deployment is needed");
         }


### PR DESCRIPTION
**Issue #, if available:**
Test GIVEN_service_running_with_rollback_safe_param_WHEN_rollback_THEN_rollback_safe_param_not_updated is flaky 

The log shows that deployment rollback fails immediately. It seems roll-back doesn't clean up stateToErroredCount so if the rolled-back service fail to start it will go to Broken state directly. 

**Description of changes:**
clean stateToErroredCount when service get out of BROKEN state (basically in re-install during deployment)

**Why is this change necessary:**
To fix flaky test

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
