### PR TITLE
Update systemd setup steps

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -19,7 +19,7 @@
             <outputDirectory>/bin</outputDirectory>
             <includes>
                 <include>loader</include>
-                <include>greengrass.service</include>
+                <include>greengrass.service.template</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/scripts/greengrass.service.template
+++ b/scripts/greengrass.service.template
@@ -4,9 +4,10 @@ Description=Greengrass Core
 [Service]
 Type=simple
 PIDFile=REPLACE_WITH_GG_LOADER_PID_FILE
-Restart=always
+RemainAfterExit=no
+Restart=on-failure
 RestartSec=10
-ExecStart=REPLACE_WITH_GG_LOADER_FILE
+ExecStart=/bin/sh REPLACE_WITH_GG_LOADER_FILE
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main/java/com/aws/iot/evergreen/easysetup/README.md
+++ b/src/main/java/com/aws/iot/evergreen/easysetup/README.md
@@ -40,7 +40,7 @@ This workflow has been implemented for Ubuntu. Use as a reference.
 # Move GreengrassCore-2.0.0.zip to test device
 # Set up aws creds
 unzip GreengrassCore-2.0.0.zip -d GreengrassCore
-sudo java -Droot=~/gg_home -Dlog.level=ERROR -jar ./GreengrassCore/lib/Evergreen.jar --provision true --aws-region us-east-1 --thing-name <test-device> --setup-tes true -tra <test-role-alias> -ss true
+java -Droot=~/gg_home -Dlog.level=WARN -jar ./GreengrassCore/lib/Evergreen.jar --provision true --aws-region us-east-1 --thing-name <test-device> --setup-tes true -tra <test-role-alias> -ss true
 
 # Verify the setup
 tree ~/gg_home/

