### PR TITLE
fix: set permissions on paths that we create to 755 instead of 700

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -610,7 +610,7 @@ public final class Utils {
                 // This only supports POSIX compliant file permission right now. We will need to
                 // change this when trying to support Greengrass in Non-POSIX OS.
                 Files.createDirectories(p,
-                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x")));
             }
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Paths created by Greengrass have been created with 700 permissions which is causing issues because if multiple levels of directories are created, then not all users have permissions to traverse the tree. Specifically, `ggc_user` wouldn't have permission to execute a python script because not all of the directories on the path are readable/executable by ggc_user.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
