### PR TITLE
fix(spooler): Improving spooler latency

### DIFF
--- a/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
@@ -56,6 +56,19 @@ class InMemorySpoolTest {
     }
 
     @Test
+    void GIVEN_publish_request_should_not_be_null_WHEN_pop_id_THEN_continue_if_request_is_null() throws InterruptedException, SpoolerStoreException {
+        PublishRequest request = PublishRequest.builder().topic("spool").payload(new byte[0])
+                .qos(QualityOfService.AT_MOST_ONCE).build();
+
+        long id1 = spool.addMessage(request);
+        long id2 = spool.addMessage(request);
+        spool.removeMessageById(id1);
+
+        long id = spool.popId();
+        assertEquals(id2, id);
+    }
+
+    @Test
     void GIVEN_spooler_is_not_full_WHEN_add_message_THEN_add_message_without_message_dropped() throws InterruptedException, SpoolerStoreException {
         PublishRequest request = PublishRequest.builder().topic("spool").payload(new byte[0])
                 .qos(QualityOfService.AT_MOST_ONCE).build();


### PR DESCRIPTION

**Description of changes:**
In the MqttClient, instead of using the  ScheduledExecutorService, executorService is used to control the spooling process. While the mqttClient is online, the spooler always working and waiting for the next available message if the the queue is empty. 

**Why is this change necessary:**
Original, the spooler would sleep for 5 seconds if the queue is empty. The sleeping time would result in the latency of the message publishing. 

**How was this change tested:**
test with "mvn verify"

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
