### PR TITLE
Fix tests, Refactor truncate tlog

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -61,6 +61,7 @@ import javax.inject.Inject;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.PREV_VERSION_CONFIG_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.ANY_VERSION;
+import static org.apache.commons.io.FileUtils.ONE_MB;
 
 public class ComponentManager implements InjectionActions {
     private static final Logger logger = LogManager.getLogger(ComponentManager.class);
@@ -70,7 +71,7 @@ public class ComponentManager implements InjectionActions {
     private static final String PACKAGE_IDENTIFIER = "packageIdentifier";
     private static final String COMPONENT_STR = "component";
 
-    private static final long DEFAULT_MIN_DISK_AVAIL_BYTES = 1_000_000L;
+    private static final long DEFAULT_MIN_DISK_AVAIL_BYTES = 20 * ONE_MB;
 
     private final S3Downloader s3ArtifactsDownloader;
     private final GreengrassRepositoryDownloader greengrassArtifactDownloader;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Fix `ConfigurationWriterTest` failure because of previous assumption that `config.lookup` does not create tlog entry.
- Refactor truncate tlog code because `ConfigurationWriter.childChanged` is already called from the publish thread. We can only queue a task without waiting
- Increase ComponentStore safe limit to 20 MB so that it's practically meaningful and maybe UAT can pass more consistently.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
