### PR TITLE
Fix multiple kernel update bugs

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -37,7 +37,6 @@ launch_kernel() {
 }
 
 flip_link() {
-  rm -r $(readlink $2) || true
   rm $2 || true
   ln -s $(readlink $1) $2
   rm $1 || true

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
@@ -329,7 +329,7 @@ public class GreengrassService implements InjectionActions {
      * @return future completes when the lifecycle thread shuts down.
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public final CompletableFuture<Void> close() {
+    public CompletableFuture<Void> close() {
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 
         context.get(Executor.class).execute(() -> {

--- a/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.deployment.activator;
 
 import com.aws.greengrass.config.Configuration;
+import com.aws.greengrass.config.ConfigurationWriter;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
 import com.aws.greengrass.deployment.bootstrap.BootstrapManager;
@@ -62,6 +63,10 @@ class KernelUpdateActivatorTest {
     Deployment deployment;
     @Mock
     Map<String, Object> newConfig;
+    @Mock
+    ConfigurationWriter tlog;
+    @Mock
+    KernelLifecycle lifecycle;
 
     KernelUpdateActivator kernelUpdateActivator;
 
@@ -75,7 +80,8 @@ class KernelUpdateActivatorTest {
         kernelUpdateActivator = new KernelUpdateActivator(kernel, bootstrapManager);
         lenient().doReturn(DeploymentDocument.builder().timestamp(0L).deploymentId("testId").build())
                 .when(deployment).getDeploymentDocumentObj();
-        lenient().doReturn(mock(KernelLifecycle.class)).when(context).get(eq(KernelLifecycle.class));
+        lenient().doReturn(tlog).when(lifecycle).getTlog();
+        lenient().doReturn(lifecycle).when(context).get(eq(KernelLifecycle.class));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**
P41828435

**Description of changes:**
1. In loader, avoid unintentionally deleting launch directory during flip_link, which might be actively used by other symlinks
1. Close tlog before merging configuration in kernel update. Without the fix, if unexpected crashes happen before launch directory link is flipped, kernel will restart into tlog with new config but won't know about the deployment execution.
1. Make GreengrassService.close non-final so that Lambda can override the behavior
1. When cleanup launch directory (`alts/init` in the example below), `Utils.deleteFileRecursively` will follow the link `alts/init/distro` and clean up all files under `/private/var/folders/lm/gb8hmh3j6gvf5yf04fhmq0w0fjxd22/T/kernel-unzip3642652400857784954`, but we only want to clean the symlink and files directly under `alts/init`. This is the root cause of P41828435.
```
├── alts
│   ├── current -> /Volumes/workplace/UAT/src/EvergreenFeatures/test_result/1b4f43b7c940a12716847468cb154af147739083/alts/init
│   └── init
│       ├── distro -> /private/var/folders/lm/gb8hmh3j6gvf5yf04fhmq0w0fjxd22/T/kernel-unzip3642652400857784954
│       └── launch.params
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
