### PR TITLE
Block IPC config update notification for noisy events

### DIFF
--- a/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
@@ -422,8 +422,9 @@ public class ConfigStoreIPCEventStreamAgent {
         }
 
         private void handleConfigNodeUpdate(WhatHappened whatHappened, Node changedNode, String componentName) {
-            // Blocks from sending an event on subscription
-            if (changedNode == null || WhatHappened.initialized.equals(whatHappened)) {
+            // Blocks from sending an event on subscription, or events IPC subscriber isn't interested in knowing about
+            if (changedNode == null || WhatHappened.initialized.equals(whatHappened) || WhatHappened.timestampUpdated
+                    .equals(whatHappened) || WhatHappened.interiorAdded.equals(whatHappened)) {
                 return;
             }
             // The path sent in config update event should be the path for the changed node within the component


### PR DESCRIPTION
**Issue #, if available:**
We found in popanmol@'s UAT that config IPC subscriber triggers update events from server in case of events like timestampUpdated which we added for our internal config management, but the event doesn't have information that config value hasn't changed or no child config has changed etc. 
Because of this, when a deployment has a previously deployed component which has no change at all, the component's config timestamp still gets updated even though values are unchanged, so we end up sending update events to the IPC client

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
