### PR TITLE
chore: Include the readme and copyright info directly in the zip

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -29,5 +29,15 @@
                 <include>nucleus-build.properties</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>LICENSE</include>
+                <include>NOTICE</include>
+                <include>README.md</include>
+                <include>THIRD-PARTY-LICENSES</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This change simply includes the README and other static info inside the distribution zip.

**Why is this change necessary:**

**How was this change tested:**

- `mvn package -DskipTests`

```
% unzip -l target/aws.greengrass.nucleus.zip
Archive:  target/aws.greengrass.nucleus.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  12-18-2020 16:04   lib/
 53652858  12-18-2020 16:04   lib/Greengrass.jar
        0  12-18-2020 16:04   bin/
      234  12-18-2020 15:57   bin/greengrass.service.template
     2398  12-18-2020 15:57   bin/loader
        0  12-18-2020 15:57   conf/
      500  12-18-2020 15:57   conf/nucleus-build.properties
      121  12-18-2020 15:57   NOTICE
    10142  12-18-2020 15:57   LICENSE
    76527  12-18-2020 15:57   THIRD-PARTY-LICENSES
     3482  12-18-2020 15:57   README.md
---------                     -------
 53746262                     11 files
```

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
