### PR TITLE
Correctly unwrap errors which are wrapped due to MQTT proxy + Fix multiple subscription

### DIFF
--- a/src/main/java/com/aws/greengrass/builtin/services/cli/CLIServiceAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/cli/CLIServiceAgent.java
@@ -1,6 +1,7 @@
 package com.aws.greengrass.builtin.services.cli;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.LocalOverrideRequest;
@@ -303,15 +304,14 @@ public class CLIServiceAgent {
             throws InvalidArgumentsError, ResourceNotFoundError {
         validateGetLocalDeploymentStatusRequest(request);
         Topics localDeployments = serviceConfig.findTopics(PERSISTENT_LOCAL_DEPLOYMENTS);
-        if (localDeployments == null || localDeployments.find(request.getDeploymentId(),
-                PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_STATUS) == null) {
+        if (localDeployments == null || localDeployments.find(request.getDeploymentId()) == null) {
             throw new ResourceNotFoundError("Cannot find deployment", LOCAL_DEPLOYMENT_RESOURCE,
                     request.getDeploymentId());
         } else {
-            Topics deployment = localDeployments.findTopics(request.getDeploymentId());
+            Topic deployment = localDeployments.find(request.getDeploymentId());
+            Map<String, Object> deploymentDetails = (Map<String, Object>) deployment.getOnce();
             DeploymentStatus status =
-                    Coerce.toEnum(DeploymentStatus.class,
-                            deployment.find(PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_STATUS));
+                    (DeploymentStatus) deploymentDetails.get(PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_STATUS);
             return GetLocalDeploymentStatusResponse.builder()
                     .deployment(LocalDeployment.builder().deploymentId(request.getDeploymentId())
                             .status(status).build()).build();
@@ -326,12 +326,12 @@ public class CLIServiceAgent {
     public ListLocalDeploymentResponse listLocalDeployments(Topics serviceConfig) {
         List<LocalDeployment> persistedDeployments = new ArrayList<>();
         Topics localDeployments = serviceConfig.findTopics(PERSISTENT_LOCAL_DEPLOYMENTS);
-        localDeployments.forEach(topics -> {
-            Topics deploymentDetails = (Topics) topics;
+        localDeployments.deepForEachTopic(topic -> {
+            Map<String, Object> deploymentDetails = (Map<String, Object>) topic.getOnce();
             persistedDeployments.add(LocalDeployment.builder()
-                    .deploymentId(Coerce.toString(deploymentDetails.find(PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_ID)))
-                    .status(Coerce.toEnum(DeploymentStatus.class, deploymentDetails.find(
-                            PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_STATUS)))
+                    .deploymentId((String) deploymentDetails.get(PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_ID))
+                    .status((DeploymentStatus) deploymentDetails.get(
+                            PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_STATUS))
                     .build());
         });
         return ListLocalDeploymentResponse.builder().localDeployments(persistedDeployments).build();
@@ -345,8 +345,8 @@ public class CLIServiceAgent {
     public void persistLocalDeployment(Topics serviceConfig, Map<String, Object> deploymentDetails) {
         Topics localDeployments = serviceConfig.lookupTopics(PERSISTENT_LOCAL_DEPLOYMENTS);
         String deploymentId = (String) deploymentDetails.get(PERSISTED_DEPLOYMENT_STATUS_KEY_LOCAL_DEPLOYMENT_ID);
-        Topics localDeploymentDetails = localDeployments.lookupTopics(deploymentId);
-        localDeploymentDetails.replaceAndWait(deploymentDetails);
+        Topic localDeploymentDetails = localDeployments.lookup(deploymentId);
+        localDeploymentDetails.withValue(deploymentDetails);
         // TODO: Remove the succeeded deployments if the number of deployments have exceeded max limit
     }
 

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -505,10 +505,10 @@ public class IotJobsHelperTest {
     }
 
     @Test
-    public void WHEN_mqttConnection_resumes_THEN_jobsclient_resubscribes_and_call_publish_persisted_deployment_status() {
+    public void WHEN_mqttConnection_resumes_THEN_jobsclient_doesnt_resub_and_call_publish_persisted_deployment_status() {
         verify(mockIotJobsClient, times(1)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         iotJobsHelper.getCallbacks().onConnectionResumed(false);
-        verify(mockIotJobsClient, times(2)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
+        verify(mockIotJobsClient, times(1)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(deploymentStatusKeeper).publishPersistedStatusUpdates(eq(IOT_JOBS));
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This does not fix the error that I talked about in the chatroom, however it unwraps exceptions which can help us be more intelligent in how the retries are implemented when that happens. Also fixes duplicate subscriptions to Jobs.

**Why is this change necessary:**
Our MqttClient class does not return futures for subscribe, instead it runs that as synchronous. The IotJobsClient uses a WrapperMqttClientConnection which wraps the synchronous calls in a future. This causes the future to resolve with an `ExecutionException` even though the real error may be a timeoutexception or an interruptedexception. Therefore, this change unwraps the cause to rethrow the real exception.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
