### PR TITLE
Only log in pubsub when it actually subscribes or unsubscribes

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCPubSubTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCPubSubTest.java
@@ -216,13 +216,13 @@ class IPCPubSubTest {
         AtomicInteger atomicInteger = new AtomicInteger();
 
         CountDownLatch subscriptionLatch = new CountDownLatch(1);
-        
+
         String authToken = IPCTestUtils.getAuthTokeForService(kernel, "SubscribeAndPublish");
         SocketOptions socketOptions = TestUtils.getSocketOptionsForIPC();
         try (EventStreamRPCConnection clientConnection =
                      IPCTestUtils.connectToGGCOverEventStreamIPC(socketOptions, authToken, kernel);
             AutoCloseable l = TestUtils.createCloseableLogListener(m -> {
-                if (m.getMessage().contains("Subscribing to topic")) {
+                if (m.getMessage().contains("Subscribed to topic")) {
                     subscriptionLatch.countDown();
                 }
             })){
@@ -312,7 +312,7 @@ class IPCPubSubTest {
         subscribeToTopicRequest.setTopic(topicName);
         CountDownLatch subscriptionLatch = new CountDownLatch(1);
         Slf4jLogAdapter.addGlobalListener(m -> {
-            if (m.getMessage().contains("Subscribing to topic")) {
+            if (m.getMessage().contains("Subscribed to topic")) {
                 subscriptionLatch.countDown();
             }
         });


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Prevent logging pubsub requests which are no-ops (subscribing when already subscribed, unsubscribing when not subscribed).

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
