### PR TITLE
log: provide detailed error message when device not configured to talk to cloud

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.deployment;
 import com.aws.greengrass.dependency.InjectionActions;
 import com.aws.greengrass.deployment.exceptions.AWSIotException;
 import com.aws.greengrass.deployment.exceptions.ConnectionUnavailableException;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import com.aws.greengrass.deployment.model.DeploymentTaskMetadata;
@@ -275,8 +276,12 @@ public class IotJobsHelper implements InjectionActions {
     @Override
     @SuppressFBWarnings
     public void postInject() {
-        if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
-            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. IOT job deployment is offline");
+        try {
+            // Not using isDeviceConfiguredToTalkToCloud() in order to provide the detailed error message to user
+            deviceConfiguration.validate();
+        } catch (DeviceConfigurationException e) {
+            logger.atWarn().log("Device not configured to talk to AWS Iot cloud. IOT job deployment is offline: {}",
+                    e.getMessage());
             return;
         }
 

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -122,7 +122,6 @@ class IotJobsHelperTest {
         Topic mockThingNameTopic = mock(Topic.class);
         when(mockThingNameTopic.getOnce()).thenReturn(TEST_THING_NAME);
         when(deviceConfiguration.getThingName()).thenReturn(mockThingNameTopic);
-        when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         when(mockIotJobsClientFactory.getIotJobsClientWrapper(any())).thenReturn(mockIotJobsClientWrapper);
         when(mockWrapperMqttConnectionFactory.getAwsIotMqttConnection(any()))
                 .thenReturn(mockWrapperMqttClientConnection);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Before: `[WARN] (main) com.aws.greengrass.deployment.IotJobsHelper: Device not configured to talk to AWS Iot cloud. IOT job deployment is offline`

After: `[WARN] (main) com.aws.greengrass.deployment.IotJobsHelper: Device not configured to talk to AWS Iot cloud. IOT job deployment is offline: [thingName cannot be empty, certificateFilePath cannot be empty, privateKeyPath cannot be empty, rootCaPath cannot be empty, iotDataEndpoint cannot be empty, iotCredEndpoint cannot be empty]. {}`

**Why is this change necessary:**
Provide some detailed reason for why device is offline.

**How was this change tested:**
Manually run nucleus without provisioning.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
