### PR TITLE
fix: Catch NoSuchMethodError in ALPN implementation for old JDK8 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,11 +141,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sts</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>iam</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/PluginService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/PluginService.java
@@ -14,12 +14,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Map;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
 
-@Singleton
 public class PluginService extends GreengrassService {
     @Inject
     private EZPlugins ezPlugins;

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/PluginService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/PluginService.java
@@ -14,10 +14,12 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
 
+@Singleton
 public class PluginService extends GreengrassService {
     @Inject
     private EZPlugins ezPlugins;

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -39,11 +39,13 @@ public class S3SdkClientFactory {
     public S3SdkClientFactory(DeviceConfiguration deviceConfiguration, LazyCredentialProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
         deviceConfiguration.getAWSRegion().subscribe((what, node) -> {
-            Region region;
+            Region region = null;
             try {
                 region = new DefaultAwsRegionProviderChain().getRegion();
             } catch (RuntimeException ignored) {
-                region = Region.of(Coerce.toString(node));
+            }
+            if (region == null) {
+                region = Region.of(Coerce.toString(deviceConfiguration.getAWSRegion()));
             }
             this.s3Client =
                     S3Client.builder().httpClient(ProxyUtils.getSdkHttpClient())

--- a/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
+++ b/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
@@ -50,9 +50,16 @@ public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
     @Override
     protected final void prepareSocket(final SSLSocket socket) {
         // BEGIN GG MODIFICATIONS
-        SSLParameters params = new SSLParameters();
-        params.setApplicationProtocols(new String[]{"x-amzn-http-ca", "http/1.1"});
-        socket.setSSLParameters(params);
+        try {
+            SSLParameters params = new SSLParameters();
+            params.setApplicationProtocols(new String[]{"x-amzn-http-ca", "http/1.1"});
+            socket.setSSLParameters(params);
+        } catch (NoSuchMethodError e) {
+            log.debug(() -> "Unable to configure socket for ALPN. Ports other than 443 may not work.");
+            // Java 8 did not launch with ALPN support, but it was backported in April 2020 with JDK8u252.
+            // Catching the error here so that we can continue to work with older JDKs since the user may not
+            // even require ALPN to work.
+        }
         // END GG MODIFICATIONS
 
         String[] supported = socket.getSupportedProtocols();

--- a/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
+++ b/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
@@ -55,7 +55,7 @@ public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
             params.setApplicationProtocols(new String[]{"x-amzn-http-ca", "http/1.1"});
             socket.setSSLParameters(params);
         } catch (NoSuchMethodError e) {
-            log.debug(() -> "Unable to configure socket for ALPN. Ports other than 443 may not work.");
+            log.debug(() -> "Unable to configure socket for ALPN. Ports other than 443 may still work.");
             // Java 8 did not launch with ALPN support, but it was backported in April 2020 with JDK8u252.
             // Catching the error here so that we can continue to work with older JDKs since the user may not
             // even require ALPN to work.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Catches `NoSuchMethodError` in the ALPN implementation since ALPN did not launch with Java 8, but was only backported from Java 9 in April 2020 with JDK8u252. By catching the exception we will enable users to still use port 8443 without issue, it is just that port 443 won't work for the greengrass-ats endpoint.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
