### PR TITLE
Log exception from DeviceConfiguration validation so users will know …

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -279,7 +279,7 @@ public class IotJobsHelper implements InjectionActions {
         try {
             deviceConfiguration.validate();
         } catch (DeviceConfigurationException e) {
-            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. Device will run in offline mode");
+            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. Device will run in offline mode", e);
             return;
         }
         mqttClient.addToCallbackEvents(callbacks);

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.testcommons.testutilities;
 
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
 import com.aws.greengrass.util.Utils;
@@ -130,6 +131,7 @@ public class ExceptionLogProtector implements BeforeEachCallback, AfterEachCallb
         ignoreExceptionWithMessage(context, "Unable to load region information from any provider in the chain");
         ignoreExceptionWithMessageSubstring(context, "Failed to connect to service endpoint:");
         ignoreExceptionWithMessageSubstring(context, "Forbidden (Service: null; Status Code: 403;");
+        ignoreExceptionOfType(context, DeviceConfigurationException.class);
 
         // Ignore IPC error which somehow happens even though we ignore it in the tests which cause it
         // (probably threading?)


### PR DESCRIPTION
…what the problem is

**Issue #, if available:**

**Description of changes:**
Simple change to log the DeviceConfiguration exception so that users will be told _what_ they are missing instead of seeing an opaque error.


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
