### PR TITLE
improvement: Make Greengrass-ATS endpoint configurable

### DIFF
--- a/aws.greengrass.Nucleus.yaml
+++ b/aws.greengrass.Nucleus.yaml
@@ -2,7 +2,7 @@
 RecipeFormatVersion: '2020-01-25'
 ComponentName: aws.greengrass.Nucleus
 ComponentType: aws.greengrass.nucleus
-ComponentDescription: Core functionality for device side orchestration of deployments and life-cycle management for execution of Greengrass components and applications. This includes features such as starting, stopping, and monitoring execution of components and apps, inter-process communication server for communication between components, component installation and configuration management. This is a fundamental cornerstone of open-sourcing Greengrass, providing documentation and ability to debug Greengrass Core.
+ComponentDescription: Core functionality for device side orchestration of deployments and lifecycle management for execution of Greengrass components and applications. This includes features such as starting, stopping, and monitoring execution of components and apps, inter-process communication server for communication between components, component installation and configuration management. This is a fundamental cornerstone of open-sourcing Greengrass, providing documentation and ability to debug Greengrass Core.
 ComponentPublisher: AWS
 ComponentVersion: '2.0.0'
 ComponentConfiguration:
@@ -10,6 +10,7 @@ ComponentConfiguration:
     jvmOptions: ""
     iotDataEndpoint: ""
     iotCredEndpoint: ""
+    greengrassDataPlanePort: 8443
     awsRegion: ""
     iotRoleAlias: ""
     mqtt: {}

--- a/codestyle/findbugs-exclude.xml
+++ b/codestyle/findbugs-exclude.xml
@@ -23,6 +23,7 @@
             <Package name="software.amazon.awssdk.aws.greengrass.model"/>
             <Package name="software.amazon.awssdk.eventstreamrpc"/>
             <Package name="software.amazon.awssdk.eventstreamrpc.model"/>
+            <Package name="software.amazon.awssdk.http.apache.internal.conn"/>
         </Or>
     </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -608,6 +608,17 @@
                                         <exclude>org/slf4j/impl/StaticLoggerBinder.class</exclude>
                                     </excludes>
                                 </filter>
+                                <!-- We provide our own SdkTlsSocketFactory to support ALPN, so make sure not to
+                                include this version from the SDK (though ours should be preferred anyway, just make
+                                sure here)
+                                Remove this if/when the SDK supports ALPN officially.
+                                !-->
+                                <filter>
+                                    <artifact>software.amazon.awssdk:apache-client:jar:*</artifact>
+                                    <excludes>
+                                        <exclude>software.amazon.awssdk.http.apache.internal.conn.SdkTlsSocketFactory.class</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                         </configuration>
                     </execution>

--- a/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
@@ -124,7 +124,8 @@ public class GreengrassComponentServiceClientFactory {
             logger.atError().setCause(e).log("Caught exception while parsing Nucleus args");
             throw new RuntimeException(e);
         }
