### PR TITLE
Parameterize IotConnectionManager HTTP port

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -35,6 +35,7 @@ public class DeviceConfiguration {
     public static final String DEVICE_PARAM_THING_NAME = "thingName";
     public static final String DEVICE_PARAM_IOT_DATA_ENDPOINT = "iotDataEndpoint";
     public static final String DEVICE_PARAM_IOT_CRED_ENDPOINT = "iotCredEndpoint";
+    public static final String DEVICE_PARAM_IOT_HTTP_PORT = "iotHttpPort";
     public static final String DEVICE_PARAM_PRIVATE_KEY_PATH = "privateKeyPath";
     public static final String DEVICE_PARAM_CERTIFICATE_FILE_PATH = "certificateFilePath";
     public static final String DEVICE_PARAM_ROOT_CA_PATH = "rootCaPath";
@@ -47,6 +48,7 @@ public class DeviceConfiguration {
     private static final String CANNOT_BE_EMPTY = " cannot be empty";
     private static final Logger logger = LogManager.getLogger(DeviceConfiguration.class);
     private static final String FALLBACK_DEFAULT_REGION = "us-east-1";
+    private static final int IOT_HTTP_PORT_DEFAULT = 8443;
 
     private final Kernel kernel;
 
@@ -152,6 +154,10 @@ public class DeviceConfiguration {
         return getTopic(DEVICE_PARAM_IOT_CRED_ENDPOINT);
     }
 
+    public Topic getIotHttpPort() {
+        return getTopic(DEVICE_PARAM_IOT_HTTP_PORT, IOT_HTTP_PORT_DEFAULT);
+    }
+
     public Topic getAWSRegion() {
         return getTopic(DEVICE_PARAM_AWS_REGION).addValidator(regionValidator);
     }
@@ -187,12 +193,17 @@ public class DeviceConfiguration {
         String iotDataEndpoint = Coerce.toString(getIotDataEndpoint());
         String iotCredEndpoint = Coerce.toString(getIotCredentialEndpoint());
         String awsRegion = Coerce.toString(getAWSRegion());
+        int iotHttpPort = Coerce.toInt(getIotHttpPort());
         validateDeviceConfiguration(thingName, certificateFilePath, privateKeyPath, rootCAPath, iotDataEndpoint,
-                iotCredEndpoint, awsRegion);
+                iotCredEndpoint, iotHttpPort, awsRegion);
     }
 
     private Topic getTopic(String parameterName) {
         return kernel.getConfig().lookup(SYSTEM_NAMESPACE_KEY, parameterName).dflt("");
+    }
+
+    private Topic getTopic(String parameterName, Object defaultValue) {
+        return kernel.getConfig().lookup(SYSTEM_NAMESPACE_KEY, parameterName).dflt(defaultValue);
     }
 
     private Topics getTopics(String parameterName) {
@@ -201,7 +212,7 @@ public class DeviceConfiguration {
 
     private void validateDeviceConfiguration(String thingName, String certificateFilePath, String privateKeyPath,
                                              String rootCAPath, String iotDataEndpoint, String iotCredEndpoint,
-                                             String awsRegion) throws DeviceConfigurationException {
+                                             int iotHttpPort, String awsRegion) throws DeviceConfigurationException {
         List<String> errors = new ArrayList<>();
         if (Utils.isEmpty(thingName)) {
             errors.add(DEVICE_PARAM_THING_NAME + CANNOT_BE_EMPTY);
@@ -220,6 +231,9 @@ public class DeviceConfiguration {
         }
         if (Utils.isEmpty(iotCredEndpoint)) {
             errors.add(DEVICE_PARAM_IOT_CRED_ENDPOINT + CANNOT_BE_EMPTY);
+        }
+        if (Utils.isEmpty(String.valueOf(iotHttpPort))) {
+            errors.add(DEVICE_PARAM_IOT_HTTP_PORT + CANNOT_BE_EMPTY);
         }
         if (Utils.isEmpty(awsRegion)) {
             errors.add(DEVICE_PARAM_AWS_REGION + CANNOT_BE_EMPTY);

--- a/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
+++ b/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
@@ -30,8 +30,6 @@ import javax.inject.Inject;
 public class IotConnectionManager implements Closeable {
     // TODO: Move Iot related classes to a central location
     private static final Logger LOGGER = LogManager.getLogger(IotConnectionManager.class);
-    // TODO: ALPN support, and validate how does it work if port is also part of URL
-    private static final int IOT_PORT = 8443;
     // Max wait time for device to establish mTLS connection with IOT core
     private static final long TIMEOUT_FOR_CONNECTION_SETUP_SECONDS = Duration.ofMinutes(1).getSeconds();
     private final HttpClientConnectionManager connManager;
@@ -57,13 +55,14 @@ public class IotConnectionManager implements Closeable {
         final String certPath = Coerce.toString(deviceConfiguration.getCertificateFilePath());
         final String keyPath = Coerce.toString(deviceConfiguration.getPrivateKeyFilePath());
         final String caPath = Coerce.toString(deviceConfiguration.getRootCAFilePath());
+        final Integer iotHttpPort = Coerce.toInt(deviceConfiguration.getIotHttpPort());
         try (TlsContextOptions tlsCtxOptions = TlsContextOptions.createWithMtlsFromPath(certPath, keyPath)) {
             // TODO: Proxy support, ALPN support. Reuse connections across kernel
             tlsCtxOptions.overrideDefaultTrustStoreFromPath(null, caPath);
             return HttpClientConnectionManager
                     .create(new HttpClientConnectionManagerOptions().withClientBootstrap(clientBootstrap)
                             .withSocketOptions(new SocketOptions()).withTlsContext(new TlsContext(tlsCtxOptions))
-                            .withPort(IOT_PORT).withUri(URI.create(
+                            .withPort(iotHttpPort).withUri(URI.create(
                                     "https://" + Coerce.toString(deviceConfiguration.getIotCredentialEndpoint()))));
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Allow customers to specify the port that IotConnectionManager uses under the system parameter iotHttpPort.

**Why is this change necessary:**
This is necessary so customers aren't required to open port 8443 if they are behind a firewall.

**How was this change tested:**
Tested locally using TES to connect to the cloud over port 443.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
