### PR TITLE
Kill component process gracefully

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -289,6 +289,8 @@ public class UnixPlatform extends Platform {
         if (force) {
             process.destroyForcibly();
         }
+        // calling process.destroy() here when force==false will cause the child process (component process) to be
+        // terminated immediately. This prevents the component process from shutting down gracefully.
 
         return pids;
     }


### PR DESCRIPTION
**Issue #, if available:**

Current behavior:
When killProcessAndChildren is called with force ==FALSE a SIGINT is send to the component process and process.destroy() is called for the shell process that created the component process. Calling process.destroy() on the shell process causes the component process to be terminated immediately, without enough time to execute its shutdown hooks.

Fix:
When killProcessAndChildren is called with force ==FALSE , only send SIGINT to the component process. When the component process exists the shell process will exist as well.

If the component process does not exits in a specified time, killProcessAndChildren is called later with force == TRUE which sends a SIGKILL to the component process and the shell process.


**How was this change tested:**
Tested using UAT's: https://code.amazon.com/reviews/CR-40378654


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
