### PR TITLE
improvement(easysetup): Do not attempt creating role policy if it exists

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -55,6 +55,7 @@ with the following access, you can then use our E2E tests.
 - `greengrass:*`
 - `s3:*`
 - `iam:*`
+- `sts:*`
 
 To run only the E2E tests, run the following commands:
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,10 @@
             <artifactId>s3</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-process-killer</artifactId>
             <version>1.10</version>

--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -420,7 +420,7 @@ public class GreengrassSetup {
         }
         outStream.printf("Setting up resources for %s ... %n", TokenExchangeService.TOKEN_EXCHANGE_SERVICE_TOPICS);
         deviceProvisioningHelper.setupIoTRoleForTes(tesRoleName, tesRoleAliasName, thingInfo.getCertificateArn());
-        deviceProvisioningHelper.createAndAttachRolePolicy(tesRoleName);
+        deviceProvisioningHelper.createAndAttachRolePolicy(tesRoleName, Region.of(awsRegion));
         outStream.println("Configuring Nucleus with provisioned resource details...");
         deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, awsRegion, tesRoleAliasName);
         outStream.println("Successfully configured Nucleus with provisioned resource details!");

--- a/src/main/java/com/aws/greengrass/util/StsSdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/StsSdkClientFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.iam.model.LimitExceededException;
+import software.amazon.awssdk.services.iam.model.ServiceFailureException;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.StsException;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Accessor for AWS STS SDK.
+ */
+public final class StsSdkClientFactory {
+    private static final Set<Class<? extends Exception>> retryableIamExceptions = new HashSet<>(
+            Arrays.asList(StsException.class, LimitExceededException.class, ServiceFailureException.class));
+
+    private static final RetryCondition retryCondition = OrRetryCondition
+            .create(RetryCondition.defaultRetryCondition(), RetryOnExceptionsCondition.create(retryableIamExceptions));
+
+    private static final RetryPolicy retryPolicy =
+            RetryPolicy.builder().numRetries(5).backoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+                    .retryCondition(retryCondition).build();
+
+    private StsSdkClientFactory() {
+    }
+
+    /**
+     * Build StsClient.
+     *
+     * @param awsRegion aws region
+     * @return StsClient instance
+     */
+    public static StsClient getStsClient(String awsRegion) {
+        return StsClient.builder().region(Region.of(awsRegion)).httpClient(ProxyUtils.getSdkHttpClient())
+                .overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(retryPolicy).build()).build();
+    }
+}

--- a/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
@@ -53,6 +53,7 @@ import software.amazon.awssdk.services.iot.model.Policy;
 import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.iot.model.RoleAliasDescription;
 import software.amazon.awssdk.services.iot.model.UpdateCertificateRequest;
+import software.amazon.awssdk.services.sts.StsClient;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -81,6 +82,8 @@ class DeviceProvisioningHelperTest {
     private IotClient iotClient;
     @Mock
     private IamClient iamClient;
+    @Mock
+    private StsClient stsClient;
     @Mock
     private GreengrassV2Client greengrassClient;
     @Mock
@@ -112,7 +115,8 @@ class DeviceProvisioningHelperTest {
 
     @BeforeEach
     void setup() {
-        deviceProvisioningHelper = new DeviceProvisioningHelper(System.out, iotClient, iamClient, greengrassClient);
+        deviceProvisioningHelper = new DeviceProvisioningHelper(System.out, iotClient, iamClient, stsClient,
+                greengrassClient);
     }
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -97,7 +97,7 @@ class GreengrassSetupTest {
         verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
-        verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any());
+        verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any());
     }
 
     @Test
@@ -337,7 +337,7 @@ class GreengrassSetupTest {
         verify(deviceProvisioningHelper, times(1)).createThing(any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
-        verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any());
+        verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any());
     }
 
     @Test
@@ -355,7 +355,7 @@ class GreengrassSetupTest {
         verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
-        verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any());
+        verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any());
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/802

**Description of changes:**
When `--provision` option is set during setup, it currently creates the token exchange IAM role policy directly. Users may create the role/role alias/policy resources outside the setup in order to scope down the permissions needed on the device for setup even further. In that case, checking for the resource through the GetPolicy API first and creating only if the resource does not exist would be desirable.

**Why is this change necessary:**

**How was this change tested:**
Manually tested provisioning and starting nucleus

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
