### PR TITLE
Update config resolution and merge workflow

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/MqttReconnectTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/MqttReconnectTest.java
@@ -43,7 +43,7 @@ import static com.aws.greengrass.deployment.IotJobsHelper.UPDATE_DEPLOYMENT_STAT
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
-import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessageSubstring;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(GGExtension.class)
@@ -89,8 +89,8 @@ class MqttReconnectTest extends BaseE2ETestCase {
     void GIVEN_new_deployment_while_device_online_WHEN_mqtt_disconnects_and_reconnects_THEN_job_executes_successfully(
             ExtensionContext context) throws Exception {
         ignoreExceptionUltimateCauseOfType(context, MqttException.class);
-        ignoreExceptionWithMessage(context,
-                "No valid versions were found for this package based on provided requirement");
+        ignoreExceptionWithMessageSubstring(context,
+                "No valid versions were found for this component based on provided requirement");
 
         CountDownLatch jobInProgress = new CountDownLatch(1);
         CountDownLatch jobCompleted = new CountDownLatch(1);

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
@@ -84,7 +84,8 @@ public class ComponentServiceHelper {
         } catch (AmazonClientException e) {
             // TODO: This should be expanded to handle various types of retryable/non-retryable exceptions
             throw new PackageDownloadException(
-                    "No valid versions were found for this package based on provided requirement", e);
+                    "No valid versions were found for this component based on provided requirement: "
+                            + findComponentRequest, e);
         }
         ret.sort(null);
         return ret;

--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -115,6 +115,13 @@ public class KernelConfigResolver {
             servicesConfig.put(packageToDeploy.getName(),
                     getServiceConfig(packageToDeploy, document, packagesToDeploy, parameterAndDependencyCache));
         }
+        kernel.getMain().getDependencies().forEach((greengrassService, dependencyType) -> {
+            // Add all builtin dependencies
+            if (greengrassService.isBuiltin()) {
+                servicesConfig.putIfAbsent(greengrassService.getName(), greengrassService.getConfig().toPOJO());
+            }
+        });
+
         servicesConfig.put(kernel.getMain().getName(), getMainConfig(rootPackages));
 
         // Services need to be under the services namespace in kernel config
@@ -281,7 +288,7 @@ public class KernelConfigResolver {
         Map<String, Object> mainServiceConfig = new HashMap<>();
         ArrayList<String> mainDependencies = new ArrayList<>(rootPackages);
         kernel.getMain().getDependencies().forEach((greengrassService, dependencyType) -> {
-            // Add all autostart dependencies
+            // Add all builtin dependencies
             if (greengrassService.isBuiltin()) {
                 mainDependencies.add(greengrassService.getName() + ":" + dependencyType);
             }

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -177,6 +177,11 @@ public class DeploymentDirectoryManager {
         return getDeploymentDirectoryPath().resolve(TARGET_CONFIG_FILE);
     }
 
+
+    public Path getTmpConfigFilePath() throws IOException {
+        return getDeploymentDirectoryPath().resolve("tmp.tlog");
+    }
+
     /**
      * Resolve file path to persisted bootstrap task list of an ongoing deployment.
      *

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ExecutorService;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_ID_LOG_KEY;
-import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_MERGE_BEHAVIOR;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.MERGE_CONFIG_EVENT_KEY;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.MERGE_ERROR_LOG_EVENT_KEY;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.waitForServicesToStart;
@@ -72,9 +71,9 @@ public class DefaultActivator extends DeploymentActivator {
 
         // when deployment adds a new dependency (component B) to component A
         // the config for component B has to be merged in before externalDependenciesTopic of component A trigger
-        // executing mergeMap using publish thread ensures this
+        // executing updateMap using publish thread ensures this
         kernel.getContext().runOnPublishQueueAndWait(() ->
-                kernel.getConfig().updateMap(deploymentDocument.getTimestamp(), newConfig, DEPLOYMENT_MERGE_BEHAVIOR));
+                updateKernelConfig(deploymentDocument.getTimestamp(), newConfig));
 
         // wait until topic listeners finished processing mergeMap changes.
         kernel.getContext().runOnPublishQueue(() -> {

--- a/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_MERGE_BEHAVIOR;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.MERGE_ERROR_LOG_EVENT_KEY;
 
 public abstract class DeploymentActivator {
@@ -47,6 +48,10 @@ public abstract class DeploymentActivator {
                     DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE, e));
             return false;
         }
+    }
+
+    protected void updateKernelConfig(long timestamp, Map<String, Object> newConfig) {
+        kernel.getConfig().updateMap(timestamp, newConfig, DEPLOYMENT_MERGE_BEHAVIOR);
     }
 
     protected long rollbackConfig(CompletableFuture<DeploymentResult> totallyCompleteFuture, Throwable failureCause) {

--- a/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
@@ -64,7 +64,8 @@ public class KernelUpdateActivator extends DeploymentActivator {
         DeploymentDocument deploymentDocument = deployment.getDeploymentDocumentObj();
         // Wait for all services to close
         kernel.getContext().get(KernelLifecycle.class).stopAllServices(30);
-        kernel.getConfig().mergeMap(deploymentDocument.getTimestamp(), newConfig);
+        updateKernelConfig(deploymentDocument.getTimestamp(), newConfig);
+
         Path bootstrapTaskFilePath;
         try {
             bootstrapTaskFilePath = deploymentDirectoryManager.getBootstrapTaskFilePath();

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
@@ -85,6 +86,9 @@ class KernelConfigResolverTest {
     void setupMocks() {
         path = Paths.get("Artifacts", TEST_INPUT_PACKAGE_A);
         lenient().when(componentStore.resolveArtifactDirectoryPath(any())).thenReturn(path.toAbsolutePath());
+        Topics mockRunnnigServiceConfig = mock(Topics.class);
+        lenient().when(alreadyRunningService.getConfig()).thenReturn(mockRunnnigServiceConfig);
+        lenient().when(mockRunnnigServiceConfig.toPOJO()).thenReturn(Collections.emptyMap());
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Always add back component configurations of builtins
1. Ensure kernel update uses the same workflow as default deployments
1. Minor improvements on Telemetry integ test and component download error message

**Why is this change necessary:**
Configurations for 1P builtin components are lost after deployments. See detailed tlogs before and after config merge https://paste.amazon.com/show/huiyn/1601068774

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
