### PR TITLE
Wait for publish queue to clear before shutting down

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -126,7 +126,10 @@ public class Kernel {
         context.put(ThreadPoolExecutor.class, ses);
 
         Thread.setDefaultUncaughtExceptionHandler(new KernelExceptionHandler());
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> this.shutdown(-1)));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            logger.atWarn().log("Shutting down Nucleus due to external signal");
+            this.shutdown(-1);
+        }));
 
         nucleusPaths = new NucleusPaths();
         context.put(NucleusPaths.class, nucleusPaths);

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -271,6 +271,7 @@ public class KernelLifecycle {
      */
     public void softShutdown(int timeoutSeconds) {
         logger.atDebug("system-shutdown").log("Start soft shutdown");
+        kernel.getContext().waitForPublishQueueToClear();
         close(tlog);
         // Update effective config with our last known state
         kernel.writeEffectiveConfig();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Wait for the publish queue to empty out before closing the tlog so that we shutdown in a consistent state.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
