### PR TITLE
Always cleanup EventLoopGroup even if an exception occurs during construction

### DIFF
--- a/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/BasicExampleBenchmark.java
+++ b/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/BasicExampleBenchmark.java
@@ -23,11 +23,14 @@ public class BasicExampleBenchmark {
     @Benchmark
     public void testMethod() throws Exception {
         Kernel kernel = new Kernel();
-        kernel.parseArgs("-i", BasicExampleBenchmark.class.getResource("config.yaml").toString());
-        kernel.launch();
-        Thread.sleep(20000);
-        ForcedGcMemoryProfiler.recordUsedMemory();
-        kernel.shutdown();
+        try {
+            kernel.parseArgs("-i", BasicExampleBenchmark.class.getResource("config.yaml").toString());
+            kernel.launch();
+            Thread.sleep(20000);
+            ForcedGcMemoryProfiler.recordUsedMemory();
+        } finally {
+            kernel.shutdown();
+        }
     }
 
 }

--- a/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -50,16 +50,15 @@ public class DependencyResolverBenchmark {
     @State(Scope.Benchmark)
     public abstract static class DRIntegration {
         private DeploymentDocument jobDoc = new DeploymentDocument("mockJob1",
-                Arrays.asList(
-                        new DeploymentPackageConfiguration("boto3", true, "1.9.128", new HashMap<>()),
-                        new DeploymentPackageConfiguration("awscli", true, "1.16.144", new HashMap<>())),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS));
+                Arrays.asList(new DeploymentPackageConfiguration("boto3", true, "1.9.128", new HashMap<>()),
+                        new DeploymentPackageConfiguration("awscli", true, "1.16.144", new HashMap<>())), "mockGroup1",
+                1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS));
 
         private DependencyResolver resolver;
         private List<ComponentIdentifier> result;
         private Kernel kernel;
 
-        @Setup
+        @Setup(Level.Trial)
         public void setup() throws IOException {
             kernel = new Kernel();
             kernel.parseArgs("-i", DependencyResolverBenchmark.class.getResource(getConfigFile()).toString());
@@ -88,8 +87,8 @@ public class DependencyResolverBenchmark {
 
         @Benchmark
         public List<ComponentIdentifier> measure() throws Exception {
-            result = resolver.resolveDependencies(jobDoc, Topics.of(kernel.getContext(),
-                    DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null));
+            result = resolver.resolveDependencies(jobDoc,
+                    Topics.of(kernel.getContext(), DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null));
             return result;
         }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
EventLoopGroup wasn't cleaned in the IotConnectionManager if initializing the connection failed, so this change ensures that we definitely do close it to close any stray file descriptors.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
