### PR TITLE
Truncate any existing data in recipes when copying

### DIFF
--- a/src/main/java/com/aws/greengrass/builtin/services/cli/CLIServiceAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/cli/CLIServiceAgent.java
@@ -51,7 +51,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -277,8 +276,7 @@ public class CLIServiceAgent {
             // Write the recipe as YAML with the proper filename into the store
             Path copyTo = to.resolve(String.format(RECIPE_FILE_NAME_FORMAT, recipe.getComponentName(),
                     recipe.getComponentVersion().getValue()));
-            Files.write(copyTo, SerializerFactory.getRecipeSerializer().writeValueAsBytes(recipe),
-                    StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+            Files.write(copyTo, SerializerFactory.getRecipeSerializer().writeValueAsBytes(recipe));
         }
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
By not having TRUNCATE_EXISTING set, if a recipe file is already existing, the write _could_ corrupt the recipe if the new recipe is smaller than the old one because the old one would still have data off the end.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
