### PR TITLE
Use anonymous credentials for GCS

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
@@ -6,6 +6,8 @@
 package com.aws.greengrass.componentmanager;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.evergreen.AWSEvergreen;
 import com.amazonaws.services.evergreen.AWSEvergreenClientBuilder;
@@ -65,7 +67,11 @@ public class GreengrassComponentServiceClientFactory {
                     .log("Error during configure greengrass client mutual auth", e);
         }
         AWSEvergreenClientBuilder clientBuilder =
-                AWSEvergreenClientBuilder.standard().withClientConfiguration(clientConfiguration);
+                AWSEvergreenClientBuilder.standard()
+                        // Use an empty credential provider because our requests don't need SigV4
+                        // signing, as they are going through IoT Core instead
+                        .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                        .withClientConfiguration(clientConfiguration);
         String region = Coerce.toString(deviceConfiguration.getAWSRegion());
 
         if (!Utils.isEmpty(region)) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set null credential provider in GCS client so that it doesn't try to pull credentials from the environment and fail.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
