### PR TITLE
[DNM] Initial dev tools deployment issue fixes

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -448,8 +448,12 @@ public class DeviceProvisioningHelper {
      */
     public void createInitialDeploymentIfNeeded(ThingInfo thingInfo, String thingGroupName) {
         if (Utils.isNotEmpty(thingGroupName) && thingGroupExists) {
+            // Skip creating a dev tools deployment to existing thing group since it can remove existing components if
+            // and can add to cost because it will be applied to all existing devices in the group
             outStream.println(
-                    "Thing group exists, no need to create a deployment for Greengrass first party components");
+                    "Thing group exists, it could have existing deployment and devices, hence NOT creating deployment "
+                            + "for Greengrass first party dev tools, please manually create a deployment if you wish "
+                            + "to");
             return;
         }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
DEPPRECATED NOTES
finthomp@ reported this bug. Earlier we didn't plan to have a dedicated option `--deploy-dev-tools` so we had conditional logic for when to create the initial deployment for cli, but when we added the option, that conditional logic should have been removed since the decision is for customers to make.

Although I just realized this will end up removing components from any existing deployment to the existing thing group so not sure if that will be desirable, pausing this for a bit until that discussion has an outcome


LATEST NOTES
1] Fix message when we skip creating cli deployment for existing thing group even if --deploy-dev-tools option is set to true
Always creating a deployment is bad - it will wipe out existing components deployed to the existing thing group
Reading active deployment and modifying it with cli component is bad at the moment without thinking through - we need to be able to retain all deployment configuration for an existing active deployment, and even after getting that right, it will be pushed to all existing devices in the group which will add to cost to customers
Not creating deployment to existing thing group and logging - can safely do for GA

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
