### PR TITLE
fix: remove redundant network call

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/S3Downloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/S3Downloader.java
@@ -127,8 +127,6 @@ public class S3Downloader extends ArtifactDownloader {
             region = RetryUtils.runWithRetry(s3ClientExceptionRetryConfig,
                     () -> s3ClientFactory.getS3Client().getBucketLocation(getBucketLocationRequest)
                             .locationConstraintAsString(), "get-bucket-location", logger);
-            region = s3ClientFactory.getS3Client().getBucketLocation(getBucketLocationRequest)
-                    .locationConstraintAsString();
         } catch (InterruptedException e) {
             throw e;
         } catch (S3Exception e) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove the duplicate S3 `getBucketLocation` call.

**Why is this change necessary:**
The removed lines are duplicated with line 127-129.
**How was this change tested:**
All the unit and integration tests pass.
**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
