### PR TITLE
Close Files.list() and Files.walk() streams

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.model.ComponentUpdatePolicyEvents;
@@ -108,7 +107,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
     }
 
     @BeforeEach
-    void before(TestInfo testInfo) {
+    void before() {
         kernel = new Kernel();
         NoOpPathOwnershipHandler.register(kernel);
         deploymentConfigMerger = kernel.getContext().get(DeploymentConfigMerger.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -65,7 +65,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(GGExtension.class)
-public class DeploymentServiceIntegrationTest extends BaseITCase {
+class DeploymentServiceIntegrationTest extends BaseITCase {
     private static final Logger logger = LogManager.getLogger(DeploymentServiceIntegrationTest.class);
     private static final ObjectMapper OBJECT_MAPPER =
             new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCMqttProxyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCMqttProxyTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(GGExtension.class)
-public class IPCMqttProxyTest {
+class IPCMqttProxyTest {
     private static final Logger logger = LogManager.getLogger(IPCMqttProxyTest.class);
     private static final int TIMEOUT_FOR_MQTTPROXY_SECONDS = 20;
     private static final String TEST_PUBLISH_TOPIC = "A/B/C";

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/util/platforms/unix/UnixPlatformIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/util/platforms/unix/UnixPlatformIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @ExtendWith(GGExtension.class)
 @EnabledOnOs({OS.LINUX, OS.MAC})
-public class UnixPlatformIntegrationTest {
+class UnixPlatformIntegrationTest {
 
     UnixPlatform platform;
 

--- a/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
@@ -320,7 +320,7 @@ public class ConfigStoreIPCEventStreamAgent {
                 keyPath = request.getKeyPath().toArray(new String[0]);
             }
             if (keyPath.length == 0 && request.getValueToMerge().keySet().stream()
-                    .filter(key -> restrictedConfigurationFields.contains(key)).findAny().isPresent()
+                    .anyMatch(key -> restrictedConfigurationFields.contains(key))
             || keyPath.length != 0 && restrictedConfigurationFields.contains(request.getKeyPath().get(0))) {
                 throw new InvalidArgumentsError("Config update is not allowed for following fields "
                         + restrictedConfigurationFields);

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.LongStream;
 import javax.inject.Inject;
 
 public class ComponentStore {
@@ -401,8 +402,10 @@ public class ComponentStore {
      */
     public long getContentSize() throws PackageLoadingException {
         try {
-            return Files.walk(nucleusPaths.componentStorePath()).map(Path::toFile).filter(File::isFile)
-                    .mapToLong(File::length).sum();
+            try (LongStream lengths = Files.walk(nucleusPaths.componentStorePath()).map(Path::toFile)
+                    .filter(File::isFile).mapToLong(File::length)) {
+                return lengths.sum();
+            }
         } catch (IOException e) {
             throw new PackageLoadingException("Failed to access package store", e);
         }

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -208,7 +208,7 @@ public class DependencyResolver {
         componentsToResolve.add(targetComponentName);
 
         Map<String, ComponentIdentifier> resolvedComponents = new HashMap<>();
-        while (componentsToResolve.size() != 0) {
+        while (!componentsToResolve.isEmpty()) {
             String componentToResolve = componentsToResolve.poll();
             Map<String, Requirement> versionConstraints =
                     new HashMap<>(componentNameToVersionConstraints.get(componentToResolve));

--- a/src/main/java/com/aws/greengrass/componentmanager/converter/RecipeLoader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/converter/RecipeLoader.java
@@ -39,7 +39,7 @@ import javax.inject.Inject;
 
 public class RecipeLoader {
     // GG_NEEDS_REVIEW: TODO:[P41216663]: add logging
-    private static final Logger LOGGER = LogManager.getLogger(PlatformResolver.class);
+    private static final Logger LOGGER = LogManager.getLogger(RecipeLoader.class);
 
     private final PlatformResolver platformResolver;
 
@@ -152,9 +152,8 @@ public class RecipeLoader {
      */
     private static Set<String> collectAllSelectors(@Nonnull List<PlatformSpecificManifest> manifests) {
         Set<String> allSelectors = new HashSet<>();
-        manifests.stream().map(m -> m.getSelections()).filter(s -> s != null).forEach(s -> {
-            allSelectors.addAll(s);
-        });
+        manifests.stream().map(PlatformSpecificManifest::getSelections)
+                .filter(Objects::nonNull).forEach(allSelectors::addAll);
         allSelectors.add(PlatformResolver.ALL_KEYWORD); // implicit, it is ok if it was specified explicitly
         return allSelectors;
     }

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -64,6 +64,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 
 import static com.amazon.aws.iot.greengrass.component.common.SerializerFactory.getRecipeSerializer;
@@ -509,52 +510,55 @@ public class DeploymentService extends GreengrassService {
         }
     }
 
-
+    @SuppressWarnings("PMD.ExceptionAsFlowControl")
     private void copyRecipesToComponentStore(Path from) throws IOException {
-        for (Path r : Files.walk(from).collect(Collectors.toList())) {
-            String ext = Utils.extension(r.toString());
-            ComponentRecipe recipe = null;
+        try (Stream<Path> files = Files.walk(from)) {
+            for (Path r : files.collect(Collectors.toList())) {
+                String ext = Utils.extension(r.toString());
+                ComponentRecipe recipe = null;
 
-            //reading it in as a recipe, so that will fail if it is malformed with a good error.
-            //The second reason to do this is to parse the name and version so that we can properly name
-            //the file when writing it into the local recipe store.
-            try {
-                if (r.toFile().length() > 0) {
-                    switch (ext.toLowerCase()) {
-                        case "yaml":
-                        case "yml":
-                            recipe = getRecipeSerializer().readValue(r.toFile(), ComponentRecipe.class);
-                            break;
-                        case "json":
-                            recipe = getRecipeSerializerJson().readValue(r.toFile(), ComponentRecipe.class);
-                            break;
-                        default:
-                            break;
+                //reading it in as a recipe, so that will fail if it is malformed with a good error.
+                //The second reason to do this is to parse the name and version so that we can properly name
+                //the file when writing it into the local recipe store.
+                try {
+                    if (r.toFile().length() > 0) {
+                        switch (ext.toLowerCase()) {
+                            case "yaml":
+                            case "yml":
+                                recipe = getRecipeSerializer().readValue(r.toFile(), ComponentRecipe.class);
+                                break;
+                            case "json":
+                                recipe = getRecipeSerializerJson().readValue(r.toFile(), ComponentRecipe.class);
+                                break;
+                            default:
+                                break;
+                        }
                     }
+                } catch (IOException e) {
+                    // Throw on error so that the user will receive this message and we will stop the deployment.
+                    // This is to fail fast while providing actionable feedback.
+                    throw new IOException(
+                            String.format("Unable to parse %s as a recipe due to: %s", r.toString(), e.getMessage()),
+                            e);
                 }
-            } catch (IOException e) {
-                // Throw on error so that the user will receive this message and we will stop the deployment.
-                // This is to fail fast while providing actionable feedback.
-                throw new IOException(String.format("Unable to parse %s as a recipe due to: %s",
-                        r.toString(), e.getMessage()), e);
-            }
-            if (recipe == null) {
-                logger.atError().log("Skipping file {} because it was not recognized as a recipe", r);
-                continue;
-            }
+                if (recipe == null) {
+                    logger.atError().log("Skipping file {} because it was not recognized as a recipe", r);
+                    continue;
+                }
 
-            // Write the recipe as YAML with the proper filename into the store
-            ComponentIdentifier componentIdentifier =
-                    new ComponentIdentifier(recipe.getComponentName(), recipe.getComponentVersion());
+                // Write the recipe as YAML with the proper filename into the store
+                ComponentIdentifier componentIdentifier =
+                        new ComponentIdentifier(recipe.getComponentName(), recipe.getComponentVersion());
 
-            try {
-                componentStore.savePackageRecipe(componentIdentifier,
-                        getRecipeSerializer().writeValueAsString(recipe));
-            } catch (PackageLoadingException e) {
-                // Throw on error so that the user will receive this message and we will stop the deployment.
-                // This is to fail fast while providing actionable feedback.
-                throw new IOException(String.format("Unable to copy recipe for '%s' to component store due to: %s",
-                        componentIdentifier.toString(), e.getMessage()), e);
+                try {
+                    componentStore
+                            .savePackageRecipe(componentIdentifier, getRecipeSerializer().writeValueAsString(recipe));
+                } catch (PackageLoadingException e) {
+                    // Throw on error so that the user will receive this message and we will stop the deployment.
+                    // This is to fail fast while providing actionable feedback.
+                    throw new IOException(String.format("Unable to copy recipe for '%s' to component store due to: %s",
+                            componentIdentifier.toString(), e.getMessage()), e);
+                }
             }
         }
     }

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
@@ -142,7 +142,7 @@ public class DeploymentStatusKeeper {
         if (stringFunctionMap != null) {
             return new ArrayList<>(stringFunctionMap.values());
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -94,6 +94,7 @@ public class ShadowDeploymentListener implements InjectionActions {
     };
     private String lastConfigurationArn;
     private Integer lastVersion;
+    protected static final Random JITTER = new Random();
 
     @Override
     public void postInject() {
@@ -165,8 +166,7 @@ public class ShadowDeploymentListener implements InjectionActions {
             }
             try {
                 // Wait for sometime and then try to subscribe again
-                Random jitter = new Random();
-                Thread.sleep(WAIT_TIME_TO_SUBSCRIBE_AGAIN_IN_MS + jitter.nextInt(10_000));
+                Thread.sleep(WAIT_TIME_TO_SUBSCRIBE_AGAIN_IN_MS + JITTER.nextInt(10_000));
             } catch (InterruptedException interruptedException) {
                 logger.atWarn().log("Interrupted while subscribing to device shadow topics");
                 return;

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/RunWithPathOwnershipHandler.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/RunWithPathOwnershipHandler.java
@@ -78,6 +78,7 @@ public class RunWithPathOwnershipHandler {
         setPermissions(workPath, permission, true);
     }
 
+    @SuppressWarnings("PMD.ForLoopCanBeForeach")
     void setPermissions(Path p, FileSystemPermission permission,  boolean applyToRoot) throws IOException {
         if (Files.notExists(p)) {
             return;

--- a/src/main/java/com/aws/greengrass/util/Digest.java
+++ b/src/main/java/com/aws/greengrass/util/Digest.java
@@ -56,11 +56,9 @@ public final class Digest {
      * @param digest1 first digest to compare
      * @param digest2 second digest to compare
      * @return whether two digests are equal
-     * @throws NoSuchAlgorithmException when no implementation for message digest is available
      */
-    public static boolean isEqual(String digest1, String digest2) throws NoSuchAlgorithmException {
-        MessageDigest messageDigest = MessageDigest.getInstance(DIGEST_ALGO);
-        return messageDigest.isEqual(digest1.getBytes(StandardCharsets.UTF_8),
+    public static boolean isEqual(String digest1, String digest2) {
+        return MessageDigest.isEqual(digest1.getBytes(StandardCharsets.UTF_8),
                 digest2.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/aws/greengrass/util/Permissions.java
+++ b/src/main/java/com/aws/greengrass/util/Permissions.java
@@ -36,6 +36,7 @@ public final class Permissions {
      * @param permission the permission to apply.
      * @throws IOException if an error occurs.
      */
+    @SuppressWarnings("PMD.ForLoopCanBeForeach")
     public static void setArtifactPermission(Path p, FileSystemPermission permission) throws IOException {
         if (p == null || !Files.exists(p)) {
             return;

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -423,9 +423,7 @@ public class UnixPlatform extends Platform {
                     .withOut(o -> {
                         out.accept(o);
                         output.append(o);
-                    }).withErr(e -> {
-                        error.append(e);
-                    }).exec();
+                    }).withErr(error::append).exec();
             if (!exit.isPresent() || exit.get() != 0) {
                 throw new IOException(String.format(
                         String.format("%s - command: %s, output: %s , error: %s ", msg, cmdStr, output.toString(),

--- a/src/test/java/com/aws/greengrass/authorization/AuthorizationIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/AuthorizationIPCAgentTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class AuthorizationIPCAgentTest {
+class AuthorizationIPCAgentTest {
     private static final String TEST_TOKEN = "token";
     @Mock
     OperationContinuationHandlerContext mockContext;

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderFactoryTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class ArtifactDownloaderFactoryTest {
+class ArtifactDownloaderFactoryTest {
 
     Path testDir = Paths.get("foo");
 

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class ArtifactDownloaderTest {
+class ArtifactDownloaderTest {
 
     private static final String LOCAL_FILE_NAME = "artifact.txt";
 

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
@@ -15,14 +15,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.model.DeploymentStatus;
 import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,9 +43,6 @@ class DeploymentStatusKeeperTest {
 
     @Mock
     private DeploymentService deploymentService;
-
-    @TempDir
-    Path mockPath;
 
     private static final Function<Map<String, Object>, Boolean> DUMMY_CONSUMER = (details) -> false;
     private static final String DUMMY_SERVICE_NAME = "dummyService";

--- a/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
@@ -132,8 +132,8 @@ class DeploymentDocumentConverterTest {
                         .findAny().get();
 
         assertThat(newRootComponentConfig.getResolvedVersion(), is("2.0.0"));
-        assertEquals(newRootComponentConfig.getConfigurationUpdateOperation(), null);
-        assertEquals(newRootComponentConfig.getRunWith().getPosixUser(), "foo:bar");
+        assertNull(newRootComponentConfig.getConfigurationUpdateOperation());
+        assertEquals("foo:bar", newRootComponentConfig.getRunWith().getPosixUser());
 
 
         DeploymentPackageConfiguration DependencyComponentConfig =

--- a/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @ExtendWith(GGExtension.class)
-public class RunWithTest {
+class RunWithTest {
     static final ObjectMapper MAPPER = new ObjectMapper();
 
     @ParameterizedTest

--- a/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class IPCEventStreamServiceTest {
+class IPCEventStreamServiceTest {
     private IPCEventStreamService ipcEventStreamService;
     protected static ObjectMapper OBJECT_MAPPER =
             new ObjectMapper().configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false)
@@ -114,7 +114,7 @@ public class IPCEventStreamServiceTest {
 
     @Test
     @SuppressWarnings("PMD.CloseResource")
-    public void testClientConnection() throws Exception {
+    void testClientConnection() throws Exception {
         CountDownLatch connectionLatch = new CountDownLatch(1);
         EventStreamRPCConnection connection = null;
         try (EventLoopGroup elg = new EventLoopGroup(1);

--- a/src/test/java/com/aws/greengrass/ipc/modules/LifecycleIPCServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/modules/LifecycleIPCServiceTest.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class LifecycleIPCServiceTest {
+class LifecycleIPCServiceTest {
 
     LifecycleIPCService lifecycleIPCService;
 
@@ -46,7 +46,7 @@ public class LifecycleIPCServiceTest {
     }
 
     @Test
-    public void testHandlersRegistered() {
+    void testHandlersRegistered() {
         lifecycleIPCService.startup();
         ArgumentCaptor<Function> argumentCaptor = ArgumentCaptor.forClass(Function.class);
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/RunWithPathOwnershipHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/RunWithPathOwnershipHandlerTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
-public class RunWithPathOwnershipHandlerTest {
+class RunWithPathOwnershipHandlerTest {
 
     RunWithPathOwnershipHandler handler;
 
@@ -97,7 +97,7 @@ public class RunWithPathOwnershipHandlerTest {
     }
 
     @Test
-    public void GIVEN_paths_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
+    void GIVEN_paths_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
         doReturn(existing).when(paths).artifactPath(id);
         doReturn(existing).when(paths).unarchiveArtifactPath(id);
         doReturn(workPath).when(paths).workPath(any());
@@ -115,7 +115,7 @@ public class RunWithPathOwnershipHandlerTest {
     }
 
     @Test
-    public void GIVEN_archive_path_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
+    void GIVEN_archive_path_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
         doReturn(existing).when(paths).artifactPath(id);
         doReturn(nonExisting).when(paths).unarchiveArtifactPath(id);
         doReturn(nonExisting).when(paths).workPath(any());
@@ -127,7 +127,7 @@ public class RunWithPathOwnershipHandlerTest {
     }
 
     @Test
-    public void GIVEN_unarchive_path_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
+    void GIVEN_unarchive_path_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
         doReturn(nonExisting).when(paths).artifactPath(id);
         doReturn(existing).when(paths).unarchiveArtifactPath(id);
         doReturn(nonExisting).when(paths).workPath(any());
@@ -137,7 +137,7 @@ public class RunWithPathOwnershipHandlerTest {
     }
 
     @Test
-    public void GIVEN_no_path_and_run_with_WHEN_updateOwner_THEN_no_update_paths() throws IOException {
+    void GIVEN_no_path_and_run_with_WHEN_updateOwner_THEN_no_update_paths() throws IOException {
         doReturn(nonExisting).when(paths).artifactPath(id);
         doReturn(nonExisting).when(paths).unarchiveArtifactPath(id);
         doReturn(nonExisting).when(paths).workPath(any());
@@ -147,7 +147,7 @@ public class RunWithPathOwnershipHandlerTest {
     }
 
     @Test
-    public void GIVEN_work_path_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
+    void GIVEN_work_path_and_run_with_WHEN_updateOwner_THEN_update_paths() throws IOException {
         doReturn(nonExisting).when(paths).artifactPath(id);
         doReturn(nonExisting).when(paths).unarchiveArtifactPath(id);
         doReturn(workPath).when(paths).workPath(any());

--- a/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
-public class InMemorySpoolTest {
+class InMemorySpoolTest {
 
     @Mock
     DeviceConfiguration deviceConfiguration;

--- a/src/test/java/com/aws/greengrass/testing/TestFeatureParametersTest.java
+++ b/src/test/java/com/aws/greengrass/testing/TestFeatureParametersTest.java
@@ -18,15 +18,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class TestFeatureParametersTest {
+class TestFeatureParametersTest {
 
     @AfterEach
-    public void disableFeatureParametersAfter() {
+    void disableFeatureParametersAfter() {
         TestFeatureParameters.internalDisableTestingFeatureParameters();
     }
 
     @Test
-    public void GIVEN_feature_flag_retrieved_WHEN_not_enabled_THEN_use_provided_value() {
+    void GIVEN_feature_flag_retrieved_WHEN_not_enabled_THEN_use_provided_value() {
         String providedValue = "ThisValueWasProvided";
         String featureFlag = "SomeFeatureFlagThatDoesNotGetValidated";
 
@@ -36,7 +36,7 @@ public class TestFeatureParametersTest {
     }
 
     @Test
-    public void GIVEN_feature_flag_retrieved_WHEN_enabled_THEN_use_override_value() {
+    void GIVEN_feature_flag_retrieved_WHEN_enabled_THEN_use_override_value() {
         String featureFlag = "SomeFeatureFlagThatWouldBeHandled";
         Integer someInputValue = 1234;
         Integer specificReturnValue = 5678; // checked by reference
@@ -51,7 +51,7 @@ public class TestFeatureParametersTest {
     }
 
     @Test
-    public void GIVEN_feature_flag_retrieved_WHEN_disabled_THEN_use_provided_value() {
+    void GIVEN_feature_flag_retrieved_WHEN_disabled_THEN_use_provided_value() {
         String featureFlag = "SomeFeatureFlagThatWouldBeHandled";
         Integer someInputValue = 1234;
         Integer specificReturnValue = 5678; // checked by reference

--- a/src/test/java/com/aws/greengrass/util/DigestTest.java
+++ b/src/test/java/com/aws/greengrass/util/DigestTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(GGExtension.class)
-public class DigestTest {
+class DigestTest {
 
     @Test
     void GIVEN_digest_WHEN_calculate_THEN_correct_value_returned() throws NoSuchAlgorithmException {

--- a/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RetryUtilsTest {
+class RetryUtilsTest {
 
     Logger logger = LogManager.getLogger(this.getClass()).createChild();
     RetryUtils.RetryConfig config = RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(1))

--- a/src/test/java/com/aws/greengrass/util/platforms/WindowsPlatformTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/WindowsPlatformTest.java
@@ -14,10 +14,10 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith({GGExtension.class})
-public class WindowsPlatformTest {
+class WindowsPlatformTest {
 
     @Test
-    public void GIVEN_command_WHEN_decorate_THEN_is_decorated() {
+    void GIVEN_command_WHEN_decorate_THEN_is_decorated() {
         assertThat(new WindowsPlatform.CmdDecorator()
                         .decorate("echo", "hello"),
                 is(arrayContaining("cmd.exe", "/C", "echo", "hello")));

--- a/src/test/java/com/aws/greengrass/util/platforms/unix/UnixPlatformTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/unix/UnixPlatformTest.java
@@ -15,18 +15,18 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith({GGExtension.class})
-public class UnixPlatformTest   {
+class UnixPlatformTest   {
 
     private static String[] command = {"echo", "hello", "world"};
 
     @Test
-    public void GIVEN_no_user_and_no_group_WHEN_decorate_THEN_do_not_generate_sudo_with_user_and_group() {
+    void GIVEN_no_user_and_no_group_WHEN_decorate_THEN_do_not_generate_sudo_with_user_and_group() {
         assertThat(new UnixPlatform.SudoDecorator().decorate(command),
                 is(arrayContaining(command)));
     }
 
     @Test
-    public void GIVEN_user_and_group_WHEN_decorate_THEN_generate_sudo_with_user_and_group() {
+    void GIVEN_user_and_group_WHEN_decorate_THEN_generate_sudo_with_user_and_group() {
         assertThat(new UnixPlatform.SudoDecorator()
                         .withUser("foo")
                         .withGroup("bar")
@@ -36,7 +36,7 @@ public class UnixPlatformTest   {
     }
 
     @Test
-    public void GIVEN_numeric_user_and_group_WHEN_decorate_THEN_generate_sudo_with_prefix() {
+    void GIVEN_numeric_user_and_group_WHEN_decorate_THEN_generate_sudo_with_prefix() {
         assertThat(new UnixPlatform.SudoDecorator()
                         .withUser("100")
                         .withGroup("200")
@@ -47,7 +47,7 @@ public class UnixPlatformTest   {
     }
 
     @Test
-    public void GIVEN_user_WHEN_decorate_THEN_generate_sudo_without_group() {
+    void GIVEN_user_WHEN_decorate_THEN_generate_sudo_without_group() {
         assertThat(new UnixPlatform.SudoDecorator()
                         .withUser("foo")
                         .decorate(command),

--- a/src/test/java/com/aws/greengrass/util/platforms/unix/UnixRunWithGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/unix/UnixRunWithGeneratorTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doReturn;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class UnixRunWithGeneratorTest {
+class UnixRunWithGeneratorTest {
 
 
     UnixRunWithGenerator generator;
@@ -58,7 +58,7 @@ public class UnixRunWithGeneratorTest {
     }
 
     @Test
-    public void GIVEN_component_run_with_uid_gid_WHEN_generate_THEN_use_component() {
+    void GIVEN_component_run_with_uid_gid_WHEN_generate_THEN_use_component() {
         doReturn(Topic.of(context, POSIX_USER_KEY, "123:456"))
                 .when(config).find(RUN_WITH_NAMESPACE_TOPIC, POSIX_USER_KEY);
         Optional<RunWith> result = generator.generate(deviceConfig, config);
@@ -69,7 +69,7 @@ public class UnixRunWithGeneratorTest {
     }
 
     @Test
-    public void GIVEN_component_run_with_user_group_WHEN_generate_THEN_use_component() {
+    void GIVEN_component_run_with_user_group_WHEN_generate_THEN_use_component() {
         doReturn(Topic.of(context, POSIX_USER_KEY, "foo:bar"))
                 .when(config).find(RUN_WITH_NAMESPACE_TOPIC, POSIX_USER_KEY);
         Optional<RunWith> result = generator.generate(deviceConfig, config);
@@ -80,7 +80,7 @@ public class UnixRunWithGeneratorTest {
     }
 
     @Test
-    public void GIVEN_component_run_with_user_WHEN_generate_THEN_use_component() throws IOException {
+    void GIVEN_component_run_with_user_WHEN_generate_THEN_use_component() throws IOException {
         doReturn(Topic.of(context, POSIX_USER_KEY, "foo"))
                 .when(config).find(RUN_WITH_NAMESPACE_TOPIC, POSIX_USER_KEY);
 
@@ -95,7 +95,7 @@ public class UnixRunWithGeneratorTest {
     }
 
     @Test
-    public void GIVEN_component_run_with_user_WHEN_no_group_generate_THEN_return_empty() throws IOException {
+    void GIVEN_component_run_with_user_WHEN_no_group_generate_THEN_return_empty() throws IOException {
         doReturn(Topic.of(context, POSIX_USER_KEY, "foo"))
                 .when(config).find(RUN_WITH_NAMESPACE_TOPIC, POSIX_USER_KEY);
 
@@ -107,7 +107,7 @@ public class UnixRunWithGeneratorTest {
     }
 
     @Test
-    public void GIVEN_valid_default_run_with_user_WHEN_generate_and_group_exists_THEN_use_default()
+    void GIVEN_valid_default_run_with_user_WHEN_generate_and_group_exists_THEN_use_default()
             throws IOException  {
         doReturn(Topic.of(context, POSIX_USER_KEY, "foo"))
                 .when(deviceConfig).getRunWithDefaultPosixUser();
@@ -123,7 +123,7 @@ public class UnixRunWithGeneratorTest {
     }
 
     @Test
-    public void GIVEN_default_run_with_user_group_WHEN_generate_THEN_use_default() throws IOException {
+    void GIVEN_default_run_with_user_group_WHEN_generate_THEN_use_default() throws IOException {
         doReturn(Topic.of(context, RUN_WITH_DEFAULT_POSIX_USER, "foo:bar"))
                 .when(deviceConfig).getRunWithDefaultPosixUser();
         doReturn(Topic.of(context,  RUN_WITH_DEFAULT_POSIX_SHELL, "/foo/bar"))
@@ -138,7 +138,7 @@ public class UnixRunWithGeneratorTest {
     }
 
     @Test
-    public void GIVEN_is_root_WHEN_generate_THEN_return_empty() throws IOException {
+    void GIVEN_is_root_WHEN_generate_THEN_return_empty() throws IOException {
         doReturn(userAttr).when(platform).lookupCurrentUser();
         doReturn(true).when(userAttr).isSuperUser();
 
@@ -148,7 +148,7 @@ public class UnixRunWithGeneratorTest {
 
 
     @Test
-    public void GIVEN_non_root_WHEN_generate_THEN_use_user()throws IOException  {
+    void GIVEN_non_root_WHEN_generate_THEN_use_user()throws IOException  {
         doReturn(userAttr).when(platform).lookupCurrentUser();
         doReturn(false).when(userAttr).isSuperUser();
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`Files.list()` opens a stream of paths with file handles to all the paths. Is must be used with `close()` in order to close all the handles that it opens up, however we were not doing that. This PR uses try-with-resources to properly close the stream and release the handles.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
