### PR TITLE
Update shared object mapper to expose reader and writer only

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -123,7 +123,7 @@ public class DeploymentDirectoryManager {
 
     private void writeDeploymentMetadata(Path filePath, Deployment deployment) throws IOException {
         try (OutputStream out = Files.newOutputStream(filePath)) {
-            SerializerFactory.getJsonObjectMapper().writeValue(out, deployment);
+            SerializerFactory.getJsonObjectWriter().writeValue(out, deployment);
         }
     }
 
@@ -142,7 +142,7 @@ public class DeploymentDirectoryManager {
         Path filePath = getDeploymentMetadataFilePath();
         logger.atInfo().kv(FILE_LOG_KEY, filePath).log("Load deployment metadata");
         try (InputStream in = Files.newInputStream(filePath)) {
-            return SerializerFactory.getJsonObjectMapper().readValue(in, Deployment.class);
+            return SerializerFactory.getJsonObjectReader().forType(Deployment.class).readValue(in);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -421,8 +421,8 @@ public class DeploymentService extends GreengrassService {
         try {
             switch (deployment.getDeploymentType()) {
                 case LOCAL:
-                    LocalOverrideRequest localOverrideRequest = SerializerFactory.getJsonObjectMapper().readValue(
-                            jobDocumentString, LocalOverrideRequest.class);
+                    LocalOverrideRequest localOverrideRequest = SerializerFactory.getJsonObjectReader().forType(
+                            LocalOverrideRequest.class).readValue(jobDocumentString);
                     Map<String, String> rootComponents = new HashMap<>();
                     Set<String> rootComponentsInRequestedGroup = new HashSet<>();
                     config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS,
@@ -445,8 +445,8 @@ public class DeploymentService extends GreengrassService {
                     break;
                 case IOT_JOBS:
                 case SHADOW:
-                    FleetConfiguration config = SerializerFactory.getJsonObjectMapper()
-                            .readValue(jobDocumentString, FleetConfiguration.class);
+                    FleetConfiguration config = SerializerFactory.getJsonObjectReader()
+                            .forType(FleetConfiguration.class).readValue(jobDocumentString);
                     document = DeploymentDocumentConverter.convertFromFleetConfiguration(config);
                     break;
                 default:

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -188,7 +188,7 @@ public class IotJobsHelper implements InjectionActions {
 
         String documentString;
         try {
-            documentString = SerializerFactory.getJsonObjectMapper().writeValueAsString(jobExecutionData.jobDocument);
+            documentString = SerializerFactory.getJsonObjectWriter().writeValueAsString(jobExecutionData.jobDocument);
         } catch (JsonProcessingException e) {
             //TODO: Handle when job document is incorrect json.
             // This should not happen as we are converting a HashMap

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -238,7 +238,7 @@ public class ShadowDeploymentListener implements InjectionActions {
 
         String configurationString;
         try {
-            configurationString = SerializerFactory.getJsonObjectMapper().writeValueAsString(configuration);
+            configurationString = SerializerFactory.getJsonObjectWriter().writeValueAsString(configuration);
         } catch (JsonProcessingException e) {
             logger.atError("Unable to process shadow update", e);
             return;

--- a/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
@@ -192,7 +192,7 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
         Files.createFile(persistedTaskFilePath);
 
         try (OutputStream out = Files.newOutputStream(persistedTaskFilePath)) {
-            SerializerFactory.getJsonObjectMapper().writeValue(out, bootstrapTaskStatusList);
+            SerializerFactory.getJsonObjectWriter().writeValue(out, bootstrapTaskStatusList);
         }
         logger.atInfo().kv("filePath", persistedTaskFilePath).log("Bootstrap task list is saved to file");
     }
@@ -210,8 +210,8 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
 
         try (InputStream input = Files.newInputStream(persistedTaskFilePath)) {
             bootstrapTaskStatusList.clear();
-            bootstrapTaskStatusList.addAll(SerializerFactory.getJsonObjectMapper()
-                    .readValue(input, new TypeReference<List<BootstrapTaskStatus>>(){}));
+            bootstrapTaskStatusList.addAll(SerializerFactory.getJsonObjectReader()
+                    .forType(new TypeReference<List<BootstrapTaskStatus>>(){}).readValue(input));
         }
     }
 

--- a/src/main/java/com/aws/greengrass/util/SerializerFactory.java
+++ b/src/main/java/com/aws/greengrass/util/SerializerFactory.java
@@ -2,15 +2,18 @@ package com.aws.greengrass.util;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import lombok.Getter;
 
 public final class SerializerFactory {
     private static final ObjectMapper JSON_OBJECT_MAPPER =
             new ObjectMapper().configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false)
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-    public static ObjectMapper getJsonObjectMapper() {
-        return JSON_OBJECT_MAPPER;
-    }
+    @Getter
+    private static final ObjectReader jsonObjectReader = JSON_OBJECT_MAPPER.reader();
+    @Getter
+    private static final ObjectWriter jsonObjectWriter = JSON_OBJECT_MAPPER.writer();
 
     private SerializerFactory() {
     }


### PR DESCRIPTION
**Issue #, if available:**
MqttReconnectTest failure. Full log https://paste.amazon.com/show/huiyn/1602016001

It appears that DeploymentDirectoryManager was stuck for 5 min until timeout while trying to persist deployment data to disk using the shared object mapper. 
The potential root cause may be that when calling objectmapper.readvalue for a specify type/class, the deserialization configuration of the object mapper is reconfigured, which is not thread-safe. See more http://fasterxml.github.io/jackson-databind/javadoc/2.10/com/fasterxml/jackson/databind/ObjectMapper.html

Relevant log
```
2020-10-06T18:49:52.3188863Z 2020-10-06T18:49:51.957Z [INFO] (pool-8-thread-11) com.aws.greengrass.deployment.DeploymentDirectoryManager: Create work directory for new deployment. {deploymentId=arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/e2etestgroup-2734587a-e3e2-4631-a7dd-9880abb1f8b3:1, link=/tmp/junit4897414752114556411/deployments/ongoing, directory=/tmp/junit4897414752114556411/deployments/arn.aws.greengrass.us-east-1.698947471564.configuration.thinggroup+e2etestgroup-2734587a-e3e2-4631-a7dd-9880abb1f8b3.1}
2020-10-06T18:49:52.3208076Z 2020-10-06T18:49:51.957Z [INFO] (pool-8-thread-11) com.aws.greengrass.deployment.DeploymentDirectoryManager: Persist deployment metadata. {file=/tmp/junit4897414752114556411/deployments/arn.aws.greengrass.us-east-1.698947471564.configuration.thinggroup+e2etestgroup-2734587a-e3e2-4631-a7dd-9880abb1f8b3.1/deployment_metadata.json, deploymentId=arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/e2etestgroup-2734587a-e3e2-4631-a7dd-9880abb1f8b3:1}
2020-10-06T18:49:52.3221571Z 2020-10-06T18:49:51.962Z [WARN] (aws.greengrass.TokenExchangeService-lifecycle) aws.greengrass.TokenExchangeService: service-state-transition-interrupted. Service lifecycle thread interrupted. Thread will exit now. {serviceName=aws.greengrass.TokenExchangeService, currentState=NEW}
2020-10-06T18:49:52.3228089Z 2020-10-06T18:49:51.962Z [WARN] (pool-8-thread-4) com.aws.greengrass.deployment.ShadowDeploymentListener: Interrupted while subscribing to device shadow topics. {}
2020-10-06T18:49:52.3233062Z 2020-10-06T18:49:51.962Z [INFO] (Serialized listener processor) com.aws.greengrass.lifecyclemanager.KernelLifecycle: executor-service-shutdown-initiated. {}
2020-10-06T18:49:52.3237686Z 2020-10-06T18:49:51.966Z [INFO] (main) com.aws.greengrass.lifecyclemanager.KernelLifecycle: Waiting for executors to shutdown. {}
2020-10-06T18:54:55.7315374Z 2020-10-06T18:49:51.984Z [ERROR] (pool-8-thread-11) DeploymentService: Unable to create deployment directory. {serviceName=DeploymentService, currentState=FINISHED}
2020-10-06T18:54:55.7378885Z java.nio.channels.ClosedByInterruptException
2020-10-06T18:54:55.7382462Z 	at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
2020-10-06T18:54:55.7418272Z 	at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:216)
2020-10-06T18:54:55.7421723Z 	at java.nio.channels.Channels.writeFullyImpl(Channels.java:78)
2020-10-06T18:54:55.7425221Z 	at java.nio.channels.Channels.writeFully(Channels.java:101)
2020-10-06T18:54:55.7427702Z 	at java.nio.channels.Channels.access$000(Channels.java:61)
2020-10-06T18:54:55.7430009Z 	at java.nio.channels.Channels$1.write(Channels.java:174)
2020-10-06T18:54:55.7434641Z 	at com.fasterxml.jackson.core.json.UTF8JsonGenerator._flushBuffer(UTF8JsonGenerator.java:2136)
2020-10-06T18:54:55.7450859Z 	at com.fasterxml.jackson.core.json.UTF8JsonGenerator.close(UTF8JsonGenerator.java:1180)
2020-10-06T18:54:55.7458856Z 	at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:4099)
2020-10-06T18:54:55.7462192Z 	at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3360)
2020-10-06T18:54:55.7467599Z 	at com.aws.greengrass.deployment.DeploymentDirectoryManager.writeDeploymentMetadata(DeploymentDirectoryManager.java:126)
2020-10-06T18:54:55.7474605Z 	at com.aws.greengrass.deployment.DeploymentDirectoryManager.writeDeploymentMetadata(DeploymentDirectoryManager.java:121)
2020-10-06T18:54:55.7480550Z 	at com.aws.greengrass.deployment.DeploymentService.createNewDeployment(DeploymentService.java:380)
2020-10-06T18:54:55.7584934Z 	at com.aws.greengrass.deployment.DeploymentService.startup(DeploymentService.java:213)
2020-10-06T18:54:55.7589259Z 	at com.aws.greengrass.lifecyclemanager.Lifecycle.lambda$handleStateTransitionStartingToRunningAsync$9(Lifecycle.java:522)
2020-10-06T18:54:55.7592781Z 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
2020-10-06T18:54:55.7629763Z 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
2020-10-06T18:54:55.7632441Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2020-10-06T18:54:55.7635436Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2020-10-06T18:54:55.7637351Z 	at java.lang.Thread.run(Thread.java:748)
```

**Description of changes:**
Replace the share ObjectMapper with ObjectReader and ObjectWriter, which should be lightweight and threadsafe.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