-        return RegionUtils.getGreengrassDataPlaneEndpoint(Coerce.toString(deviceConfiguration.getAWSRegion()), stage);
+        return RegionUtils.getGreengrassDataPlaneEndpoint(Coerce.toString(deviceConfiguration.getAWSRegion()), stage,
+                Coerce.toInt(deviceConfiguration.getGreengrassDataPlanePort()));
     }
 
     private void configureClientMutualTLS(ApacheHttpClient.Builder httpBuilder,

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -90,6 +90,8 @@ public class DeviceConfiguration {
     public static final String DEVICE_PARAM_PROXY_PASSWORD = "password";
     public static final long COMPONENT_STORE_MAX_SIZE_DEFAULT_BYTES = 10_000_000_000L;
     public static final long DEPLOYMENT_POLLING_FREQUENCY_DEFAULT_SECONDS = 15L;
+    private static final String DEVICE_PARAM_GG_DATA_PLANE_PORT = "greengrassDataPlanePort";
+    private static final int GG_DATA_PLANE_PORT_DEFAULT = 8443;
 
     private static final String DEVICE_PARAM_ENV_STAGE = "envStage";
     private static final String DEFAULT_ENV_STAGE = "prod";
@@ -102,7 +104,6 @@ public class DeviceConfiguration {
     protected static final String NUCLEUS_BUILD_METADATA_FILENAME = "nucleus-build.properties";
     protected static final String NUCLEUS_BUILD_METADATA_DIRECTORY = "conf";
     protected static final String FALLBACK_VERSION = "0.0.0";
-
     private final Kernel kernel;
 
     private final Validator deTildeValidator;
@@ -359,6 +360,10 @@ public class DeviceConfiguration {
 
     public Topic getAWSRegion() {
         return getTopic(DEVICE_PARAM_AWS_REGION).dflt("").addValidator(regionValidator);
+    }
+
+    public Topic getGreengrassDataPlanePort() {
+        return getTopic(DEVICE_PARAM_GG_DATA_PLANE_PORT).dflt(GG_DATA_PLANE_PORT_DEFAULT);
     }
 
     // Why have this method as well as the one above? The reason is that the validator

--- a/src/main/java/com/aws/greengrass/util/RegionUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RegionUtils.java
@@ -14,9 +14,9 @@ public final class RegionUtils {
     private static final String IOT_CORE_CONTROL_PLANE_ENDPOINT_FORMAT = "https://%s.%s.iot.%s";
     private static final Map<IotSdkClientFactory.EnvironmentStage, String>
             GREENGRASS_DATA_PLANE_STAGE_TO_ENDPOINT_FORMAT = ImmutableMap.of(
-            IotSdkClientFactory.EnvironmentStage.PROD, "https://greengrass-ats.iot.%s.%s:8443",
-            IotSdkClientFactory.EnvironmentStage.GAMMA, "https://greengrass-ats.gamma.%s.iot.%s:8443",
-            IotSdkClientFactory.EnvironmentStage.BETA, "https://greengrass-ats.beta.%s.iot.%s:8443"
+            IotSdkClientFactory.EnvironmentStage.PROD, "https://greengrass-ats.iot.%s.%s:%s",
+            IotSdkClientFactory.EnvironmentStage.GAMMA, "https://greengrass-ats.gamma.%s.iot.%s:%s",
+            IotSdkClientFactory.EnvironmentStage.BETA, "https://greengrass-ats.beta.%s.iot.%s:%s"
     );
     private static final Map<IotSdkClientFactory.EnvironmentStage, String>
             GREENGRASS_CONTROL_PLANE_STAGE_TO_ENDPOINT_FORMAT = ImmutableMap.of(
@@ -44,12 +44,14 @@ public final class RegionUtils {
      * Get Greengrass Data Plane Endpoint by region and stage.
      * @param awsRegion aws region
      * @param stage environment stage
+     * @param port endpoint port
      * @return Greengrass ServiceEndpoint
      */
     public static String getGreengrassDataPlaneEndpoint(String awsRegion,
-                                                        IotSdkClientFactory.EnvironmentStage stage) {
+                                                        IotSdkClientFactory.EnvironmentStage stage,
+                                                        int port) {
         String dnsSuffix = Region.of(awsRegion).metadata().partition().dnsSuffix();
-        return String.format(GREENGRASS_DATA_PLANE_STAGE_TO_ENDPOINT_FORMAT.get(stage), awsRegion, dnsSuffix);
+        return String.format(GREENGRASS_DATA_PLANE_STAGE_TO_ENDPOINT_FORMAT.get(stage), awsRegion, dnsSuffix, port);
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
+++ b/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.http.apache.internal.conn;
+
+import org.apache.http.HttpHost;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.apache.internal.net.SdkSocket;
+import software.amazon.awssdk.http.apache.internal.net.SdkSslSocket;
+import software.amazon.awssdk.utils.Logger;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+
+/**
+ * Used to enforce the preferred TLS protocol during SSL handshake.
+ *
+ * Modified by Greengrass to add ALPN header.
+ */
+@SdkInternalApi
+public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
+
+    private static final Logger log = Logger.loggerFor(SdkTlsSocketFactory.class);
+    private final SSLContext sslContext;
+
+    public SdkTlsSocketFactory(final SSLContext sslContext, final HostnameVerifier hostnameVerifier) {
+        super(sslContext, hostnameVerifier);
+        if (sslContext == null) {
+            throw new IllegalArgumentException(
+                    "sslContext must not be null. " + "Use SSLContext.getDefault() if you are unsure.");
+        }
+        this.sslContext = sslContext;
+    }
+
+    /**
+     * {@inheritDoc} Used to enforce the preferred TLS protocol during SSL handshake.
+     */
+    @Override
+    protected final void prepareSocket(final SSLSocket socket) {
+        // BEGIN GG MODIFICATIONS
+        SSLParameters params = new SSLParameters();
+        params.setApplicationProtocols(new String[]{"x-amzn-http-ca", "http/1.1"});
+        socket.setSSLParameters(params);
+        // END GG MODIFICATIONS
+
+        String[] supported = socket.getSupportedProtocols();
+        String[] enabled = socket.getEnabledProtocols();
+        log.debug(() -> String.format("socket.getSupportedProtocols(): %s, socket.getEnabledProtocols(): %s",
+                                      Arrays.toString(supported),
+                                      Arrays.toString(enabled)));
+        List<String> target = new ArrayList<>();
+        if (supported != null) {
+            // Append the preferred protocols in descending order of preference
+            // but only do so if the protocols are supported
+            TlsProtocol[] values = TlsProtocol.values();
+            for (TlsProtocol value : values) {
+                String pname = value.getProtocolName();
+                if (existsIn(pname, supported)) {
+                    target.add(pname);
+                }
+            }
+        }
+        if (enabled != null) {
+            // Append the rest of the already enabled protocols to the end
+            // if not already included in the list
+            for (String pname : enabled) {
+                if (!target.contains(pname)) {
+                    target.add(pname);
+                }
+            }
+        }
+        if (target.size() > 0) {
+            String[] enabling = target.toArray(new String[0]);
+            socket.setEnabledProtocols(enabling);
+            log.debug(() -> "TLS protocol enabled for SSL handshake: " + Arrays.toString(enabling));
+        }
+    }
+
+    /**
+     * Returns true if the given element exists in the given array; false otherwise.
+     */
+    private boolean existsIn(String element, String[] a) {
+        for (String s : a) {
+            if (element.equals(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Socket connectSocket(
+            final int connectTimeout,
+            final Socket socket,
+            final HttpHost host,
+            final InetSocketAddress remoteAddress,
+            final InetSocketAddress localAddress,
+            final HttpContext context) throws IOException {
+        log.debug(() -> String.format("Connecting to %s:%s", remoteAddress.getAddress(), remoteAddress.getPort()));
+
+        Socket connectedSocket = super.connectSocket(connectTimeout, socket, host, remoteAddress, localAddress, context);
+
+        if (connectedSocket instanceof SSLSocket) {
+            return new SdkSslSocket((SSLSocket) connectedSocket);
+        }
+
+        return new SdkSocket(connectedSocket);
+    }
+
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Makes the Greengrass-ATS endpoint port configurable from 8443 (default) to 443 (optional).
Adds an option in the Nucleus configuration called "greengrassDataPlanePort" which can be configured through a deployment. Needed to copy `SdkTlsSocketFactory` from the SDK and override `prepareSocket` so that we can add ALPN to the socket before it is used by the SDK since the SDK has no such support for this right now.

Note to reviewers: do not review `SdkTlsSocketFactory` except for what is between the "modification markers". The rest of the code is directly from the SDK and should not be changed.

**Why is this change necessary:**
Some customers require that all traffic uses port 443, this change enables that functionality. Default is still to use port 8443.

**How was this change tested:**
Manually verified that when set to port 443 the nucleus is still able to perform a deployment (which requires that the ats endpoint is working correctly). Verified that without the changes to the SDK socket factory to add ALPN, we are rejected by the cloud.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
