### PR TITLE
fix(deployment): Get the correct configuration map from the new deployment configuration

### DIFF
--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.WAIT_SVC_START_POLL_INTERVAL_MILLISEC;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
@@ -424,10 +425,12 @@ class DeploymentConfigMergerTest {
         Map<String, Object> newConfig = new HashMap<>();
         Map<String, Object> newConfig2 = new HashMap<>();
         Map<String, Object> newConfig3 = new HashMap<>();
-        newConfig3.put(DEVICE_PARAM_AWS_REGION, "us-east-1");
-        newConfig3.put(DEVICE_PARAM_IOT_CRED_ENDPOINT, "xxxxxx.credentials.iot.us-east-1.amazonaws.com");
-        newConfig3.put(DEVICE_PARAM_IOT_DATA_ENDPOINT, "xxxxxx-ats.iot.us-east-1.amazonaws.com");
+        Map<String, Object> newConfig4 = new HashMap<>();
+        newConfig4.put(DEVICE_PARAM_AWS_REGION, "us-east-1");
+        newConfig4.put(DEVICE_PARAM_IOT_CRED_ENDPOINT, "xxxxxx.credentials.iot.us-east-1.amazonaws.com");
+        newConfig4.put(DEVICE_PARAM_IOT_DATA_ENDPOINT, "xxxxxx-ats.iot.us-east-1.amazonaws.com");
 
+        newConfig3.put(CONFIGURATION_CONFIG_KEY, newConfig4);
         newConfig2.put(DEFAULT_NUCLEUS_COMPONENT_NAME, newConfig3);
         newConfig.put(SERVICES_NAMESPACE_TOPIC, newConfig2);
         // GIVEN
@@ -486,7 +489,9 @@ class DeploymentConfigMergerTest {
         Map<String, Object> newConfig = new HashMap<>();
         Map<String, Object> newConfig2 = new HashMap<>();
         Map<String, Object> newConfig3 = new HashMap<>();
-        newConfig3.put(DEVICE_PARAM_AWS_REGION, "us-east-1");
+        Map<String, Object> newConfig4 = new HashMap<>();
+        newConfig4.put(DEVICE_PARAM_AWS_REGION, "us-east-1");
+        newConfig3.put(CONFIGURATION_CONFIG_KEY, newConfig4);
         newConfig2.put(DEFAULT_NUCLEUS_COMPONENT_NAME, newConfig3);
         newConfig.put(SERVICES_NAMESPACE_TOPIC, newConfig2);
         // GIVEN


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, it was getting the entire Nucleus namespace topics. This will ensure we get the correct map containing just the configuration for Nucleus based on the new deployment.

**Why is this change necessary:**
We want the deployment to fail on bad configurations for IoT credentials and data endpoints.

**How was this change tested:**
Updated unit tests. Added UATs.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
