### PR TITLE
minor fix for platform no matching unit test to pass on dev desktop

### DIFF
--- a/src/test/resources/com/aws/iot/evergreen/packagemanager/converter/sample_recipe_with_no_matching_platform.yaml
+++ b/src/test/resources/com/aws/iot/evergreen/packagemanager/converter/sample_recipe_with_no_matching_platform.yaml
@@ -7,7 +7,7 @@ version: '1.0.0'
 componentType: raw
 manifests:
   - platform:
-      os: fedora # not supported
+      os: raspbian # we don't run unit test on raspbian for now
       architecture: all
     lifecycle:
       install: echo install


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Phil found out that when running on our dev desktop which is amazon linux, `fedora` is detected as platform... We are going to revamp this soon to make it fail closed, so just unblock tests for now.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
