### PR TITLE
Set work path ownership

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -22,7 +22,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import com.aws.greengrass.testcommons.testutilities.NoOpArtifactHandler;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,7 +61,7 @@ public class DeploymentServiceIntegrationTest extends BaseITCase {
     void before(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, PackageDownloadException.class);
         kernel = new Kernel();
-        NoOpArtifactHandler.register(kernel);
+        NoOpPathOwnershipHandler.register(kernel);
         kernel.parseArgs("-i",
                 DeploymentServiceIntegrationTest.class.getResource("onlyMain.yaml").toString());
         // ensure deployment service starts

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -22,7 +22,7 @@ import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.integrationtests.ipc.IPCTestUtils;
-import com.aws.greengrass.testcommons.testutilities.NoOpArtifactHandler;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.lifecyclemanager.GenericExternalService;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -166,7 +166,7 @@ class DeploymentTaskIntegrationTest {
     static void setupKernel() {
         System.setProperty("root", rootDir.toAbsolutePath().toString());
         kernel = new Kernel();
-        NoOpArtifactHandler.register(kernel);
+        NoOpPathOwnershipHandler.register(kernel);
 
         kernel.parseArgs("-i", DeploymentTaskIntegrationTest.class.getResource("onlyMain.yaml").toString());
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DynamicComponentConfigurationValidationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DynamicComponentConfigurationValidationTest.java
@@ -17,7 +17,7 @@ import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.deployment.model.FailureHandlingPolicy;
 import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.integrationtests.ipc.IPCTestUtils;
-import com.aws.greengrass.testcommons.testutilities.NoOpArtifactHandler;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.ipc.IPCClient;
 import com.aws.greengrass.ipc.IPCClientImpl;
 import com.aws.greengrass.ipc.config.KernelIPCClientConfig;
@@ -91,7 +91,7 @@ class DynamicComponentConfigurationValidationTest extends BaseITCase {
         ignoreExceptionWithMessage(context, "Connection reset by peer");
         socketOptions = TestUtils.getSocketOptionsForIPC();
         kernel = new Kernel();
-        NoOpArtifactHandler.register(kernel);
+        NoOpPathOwnershipHandler.register(kernel);
         deploymentConfigMerger = new DeploymentConfigMerger(kernel);
         kernel.parseArgs("-i",
                 DynamicComponentConfigurationValidationTest.class.getResource("onlyMain.yaml").toString());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
@@ -16,7 +16,7 @@ import com.aws.greengrass.ipc.services.cli.models.DeploymentStatus;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
-import com.aws.greengrass.testcommons.testutilities.NoOpArtifactHandler;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.util.Coerce;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.EventLoopGroup;
@@ -65,7 +65,7 @@ public final class IPCTestUtils {
 
     public static Kernel prepareKernelFromConfigFile(String configFile, Class testClass, String... serviceNames) throws InterruptedException {
         Kernel kernel = new Kernel();
-        NoOpArtifactHandler.register(kernel);
+        NoOpPathOwnershipHandler.register(kernel);
         kernel.parseArgs("-i", testClass.getResource(configFile).toString());
         // ensure awaitIpcServiceLatch starts
         CountDownLatch awaitIpcServiceLatch = new CountDownLatch(serviceNames.length);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceTest.java
@@ -13,7 +13,7 @@ import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.lifecyclemanager.GenericExternalService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
-import com.aws.greengrass.testcommons.testutilities.NoOpArtifactHandler;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +23,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -42,6 +44,8 @@ import static com.aws.greengrass.testcommons.testutilities.TestUtils.createClose
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,7 +62,7 @@ class GenericExternalServiceTest extends BaseITCase {
     @BeforeEach
     void beforeEach() {
         kernel = new Kernel();
-        NoOpArtifactHandler.register(kernel);
+        NoOpPathOwnershipHandler.register(kernel);
     }
 
     @AfterEach
@@ -350,6 +354,20 @@ class GenericExternalServiceTest extends BaseITCase {
             assertTrue(countDownLatch.await(20, TimeUnit.SECONDS), "expect log finished");
             assertThat(stdouts, hasItem(containsString(String.format("install as %s", expectedInstallUser))));
             assertThat(stdouts, hasItem(containsString(String.format("run as %s", expectedRunUser))));
+
+
+            // get work path (workPath(service) sets permissions)
+            Path echoServiceWorkPath = kernel.getNucleusPaths().workPath().resolve("echo_service");
+            Path installedFile = echoServiceWorkPath.resolve("install-file");
+            Path runFile = echoServiceWorkPath.resolve("run-file");
+
+            assertThat(installedFile.toString(), installedFile.toFile(), anExistingFile());
+            assertThat(runFile.toString(), runFile.toFile(), anExistingFile());
+
+            assertThat(Files.getOwner(echoServiceWorkPath).getName(), is(expectedInstallUser));
+            assertThat(Files.getOwner(installedFile).getName(), is(expectedInstallUser));
+            assertThat(Files.getOwner(runFile).getName(), is(expectedRunUser));
+
         }
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
@@ -31,7 +31,7 @@ import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.status.OverallStatus;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.exceptions.TLSAuthException;
-import com.aws.greengrass.testcommons.testutilities.NoOpArtifactHandler;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import org.junit.jupiter.api.AfterEach;
@@ -119,7 +119,7 @@ class IotJobsFleetStatusServiceTest extends BaseITCase {
                     return cf;
                 });
         kernel = new Kernel();
-        NoOpArtifactHandler.register(kernel);
+        NoOpPathOwnershipHandler.register(kernel);
         kernel.parseArgs("-i", IotJobsFleetStatusServiceTest.class.getResource("onlyMain.yaml").toString());
         kernel.getContext().put(MqttClient.class, mqttClient);
         kernel.getContext().put(IotJobsClient.class, mockIotJobsClient);

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_privilege.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_privilege.yaml
@@ -15,9 +15,13 @@ services:
   echo_service:
     lifecycle:
       install:
-        posix: echo "install as `id -u -n`"
+        posix: |-
+          echo "install as `id -u -n`"
+          touch ./install-file
       run:
         posix:
           requiresPrivilege: true
-          script: echo "run as `id -u -n`"
+          script: |-
+            echo "run as `id -u -n`"
+            touch ./run-file
     version: 1.0.0

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user.yaml
@@ -15,7 +15,11 @@ services:
   echo_service:
     lifecycle:
       install:
-        posix: echo "install as `id -u -n`"
+        posix: |-
+          echo "install as `id -u -n`"
+          touch ./install-file
       run:
-        posix: echo "run as `id -u -n`"
+        posix: |-
+          echo "run as `id -u -n`"
+          touch ./run-file
     version: 1.0.0

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user_shell.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user_shell.yaml
@@ -15,7 +15,11 @@ services:
   echo_service:
     lifecycle:
       install:
-        posix: echo "install as `id -u -n`"
+        posix: |-
+          echo "install as `id -u -n`"
+          touch ./install-file
       run:
-        posix: echo "run as `id -u -n`"
+        posix: |-
+          echo "run as `id -u -n`"
+          touch ./run-file
     version: 1.0.0

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/RunWithPathOwnershipHandler.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/RunWithPathOwnershipHandler.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.lifecyclemanager;
 
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
-import com.aws.greengrass.util.CrashableFunction;
 import com.aws.greengrass.util.FileSystemPermission;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.platforms.Platform;
@@ -21,9 +20,9 @@ import static com.aws.greengrass.util.FileSystemPermission.Option.IgnorePermissi
 import static com.aws.greengrass.util.FileSystemPermission.Option.Recurse;
 
 /**
- * Update artifact ownership based on service RunWith information.
+ * Update ownership based on service RunWith information.
  */
-public class RunWithArtifactHandler {
+public class RunWithPathOwnershipHandler {
 
     final NucleusPaths nucleusPaths;
 
@@ -35,7 +34,7 @@ public class RunWithArtifactHandler {
      * @param paths paths in the nucleus.
      */
     @Inject
-    public RunWithArtifactHandler(NucleusPaths paths) {
+    public RunWithPathOwnershipHandler(NucleusPaths paths) {
         this(paths, Platform.getInstance());
     }
 
@@ -45,14 +44,14 @@ public class RunWithArtifactHandler {
      * @param paths paths in the nucleus.
      * @param platform the platform instance.
      */
-    public RunWithArtifactHandler(NucleusPaths paths, Platform platform) {
+    public RunWithPathOwnershipHandler(NucleusPaths paths, Platform platform) {
         this.nucleusPaths = paths;
         this.platform = platform;
     }
 
     /**
-     * Update the owner of the artifacts in the component on the local filesystem. The user and group of from the
-     * RunWith parameter are used.
+     * Update the owner of the artifacts and work path in the component on the local filesystem. The user and group of
+     * from the RunWith parameter are used.
      *
      * @param id      the component to update.
      * @param runWith the user/group that should own the files.
@@ -62,6 +61,7 @@ public class RunWithArtifactHandler {
     public void updateOwner(ComponentIdentifier id, RunWith runWith) throws IOException {
         Path artifacts = nucleusPaths.artifactPath(id);
         Path unarchived = nucleusPaths.unarchiveArtifactPath(id);
+        Path workPath = nucleusPaths.workPath(id.getName());
 
         FileSystemPermission permission = FileSystemPermission.builder()
                 .ownerUser(runWith.getUser())
@@ -70,15 +70,24 @@ public class RunWithArtifactHandler {
 
         // change ownership of files within the artifact dirs, but don't change the artifact dir itself as that would
         // make it writable to the user
-        CrashableFunction<Path, Void, IOException> f = (p) -> {
-            if (Files.exists(p)) {
-                for (Iterator<Path> it = Files.list(p).iterator(); it.hasNext(); ) {
-                    platform.setPermissions(permission, it.next(), Recurse, IgnorePermission);
-                }
-            }
-            return null;
-        };
-        f.apply(artifacts);
-        f.apply(unarchived);
+        setPermissions(artifacts, permission, false);
+        setPermissions(unarchived, permission, false);
+
+        // change ownership of work dir
+        setPermissions(workPath, permission, true);
     }
+
+    void setPermissions(Path p, FileSystemPermission permission,  boolean applyToRoot) throws IOException {
+        if (Files.notExists(p)) {
+            return;
+        }
+        if (applyToRoot) {
+            platform.setPermissions(permission, p, Recurse, IgnorePermission);
+        } else {
+            for (Iterator<Path> it = Files.list(p).iterator(); it.hasNext(); ) {
+                platform.setPermissions(permission, it.next(), Recurse, IgnorePermission);
+            }
+        }
+    }
+
 }

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/NoOpPathOwnershipHandler.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/NoOpPathOwnershipHandler.java
@@ -8,7 +8,7 @@ package com.aws.greengrass.testcommons.testutilities;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.RunWith;
-import com.aws.greengrass.lifecyclemanager.RunWithArtifactHandler;
+import com.aws.greengrass.lifecyclemanager.RunWithPathOwnershipHandler;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.platforms.Platform;
 
@@ -18,13 +18,13 @@ import java.io.IOException;
  * Integration tests running as non super user cannot change artifacts. This will skip the ownership update so tests
  * will pass if user is not a super user.
  */
-public class NoOpArtifactHandler extends RunWithArtifactHandler {
+public class NoOpPathOwnershipHandler extends RunWithPathOwnershipHandler {
 
     public static void register(Kernel kernel) {
-        kernel.getContext().put(RunWithArtifactHandler.class, new NoOpArtifactHandler(kernel.getNucleusPaths()));
+        kernel.getContext().put(RunWithPathOwnershipHandler.class, new NoOpPathOwnershipHandler(kernel.getNucleusPaths()));
     }
 
-    public NoOpArtifactHandler(NucleusPaths paths) {
+    public NoOpPathOwnershipHandler(NucleusPaths paths) {
         super(paths);
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Service work path needs to owned by the user running the service

**Why is this change necessary:**
So that services can create files in their work directories

**How was this change tested:**
Integration + E2E tests running as root
running Lambda&smoke UATs

**Any additional information or context required to review the change:**
Lambda overrides `GenericExternalService#updateArtifactOwner` method. Once this is changed the method can be removed.

Lambda needs to set its ownership separately.

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
