### PR TITLE
Fix log when shutting tes

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
+++ b/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
@@ -79,8 +79,8 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
     @SuppressWarnings("PMD.CloseResource")
     protected void startup() {
         // TODO: Support tes restart with change in configuration like port, roleAlias.
-        logger.atInfo().addKeyValue(PORT_TOPIC, port)
-                .addKeyValue(IOT_ROLE_ALIAS_TOPIC, iotRoleAlias).log("Attempting to start server at configured port {}", port);
+        logger.atInfo().addKeyValue(PORT_TOPIC, port).addKeyValue(IOT_ROLE_ALIAS_TOPIC, iotRoleAlias)
+                .log("Attempting to start server at configured port {}", port);
         try {
             validateConfig();
             server = new HttpServerImpl(port, credentialRequestHandler);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We were logging configured port which is optional. Instead log the real tes server port.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