--- a/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/Kernel.java
@@ -46,7 +46,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,6 +82,8 @@ public class Kernel {
     public static final String SERVICE_TYPE_TOPIC_KEY = "componentType";
     public static final String SERVICE_TYPE_TO_CLASS_MAP_KEY = "componentTypeToClassMap";
     private static final String PLUGIN_SERVICE_TYPE_NAME = "plugin";
+    static final String DEFAULT_CONFIG_YAML_FILE = "config.yaml";
+    static final String DEFAULT_CONFIG_TLOG_FILE = "config.tlog";
 
     @Getter
     private final Context context;
@@ -286,7 +287,7 @@ public class Kernel {
 
     public void writeEffectiveConfig() {
         // TODO: what file extension should we use?  The syntax is yaml, but the semantics are "evergreen"
-        writeEffectiveConfig(configPath.resolve("effectiveConfig.evg"));
+        writeEffectiveConfig(configPath.resolve(DEFAULT_CONFIG_YAML_FILE));
     }
 
     /**
@@ -321,15 +322,8 @@ public class Kernel {
      * @param w Writer to write config into
      */
     public void writeConfig(Writer w) {
-        Map<String, Object> serviceMap = new LinkedHashMap<>();
-        orderedDependencies().forEach(l -> {
-            if (l != null) {
-                serviceMap.put(l.getName(), l.getServiceConfig().toPOJO());
-            }
-        });
-
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put(SERVICES_NAMESPACE_TOPIC, serviceMap);
+        configMap.put(SERVICES_NAMESPACE_TOPIC, config.findTopics(SERVICES_NAMESPACE_TOPIC).toPOJO());
         configMap.put(DeviceConfiguration.SYSTEM_NAMESPACE_KEY,
                 config.findTopics(DeviceConfiguration.SYSTEM_NAMESPACE_KEY).toPOJO());
         try {

--- a/src/main/java/com/aws/iot/evergreen/kernel/KernelAlternatives.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/KernelAlternatives.java
@@ -41,6 +41,7 @@ public class KernelAlternatives {
     private static final String INITIAL_SETUP_DIR = "init";
     private static final String KERNEL_DISTRIBUTION_DIR = "distro";
     private static final String SYSTEMD_SERVICE_FILE = "greengrass.service";
+    private static final String SYSTEMD_SERVICE_TEMPLATE = "greengrass.service.template";
     private static final String KERNEL_BIN_DIR = "bin";
     private static final String KERNEL_LIB_DIR = "lib";
     private static final String LOADER_PID_FILE = "loader.pid";
@@ -94,6 +95,10 @@ public class KernelAlternatives {
     }
 
     public Path getServiceTemplatePath() {
+        return currentDir.resolve(KERNEL_DISTRIBUTION_DIR).resolve(KERNEL_BIN_DIR).resolve(SYSTEMD_SERVICE_TEMPLATE);
+    }
+
+    public Path getServiceConfigPath() {
         return currentDir.resolve(KERNEL_DISTRIBUTION_DIR).resolve(KERNEL_BIN_DIR).resolve(SYSTEMD_SERVICE_FILE);
     }
 
@@ -129,7 +134,7 @@ public class KernelAlternatives {
     /**
      * Locate launch directory of Kernel, assuming unpack directory tree as below.
      * ├── bin
-     * │   ├── greengrass.service
+     * │   ├── greengrass.service.template
      * │   └── loader
      * └── lib
      *     └── Evergreen.jar

--- a/src/main/java/com/aws/iot/evergreen/kernel/KernelLifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/kernel/KernelLifecycle.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.aws.iot.evergreen.kernel.Kernel.CONTEXT_SERVICE_IMPLEMENTERS;
+import static com.aws.iot.evergreen.kernel.Kernel.DEFAULT_CONFIG_TLOG_FILE;
+import static com.aws.iot.evergreen.kernel.Kernel.DEFAULT_CONFIG_YAML_FILE;
 import static com.aws.iot.evergreen.kernel.KernelVersion.KERNEL_VERSION;
 import static com.aws.iot.evergreen.util.Utils.close;
 import static com.aws.iot.evergreen.util.Utils.deepToString;
@@ -90,8 +92,8 @@ public class KernelLifecycle {
     }
 
     void initConfigAndTlog() {
-        Path transactionLogPath = kernel.getConfigPath().resolve("config.tlog");
-        Path configurationFile = kernel.getConfigPath().resolve("config.yaml");
+        Path transactionLogPath = kernel.getConfigPath().resolve(DEFAULT_CONFIG_TLOG_FILE);
+        Path configurationFile = kernel.getConfigPath().resolve(DEFAULT_CONFIG_YAML_FILE);
 
 
         try {

--- a/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
+++ b/src/test/java/com/aws/iot/evergreen/kernel/KernelTest.java
@@ -69,14 +69,15 @@ import static org.mockito.Mockito.when;
 class KernelTest {
     private static final String EXPECTED_CONFIG_OUTPUT =
             "services:\n"
+            + "  main:\n"
+            + "    dependencies:\n"
+            + "    - \"service1\"\n"
+            + "    lifecycle: {}\n"
             + "  service1:\n"
             + "    dependencies: []\n"
             + "    lifecycle:\n"
             + "      run:\n"
-            + "        script: \"test script\"\n"
-            + "  main:\n"
-            + "    dependencies:\n"
-            + "    - \"service1\"\n";
+            + "        script: \"test script\"\n";
 
     @TempDir
     protected Path tempRootDir;
@@ -202,7 +203,7 @@ class KernelTest {
         assertThat(writer.toString(), containsString(EXPECTED_CONFIG_OUTPUT));
 
         kernel.writeEffectiveConfig();
-        String readFile = new String(Files.readAllBytes(kernel.getConfigPath().resolve("effectiveConfig.evg")),
+        String readFile = new String(Files.readAllBytes(kernel.getConfigPath().resolve("config.yaml")),
                 StandardCharsets.UTF_8);
         assertThat(readFile, containsString(EXPECTED_CONFIG_OUTPUT));
     }


### PR DESCRIPTION
Fix effective config dump and remove duplicate config file

**Issue #, if available:**

**Description of changes:**

- Update systemd setup
  - Use Java IO to prepare `.service` file
  - `sudo` is no longer a requirement until systemd setup
- Fix effective config dump in config.yaml and remove effectiveconfig.evg

**Why is this change necessary:**

**How was this change tested:**
- Manually tested systemd setup on Ubuntu18.04 and RH8
- Unit test for effective config

**Any additional information or context required to review the change:**

**Checklist:**
 - [x] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
