### PR TITLE
feat(fleetstatusservice): make periodic update interval for Fleet Status Service configurable

### DIFF
--- a/README_CONFIG_SCHEMA.md
+++ b/README_CONFIG_SCHEMA.md
@@ -161,6 +161,8 @@ services:
       iotCredEndpoint: "xxxxxx.credentials.iot.us-east-1.amazonaws.com"
       iotDataEndpoint: "xxxxxx-ats.iot.us-east-1.amazonaws.com"
       iotRoleAlias: "tes_alias"
+      fleetStatus:
+        periodicStatusPublishIntervalSeconds: "86400"
       logging:
         level: INFO
         fileSizeKB: 1024

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -93,7 +93,7 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
                     fssRunning.countDown();
                 }
                 FleetStatusService fleetStatusService = (FleetStatusService) service;
-                fleetStatusService.setPeriodicUpdateIntervalSec(5);
+                fleetStatusService.setPeriodicPublishIntervalSec(5);
                 fleetStatusService.schedulePeriodicFleetStatusDataUpdate(false);
             }
             if (service.getName().equals(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
@@ -41,7 +41,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
-import static com.aws.greengrass.status.FleetStatusService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
+import static com.aws.greengrass.status.FleetStatusService.DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC;
 import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.DEFAULT_TELEMETRY_METRICS_PUBLISH_TOPIC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_AGENT_SERVICE_TOPICS;
@@ -82,7 +82,7 @@ class TelemetryAgentTest extends BaseITCase {
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any()))
                 .thenReturn(publishInterval);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC), any()))
-                .thenReturn(DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC);
+                .thenReturn(DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC);
         TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -105,6 +105,7 @@ public class DeviceConfiguration {
     public static final String RUN_WITH_DEFAULT_WINDOWS_USER = "windowsUser";
     public static final String RUN_WITH_DEFAULT_POSIX_SHELL = "posixShell";
     public static final String RUN_WITH_DEFAULT_POSIX_SHELL_VALUE = "sh";
+    public static final String FLEET_STATUS_CONFIG_TOPICS = "fleetStatus";
 
     public static final String IOT_ROLE_ALIAS_TOPIC = "iotRoleAlias";
     public static final String COMPONENT_STORE_MAX_SIZE_BYTES = "componentStoreMaxSizeBytes";
@@ -220,6 +221,15 @@ public class DeviceConfiguration {
      */
     public Topics getTelemetryConfigurationTopics() {
         return getTopics(TELEMETRY_CONFIG_LOGGING_TOPICS);
+    }
+
+    /**
+     * Get the fleet status configuration.
+     *
+     * @return Configuration for fleet status service.
+     */
+    public Topics getStatusConfigurationTopics() {
+        return getTopics(FLEET_STATUS_CONFIG_TOPICS);
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -51,7 +51,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
@@ -61,10 +60,11 @@ import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ST
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_TYPE_KEY_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
+import static com.aws.greengrass.deployment.DeviceConfiguration.FLEET_STATUS_CONFIG_TOPICS;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.IOT_JOBS;
-import static com.aws.greengrass.status.FleetStatusService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
+import static com.aws.greengrass.status.FleetStatusService.DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC;
 import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC;
-import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC;
+import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC;
 import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_SEQUENCE_NUMBER_TOPIC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -147,7 +147,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     void GIVEN_component_status_change_WHEN_deployment_finishes_THEN_MQTT_Sent_with_fss_data_with_overall_healthy_state()
             throws ServiceLoadException, IOException, InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
         Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
@@ -173,12 +174,12 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockDeploymentService.getConfig()).thenReturn(config);
         when(mockDeploymentService.isComponentRoot("MockService")).thenReturn(true);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
+
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the job status for an ongoing deployment to SUCCEEDED.
@@ -237,7 +238,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     void GIVEN_component_status_changes_to_broken_WHEN_deployment_finishes_THEN_MQTT_Sent_with_fss_data_with_overall_unhealthy_state()
             throws ServiceLoadException, IOException, InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
         Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
@@ -259,12 +261,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
 
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the job status for an ongoing deployment to IN_PROGRESS.
@@ -313,17 +314,17 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_component_status_change_WHEN_deployment_does_not_finish_THEN_No_MQTT_Sent_with_fss_data() throws InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
 
         // Set up all the mocks
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the state of an EG service.
@@ -343,18 +344,18 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_component_status_change_WHEN_MQTT_connection_interrupted_THEN_No_MQTT_Sent_with_fss_data() throws InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
 
         // Set up all the mocks
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
         doNothing().when(mockMqttClient).addToCallbackEvents(mqttClientConnectionEventsArgumentCaptor.capture());
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         Map<String, Object> map = new HashMap<>();
@@ -380,7 +381,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     void GIVEN_component_status_change_WHEN_periodic_update_triggered_THEN_MQTT_Sent_with_fss_data_with_overall_healthy_state()
             throws InterruptedException, ServiceLoadException, IOException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "3");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("3");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
         Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
@@ -401,12 +403,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS(3);
+        fleetStatusService = createFSS(3);
         fleetStatusService.startup();
 
         TimeUnit.SECONDS.sleep(5);
@@ -433,7 +434,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     void GIVEN_periodic_update_less_than_default_WHEN_config_read_THEN_sets_publish_interval_to_default()
             throws InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "3");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("3");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
         Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
