### PR TITLE
Fix test timeouts

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCCliTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCCliTest.java
@@ -109,14 +109,14 @@ class IPCCliTest {
 
     private static Kernel kernel;
     private static final int LOCAL_DEPLOYMENT_TIMEOUT_SECONDS = 15;
-    private static final int SERVICE_STATE_CHECK_TIMEOUT_SECONDS = 15;
+    private static final int SERVICE_STATE_CHECK_TIMEOUT_SECONDS = 30;
     private IPCClient client;
     private static final ObjectMapper OBJECT_MAPPER =
             new ObjectMapper().configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false)
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @BeforeAll
-    static void beforeAll() throws InterruptedException, ServiceLoadException {
+    static void beforeAll() throws InterruptedException {
         kernel = prepareKernelFromConfigFile("ipc.yaml", IPCCliTest.class, CLI_SERVICE, TEST_SERVICE_NAME);
         BaseITCase.setDeviceConfig(kernel, DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS, 1L);
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The deployment polling time is 15 seconds when the kernel first starts and isn't set to 1 second until the first 15 seconds expires. This causes the test to fail after waiting the 15 seconds.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
