### PR TITLE
fix(plugins): Require plugins to be singletons

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -434,7 +434,8 @@ public class Kernel {
                         ret = (GreengrassService) context.newInstance(clazz);
                     }
 
-                    if (clazz.getAnnotation(Singleton.class) != null) {
+                    // Force plugins to be singletons
+                    if (clazz.getAnnotation(Singleton.class) != null || PluginService.class.isAssignableFrom(clazz)) {
                         context.put(ret.getClass(), v);
                     }
                     if (clazz.getAnnotation(ImplementsService.class) != null) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
All plugin services should be singletons. Instead of requiring each plugin to add the singleton annotation, this change simply forces them to be singletons by identifying them as a subclass of `PluginService`. This change prevents unnecessary duplication of injected services.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
