### PR TITLE
Get filename from greengrass uri

### DIFF
--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/GreengrassRepositoryDownloaderTest.java
@@ -26,7 +26,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -35,7 +34,9 @@ import java.util.Base64;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -80,7 +81,7 @@ class GreengrassRepositoryDownloaderTest {
         ComponentIdentifier pkgId = new ComponentIdentifier("CoolService", new Semver("1.0.0"));
         Path testCache = ComponentTestResourceHelper.getPathForLocalTestCache();
         Path saveToPath = testCache.resolve("CoolService").resolve("1.0.0");
-        Path artifactFilePath = saveToPath.resolve("artifact.txt");
+        Path artifactFilePath = saveToPath.resolve("artifactName");
         Files.createDirectories(saveToPath);
         String checksum = Base64.getEncoder()
                 .encodeToString(MessageDigest.getInstance(SHA256).digest(Files.readAllBytes(mockArtifactPath)));
@@ -114,19 +115,15 @@ class GreengrassRepositoryDownloaderTest {
     }
 
     @Test
-    void GIVEN_filename_in_disposition_WHEN_attempt_resolve_filename_THEN_parse_filename() throws Exception {
-        String filename = downloader.extractFilename(new URL("https://www.amazon.com/artifact.txt"),
-                "attachment; " + "filename=\"filename.jpg\"");
-
-        assertThat(filename, is("filename.jpg"));
+    void GIVEN_filename_in_uri_WHEN_attempt_resolve_filename_THEN_parse_filename() {
+        String filename = downloader.getFilename(ComponentArtifact.builder().artifactUri(
+                URI.create("greengrass:abcd.jj")).build());
+        assertThat(filename, is("abcd.jj"));
+        filename = downloader.getFilename(ComponentArtifact.builder().artifactUri(
+                URI.create("greengrass:abcd")).build());
+        assertThat(filename, is("abcd"));
+        filename = downloader.getFilename(ComponentArtifact.builder().artifactUri(
+                URI.create("greengrass:jkdfjk/kdjfkdj/abcd.jj")).build());
+        assertThat(filename, is("abcd.jj"));
     }
-
-    @Test
-    void GIVEN_filename_in_url_WHEN_attempt_resolve_filename_THEN_parse_filename() throws Exception {
-        String filename =
-                downloader.extractFilename(new URL("https://www.amazon.com/artifact.txt?key=value"), "attachment");
-
-        assertThat(filename, is("artifact.txt"));
-    }
-
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Pull the filename from the greengrass URI instead of taking it from the disposition header.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
