### PR TITLE
NPE protection for merging config

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/KernelConfigResolver.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
@@ -151,8 +150,11 @@ public class KernelConfigResolver {
 
         // State information for deployments
         resolvedServiceConfig.put(VERSION_CONFIG_KEY, packageRecipe.getVersion().getValue());
-        resolvedServiceConfig.put(PARAMETERS_CONFIG_KEY, resolvedParams.stream()
-                .collect(Collectors.toMap(PackageParameter::getName, PackageParameter::getValue)));
+        Map<String, String> map = new HashMap<>();
+        for (PackageParameter resolvedParam : resolvedParams) {
+            map.put(resolvedParam.getName(), resolvedParam.getValue());
+        }
+        resolvedServiceConfig.put(PARAMETERS_CONFIG_KEY, map);
 
         return resolvedServiceConfig;
     }

--- a/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageParameter.java
+++ b/src/main/java/com/aws/iot/evergreen/packagemanager/models/PackageParameter.java
@@ -3,8 +3,10 @@ package com.aws.iot.evergreen.packagemanager.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -14,8 +16,10 @@ import java.util.Set;
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @JsonSerialize
+@AllArgsConstructor
 public class PackageParameter {
 
+    @NonNull
     @EqualsAndHashCode.Include
     private final String name;
 
@@ -36,20 +40,6 @@ public class PackageParameter {
     public PackageParameter(@JsonProperty("name") String name, @JsonProperty("value") String value,
                             @JsonProperty("type") String type) {
         this(name, value, ParameterType.valueOf(type.toUpperCase()));
-    }
-
-    /**
-     * Create a Package Param object.
-     *
-     * @param name  Name of the parameter
-     * @param value Default value for the parameter
-     * @param type  Parameter Type enum value
-     */
-    public PackageParameter(String name, String value, ParameterType type) {
-        this.name = name;
-        this.type = type;
-        // TODO: Validate type and initialize corresponding type here?
-        this.value = value;
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`Collectors.toMap` fails with null values, which shouldn't happen. This change switches the stream method to a typical loop instead which correctly handles the null value.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
