### PR TITLE
Set up kernel alts before launch

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
@@ -148,6 +148,7 @@ public class KernelCommandLine {
 
         bootstrapManager = new BootstrapManager(kernel);
         kernel.getContext().put(BootstrapManager.class, bootstrapManager);
+        kernel.getContext().get(KernelAlternatives.class);
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use context to create `KernelAlternatives` when initializing paths so that the KernelAlternatives will setup the paths ASAP.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
