### PR TITLE
Do not create Kernel in constructor so that commands can cause it to …

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -189,8 +189,8 @@ public class GreengrassSetup {
     private boolean setupSystemService = SETUP_SYSTEM_SERVICE_ARG_DEFAULT;
     private boolean kernelStart = KERNEL_START_ARG_DEFAULT;
     private boolean deployDevTools = DEPLOY_DEV_TOOLS_ARG_DEFAULT;
-    private final Platform platform;
-    private final Kernel kernel;
+    private Platform platform;
+    private Kernel kernel;
 
     /**
      * Constructor to create an instance using CLI args.
@@ -203,8 +203,6 @@ public class GreengrassSetup {
         this.setupArgs = setupArgs;
         this.outStream = outStream;
         this.errStream = errStream;
-        this.platform = Platform.getInstance();
-        this.kernel = new Kernel();
     }
 
     /**
@@ -260,6 +258,9 @@ public class GreengrassSetup {
             return;
         }
 
+        if (kernel == null) {
+            kernel = new Kernel();
+        }
         kernel.parseArgs(kernelArgs.toArray(new String[]{}));
 
         DeviceConfiguration deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
@@ -429,6 +430,9 @@ public class GreengrassSetup {
             return;
         }
         try {
+            if (platform == null) {
+                platform = Platform.getInstance();
+            }
             // If not super user we cannot create anything
             if (!platform.lookupCurrentUser().isSuperUser()) {
                 return;


### PR DESCRIPTION
…quit without needing to kill the JVM

**Issue #, if available:**

**Description of changes:**
This change makes us create the Kernel only when we actually need it. Without this change the `--version` and `--help` commands cannot cause the JVM to exit since there are threads running in the Kernel and the user needs to Ctrl+C.

Does the same change for `Platform` because without the change some log lines would be printed to stdout which makes it more difficult to parse the version out from stdout which IDT (among others) would want to do.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
