### PR TITLE
Updating the IPC server and client library. Aborting server if symlin…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,7 @@
                                 <exclude>codestyle/**</exclude>
                                 <exclude>src/test/greengrass-nucleus-benchmark/**</exclude>
                                 <exclude>src/*/resources/**</exclude>
+                                <exclude>**/awssdk/**</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>

--- a/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
@@ -136,7 +136,9 @@ public class IPCEventStreamService implements Startable, Closeable {
             }
 
         } catch (IOException e) {
-            logger.atError().setCause(e).log("Cannot setup symlinks for the ipc server socket path");
+            logger.atError().setCause(e).log("Cannot setup symlinks for the ipc server socket path and the socket "
+                    + "filepath is longer than 108 chars so unable to start IPC server");
+            return;
         }
 
         // For domain sockets:

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/CreateLocalDeploymentOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/CreateLocalDeploymentOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/CreateLocalDeploymentResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/CreateLocalDeploymentResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/DeferComponentUpdateOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/DeferComponentUpdateOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/DeferComponentUpdateResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/DeferComponentUpdateResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractCreateLocalDeploymentOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractCreateLocalDeploymentOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractDeferComponentUpdateOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractDeferComponentUpdateOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetComponentDetailsOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetComponentDetailsOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetConfigurationOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetConfigurationOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetLocalDeploymentStatusOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetLocalDeploymentStatusOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetSecretValueOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetSecretValueOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListComponentsOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListComponentsOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListLocalDeploymentsOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListLocalDeploymentsOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPublishToIoTCoreOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPublishToIoTCoreOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPublishToTopicOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPublishToTopicOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractRestartComponentOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractRestartComponentOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSendConfigurationValidityReportOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSendConfigurationValidityReportOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractStopComponentOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractStopComponentOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToComponentUpdatesOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToComponentUpdatesOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToConfigurationUpdateOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToConfigurationUpdateOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToIoTCoreOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToIoTCoreOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToTopicOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToTopicOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToValidateConfigurationUpdatesOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToValidateConfigurationUpdatesOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateConfigurationOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateConfigurationOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateRecipesAndArtifactsOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateRecipesAndArtifactsOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateStateOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateStateOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractValidateAuthorizationTokenOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractValidateAuthorizationTokenOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetComponentDetailsOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetComponentDetailsOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetComponentDetailsResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetComponentDetailsResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetConfigurationOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetConfigurationOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetConfigurationResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetConfigurationResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetLocalDeploymentStatusOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetLocalDeploymentStatusOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetLocalDeploymentStatusResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetLocalDeploymentStatusResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetSecretValueOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetSecretValueOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GetSecretValueResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GetSecretValueResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPC.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPC.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.util.Optional;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCClient.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCClient.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCServiceModel.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCServiceModel.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/ListComponentsOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/ListComponentsOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/ListComponentsResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/ListComponentsResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/ListLocalDeploymentsOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/ListLocalDeploymentsOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/ListLocalDeploymentsResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/ListLocalDeploymentsResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToIoTCoreOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToIoTCoreOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToIoTCoreResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToIoTCoreResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToTopicOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToTopicOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToTopicResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/PublishToTopicResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/RestartComponentOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/RestartComponentOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/RestartComponentResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/RestartComponentResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SendConfigurationValidityReportOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SendConfigurationValidityReportOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SendConfigurationValidityReportResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SendConfigurationValidityReportResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/StopComponentOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/StopComponentOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/StopComponentResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/StopComponentResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToComponentUpdatesOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToComponentUpdatesOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToComponentUpdatesResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToComponentUpdatesResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToConfigurationUpdateOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToConfigurationUpdateOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToConfigurationUpdateResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToConfigurationUpdateResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToIoTCoreOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToIoTCoreOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToIoTCoreResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToIoTCoreResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToTopicOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToTopicOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToTopicResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToTopicResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToValidateConfigurationUpdatesOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToValidateConfigurationUpdatesOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToValidateConfigurationUpdatesResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/SubscribeToValidateConfigurationUpdatesResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateConfigurationOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateConfigurationOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateConfigurationResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateConfigurationResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateRecipesAndArtifactsOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateRecipesAndArtifactsOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateRecipesAndArtifactsResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateRecipesAndArtifactsResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateStateOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateStateOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateStateResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/UpdateStateResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/ValidateAuthorizationTokenOperationContext.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/ValidateAuthorizationTokenOperationContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Class;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/ValidateAuthorizationTokenResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/ValidateAuthorizationTokenResponseHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass;
 
 import java.lang.Override;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/BinaryMessage.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/BinaryMessage.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ComponentDetails.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ComponentDetails.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ComponentNotFoundError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ComponentNotFoundError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ComponentUpdatePolicyEvents.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ComponentUpdatePolicyEvents.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvent.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvent.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvents.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationUpdateEvents.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationValidityReport.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationValidityReport.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationValidityStatus.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConfigurationValidityStatus.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConflictError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ConflictError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/CreateLocalDeploymentResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/DeferComponentUpdateRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/DeferComponentUpdateRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/DeferComponentUpdateResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/DeferComponentUpdateResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/DeploymentStatus.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/DeploymentStatus.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/FailedUpdateConditionCheckError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/FailedUpdateConditionCheckError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetComponentDetailsResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetConfigurationRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetConfigurationRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetConfigurationResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetConfigurationResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetLocalDeploymentStatusResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetSecretValueRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetSecretValueRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetSecretValueResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GetSecretValueResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/GreengrassCoreIPCError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/GreengrassCoreIPCError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.String;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidArgumentError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidArgumentError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidArgumentsError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidArgumentsError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidArtifactsDirectoryPathError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidArtifactsDirectoryPathError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidRecipeDirectoryPathError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidRecipeDirectoryPathError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidTokenError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/InvalidTokenError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/IoTCoreMessage.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/IoTCoreMessage.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/JsonMessage.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/JsonMessage.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/LifecycleState.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/LifecycleState.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListComponentsRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListComponentsRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListComponentsResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListComponentsResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListLocalDeploymentsRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListLocalDeploymentsRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListLocalDeploymentsResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ListLocalDeploymentsResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/LocalDeployment.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/LocalDeployment.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/MQTTMessage.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/MQTTMessage.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/PostComponentUpdateEvent.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/PostComponentUpdateEvent.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/PreComponentUpdateEvent.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/PreComponentUpdateEvent.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishMessage.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishMessage.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToIoTCoreRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToIoTCoreRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToIoTCoreResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToIoTCoreResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToTopicRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToTopicRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToTopicResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/PublishToTopicResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/QOS.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/QOS.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/RequestStatus.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/RequestStatus.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ResourceNotFoundError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ResourceNotFoundError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/RestartComponentRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/RestartComponentRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/RestartComponentResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/RestartComponentResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SecretValue.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SecretValue.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SendConfigurationValidityReportRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SendConfigurationValidityReportRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SendConfigurationValidityReportResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SendConfigurationValidityReportResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ServiceError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ServiceError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/StopComponentRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/StopComponentRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/StopComponentResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/StopComponentResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToComponentUpdatesRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToComponentUpdatesRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToComponentUpdatesResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToComponentUpdatesResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToConfigurationUpdateRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToConfigurationUpdateRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToConfigurationUpdateResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToConfigurationUpdateResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToIoTCoreRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToIoTCoreRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToIoTCoreResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToIoTCoreResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToTopicResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToValidateConfigurationUpdatesRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToValidateConfigurationUpdatesRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToValidateConfigurationUpdatesResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscribeToValidateConfigurationUpdatesResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscriptionResponseMessage.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/SubscriptionResponseMessage.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/UnauthorizedError.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/UnauthorizedError.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateConfigurationRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateConfigurationRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateConfigurationResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateConfigurationResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateRecipesAndArtifactsRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateRecipesAndArtifactsRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateRecipesAndArtifactsResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateRecipesAndArtifactsResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateStateRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateStateRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateStateResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/UpdateStateResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import java.lang.Object;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenRequest.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenRequest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenResponse.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateAuthorizationTokenResponse.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvent.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvent.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvents.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/model/ValidateConfigurationUpdateEvents.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.aws.greengrass.model;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.Header;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthorizationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthorizationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.function.Function;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import com.google.gson.Gson;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 public class DeserializationException extends RuntimeException {

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamClosedException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamClosedException.java
@@ -1,13 +1,8 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 public class EventStreamClosedException extends RuntimeException {
     public EventStreamClosedException(long continauationId) {
-        // GG_NEEDS_REVIEW: TODO: Is hex formatting here useful? It is short, but not consistent anywhere else yet
+        //TODO: Is hex formatting here useful? It is short, but not consistent anywhere else yet
         super(String.format("EventStream continuation [%s] is already closed!", Long.toHexString(continauationId)));
     }
 }

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.Collection;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import com.google.gson.*;
@@ -27,6 +22,7 @@ import java.util.*;
 public abstract class EventStreamRPCServiceModel {
     private static final Gson GSON;
 
+    public static final String VERSION_HEADER = ":version";
     public static final String CONTENT_TYPE_HEADER = ":content-type";
     public static final String CONTENT_TYPE_APPLICATION_TEXT = "text/plain";
     public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
@@ -149,7 +145,7 @@ public abstract class EventStreamRPCServiceModel {
     private static final Map<String, Class<? extends EventStreamJsonMessage>> FRAMEWORK_APPLICATION_MODEL_TYPES
             = new HashMap<>();
     static {
-        // GG_NEEDS_REVIEW: TODO: find a reliable way to verify all of these are set? reflection cannot scan a package
+        //TODO: find a reliable way to verify all of these are set? reflection cannot scan a package
         FRAMEWORK_APPLICATION_MODEL_TYPES.put(AccessDeniedException.ERROR_CODE, AccessDeniedException.class);
         FRAMEWORK_APPLICATION_MODEL_TYPES.put(InternalServerException.ERROR_CODE, InternalServerException.class);
         FRAMEWORK_APPLICATION_MODEL_TYPES.put(UnsupportedOperationException.ERROR_CODE, UnsupportedOperationException.class);
@@ -213,6 +209,16 @@ public abstract class EventStreamRPCServiceModel {
      * @return
      */
     protected Gson getGson() {
+        return GSON;
+    }
+
+    /**
+     * In situations where the framework needs to do some JSON processing
+     * without a specific service/operation in context
+     *
+     * @return the static Gson instance capable of processing the basics of EventStreamableJsonMessage
+     */
+    public static Gson getStaticGson() {
         return GSON;
     }
 

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidDataException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidDataException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.MessageType;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 public class InvalidServiceConfigurationException extends RuntimeException {

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/IpcServer.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/IpcServer.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.Set;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/MessageAmendInfo.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/MessageAmendInfo.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.Header;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandler.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.nio.charset.StandardCharsets;
@@ -248,7 +243,7 @@ public abstract class OperationContinuationHandler
 
         try {
             if (initialRequest != null) {
-                // GG_NEEDS_REVIEW: TODO: FIX empty close messages arrive here and throw exception
+                //TODO: FIX empty close messages arrive here and throw exception
                 final StreamingRequestType streamEvent = serviceModel.fromJson(getStreamingRequestClass(), bytes);
                 //exceptions occurring during this processing will result in closure of stream
                 handleStreamEvent(streamEvent);
@@ -284,8 +279,8 @@ public abstract class OperationContinuationHandler
             byte[] outputPayload = "InternalServerError".getBytes(StandardCharsets.UTF_8);
             responseHeaders.add(Header.createHeader(EventStreamRPCServiceModel.CONTENT_TYPE_HEADER,
                     EventStreamRPCServiceModel.CONTENT_TYPE_APPLICATION_TEXT));
-            // GG_NEEDS_REVIEW: TODO: are there any exceptions we wouldn't want to return a generic server fault?
-            // GG_NEEDS_REVIEW: TODO: this is the kind of exception that should be logged with a request ID especially in a server-client context
+            // TODO: are there any exceptions we wouldn't want to return a generic server fault?
+            // TODO: this is the kind of exception that should be logged with a request ID especially in a server-client context
             LOGGER.severe(String.format("[%s] operation threw unexpected %s: %s", getOperationName(),
                     e.getClass().getCanonicalName(), e.getMessage()));
             e.printStackTrace();

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.ServerConnection;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.Collection;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationModelContext.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationModelContext.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/SerializationException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/SerializationException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 public class SerializationException extends RuntimeException {

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
@@ -1,24 +1,14 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import software.amazon.awssdk.crt.eventstream.Header;
-import software.amazon.awssdk.crt.eventstream.MessageFlags;
-import software.amazon.awssdk.crt.eventstream.MessageType;
-import software.amazon.awssdk.crt.eventstream.ServerConnection;
-import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
-import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
-import software.amazon.awssdk.crt.eventstream.ServerConnectionHandler;
+import software.amazon.awssdk.crt.eventstream.*;
 
 public class ServiceOperationMappingContinuationHandler extends ServerConnectionHandler {
     private static final Logger LOGGER = Logger.getLogger(ServiceOperationMappingContinuationHandler.class.getName());
@@ -63,53 +53,65 @@ public class ServiceOperationMappingContinuationHandler extends ServerConnection
      */
     protected void onConnectRequest(List<Header> headers, byte[] payload) {
         final int[] responseMessageFlag = { 0 };
-        MessageType acceptResponseType = MessageType.ConnectAck;
+        final MessageType acceptResponseType = MessageType.ConnectAck;
 
         final AuthenticationHandler authentication = serviceHandler.getAuthenticationHandler();
         final AuthorizationHandler authorization = serviceHandler.getAuthorizationHandler();
 
         try {
-            if (authentication == null) {
-                throw new IllegalStateException(String.format("%s has null authentication handler!"));
-            }
-            if (authorization == null) {
-                throw new IllegalStateException(String.format("%s has null authorization handler!"));
-            }
+            final Optional<String> versionHeader = headers.stream()
+                    .filter(header -> header.getHeaderType() == HeaderType.String
+                            && header.getName().equals(EventStreamRPCServiceModel.VERSION_HEADER))
+                    .map(header -> header.getValueAsString())
+                    .findFirst();
+            if (versionHeader.isPresent() &&
+                    Version.fromString(versionHeader.get()).equals(Version.getInstance())) {
+                //version matches
+                if (authentication == null) {
+                    throw new IllegalStateException(String.format("%s has null authentication handler!"));
+                }
+                if (authorization == null) {
+                    throw new IllegalStateException(String.format("%s has null authorization handler!"));
+                }
 
-            LOGGER.finer(String.format("%s running authentication handler", serviceHandler.getServiceName()));
-            authenticationData = authentication.apply(headers, payload);
-            if (authenticationData == null) {
-                throw new IllegalStateException(String.format("%s authentication handler returned null", serviceHandler.getServiceName()));
-            }
-            LOGGER.info(String.format("%s authenticated identity: %s", serviceHandler.getServiceName(), authenticationData.getIdentityLabel()));
+                LOGGER.finer(String.format("%s running authentication handler", serviceHandler.getServiceName()));
+                authenticationData = authentication.apply(headers, payload);
+                if (authenticationData == null) {
+                    throw new IllegalStateException(String.format("%s authentication handler returned null", serviceHandler.getServiceName()));
+                }
+                LOGGER.info(String.format("%s authenticated identity: %s", serviceHandler.getServiceName(), authenticationData.getIdentityLabel()));
 
-            final Authorization authorizationDecision = authorization.apply(authenticationData);
-            switch (authorizationDecision) {
-                case ACCEPT:
-                    LOGGER.info("Connection accepted for " + authenticationData.getIdentityLabel());
-                    responseMessageFlag[0] = MessageFlags.ConnectionAccepted.getByteValue();
-                    break;
-                case REJECT:
-                    LOGGER.info("Connection rejected for: " + authenticationData.getIdentityLabel());
-                    break;
-                default:
-                    //got a big problem if this is the outcome. Someone forgot to update this switch-case
-                    throw new RuntimeException("Unknown authorization decision for " + authenticationData.getIdentityLabel());
+                final Authorization authorizationDecision = authorization.apply(authenticationData);
+                switch (authorizationDecision) {
+                    case ACCEPT:
+                        LOGGER.info("Connection accepted for " + authenticationData.getIdentityLabel());
+                        responseMessageFlag[0] = MessageFlags.ConnectionAccepted.getByteValue();
+                        break;
+                    case REJECT:
+                        LOGGER.info("Connection rejected for: " + authenticationData.getIdentityLabel());
+                        break;
+                    default:
+                        //got a big problem if this is the outcome. Someone forgot to update this switch-case
+                        throw new RuntimeException("Unknown authorization decision for " + authenticationData.getIdentityLabel());
+                }
+            } else { //version mismatch
+                LOGGER.warning(String.format("Client version {%s} mismatches server version {%s}",
+                        versionHeader.isPresent() ? versionHeader.get() : "null",
+                        Version.getInstance().getVersionString()));
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             LOGGER.severe(String.format("%s occurred while attempting to authN/authZ connect: %s", e.getClass(), e.getMessage()));
-        }
-        finally {
-            LOGGER.info("Sending connect response for " + authenticationData.getIdentityLabel());
+        } finally {
+            final String authLabel =  authenticationData != null ? authenticationData.getIdentityLabel() : "null";
+            LOGGER.info("Sending connect response for " + authLabel);
             connection.sendProtocolMessage(null, null, acceptResponseType, responseMessageFlag[0])
                 .whenComplete((res, ex) -> {
                     if (ex != null) {
                         LOGGER.severe(String.format("Sending connection response for %s threw exception (%s): %s",
-                            authenticationData.getIdentityLabel(), ex.getClass().getCanonicalName(), ex.getMessage()));
+                           authLabel, ex.getClass().getCanonicalName(), ex.getMessage()));
                     }
                     else {
-                        LOGGER.info("Successfully sent connection response for: " + authenticationData.getIdentityLabel());
+                        LOGGER.info("Successfully sent connection response for: " + authLabel);
                     }
                     if (responseMessageFlag[0] != MessageFlags.ConnectionAccepted.getByteValue()) {
                         LOGGER.info("Closing connection due to connection not being accepted...");

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamEventPublisher.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamEventPublisher.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/UnmappedDataException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/UnmappedDataException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/Version.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/Version.java
@@ -1,0 +1,83 @@
+package software.amazon.awssdk.eventstreamrpc;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * https://semver.org/ minus the labels
+ */
+public class Version implements Comparable<Version> {
+    private final static String PATTERN_REGEX_STRING = "^(\\d+)\\.(\\d+)\\.(\\d+)$";
+    public final static Pattern PATTERN = Pattern.compile(PATTERN_REGEX_STRING);
+
+    public static final int MAJOR = 0;
+    public static final int MINOR = 1;
+    public static final int PATCH = 0;
+
+    private static final Version INSTANCE = new Version(MAJOR, MINOR, PATCH);
+
+    public static Version getInstance() { return INSTANCE; }
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    private Version(int major, int minor, int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    public String getVersionString() {
+        return String.format("%d.%d.%d", MAJOR, MINOR, PATCH);
+    }
+
+    @Override
+    public String toString() {
+        return getVersionString();
+    }
+
+    public static Version fromString(final String versionString) {
+        if (versionString == null) {
+            throw new IllegalArgumentException("Cannot extract version from null string");
+        }
+        final Matcher matcher = PATTERN.matcher(versionString);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Version string does not match regex: " + PATTERN_REGEX_STRING);
+        }
+        return new Version(Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)),
+                Integer.parseInt(matcher.group(3)));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, patch);
+    }
+
+    @Override
+    public boolean equals(final Object rhs) {
+        if (rhs == null) {
+            return false;
+        }
+        if (rhs instanceof Version) {
+            return compareTo((Version)rhs) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public int compareTo(final Version rhs) {
+        if (rhs == null) {
+            throw new IllegalArgumentException("Cannot compare to null version!");
+        }
+        if (major - rhs.major == 0) {
+            if (minor - rhs.minor == 0) {
+                return patch - rhs.patch;
+            }
+            return minor - rhs.minor;
+        }
+        return major - rhs.major;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/model/AccessDeniedException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/model/AccessDeniedException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc.model;
 
 public class AccessDeniedException extends EventStreamOperationError {

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamError.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamError.java
@@ -1,0 +1,56 @@
+package software.amazon.awssdk.eventstreamrpc.model;
+
+import software.amazon.awssdk.crt.eventstream.Header;
+import software.amazon.awssdk.crt.eventstream.MessageType;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceModel;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Used to hold event stream RPC error messages that are not tied to any service.
+ * Message info comes back with a payload of JSON like:
+ *
+ * { "message": "..." }
+ *
+ * And we map that to this exception type to convey the information
+ */
+public class EventStreamError
+        extends RuntimeException {
+
+    private final List<Header> headers;
+    private final MessageType messageType;
+
+    /**
+     * Put
+     * @param headers currently unusued, but likely a useful element for output
+     * @param payload
+     * @param messageType
+     * @return
+     */
+    public static EventStreamError create(final List<Header> headers, final byte[] payload, final MessageType messageType) {
+        final HashMap<String, Object> map = EventStreamRPCServiceModel.getStaticGson().fromJson(new String(payload), HashMap.class);
+        final String message = map.getOrDefault("message", "no message").toString();
+        return new EventStreamError(String.format("%s: %s", messageType.name(), message), headers, messageType);
+    }
+
+    public EventStreamError(String message) {
+        super(message);
+        this.messageType = null;
+        this.headers = null;
+    }
+
+    public EventStreamError(String message, List<Header> headers, MessageType messageType) {
+        super(message);
+        this.messageType = messageType;
+        this.headers = headers;
+    }
+
+    public List<Header> getMessageHeaders() {
+        return headers;
+    }
+
+    public MessageType getMessageType() {
+        return messageType;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamJsonMessage.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamJsonMessage.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc.model;
 
 import com.google.gson.Gson;
@@ -34,7 +29,7 @@ public interface EventStreamJsonMessage {
     default EventStreamJsonMessage fromJson(final Gson gson, byte[] payload) {
         final String payloadString = new String(payload, StandardCharsets.UTF_8);
         if (payloadString.equals("null")) {
-            gson.fromJson("{}", this.getClass());
+            return gson.fromJson("{}", this.getClass());
         }
         return gson.fromJson(payloadString, this.getClass());
     }

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamOperationError.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamOperationError.java
@@ -1,11 +1,5 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc.model;
 
-import com.google.gson.Gson;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -19,7 +13,6 @@ import com.google.gson.annotations.SerializedName;
 public abstract class EventStreamOperationError
         extends RuntimeException
         implements EventStreamJsonMessage {
-
     @SerializedName("_service")
     @Expose(serialize = true, deserialize = true)
     private final String _service;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/model/InternalServerException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/model/InternalServerException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc.model;
 
 public class InternalServerException extends EventStreamOperationError {

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/model/UnsupportedOperationException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/model/UnsupportedOperationException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc.model;
 
 public class UnsupportedOperationException extends EventStreamOperationError {

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/model/ValidationException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/model/ValidationException.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package software.amazon.awssdk.eventstreamrpc.model;
 
 public class ValidationException extends EventStreamOperationError {


### PR DESCRIPTION
…ks are not created and socket filepath is longer than 108 chars

**Issue #, if available:**
Updating the library. Have excluded the library code from license header check for now since this is going to change. Once the code to be checked in to Nucleus is fixed, I will update the license headers then. 

**Description of changes:**
Aborting IPC server if symlink cannot be created for socket path greater than 108 chars.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
