### PR TITLE
Don't log exception trace when spooler task is interrupted

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -436,7 +436,6 @@ public class MqttClient implements Closeable {
                 }).get();
             }
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             logger.atDebug().log("Shutting down spooler task");
         } catch (ExecutionException e) {
             logger.atError().log("Error when publishing from spooler", e);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
Logging the stack trace when the spooler task shuts down causes tests to fail

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
