### PR TITLE
fix(shadow): prevent duplicated shadow deployment at startup

### DIFF
--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -56,7 +56,6 @@ import java.util.stream.Collectors;
 
 import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
-import static com.aws.greengrass.deployment.DeploymentService.LAST_SUCCESSFUL_SHADOW_DEPLOYMENT_ID_TOPIC;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
@@ -137,9 +136,6 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         deploymentQueue = new DeploymentQueue();
         deploymentService.setDeploymentsQueue(deploymentQueue);
-        Topic lastSuccessfulDeploymentId = Topic.of(context, LAST_SUCCESSFUL_SHADOW_DEPLOYMENT_ID_TOPIC, null);
-        lenient().when(config.lookup(LAST_SUCCESSFUL_SHADOW_DEPLOYMENT_ID_TOPIC))
-                .thenReturn(lastSuccessfulDeploymentId);
     }
 
     @AfterEach


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add a check for the first shadow doc received since startup. Ignore the deployment if `reported` section exists and the ARN matches desired ARN. Because the deployment had already been processed and reported.

**Why is this change necessary:**
Fix duplicated shadow deployment when nucleus restarts.

**How was this change tested:**
Manual tests:
On EC2:
- From cloud console, deploy a component to the device that will run successfully
- Verify shadow status reported as success
- restart
- Verify log has `Deployment result already reported. Ignoring shadow update at startup.` for the previous deployment config ARN. No duplicate deployment queued
- Deploy a component to the device that will take a long time to install
- Verify shadow status reported as in progress
- restart
- Verify last device deployment is picked up again and can finish successfully.
- Deploy a component to the device that will fail to install
- Verify shadow status reported as failure
- restart
- Verify log has `Deployment result already reported. Ignoring shadow update at startup.` for the previous deployment config ARN. No duplicate deployment queued
- Deploy a component that takes long to install
- Cancel deployment before it finishes
- Verify desired shadow status is `canceled` and reported status is `in_progress`
- restart
- Verify log has `Deployment was canceled. Ignoring shadow update at startup` for the previous deployment config ARN. No duplicate deployment queued

Adding UAT scenario for the above manual test plan.

`@Smoke` run on ubuntu DUT all passed.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
