### PR TITLE
First pass at validation

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/builtin/services/configstore/ConfigStoreIPCAgent.java
+++ b/src/main/java/com/aws/iot/evergreen/builtin/services/configstore/ConfigStoreIPCAgent.java
@@ -362,8 +362,6 @@ public class ConfigStoreIPCAgent {
     public boolean validateConfiguration(String componentName, Map<String, Object> configuration,
                                          CompletableFuture<ConfigurationValidityReport> reportFuture)
             throws ValidateEventRegistrationException {
-        // TODO : Will handling a collection of components to abstract validation for the whole deployment
-        //  be better?
         if (configValidationReportFutures.containsKey(componentName)) {
             throw new ValidateEventRegistrationException(
                     "A validation request to this component is already waiting for response");

--- a/src/main/java/com/aws/iot/evergreen/deployment/DynamicComponentConfigurationValidator.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/DynamicComponentConfigurationValidator.java
@@ -1,0 +1,244 @@
+package com.aws.iot.evergreen.deployment;
+
+import com.aws.iot.evergreen.builtin.services.configstore.ConfigStoreIPCAgent;
+import com.aws.iot.evergreen.builtin.services.configstore.exceptions.ValidateEventRegistrationException;
+import com.aws.iot.evergreen.config.Topic;
+import com.aws.iot.evergreen.config.Topics;
+import com.aws.iot.evergreen.deployment.exceptions.DynamicConfigurationValidationException;
+import com.aws.iot.evergreen.deployment.exceptions.InvalidConfigFormatException;
+import com.aws.iot.evergreen.deployment.model.Deployment;
+import com.aws.iot.evergreen.deployment.model.DeploymentResult;
+import com.aws.iot.evergreen.ipc.services.configstore.ConfigurationValidityReport;
+import com.aws.iot.evergreen.ipc.services.configstore.ConfigurationValidityStatus;
+import com.aws.iot.evergreen.kernel.EvergreenService;
+import com.aws.iot.evergreen.kernel.GenericExternalService;
+import com.aws.iot.evergreen.kernel.Kernel;
+import com.aws.iot.evergreen.kernel.exceptions.ServiceLoadException;
+import com.aws.iot.evergreen.logging.api.Logger;
+import com.aws.iot.evergreen.logging.impl.LogManager;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
+import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
+import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.PARAMETERS_CONFIG_KEY;
+import static com.aws.iot.evergreen.packagemanager.KernelConfigResolver.VERSION_CONFIG_KEY;
+
+/**
+ * Asks component processes over IPC to validate proposed component configuration a deployment brings.
+ */
+public class DynamicComponentConfigurationValidator {
+    public static final String DEPLOYMENT_ID_LOG_KEY = "deploymentId";
+    private static final long DEFAULT_TIMEOUT = Duration.ofSeconds(60).toMillis();
+    private static final Logger logger = LogManager.getLogger(DeploymentConfigMerger.class);
+
+    @Inject
+    private Kernel kernel;
+
+    @Inject
+    private ConfigStoreIPCAgent configStoreIPCAgent;
+
+    /**
+     * Dynamically validate proposed configuration for a deployment.
+     *
+     * @param servicesConfig         aggregate configuration map for services proposed by the deployment
+     * @param deployment             deployment context
+     * @param deploymentResultFuture deployment result future, completed with failure result when validation fails
+     * @return if all component processes reported that their proposed configuration is valid
+     */
+    public boolean validate(Map<String, Object> servicesConfig, Deployment deployment,
+                            CompletableFuture deploymentResultFuture) {
+        logger.addDefaultKeyValue(DEPLOYMENT_ID_LOG_KEY, deployment.getDeploymentDocumentObj().getDeploymentId());
+        Set<ComponentToValidate> componentsToValidate;
+        try {
+            componentsToValidate =
+                    getComponentsToValidate(servicesConfig, deployment.getDeploymentDocumentObj().getTimestamp());
+        } catch (InvalidConfigFormatException e) {
+            deploymentResultFuture.complete(
+                    new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE,
+                            new DynamicConfigurationValidationException(e)));
+            return false;
+        }
+
+        return validateOverIpc(componentsToValidate, deploymentResultFuture);
+    }
+
+    /**
+     * A component will not be asked to validate configuration if the deployment also has changes for it that
+     * will cause restart, e.g. version change/lifecycle change etc. This helps prevent failures when the
+     * configuration to be validated has new keys or schema that the running version of the component doesn't
+     * understand and won't be able to validate. We rely on the fact that component startup logic will need to
+     * handle any configuration usage since it would be needed for the 1st time startup anyway.
+     */
+    private Set<ComponentToValidate> getComponentsToValidate(Map<String, Object> servicesConfig, long proposedTimestamp)
+            throws InvalidConfigFormatException {
+        Set<ComponentToValidate> componentsToValidate = new HashSet<>();
+
+        for (String serviceName : servicesConfig.keySet()) {
+            Topics currentServiceConfig;
+            try {
+                EvergreenService service = kernel.locate(serviceName);
+                if (!(service instanceof GenericExternalService)) {
+                    // No validation for internal services since currently all customer services are external
+                    continue;
+                }
+                currentServiceConfig = service.getServiceConfig();
+                if (currentServiceConfig == null) {
+                    continue;
+                }
+            } catch (ServiceLoadException e) {
+                // service not found, service is new
+                continue;
+            }
+            if (!(servicesConfig.get(serviceName) instanceof Map)) {
+                throw new InvalidConfigFormatException("Services config must be a map");
+            }
+            Map<String, Object> proposedServiceConfig = (Map) servicesConfig.get(serviceName);
+
+            if (!willServiceRestart(proposedServiceConfig, currentServiceConfig, proposedTimestamp)
+                    && willChildTopicsChange(proposedServiceConfig, currentServiceConfig, PARAMETERS_CONFIG_KEY,
+                    proposedTimestamp)) {
+                componentsToValidate.add(new ComponentToValidate(serviceName,
+                        (Map<String, Object>) proposedServiceConfig.get(PARAMETERS_CONFIG_KEY)));
+            }
+        }
+        return componentsToValidate;
+    }
+
+    private boolean willServiceRestart(Map<String, Object> proposedServiceConfig, Topics currentServiceConfig,
+                                       long proposedTimestamp) throws InvalidConfigFormatException {
+        // A service can also restart when its dependencies list changes or state of individual dependencies
+        // changes, but right now, there isn't a need to not validate configuration in that case. Hence this
+        // does not check that for simplicity at least for now
+        if (willChildTopicChange(proposedServiceConfig, currentServiceConfig, VERSION_CONFIG_KEY, proposedTimestamp)) {
+            return true;
+        }
+
+        if (willChildTopicChange(proposedServiceConfig, currentServiceConfig, SERVICE_DEPENDENCIES_NAMESPACE_TOPIC,
+                proposedTimestamp)) {
+            return true;
+        }
+
+        if (willChildTopicsChange(proposedServiceConfig, currentServiceConfig, SERVICE_LIFECYCLE_NAMESPACE_TOPIC,
+                proposedTimestamp)) {
+            return true;
+        }
+
+        // TODO: Check recipe flag for if service can handle dynamic configuration if not, it'll be restarted
+        //  since it's likely if services can't handle dynamic config they are not IPC aware at all
+        return false;
+    }
+
+
+    private boolean willChildTopicsChange(Map<String, Object> proposedServiceConfig, Topics currentServiceConfig,
+                                          String key, long proposedTimestamp) throws InvalidConfigFormatException {
+        Object proposed = proposedServiceConfig.get(key);
+        Topics current = currentServiceConfig.findTopics(key);
+        if (proposed instanceof Map) {
+            return willTopicsChange((Map<String, Object>) proposed, current, proposedTimestamp);
+        }
+        throw new InvalidConfigFormatException("Config for " + key + " must be a map");
+    }
+
+    private boolean willChildTopicChange(Map<String, Object> proposedServiceConfig, Topics currentServiceConfig,
+                                         String key, long proposedTimestamp) {
+        return willTopicChange(proposedServiceConfig.get(key), currentServiceConfig.find(key), proposedTimestamp);
+    }
+
+    private boolean willTopicsChange(Map<String, Object> proposedConfig, Topics currentConfig, long proposedTimestamp) {
+        AtomicBoolean willChange = new AtomicBoolean(true);
+        if (Objects.deepEquals(proposedConfig, currentConfig)) {
+            currentConfig.deepForEachTopic(topic -> {
+                if (proposedTimestamp <= topic.getModtime()) {
+                    willChange.set(false);
+                }
+            });
+        }
+        return willChange.get();
+    }
+
+    private boolean willTopicChange(Object proposedConfig, Topic currentConfig, long proposedTimestamp) {
+        return currentConfig.toPOJO().equals(proposedConfig) && proposedTimestamp == currentConfig.getModtime();
+    }
+
+    private boolean validateOverIpc(Set<ComponentToValidate> componentsToValidate,
+                                    CompletableFuture deploymentResultFuture) {
+        try {
+            String failureMsg = "Components reported that their to-be-deployed configuration is invalid";
+            boolean validationRequested = true;
+            boolean valid = true;
+            for (ComponentToValidate componentToValidate : componentsToValidate) {
+                try {
+                    validationRequested = configStoreIPCAgent
+                            .validateConfiguration(componentToValidate.componentName, componentToValidate.configuration,
+                                    componentToValidate.response);
+                    if (!validationRequested) {
+                        failureMsg = "Error requesting validation from component" + componentToValidate.componentName;
+                        break;
+                    }
+                } catch (ValidateEventRegistrationException e) {
+                    validationRequested = false;
+                    failureMsg = "Error requesting validation from component" + componentToValidate.componentName;
+                    break;
+                }
+            }
+            if (validationRequested) {
+                try {
+                    // TODO : Use configurable timeout from deployment document
+                    CompletableFuture.allOf(componentsToValidate.stream().map(ComponentToValidate::getResponse)
+                            .collect(Collectors.toSet()).toArray(new CompletableFuture[0]))
+                            .get(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+                    for (ComponentToValidate componentToValidate : componentsToValidate) {
+                        ConfigurationValidityReport report = componentToValidate.response.join();
+                        if (ConfigurationValidityStatus.INVALID.equals(report.getStatus())) {
+                            failureMsg = String.format("%s { name = %s, message = %s }", failureMsg,
+                                    componentToValidate.componentName, report.getMessage());
+                            logger.atError().kv("component", componentToValidate.componentName)
+                                    .kv("message", report.getMessage())
+                                    .log("Component reported that its to-be-deployed configuration is invalid");
+                            valid = false;
+                        }
+                    }
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    failureMsg =
+                            "Error while waiting for validation report for one or more components:" + e.getMessage();
+                    logger.atError().setCause(e).log(failureMsg);
+                    valid = false;
+                }
+            }
+            if (!valid) {
+                deploymentResultFuture.complete(
+                        new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE,
+                                new DynamicConfigurationValidationException(failureMsg)));
+            }
+            return valid;
+        } finally {
+            componentsToValidate
+                    .forEach(c -> configStoreIPCAgent.discardValidationReportTracker(c.componentName, c.response));
+        }
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    private static final class ComponentToValidate {
+        @EqualsAndHashCode.Include
+        private final String componentName;
+        private final Map<String, Object> configuration;
+        private final CompletableFuture<ConfigurationValidityReport> response = new CompletableFuture<>();
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/activator/DefaultActivator.java
@@ -6,6 +6,7 @@
 package com.aws.iot.evergreen.deployment.activator;
 
 import com.aws.iot.evergreen.deployment.DeploymentConfigMerger;
+import com.aws.iot.evergreen.deployment.DynamicComponentConfigurationValidator;
 import com.aws.iot.evergreen.deployment.exceptions.ServiceUpdateException;
 import com.aws.iot.evergreen.deployment.model.Deployment;
 import com.aws.iot.evergreen.deployment.model.DeploymentDocument;
@@ -33,28 +34,38 @@ import static com.aws.iot.evergreen.kernel.EvergreenService.SERVICES_NAMESPACE_T
  * Activation and rollback of default deployments.
  */
 public class DefaultActivator extends DeploymentActivator {
+    private DynamicComponentConfigurationValidator validator;
+
     @Inject
-    public DefaultActivator(Kernel kernel) {
+    public DefaultActivator(Kernel kernel, DynamicComponentConfigurationValidator validator) {
         super(kernel);
+        this.validator = validator;
     }
 
     @Override
     public void activate(Map<Object, Object> newConfig, Deployment deployment,
                          CompletableFuture<DeploymentResult> totallyCompleteFuture) {
+        Map<String, Object> serviceConfig;
+        if (newConfig.containsKey(SERVICES_NAMESPACE_TOPIC)) {
+            serviceConfig = (Map<String, Object>) newConfig.get(SERVICES_NAMESPACE_TOPIC);
+        } else {
+            serviceConfig = new HashMap<>();
+        }
+
+        // Ask all customer components who have signed up for dynamic component configuration changes
+        // without restarting the component to validate their own proposed component configuration.
+        if (!validator.validate(serviceConfig, deployment, totallyCompleteFuture)) {
+            return;
+        }
+
         DeploymentDocument deploymentDocument = deployment.getDeploymentDocumentObj();
         if (isAutoRollbackRequested(deploymentDocument) && !takeConfigSnapshot(totallyCompleteFuture)) {
             return;
         }
 
         String deploymentId = deploymentDocument.getDeploymentId();
-
-        DeploymentConfigMerger.AggregateServicesChangeManager servicesChangeManager;
-        if (newConfig.containsKey(SERVICES_NAMESPACE_TOPIC)) {
-            Map<String, Object> serviceConfig = (Map<String, Object>) newConfig.get(SERVICES_NAMESPACE_TOPIC);
-            servicesChangeManager = new DeploymentConfigMerger.AggregateServicesChangeManager(kernel, serviceConfig);
-        } else {
-            servicesChangeManager = new DeploymentConfigMerger.AggregateServicesChangeManager(kernel, new HashMap<>());
-        }
+        DeploymentConfigMerger.AggregateServicesChangeManager servicesChangeManager =
+                new DeploymentConfigMerger.AggregateServicesChangeManager(kernel, serviceConfig);
 
         // Get the timestamp before mergeMap(). It will be used to check whether services have started.
         long mergeTime = System.currentTimeMillis();

--- a/src/main/java/com/aws/iot/evergreen/deployment/exceptions/DynamicConfigurationValidationException.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/exceptions/DynamicConfigurationValidationException.java
@@ -1,0 +1,14 @@
+package com.aws.iot.evergreen.deployment.exceptions;
+
+public class DynamicConfigurationValidationException extends DeploymentException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public DynamicConfigurationValidationException(String message) {
+        super(message);
+    }
+
+    public DynamicConfigurationValidationException(Throwable e) {
+        super(e);
+    }
+}
+

--- a/src/main/java/com/aws/iot/evergreen/deployment/exceptions/InvalidConfigFormatException.java
+++ b/src/main/java/com/aws/iot/evergreen/deployment/exceptions/InvalidConfigFormatException.java
@@ -1,0 +1,13 @@
+package com.aws.iot.evergreen.deployment.exceptions;
+
+public class InvalidConfigFormatException extends Exception {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public InvalidConfigFormatException(String message) {
+        super(message);
+    }
+
+    public InvalidConfigFormatException(Throwable e) {
+        super(e);
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Services that consume configuration changes on deployment dynamically i.e. without restarting, need a way to indicate if the configuration brought by the deployment is bad. We decided to solve this problem by asking them to preemptively validate the proposed configuration and fail deployment if they don't like it. More details in the design doc -
https://quip-amazon.com/HVE9A5wmE4Ab/Customer-services-with-dynamic-configuration#SBM9CAtgrEM

**Why is this change necessary:**
See description

**How was this change tested:**
Currently draft, still adding tests 

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