@@ -448,22 +450,52 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         // Set up all the mocks
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
-        assertEquals(DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC, fleetStatusService.getPeriodicUpdateIntervalSec());
+        assertEquals(DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC, fleetStatusService.getPeriodicPublishIntervalSec());
+    }
+
+    @Test
+    void GIVEN_periodic_update_more_than_default_WHEN_config_read_THEN_sets_publish_interval_to_correct_value()
+            throws InterruptedException {
+        // Set up all the topics
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("90000");
+        Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
+        Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
+        Topic groupTopic1 = Topic.of(context, "arn:aws:greengrass:testRegion:12345:configuration:testGroup:12",
+                true);
+        groupsTopics.children.put(new CaseInsensitiveString("MockService"), groupTopic1);
+        groupsTopics2.children.put(new CaseInsensitiveString("MockService2"), groupTopic1);
+        allComponentToGroupsTopics.children.put(new CaseInsensitiveString("MockService"), groupsTopics);
+        allComponentToGroupsTopics.children.put(new CaseInsensitiveString("MockService2"), groupsTopics2);
+        lenient().when(config.lookupTopics(COMPONENTS_TO_GROUPS_TOPICS)).thenReturn(allComponentToGroupsTopics);
+
+        // Set up all the mocks
+        when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
+        doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
+        when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
+
+        // Create the fleet status service instance
+        fleetStatusService = createFSS();
+        fleetStatusService.startup();
+
+        assertEquals(90000, fleetStatusService.getPeriodicPublishIntervalSec());
     }
 
     @Test
     void GIVEN_component_removed_WHEN_deployment_finishes_THEN_MQTT_Sent_with_fss_data_with_overall_healthy_state()
             throws ServiceLoadException, IOException, InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         lenient().when(config.lookupTopics(COMPONENTS_TO_GROUPS_TOPICS)).thenReturn(allComponentToGroupsTopics);
 
@@ -476,12 +508,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singletonList(mockDeploymentService));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the job status for an ongoing deployment to IN_PROGRESS.
@@ -532,7 +563,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     void GIVEN_after_deployment_WHEN_component_status_changes_to_broken_THEN_MQTT_Sent_with_fss_data_with_overall_unhealthy_state()
             throws ServiceLoadException, IOException, InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
         Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
