### PR TITLE
fix(regions): Handle literal "null" region

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -290,7 +290,8 @@ public class DeviceConfiguration {
                     logger.atWarn().log("Error looking up AWS region", ex);
                 }
             }
-            if (Utils.isEmpty(region)) {
+            // Snow* devices have a null region
+            if (Utils.isEmpty(region) || "null".equals(region)) {
                 logger.atWarn().log("No AWS region found, falling back to default: {}", FALLBACK_DEFAULT_REGION);
                 region = FALLBACK_DEFAULT_REGION;
             }

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -44,7 +44,8 @@ public class S3SdkClientFactory {
                 region = new DefaultAwsRegionProviderChain().getRegion();
             } catch (RuntimeException ignored) {
             }
-            if (region == null) {
+            // Snow* devices have a null region
+            if (region == null || "null".equals(region.id())) {
                 region = Region.of(Coerce.toString(deviceConfiguration.getAWSRegion()));
             }
             this.s3Client =


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Snow* devices return the region as `"null"`, so this change handles that case and treats it as `null` so that we fallback to a real region.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
