### PR TITLE
Cleanly shutdown event loop, fix plugin componentType name

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -142,7 +142,8 @@ public class KernelConfigResolver {
                 interpolate(componentRecipe.getLifecycle(), componentIdentifier, packagesToDeploy, document,
                         parameterAndDependencyCache));
 
-        resolvedServiceConfig.put(SERVICE_TYPE_TOPIC_KEY, componentRecipe.getComponentType());
+        resolvedServiceConfig.put(SERVICE_TYPE_TOPIC_KEY,
+                componentRecipe.getComponentType() == null ? null : componentRecipe.getComponentType().name());
 
         // Generate dependencies
         List<String> dependencyConfig = new ArrayList<>();

--- a/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
+++ b/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
@@ -101,6 +101,12 @@ public class IotConnectionManager implements Closeable {
         clientBootstrap.close();
         resolver.close();
         eventLoopGroup.close();
+        try {
+            eventLoopGroup.getShutdownCompleteFuture().get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            LOGGER.atError().log("Error shutting down event loop", e);
+        }
     }
-
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -351,6 +351,13 @@ public class MqttClient implements Closeable {
         clientBootstrap.close();
         hostResolver.close();
         eventLoopGroup.close();
+        try {
+            eventLoopGroup.getShutdownCompleteFuture().get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.atError().log("Error shutting down event loop", e);
+        }
     }
 
     public void addToCallbackEvents(MqttClientConnectionEvents callbacks) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Some small fixes to cleanly shutdown the event loop and fix the componentType for lambda, plugin, and generic

**Why is this change necessary:**
If we don't wait for the event loop to fully shutdown it may lead to ugly error messages being dumped to stderr.
Uses `ComponentType.name()` to save the name instead of the json representation because those json representations aren't used elsewhere which leads to plugins not being found

**How was this change tested:**
ComponentType change is tested manually, integ tests, and UATs.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
