### PR TITLE
Publish aws.greengrass.nucleus as private component

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -105,6 +105,12 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
+      - name: Checkout Private Action
+        uses: daspn/private-actions-checkout@v2
+        with:
+          actions_list: '["aws/aws-greengrass-component-upload-action@master"]'
+          checkout_base_path: ./.github/actions
+          ssh_private_key: ${{ secrets.COMPONENT_UPLOAD_ACTION_PRIVATE_KEY }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -115,4 +121,15 @@ jobs:
       - name: Upload to S3
         run: |
           aws s3 cp target/Greengrass.jar s3://gg-evergreen-releases/${{github.repository}}/${{github.ref}}/evergreen-${{github.sha}}.jar
-          aws s3 cp target/aws.greengrass.nucleus.2.0.0.zip s3://gg-evergreen-releases/${{github.repository}}-zip/${{github.ref}}/evergreen-${{github.sha}}.zip
+          aws s3 cp target/aws.greengrass.nucleus.zip s3://gg-evergreen-releases/${{github.repository}}-zip/${{github.ref}}/evergreen-${{github.sha}}.zip
+      - run: mkdir -p target/artifacts && cp target/aws.greengrass.nucleus.zip target/artifacts/aws.greengrass.nucleus.zip
+      - uses: ./.github/actions/aws-greengrass-component-upload-action
+        name: Upload to GCS
+        env:
+          AWS_REGION: us-east-1
+        with:
+          recipePath: aws.greengrass.Nucleus.yaml
+          artifactDirectoryPath: target/artifacts
+          endpoint: https://evergreen-gamma.us-east-1.amazonaws.com
+          autoBumpVersion: true
+          publishAsPublic: false

--- a/aws.greengrass.Nucleus.yaml
+++ b/aws.greengrass.Nucleus.yaml
@@ -3,7 +3,7 @@ RecipeFormatVersion: '2020-01-25'
 ComponentName: aws.greengrass.Nucleus
 ComponentDescription: Core functionality for device side orchestration of deployments and lifecycle management for execution of Greengrass components and applications.
 ComponentPublisher: AWS
-ComponentVersion: '2.0.0'
+ComponentVersion: '0.0.0'
 Manifests:
   - Platform:
       os: macos
@@ -13,15 +13,14 @@ Manifests:
         value: -Xms512m -Xmx512m
         type: STRING
     Artifacts:
-      # TODO: set correct URI
-      - URI: S3:aws.greengrass.nucleus.2.0.0.zip
+      - URI: s3://gg-dev-artifacts/$componentName/$version/aws.greengrass.nucleus.zip
         Unarchive: zip
     Lifecycle:
       bootstrap:
           script: |-
             set -eu
             KERNEL_ROOT="{{kernel:rootPath}}"
-            UNPACK_DIR="{{artifacts:decompressedPath}}/aws.greengrass.nucleus.2.0.0"
+            UNPACK_DIR="{{artifacts:decompressedPath}}/aws.greengrass.nucleus"
             # TODO: Use builtin unpack functionality with permission preserved if available
             chmod +x "$UNPACK_DIR/bin/loader"
 
@@ -32,22 +31,21 @@ Manifests:
             exit 100
 
   - Platform:
-      os: ubuntu
+      os: linux
     Parameters:
       - name: jvmOptions
         # TODO: consider change to nested structure
         value: -Xms512m -Xmx512m
         type: STRING
     Artifacts:
-      # TODO: set correct URI
-      - URI: S3:aws.greengrass.nucleus.2.0.0.zip
+      - URI: s3://gg-dev-artifacts/$componentName/$version/aws.greengrass.nucleus.zip
         Unarchive: zip
     Lifecycle:
       bootstrap:
         script: |-
           set -eu
           KERNEL_ROOT="{{kernel:rootPath}}"
-          UNPACK_DIR="{{artifacts:decompressedPath}}/aws.greengrass.nucleus.2.0.0"
+          UNPACK_DIR="{{artifacts:decompressedPath}}/aws.greengrass.nucleus"
           # TODO: Use builtin unpack functionality with permission preserved if available
           chmod +x "$UNPACK_DIR/bin/loader"
 

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <finalName>aws.greengrass.nucleus.2.0.0</finalName>
+                    <finalName>aws.greengrass.nucleus</finalName>
                     <descriptors>
                         <descriptor>${basedir}/assembly.xml</descriptor>
                     </descriptors>

--- a/src/main/java/com/aws/greengrass/easysetup/README.md
+++ b/src/main/java/com/aws/greengrass/easysetup/README.md
@@ -38,9 +38,9 @@ OPTIONS
 ## Set up steps with Greengrass zip file
 This workflow has been implemented for Ubuntu. Use as a reference.
 ```
-# Move aws.greengrass.nucleus.2.0.0.zip to test device
+# Move aws.greengrass.nucleus.zip to test device
 # Set up aws creds
-unzip aws.greengrass.nucleus.2.0.0.zip -d GreengrassCore
+unzip aws.greengrass.nucleus.zip -d GreengrassCore
 java -Droot=~/gg_home -Dlog.level=WARN -jar ./GreengrassCore/lib/Greengrass.jar --provision true --aws-region us-east-1 --thing-name <test-device> --setup-tes true -tra <test-role-alias> -ss true
 
 # Verify the setup


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
1. Publish aws.greengrass.nucleus as a private component. Remove hardcoded version in artifact name and start versioning from 0.0.0 for now

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [x] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
