### PR TITLE
Fix component logger inheriting global log level

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.lifecyclemanager;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
 
 /**
@@ -24,14 +25,10 @@ public final class LogManagerHelper {
      * component if the logs are configured to be written to the disk.
      *
      * @param service The green grass service instance to use to subscribe to logger config.
-     * @return a logger with configuration to log to a los file with the same name.
+     * @return a logger with configuration to log to a log file with the same name.
      */
     public static Logger getComponentLogger(GreengrassService service) {
         // TODO: [P41214167]: Dynamically reconfigure service loggers
-        service.getConfig().lookupTopics(SERVICE_CONFIG_LOGGING_TOPICS)
-                .subscribe((why, newv) -> {
-                });
-
         return getComponentLogger(service.getServiceName(), service.getServiceName() + LOG_FILE_EXTENSION);
     }
 
@@ -41,9 +38,14 @@ public final class LogManagerHelper {
      *
      * @param name     The name of the component
      * @param fileName The name of the log file.
-     * @return a logger with configuration to log to a los file with the same name.
+     * @return a logger with configuration to log to a log file with the same name.
      */
     private static Logger getComponentLogger(String name, String fileName) {
-        return LogManager.getLogger(name, LoggerConfiguration.builder().fileName(fileName).build());
+        LoggerConfiguration config = LoggerConfiguration.builder()
+                // Explicitly inherit the format, otherwise the default from the builder would be used
+                .format(LogConfig.getInstance().getFormat())
+                .fileName(fileName)
+                .build();
+        return LogManager.getLogger(name, config);
     }
 }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.LogFormat;
 import com.aws.greengrass.logging.impl.config.LogStore;
+import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.NucleusPaths;
 import org.junit.jupiter.api.AfterAll;
@@ -41,12 +42,10 @@ import java.util.List;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.NUCLEUS_CONFIG_LOGGING_TOPICS;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
-import static com.aws.greengrass.lifecyclemanager.LogManagerHelper.SERVICE_CONFIG_LOGGING_TOPICS;
 import static com.aws.greengrass.telemetry.impl.MetricFactory.METRIC_LOGGER_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.io.FileMatchers.aFileNamed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -98,11 +97,9 @@ class LogManagerHelperTest {
 
     @Test
     void GIVEN_mock_service_WHEN_getComponentLogger_THEN_logs_to_correct_log_file() throws IOException {
-        Topics componentTopics = mock(Topics.class);
         when(mockGreengrassService.getServiceName()).thenReturn("MockService");
-        when(mockGreengrassService.getConfig()).thenReturn(componentTopics);
-        when(componentTopics.lookupTopics(SERVICE_CONFIG_LOGGING_TOPICS)).thenReturn(mock(Topics.class));
 
+        LogConfig.getInstance().setStore(LogStore.FILE);
         Logger componentLogger = LogManagerHelper.getComponentLogger(mockGreengrassService);
 
         componentLogger.atInfo().log("Something");
@@ -110,9 +107,7 @@ class LogManagerHelperTest {
         LogConfig logConfig = LogManager.getLogConfigurations().get("MockService");
         File logFile = new File(logConfig.getStoreName());
         assertThat(logFile, aFileNamed(equalToIgnoringCase("MockService.log")));
-        assertTrue(logFile.length() > 0);
         List<String> lines = Files.readAllLines(logFile.toPath());
-        assertThat(lines, hasSize(1));
         assertThat(lines.get(0), containsString("Something"));
 
         File ggLogFile = new File(LogManager.getRootLogConfiguration().getStoreName());
@@ -197,5 +192,16 @@ class LogManagerHelperTest {
         assertEquals(1024, LogManager.getTelemetryConfig().getFileSizeKB());
         assertEquals(10240, LogManager.getTelemetryConfig().getTotalLogStoreSizeKB());
         verify(nucleusPaths, times(0)).setLoggerPath(any(Path.class));
+    }
+
+    @Test
+    void GIVEN_nondefault_options_on_root_logger_WHEN_create_component_logger_THEN_inherits_options() {
+        LogManager
+                .reconfigureAllLoggers(LoggerConfiguration.builder().level(Level.TRACE).format(LogFormat.JSON).build());
+        when(mockGreengrassService.getServiceName()).thenReturn("MockService2");
+
+        Logger logger = LogManagerHelper.getComponentLogger(mockGreengrassService);
+        assertTrue(logger.isTraceEnabled());
+        assertEquals(LogFormat.JSON, LogManager.getLogConfigurations().get("MockService2").getFormat());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Requires: https://github.com/aws/aws-greengrass-logging-java/pull/92

This change fixes the inheritance of logging configurations in the individual component loggers. Without this change, they do not inherit settings including the log level and output format. For example, if the global logger is configured at DEBUG level, a component (lambda) which logs at debug would have its logs ignored, since the default log level is INFO and the log level setting wasn't properly inherited.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
