### PR TITLE
Use proper keypath in config IPC update

### DIFF
--- a/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
@@ -261,7 +261,8 @@ public class ConfigStoreIPCEventStreamAgent {
             Node node = configTopics.findNode(keyPath);
             if (node == null) {
                 try {
-                    configTopics.lookup(keyPath).withValueChecked(request.getNewValue().get(keyPath[0]));
+                    configTopics.lookup(keyPath)
+                            .withValueChecked(request.getNewValue().get(keyPath[keyPath.length - 1]));
                 } catch (UnsupportedInputTypeException e) {
                     throw new InvalidArgumentsError(e.getMessage());
                 }
@@ -269,7 +270,7 @@ public class ConfigStoreIPCEventStreamAgent {
             }
             // TODO :[P41210581]: UpdateConfiguration API should support updating nested configuration
             if (node instanceof Topics) {
-                throw new InvalidArgumentsError("Cannot update a " + "non-leaf config node");
+                throw new InvalidArgumentsError("Cannot update a non-leaf config node");
             }
             if (!(node instanceof Topic)) {
                 logger.atError().kv(SERVICE_NAME, serviceName)

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -256,6 +256,8 @@ public class DeviceProvisioningHelper {
 
         new DeviceConfiguration(kernel, thing.thingName, thing.dataEndpoint, thing.credEndpoint,
                 privKeyFilePath.toString(), certFilePath.toString(), caFilePath.toString(), awsRegion, roleAliasName);
+        // Make sure tlog persists the device configuration
+        kernel.getContext().waitForPublishQueueToClear();
         outStream.println("Created device configuration");
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use the last key in the keypath when pulling from the map of updates

**Why is this change necessary:**

**How was this change tested:**
Tested with UAT which is under development.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
