### PR TITLE
Don't wait for main to start

### DIFF
--- a/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
@@ -66,6 +66,8 @@ class KernelUpdateDeploymentTaskTest {
     @Mock
     GreengrassService greengrassService;
     @Mock
+    GreengrassService mainService;
+    @Mock
     ComponentManager componentManager;
 
     KernelUpdateDeploymentTask task;
@@ -76,6 +78,8 @@ class KernelUpdateDeploymentTaskTest {
         lenient().doReturn(deploymentDirectoryManager).when(context).get(DeploymentDirectoryManager.class);
         lenient().doReturn(context).when(kernel).getContext();
         lenient().doReturn("A").when(greengrassService).getName();
+        lenient().doReturn(mainService).when(kernel).getMain();
+        lenient().doReturn(true).when(greengrassService).shouldAutoStart();
         lenient().doReturn(Arrays.asList(greengrassService)).when(kernel).orderedDependencies();
         lenient().doNothing().when(componentManager).cleanupStaleVersions();
 


### PR DESCRIPTION
**Issue #, if available:**
https://issues.amazon.com/issues/P41769181
**Description of changes:**
The nucleus activate deployment shouldn't wait on main to reach desirable state because it cannot if there is a nonpinned lambda component.
**Why is this change necessary:**
It's a bug that prevents a kernel activate deployment from finishing.
**How was this change tested:**
Manually tested on the device and confirmed it's likely working because the deployment succeeds even though another downstream [issue](https://issues.amazon.com/issues/P41828435) removed all the logs.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
