### PR TITLE
Smarter unarchive to only overwrite missing or changed files

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/Unarchiver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/Unarchiver.java
@@ -41,8 +41,11 @@ public class Unarchiver {
                     Utils.createPaths(newFile.toPath());
                 } else {
                     Utils.createPaths(newFile.getParentFile().toPath());
-                    try (OutputStream fos = Files.newOutputStream(newFile.toPath())) {
-                        IOUtils.copy(zis, fos);
+                    // Only unarchive when the destination file doesn't exist or the file sizes don't match
+                    if (!newFile.exists() || zipEntry.getSize() != newFile.length()) {
+                        try (OutputStream fos = Files.newOutputStream(newFile.toPath())) {
+                            IOUtils.copy(zis, fos);
+                        }
                     }
                 }
                 zipEntry = zis.getNextEntry();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes JVM crash due to overwriting the running JAR file when unarchiving during a deployment. We previously always unarchived no matter what, because the unarchived artifacts don't have digests which we can validate against, so since we don't know if the previous attempt to unarchive was actually succesful, we just go and do it again.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
