### PR TITLE
Add step to create a thing group during provisioning

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/easysetup/README.md
+++ b/src/main/java/com/aws/iot/evergreen/easysetup/README.md
@@ -20,6 +20,7 @@ OPTIONS
 	--config, -i			Path to the configuration file to start Evergreen kernel with
 	--root, -r			Path to the directory to use as the root for Evergreen
 	--thing-name, -tn		Desired thing name to register the device with in AWS IoT cloud, ignored if --provision option is false/not specified
+    --thing-group-name, -tgn    Desired thing group to add the IoT Thing into
 	--policy-name, -pn 		Desired name for IoT thing policy, ignored if --provision option is false/not specified
 	—-tes-role-name, -trn 	        Name of the IAM role to use for TokenExchangeService for the device to talk to
                                         AWS services, if the role does not exist then it will be created in your AWS

--- a/src/test/java/com/aws/iot/evergreen/easysetup/EvergreenSetupTest.java
+++ b/src/test/java/com/aws/iot/evergreen/easysetup/EvergreenSetupTest.java
@@ -41,6 +41,7 @@ public class EvergreenSetupTest {
         evergreenSetup.parseArgs();
         evergreenSetup.provision(kernel);
         verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any(), any());
@@ -76,6 +77,7 @@ public class EvergreenSetupTest {
         evergreenSetup.parseArgs();
         evergreenSetup.provision(kernel);
         verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any(), any());
@@ -110,6 +112,7 @@ public class EvergreenSetupTest {
         evergreenSetup.parseArgs();
         evergreenSetup.provision(kernel);
         verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any());
         verify(deviceProvisioningHelper, times(0)).setupIoTRoleForTes(any(), any(), any());
         verify(deviceProvisioningHelper, times(0)).updateKernelConfigWithTesRoleInfo(any(), any());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds new option to provisioning for "thing-group-name". If it is left unspecified, then it will use "MyIotThingGroup". This is to support cloud deployments since we do not support single-device deployments right now.

**Why is this change necessary:**
To support cloud deployments out of the box.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
