### PR TITLE
improvement(various): No cloud calls if configured to run offline

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
@@ -70,6 +70,7 @@ class ComponentManagerIntegTest extends BaseITCase {
         ArtifactDownloader mockDownloader = mock(ArtifactDownloader.class);
         File artifactFile = store.resolveArtifactDirectoryPath(ident).resolve("zip.zip").toFile();
         when(mockDownloader.downloadRequired()).thenReturn(true);
+        when(mockDownloader.downloadReady()).thenReturn(true);
         when(mockDownloader.getArtifactFile()).thenReturn(artifactFile);
         when(mockDownloader.downloadToPath()).thenAnswer(downloadToPath("zip.zip", artifactFile));
 
@@ -118,6 +119,7 @@ class ComponentManagerIntegTest extends BaseITCase {
         File emptyFile = store.resolveArtifactDirectoryPath(ident).resolve("empty.txt").toFile();
         ArtifactDownloader mockDownloader = mock(ArtifactDownloader.class);
         when(mockDownloader.downloadRequired()).thenReturn(true);
+        when(mockDownloader.downloadReady()).thenReturn(true);
         when(mockDownloader.getArtifactFile()).thenReturn(scriptFile).thenReturn(emptyFile);
         when(mockDownloader.downloadToPath()).thenAnswer(downloadToPath("script.sh", scriptFile))
                 .thenAnswer(downloadToPath("empty.txt", emptyFile));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.aws.greengrass.testcommons.testutilities.Matchers.hasPermission;
@@ -70,7 +71,7 @@ class ComponentManagerIntegTest extends BaseITCase {
         ArtifactDownloader mockDownloader = mock(ArtifactDownloader.class);
         File artifactFile = store.resolveArtifactDirectoryPath(ident).resolve("zip.zip").toFile();
         when(mockDownloader.downloadRequired()).thenReturn(true);
-        when(mockDownloader.downloadReady()).thenReturn(true);
+        when(mockDownloader.checkDownloadable()).thenReturn(Optional.empty());
         when(mockDownloader.getArtifactFile()).thenReturn(artifactFile);
         when(mockDownloader.downloadToPath()).thenAnswer(downloadToPath("zip.zip", artifactFile));
 
@@ -119,7 +120,7 @@ class ComponentManagerIntegTest extends BaseITCase {
         File emptyFile = store.resolveArtifactDirectoryPath(ident).resolve("empty.txt").toFile();
         ArtifactDownloader mockDownloader = mock(ArtifactDownloader.class);
         when(mockDownloader.downloadRequired()).thenReturn(true);
-        when(mockDownloader.downloadReady()).thenReturn(true);
+        when(mockDownloader.checkDownloadable()).thenReturn(Optional.empty());
         when(mockDownloader.getArtifactFile()).thenReturn(scriptFile).thenReturn(emptyFile);
         when(mockDownloader.downloadToPath()).thenAnswer(downloadToPath("script.sh", scriptFile))
                 .thenAnswer(downloadToPath("empty.txt", emptyFile));

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -151,6 +151,12 @@ public class ComponentManager implements InjectionActions {
             // otherwise try to negotiate with cloud
             logger.atInfo().setEventType("negotiate-version-with-cloud-start").log("Negotiating version with cloud");
 
+            if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
+                throw new NoAvailableComponentVersionException(String.format(
+                        "Device is configured to run offline and no local applicable version found for component '%s' "
+                                + "satisfying requirement '%s'.", componentName, versionRequirements));
+            }
+
             resolvedComponentId =
                     negotiateVersionWithCloud(componentName, versionRequirements, localCandidateOptional.orElse(null));
 

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -369,9 +369,11 @@ public class ComponentManager implements InjectionActions {
             ArtifactDownloader downloader = artifactDownloaderFactory
                     .getArtifactDownloader(componentIdentifier, artifact, packageArtifactDirectory);
             if (downloader.downloadRequired()) {
-                if (!downloader.downloadReady()) {
+                Optional<String> errorMsg = downloader.checkDownloadable();
+                if (errorMsg.isPresent()) {
                     throw new PackageDownloadException(String.format(
-                            "Download required for artifact %s but device configs are invalid for download", artifact));
+                            "Download required for artifact %s but device configs are invalid:%n%s",
+                            artifact.getArtifactUri(), errorMsg.get()));
                 }
                 // Check disk size limits before download
                 // TODO: [P41215447]: Check artifact size for all artifacts to download early to fail early

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -372,7 +372,7 @@ public class ComponentManager implements InjectionActions {
                 Optional<String> errorMsg = downloader.checkDownloadable();
                 if (errorMsg.isPresent()) {
                     throw new PackageDownloadException(String.format(
-                            "Download required for artifact %s but device configs are invalid:%n%s",
+                            "Download required for artifact %s but device configs are invalid: %s",
                             artifact.getArtifactUri(), errorMsg.get()));
                 }
                 // Check disk size limits before download

--- a/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
@@ -53,8 +53,8 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROO
 public class GreengrassComponentServiceClientFactory {
 
     private static final Logger logger = LogManager.getLogger(GreengrassComponentServiceClientFactory.class);
-
     private GreengrassV2Client cmsClient;
+    private final boolean configValid;
 
     /**
      * Constructor with custom endpoint/region configuration.
@@ -63,6 +63,11 @@ public class GreengrassComponentServiceClientFactory {
      */
     @Inject
     public GreengrassComponentServiceClientFactory(DeviceConfiguration deviceConfiguration) {
+        if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
+            configValid = false;
+            return;
+        }
+        configValid = true;
         configureClient(deviceConfiguration);
         deviceConfiguration.onAnyChange((what, node) -> {
             if (validString(node, DEVICE_PARAM_AWS_REGION) || validPath(node, DEVICE_PARAM_ROOT_CA_PATH) || validPath(

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloader.java
@@ -28,6 +28,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class ArtifactDownloader {
@@ -230,9 +231,9 @@ public abstract class ArtifactDownloader {
 
     /**
      * Check whether the downloader has proper configs and is ready to download files.
-     * @return true if the downloader is ready for getDownloadSize, downloadToPath, etc. network calls
+     * @return Optional.empty if no errors and ready to download. Otherwise returns the error message string
      */
-    public abstract boolean downloadReady();
+    public abstract Optional<String> checkDownloadable();
 
     /**
      * Get the download size of the artifact file.

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloader.java
@@ -229,6 +229,12 @@ public abstract class ArtifactDownloader {
     }
 
     /**
+     * Check whether the downloader has proper configs and is ready to download files.
+     * @return true if the downloader is ready for getDownloadSize, downloadToPath, etc. network calls
+     */
+    public abstract boolean downloadReady();
+
+    /**
      * Get the download size of the artifact file.
      *
      * @return size of the artifact in bytes

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/GreengrassRepositoryDownloader.java
@@ -166,6 +166,11 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
         }
     }
 
+    @Override
+    public boolean downloadReady() {
+        return clientFactory.isConfigValid();
+    }
+
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
     private URL getArtifactDownloadURL(ComponentIdentifier componentIdentifier, String artifactName)
             throws InterruptedException, PackageDownloadException {

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/GreengrassRepositoryDownloader.java
@@ -28,6 +28,7 @@ import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 
 public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     private final ComponentStore componentStore;
@@ -167,8 +168,8 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     }
 
     @Override
-    public boolean downloadReady() {
-        return clientFactory.isConfigValid();
+    public Optional<String> checkDownloadable() {
+        return Optional.ofNullable(clientFactory.getConfigValidationError());
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/S3Downloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/S3Downloader.java
@@ -98,6 +98,11 @@ public class S3Downloader extends ArtifactDownloader {
         }
     }
 
+    @Override
+    public boolean downloadReady() {
+        return s3ClientFactory.isConfigValid();
+    }
+
     @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
     @Override
     public Long getDownloadSize() throws InterruptedException, PackageDownloadException {

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/S3Downloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/S3Downloader.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -99,8 +100,8 @@ public class S3Downloader extends ArtifactDownloader {
     }
 
     @Override
-    public boolean downloadReady() {
-        return s3ClientFactory.isConfigValid();
+    public Optional<String> checkDownloadable() {
+        return Optional.ofNullable(s3ClientFactory.getConfigValidationError());
     }
 
     @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.deployment;
 import com.aws.greengrass.dependency.InjectionActions;
 import com.aws.greengrass.deployment.exceptions.AWSIotException;
 import com.aws.greengrass.deployment.exceptions.ConnectionUnavailableException;
-import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import com.aws.greengrass.deployment.model.DeploymentTaskMetadata;
@@ -276,12 +275,11 @@ public class IotJobsHelper implements InjectionActions {
     @Override
     @SuppressFBWarnings
     public void postInject() {
-        try {
-            deviceConfiguration.validate();
-        } catch (DeviceConfigurationException e) {
-            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. Device will run in offline mode", e);
+        if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
+            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. IOT job deployment is offline");
             return;
         }
+
         mqttClient.addToCallbackEvents(callbacks);
         this.connection = wrapperMqttConnectionFactory.getAwsIotMqttConnection(mqttClient);
 

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -98,9 +98,8 @@ public class ShadowDeploymentListener implements InjectionActions {
 
     @Override
     public void postInject() {
-
         if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
-            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. Device will run in offline mode");
+            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. Single device deployment is offline");
             return;
         }
 

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -184,6 +184,10 @@ public class FleetStatusService extends GreengrassService {
         this.mqttClient.addToCallbackEvents(callbacks);
 
         TestFeatureParameters.registerHandlerCallback(this.getName(), this::handleTestFeatureParametersHandlerChange);
+
+        if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
+            this.isConnected.set(false);
+        }
     }
 
     @SuppressWarnings("PMD.UnusedFormalParameter")

--- a/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
@@ -142,15 +142,18 @@ public class TelemetryAgent extends GreengrassService {
         getPeriodicAggregateTimeTopic();
         getPeriodicPublishTimeTopic();
         schedulePeriodicAggregateMetrics(false);
-        schedulePeriodicPublishMetrics(false);
-
         // Subscribe to thing name changes.
         deviceConfiguration.getThingName()
                 .subscribe((why, node) -> updateThingNameAndPublishTopic(Coerce.toString(node)));
 
         if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
             this.isConnected.set(false);
+            // Right now the connection cannot be brought online without a restart.
+            // Skip setting up scheduled publish because it won't work
+            return;
         }
+
+        schedulePeriodicPublishMetrics(false);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
@@ -147,6 +147,10 @@ public class TelemetryAgent extends GreengrassService {
         // Subscribe to thing name changes.
         deviceConfiguration.getThingName()
                 .subscribe((why, node) -> updateThingNameAndPublishTopic(Coerce.toString(node)));
+
+        if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
+            this.isConnected.set(false);
+        }
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -27,6 +27,7 @@ public class S3SdkClientFactory {
     private static final Map<Region, S3Client> clientCache = new ConcurrentHashMap<>();
     private S3Client s3Client;
     private final LazyCredentialProvider credentialsProvider;
+    private final boolean configValid;
 
     /**
      * Constructor.
@@ -38,6 +39,11 @@ public class S3SdkClientFactory {
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public S3SdkClientFactory(DeviceConfiguration deviceConfiguration, LazyCredentialProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
+        if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
+            configValid = false;
+            return;
+        }
+        configValid = true;
         deviceConfiguration.getAWSRegion().subscribe((what, node) -> {
             Region region;
             try {

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
@@ -150,6 +150,7 @@ class ComponentManagerTest {
         recipeLoader = new RecipeLoader(platformResolver);
 
         lenient().when(artifactDownloader.downloadRequired()).thenReturn(true);
+        lenient().when(artifactDownloader.downloadReady()).thenReturn(true);
         lenient().when(artifactDownloaderFactory.getArtifactDownloader(any(), any(), any()))
                 .thenReturn(artifactDownloader);
         lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
@@ -150,7 +150,7 @@ class ComponentManagerTest {
         recipeLoader = new RecipeLoader(platformResolver);
 
         lenient().when(artifactDownloader.downloadRequired()).thenReturn(true);
-        lenient().when(artifactDownloader.downloadReady()).thenReturn(true);
+        lenient().when(artifactDownloader.checkDownloadable()).thenReturn(Optional.empty());
         lenient().when(artifactDownloaderFactory.getArtifactDownloader(any(), any(), any()))
                 .thenReturn(artifactDownloader);
         lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderTest.java
@@ -285,6 +285,11 @@ class ArtifactDownloaderTest {
         }
 
         @Override
+        public boolean downloadReady() {
+            return true;
+        }
+
+        @Override
         public Long getDownloadSize() {
             return (long) input.length();
         }

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/ArtifactDownloaderTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
@@ -285,8 +286,8 @@ class ArtifactDownloaderTest {
         }
 
         @Override
-        public boolean downloadReady() {
-            return true;
+        public Optional<String> checkDownloadable() {
+            return Optional.empty();
         }
 
         @Override

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -122,6 +122,7 @@ class IotJobsHelperTest {
         Topic mockThingNameTopic = mock(Topic.class);
         when(mockThingNameTopic.getOnce()).thenReturn(TEST_THING_NAME);
         when(deviceConfiguration.getThingName()).thenReturn(mockThingNameTopic);
+        when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         when(mockIotJobsClientFactory.getIotJobsClientWrapper(any())).thenReturn(mockIotJobsClientWrapper);
         when(mockWrapperMqttConnectionFactory.getAwsIotMqttConnection(any()))
                 .thenReturn(mockWrapperMqttClientConnection);

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -93,6 +93,7 @@ class MqttClientTest {
         Topics spoolerNamespace = config.lookupTopics("spooler");
         mqttNamespace.lookup(MqttClient.MQTT_OPERATION_TIMEOUT_KEY).withValue(0);
         when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttNamespace);
+        lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         lenient().when(deviceConfiguration.getSpoolerNamespace()).thenReturn(spoolerNamespace);
         lenient().when(builder.build()).thenReturn(mockConnection);
         lenient().when(mockConnection.connect()).thenReturn(CompletableFuture.completedFuture(false));

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -120,6 +120,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         lenient().when(mockGreengrassService2.getName()).thenReturn("MockService2");
         lenient().when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
+        when(mockDeviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         lenient().when(mockDeviceConfiguration.getNucleusVersion()).thenReturn(VERSION);
         Topic sequenceNumberTopic = Topic.of(context, FLEET_STATUS_SEQUENCE_NUMBER_TOPIC, "0");
         lenient().when(config.lookup(FLEET_STATUS_SEQUENCE_NUMBER_TOPIC)).thenReturn(sequenceNumberTopic);

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -111,6 +111,7 @@ class TelemetryAgentTest extends GGServiceTestUtil {
                 .thenReturn(lastPeriodicPublishTime);
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, "testThing");
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
+        when(mockDeviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
 
         lenient().when(config.lookup(DEVICE_PARAM_THING_NAME)).thenReturn(thingNameTopic);
         Topics configurationTopics = Topics.of(context, TELEMETRY_CONFIG_LOGGING_TOPICS, null);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Check if device is configured to run offline, then check and skip cloud calls in:
- IoTJobsHelper
- ShadowDeploymentListener
- MqttClient
- FleetStatusService
- TelemetryAgent
- ComponentManager

**Why is this change necessary:**
Avoid unnecessary cloud communication if device is configured to run offline.

**How was this change tested:**
While offline, install Nucleus and CLI, do a local deployment, then shutdown.
Tested with a Hello World recipe with an artifact declared without checksum.
Deployment succeeds. Also, if artifact doesn't exist, fails with expected error.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
