### PR TITLE
fix(mqtt): Terminate previous mqtt session when creating a new connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## v2.0.4
+
 ### Note to users:
 * Automatic provisioning using `--provision true` now requires `iam:GetPolicy` and `sts:GetCallerIdentity`. See
   [our documentation](https://docs.aws.amazon.com/greengrass/v2/developerguide/install-greengrass-core-v2.html#provision-minimal-iam-policy) for the full updated set of minimum permissions.
+
 ### New features:
 * Enable HTTPS traffic over port 443. You use the new greengrassDataPlanePort configuration parameter for the nucleus component to configure HTTPS communication to travel over port 443 instead of the default port 8443. (#811)(328ad0a9)
 * Add the work path recipe variable. You can use this recipe variable to get the path to components' work folders, which you can use to share files between components and their dependencies. (0fa011b)

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
@@ -69,4 +69,39 @@ class MqttTest extends BaseE2ETestCase {
 
         assertTrue(cdl.await(1, TimeUnit.MINUTES), "All messages published and received");
     }
+
+    @Test
+    void GIVEN_mqttclient_WHEN_closes_new_connection_is_created_THEN_previous_session_is_invalidated()
+            throws Throwable {
+        kernel = new Kernel().parseArgs("-r", tempRootDir.toAbsolutePath().toString());
+        setDefaultRunWithUser(kernel);
+        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, GAMMA_REGION.toString(),
+                TES_ROLE_ALIAS_NAME);
+
+        MqttClient client = kernel.getContext().get(MqttClient.class);
+
+        //subscribe to 50 topics using first connection.
+        int numberOfTopics = 50;
+        for (int i = 0; i < numberOfTopics; i++) {
+            client.subscribe(SubscribeRequest.builder().topic("A/"+ i).callback((m) -> {}).build());
+        }
+        //close the first connections and create a second connection.
+        client.close();
+        client = kernel.getContext().newInstance(MqttClient.class);
+        CountDownLatch cdl = new CountDownLatch(numberOfTopics);
+        // Using the second connection to subscribes to another 50 topics, IoT core limits subscriptions to 50 topics per connection.
+        // if the session from first connection is not terminated, subscribe operations made by second connection will not succeed.
+        for (int i = 0; i < numberOfTopics; i++) {
+            client.subscribe(SubscribeRequest.builder().topic("B/"+ i ).callback((m) -> {
+                cdl.countDown();
+                logger.atInfo().kv("remaining", cdl.getCount()).log("Received 1 message from cloud.");
+            }).build());
+        }
+        for (int i = 0; i < numberOfTopics; i++) {
+            client.publish(PublishRequest.builder().topic("B/"+ i ).payload("What's up".getBytes(StandardCharsets.UTF_8))
+                    .build()).get(5, TimeUnit.SECONDS);
+            logger.atInfo().kv("total", i + 1).log("Added 1 message to spooler.");
+        }
+        assertTrue(cdl.await(1, TimeUnit.MINUTES), "All messages published and received");
+    }
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -287,6 +287,7 @@ public class MqttClient implements Closeable {
         eventLoopGroup = new EventLoopGroup(Coerce.toInt(mqttTopics.findOrDefault(1, MQTT_THREAD_POOL_SIZE_KEY)));
         hostResolver = new HostResolver(eventLoopGroup);
         clientBootstrap = new ClientBootstrap(eventLoopGroup, hostResolver);
+        this.builderProvider = builderProvider;
         this.spool = spool;
         this.mqttOnline.set(mqttOnline);
         this.builderProvider = builderProvider;

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -282,6 +282,7 @@ public class MqttClient implements Closeable {
     protected MqttClient(DeviceConfiguration deviceConfiguration, Spool spool, boolean mqttOnline,
                          Function<ClientBootstrap, AwsIotMqttConnectionBuilder> builderProvider,
                          ExecutorService executorService) {
+
         this.deviceConfiguration = deviceConfiguration;
         mqttTopics = this.deviceConfiguration.getMQTTNamespace();
         eventLoopGroup = new EventLoopGroup(Coerce.toInt(mqttTopics.findOrDefault(1, MQTT_THREAD_POOL_SIZE_KEY)));

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -29,11 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings("PMD.CloseResource")
 @ExtendWith({GGExtension.class, MockitoExtension.class})
@@ -84,8 +80,8 @@ class AwsIotMqttClientTest {
 
         assertTrue(client.connected());
         client.reconnect();
-        verify(connection).close();
-        verify(connection).disconnect();
+        verify(connection, times(2)).close();
+        verify(connection, times(2)).disconnect();
         assertTrue(client.connected());
 
         // Ensure that we track connection state through the callbacks
@@ -97,8 +93,37 @@ class AwsIotMqttClientTest {
 
         client.close();
         assertFalse(client.connected());
+        verify(connection, times(3)).disconnect();
+        verify(connection, times(3)).close();
+    }
+
+    @Test
+    void GIVEN_individual_client_THEN_client_connects_and_disconnects_only_for_initial_connect() {
+        when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
+        when(connection.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));
+        when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
+        when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
+        when(builder.build()).thenReturn(connection);
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+                callbackEventManager);
+
+        //initial connect, client connects, disconnects and then connects
+        client.subscribe("A", QualityOfService.AT_LEAST_ONCE);
+        verify(connection, times(2)).connect();
+        verify(connection, times(1)).disconnect();
+
+        //client connected, no change in connect/disconnect calls
+        client.subscribe("B", QualityOfService.AT_LEAST_ONCE);
+        verify(connection, times(2)).connect();
+        verify(connection, times(1)).disconnect();
+        //client calls disconnect
+        client.disconnect();
         verify(connection, times(2)).disconnect();
-        verify(connection, times(2)).close();
+
+        //client calls connect
+        client.subscribe("C", QualityOfService.AT_LEAST_ONCE);
+        verify(connection, times(3)).connect();
+
     }
 
     @Test
@@ -108,6 +133,7 @@ class AwsIotMqttClientTest {
         CompletableFuture<Boolean> fut = new CompletableFuture<>();
         fut.completeExceptionally(new Exception("ex"));
         when(connection.connect()).thenReturn(fut);
+        when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
         when(connection.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
 

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -335,6 +335,7 @@ class MqttClientTest {
     @Test
     void GIVEN_keep_qos_0_when_offline_is_false_and_mqtt_is_offline_WHEN_publish_THEN_future_complete_exceptionally()
             throws InterruptedException, SpoolerStoreException {
+
         MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
         PublishRequest request = PublishRequest.builder().topic("spool").payload(new byte[0])
                 .qos(QualityOfService.AT_MOST_ONCE).build();
@@ -382,8 +383,8 @@ class MqttClientTest {
     @Test
     void GIVEN_add_message_to_spooler_throw_spooler_load_exception_WHEN_publish_THEN_return_future_complete_exceptionally(ExtensionContext context)
             throws SpoolerStoreException, InterruptedException {
-        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
 
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
         PublishRequest request = PublishRequest.builder().topic("spool").payload(new byte[10])
                 .qos(QualityOfService.AT_LEAST_ONCE).build();
         when(spool.addMessage(any())).thenThrow(new SpoolerStoreException("spooler is full"));
@@ -415,8 +416,8 @@ class MqttClientTest {
     @Test
     void GIVEN_publish_request_successfully_WHEN_spool_single_message_THEN_remove_message_from_spooler_queue()
             throws InterruptedException {
-        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, true, (c) -> builder, executorService));
 
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, true, (c) -> builder, executorService));
         long id = 1L;
         when(spool.popId()).thenReturn(id);
         PublishRequest request = PublishRequest.builder().topic("spool")
@@ -500,9 +501,9 @@ class MqttClientTest {
         ignoreExceptionOfType(context, ExecutionException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
 
-
         MqttClient client = spy(new MqttClient(deviceConfiguration, spool, true, (c) -> builder, executorService));
         client.setMqttOnline(true);
+
         long id = 1L;
         when(spool.popId()).thenReturn(id).thenReturn(id).thenThrow(InterruptedException.class);
         PublishRequest request = PublishRequest.builder().topic("spool")


### PR DESCRIPTION
**Issue #, if available:**

Greengrass v2 currently tracks the number of subscriptions that each MQTT client made, since IoT Core limits subscriptions to 50 per connection. This has a bit of a conflict when Greengrass restarts because Greengrass no longer knows how many subscriptions the client has; it would assume that the client has 0 subscriptions, even though it connected with a persistent session which may have resubscribe to up to 50 topics.

The behavior of the client which has over-subscribed is that the initial 50 subscriptions work correctly, but subsequent subscriptions, despite not erroring in anyway, simply do not work (no messages come in for them).

**Description of changes:**

When a new mqtt connection is made, the client connects with cleansession = true, then disconnects and connects with cleansession = false. This invalidates the session with IoT Core. This is done the first time a connection is established, for subsequent connects the client uses cleansession = false.

**How was this change tested:**
Unit and E2E tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ X] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
