### PR TITLE
Revert pkill change as man page online is wrong

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/util/platforms/UnixPlatform.java
+++ b/src/main/java/com/aws/iot/evergreen/util/platforms/UnixPlatform.java
@@ -40,13 +40,13 @@ public class UnixPlatform extends Platform {
         String[] cmd = {"pkill", "-" + (force ? SIGKILL : SIGINT), "-P", Integer.toString(pp.getPid())};
         Process proc = Runtime.getRuntime().exec(cmd);
         proc.waitFor();
-        if (proc.exitValue() != 1) {
+        if (proc.exitValue() != 0) {
             logger.atWarn()
                     .kv("pid", pp.getPid())
                     .kv("exit-code", proc.exitValue())
                     .kv("stdout", inputStreamToString(proc.getInputStream()))
                     .kv("stderr", inputStreamToString(proc.getErrorStream()))
-                    .log("pkill exited non-one (process not found or other error)");
+                    .log("pkill exited non-zero (process not found or other error)");
         }
 
         // If forcible, then also kill the parent (the shell)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Online man page disagrees with the man page in mac and my devdesktop, so reverting this change.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
