### PR TITLE
Fix kernel install for benchmark post cleanup to use correct dir

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -30,7 +30,7 @@ jobs:
           -jvmArgs "-Xms1m -Xmx64m -XX:MaxHeapFreeRatio=10 -XX:MinHeapFreeRatio=5 -XX:GCTimeRatio=19
           -XX:NativeMemoryTracking=summary -Xss232k"
           -prof com.aws.greengrass.jmh.profilers.ForcedGcMemoryProfiler
-      - run: rm -rf ~/.m2/repositories/com/aws/iot/evergreen-kernel
+      - run: rm -rf ~/.m2/repository/com/aws/iot/evergreen-kernel
         continue-on-error: true
         if: always()
       - name: Upload JMH Result

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -96,7 +96,7 @@ jobs:
           mvn -ntp -U install -DskipTests
           mvn -ntp -U -f src/test/evergreen-kernel-benchmark install
         if: matrix.os == 'Linux'
-      - run: rm -rf ~/.m2/repositories/com/aws/iot/evergreen-kernel
+      - run: rm -rf ~/.m2/repository/com/aws/iot/evergreen-kernel
         continue-on-error: true
         if: always()
   publish:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We need to install Greengrass to the local maven repo in order for our benchmarks to compile with it. This pollutes the local repo and can affect other builds. We had an issue before which this was supposed to fix, but we had the wrong path (repositories instead of repository).

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
