### PR TITLE
Remove outmoded storeName property

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -26,7 +26,7 @@ launch_kernel() {
   fi
   echo "jvm options: "${JVM_OPTIONS}
   echo "kernel options: "${OPTIONS}
-  java ${JVM_OPTIONS} -Dlog.store=FILE -Dlog.storeName="$GG_ROOT/logs/greengrass.log" -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS}
+  java ${JVM_OPTIONS} -Dlog.store=FILE -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS}
   kernel_exit_code=$?
   echo "kernel exit at code: "${kernel_exit_code}
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The `log.storeName` property no longer works for our logger, it causes it not log at all. So simply remove it since it isn't needed anymore, as the nucleus itself configures the log location appropriately.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