@@ -552,12 +584,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
 
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the state of an EG service.
@@ -586,17 +617,17 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_during_deployment_WHEN_periodic_update_triggered_THEN_No_MQTT_Sent() throws InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "3000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("3000");
 
         // Set up all the mocks
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the job status for an ongoing deployment to IN_PROGRESS.
@@ -615,7 +646,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     void GIVEN_MQTT_connection_interrupted_WHEN_connection_resumes_THEN_MQTT_Sent_with_event_triggered_fss_data()
             throws ServiceLoadException, IOException, InterruptedException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
         Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
@@ -639,13 +671,12 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockKernel.orderedDependencies()).thenReturn(Arrays.asList(mockGreengrassService1, mockGreengrassService2));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
         doNothing().when(mockMqttClient).addToCallbackEvents(mqttClientConnectionEventsArgumentCaptor.capture());
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the job status for an ongoing deployment to SUCCEEDED.
@@ -703,7 +734,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     void GIVEN_MQTT_connection_interrupted_WHEN_connection_resumes_THEN_MQTT_Sent_with_periodic_triggered_fss_data()
             throws InterruptedException, ServiceLoadException, IOException {
         // Set up all the topics
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "3");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("3");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupsTopics = Topics.of(context, "MockService", allComponentToGroupsTopics);
         Topics groupsTopics2 = Topics.of(context, "MockService2", allComponentToGroupsTopics);
@@ -723,13 +755,12 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
         doNothing().when(mockMqttClient).addToCallbackEvents(mqttClientConnectionEventsArgumentCaptor.capture());
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS(3);
+        fleetStatusService = createFSS(3);
         fleetStatusService.startup();
         mqttClientConnectionEventsArgumentCaptor.getValue().onConnectionInterrupted(500);
 
@@ -762,7 +793,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             throws ServiceLoadException, IOException, InterruptedException {
         // Set up all the topics
         int numServices = 1500;
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC, "10000");
+        Topics statusConfigTopics = Topics.of(context, FLEET_STATUS_CONFIG_TOPICS, null);
+        statusConfigTopics.createLeafChild(FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC).withValue("10000");
         Topics allComponentToGroupsTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topic groupTopic1 = Topic.of(context, "arn:aws:greengrass:testRegion:12345:configuration:testGroup:12",
                 true);
@@ -790,12 +822,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockKernel.orderedDependencies()).thenReturn(greengrassServices);
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, FLEET_STATUS_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockDeviceConfiguration.getStatusConfigurationTopics()).thenReturn(statusConfigTopics);
         when(context.get(ScheduledExecutorService.class)).thenReturn(ses);
 
         // Create the fleet status service instance
-        fleetStatusService = createFCS();
+        fleetStatusService = createFSS();
         fleetStatusService.startup();
 
         // Update the job status for an ongoing deployment to SUCCEEDED.
@@ -838,13 +869,13 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertThat(serviceNamesToCheck, is(IsEmptyCollection.empty()));
     }
 
-    private FleetStatusService createFCS() {
+    private FleetStatusService createFSS() {
         PlatformResolver platformResolver = new PlatformResolver(null);
         return new FleetStatusService(config, mockMqttClient,
                 mockDeploymentStatusKeeper, mockKernel, mockDeviceConfiguration, platformResolver);
     }
 
-    private FleetStatusService createFCS(int periodicUpdateIntervalSec) {
+    private FleetStatusService createFSS(int periodicUpdateIntervalSec) {
         PlatformResolver platformResolver = new PlatformResolver(null);
         return new FleetStatusService(config, mockMqttClient,
                 mockDeploymentStatusKeeper, mockKernel, mockDeviceConfiguration, platformResolver,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If the configured value is less than the default (84600 seconds), then it is set to the default.
If the configured value is more than the default, then the periodic update interval for FSS is set to that configured value.

**Why is this change necessary:**
To ensure that the customers have the ability to increase the cadence at which the status of the device is sent periodically.

**How was this change tested:**
Added unit tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [X] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
