### PR TITLE
Always merge runwith - don't set if empty and no existing value

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -258,6 +258,9 @@ public class KernelConfigResolver {
             }
 
             updateRunWith(packageConfiguration.getRunWith(), resolvedServiceConfig, componentIdentifier.getName());
+        } else {
+            // make sure existing run with is merged
+            updateRunWith(null, resolvedServiceConfig, componentIdentifier.getName());
         }
 
         Map<String, Object> resolvedConfiguration = resolveConfigurationToApply(optionalConfigUpdate.orElse(null),
@@ -273,10 +276,12 @@ public class KernelConfigResolver {
     private void updateRunWith(RunWith runWith, Map<String, Object> resolvedServiceConfig, String componentName) {
         Topics serviceTopics = kernel.findServiceTopic(componentName);
         Map<String, Object> runWithConfig = new HashMap<>();
+        boolean hasExisting = false;
         if (serviceTopics != null) {
             Topics runWithTopics = serviceTopics.findTopics(RUN_WITH_NAMESPACE_TOPIC);
             if (runWithTopics != null) {
                 runWithConfig = runWithTopics.toPOJO();
+                hasExisting = true;
             }
         }
         if (runWith != null && runWith.hasPosixUserValue()) {
@@ -286,7 +291,9 @@ public class KernelConfigResolver {
                 runWithConfig.put(POSIX_USER_KEY, runWith.getPosixUser());
             }
         }
-        resolvedServiceConfig.put(RUN_WITH_NAMESPACE_TOPIC, runWithConfig);
+        if (!runWithConfig.isEmpty() || hasExisting) {
+            resolvedServiceConfig.put(RUN_WITH_NAMESPACE_TOPIC, runWithConfig);
+        }
     }
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Ensure that the runWith is merged properly when config is not present in a new deployment

Don't create runWith topic if not necessary

**Why is this change necessary:**
To stop runWith being set on re-deployment when no change has occurred

**How was this change tested:**
Unit tests + Lambda&smoke, SM&smoke tests pass

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
