### PR TITLE
Fixing ResourceNotFoundError constructor

### DIFF
--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ResourceNotFoundError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ResourceNotFoundError.java
@@ -43,6 +43,8 @@ public class ResourceNotFoundError extends GreengrassCoreIPCError implements Eve
   public ResourceNotFoundError(String errorMessage) {
     super("ResourceNotFoundError", errorMessage);
     this.message = Optional.ofNullable(errorMessage);
+    this.resourceType = Optional.empty();
+    this.resourceName = Optional.empty();
   }
 
   public ResourceNotFoundError() {


### PR DESCRIPTION
**Issue #, if available:**
The constructor for ResourceNotFoundError does not initialize all fields which causes the message to be dropped by the IPC protocol. Fixing it here. Have communicated to ogudavid@ who will be fixing it in code generators.
**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
