### PR TITLE
Cleanup websocket proxy, add timeout to event loop shutdown future to…

### DIFF
--- a/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
+++ b/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.mqttclient.MqttClient.EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS;
+
 public class IotConnectionManager implements Closeable {
     // TODO: Move Iot related classes to a central location
     private static final Logger LOGGER = LogManager.getLogger(IotConnectionManager.class);
@@ -102,11 +104,13 @@ public class IotConnectionManager implements Closeable {
         resolver.close();
         eventLoopGroup.close();
         try {
-            eventLoopGroup.getShutdownCompleteFuture().get();
+            eventLoopGroup.getShutdownCompleteFuture().get(EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
             LOGGER.atError().log("Error shutting down event loop", e);
+        } catch (TimeoutException e) {
+            LOGGER.atError().log("Timed out shutting down event loop", e);
         }
     }
 }

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -71,7 +71,7 @@ class AwsIotMqttClientTest {
         when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
 
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, null, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager);
         assertFalse(client.connected());
 
@@ -101,9 +101,9 @@ class AwsIotMqttClientTest {
     @Test
     void GIVEN_multiple_callbacks_in_callbackEventManager_WHEN_connections_are_resumed_THEN_oneTimeCallbacks_would_be_executed_once() {
 
-        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, null, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager);
-        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, null, (x) -> null, "B", mockTopic,
+        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", mockTopic,
                 callbackEventManager);
         boolean sessionPresent = false;
         // callbackEventManager.hasCallBacked is originally set as False
@@ -129,9 +129,9 @@ class AwsIotMqttClientTest {
     @Test
     void GIVEN_multiple_callbacks_in_callbackEventManager_WHEN_connections_are_interrupted_THEN_oneTimeCallbacks_would_be_executed_once() {
 
-        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, null, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager);
-        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, null, (x) -> null, "B", mockTopic,
+        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", mockTopic,
                 callbackEventManager);
         callbackEventManager.runOnConnectionResumed(false);
         assertTrue(callbackEventManager.hasCallbacked());


### PR DESCRIPTION
… prevent hanging

**Issue #, if available:**

**Description of changes:**
Cleanup the websocket options which don't apply. Add timeout to event loop shutdown future which was causing it to hang on shutdown forever.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
