### PR TITLE
Set Nucleus value using dflt insted of just setting it

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -204,7 +204,7 @@ public class DeviceConfiguration {
         kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, SERVICE_TYPE_TOPIC_KEY)
                 .withValue(ComponentType.NUCLEUS.name());
         kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, VERSION_CONFIG_KEY)
-                .withValue(KernelVersion.KERNEL_VERSION);
+                .dflt(KernelVersion.KERNEL_VERSION);
         ArrayList<String> mainDependencies = (ArrayList) kernel.getConfig().getRoot()
                 .findOrDefault(new ArrayList<>(), SERVICES_NAMESPACE_TOPIC, MAIN_SERVICE_NAME,
                         SERVICE_DEPENDENCIES_NAMESPACE_TOPIC);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Uses `dflt` when setting the version of the nucleus in the config store so that it will take the value in from the tlog/yaml if there is a value already. This will allow our UATs to _not_ require a nucleus update all the time since the nucleus will be able to know that it is, for example, version 2.0.18 and not 2.0.0.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
