### PR TITLE
Updating pom.xml to consume iotdevicesdk 1.2.10 version from maven ce…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.15.17</version>
+                <version>2.15.47</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -112,9 +112,8 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws.services</groupId>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>greengrassv2</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -200,12 +199,6 @@
             </snapshots>
             <id>central</id>
             <url>https://repo1.maven.org/maven2</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>maven-releases</id>
-            <name>Maven releases</name>
-            <layout>default</layout>
-            <url>https://repository.apache.org/content/repositories/releases/</url>
         </pluginRepository>
         <pluginRepository>
             <id>yle-public</id>

--- a/pom.xml
+++ b/pom.xml
@@ -178,11 +178,10 @@
             <version>0.0.3</version>
             <scope>test</scope>
         </dependency>
-        <!-- TODO: Change when Iot Device SDK with greengrass ipc is released publicly-->
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
-            <artifactId>aws-iot-device-sdk-v2</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <artifactId>aws-iot-device-sdk</artifactId>
+            <version>1.2.10</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -192,6 +191,16 @@
         </dependency>
     </dependencies>
     <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </pluginRepository>
         <pluginRepository>
             <id>maven-releases</id>
             <name>Maven releases</name>

--- a/src/test/greengrass-nucleus-benchmark/pom.xml
+++ b/src/test/greengrass-nucleus-benchmark/pom.xml
@@ -16,10 +16,9 @@
             <version>${jmh.version}</version>
         </dependency>
         <dependency>
-            <!-- TODO: Change this dependency to the AWS SDK public maven repo once the V2 SDK is published there -->
-            <groupId>com.amazonaws.services</groupId>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>greengrassv2</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.15.47</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
…ntral

**Issue #, if available:**
Fast follow on consuming iotdevicesdk from maven central

**Description of changes:**
Updating iotdevicesdk dependency to version 1.2.10

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
