### PR TITLE
improvement: add work path interpolation

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -61,6 +61,7 @@ public class KernelConfigResolver {
     public static final String PREV_VERSION_CONFIG_KEY = "previousVersion";
     public static final String CONFIGURATION_CONFIG_KEY = "configuration";
     static final String ARTIFACTS_NAMESPACE = "artifacts";
+    static final String WORK_NAMESPACE = "work";
     static final String KERNEL_NAMESPACE = "kernel";
     static final String KERNEL_ROOT_PATH = "rootPath";
     static final String PARAM_NAMESPACE = "params";
@@ -117,6 +118,10 @@ public class KernelConfigResolver {
         artifactNamespace
                 .put(DECOMPRESSED_PATH_KEY, (id) -> nucleusPaths.unarchiveArtifactPath(id).toAbsolutePath().toString());
         systemParameters.put(ARTIFACTS_NAMESPACE, artifactNamespace);
+
+        HashMap<String, CrashableFunction<ComponentIdentifier, String, IOException>> workNamespace = new HashMap<>();
+        workNamespace.put(PATH_KEY, (id) -> nucleusPaths.workPath(id.getName()).toAbsolutePath().toString());
+        systemParameters.put(WORK_NAMESPACE, workNamespace);
 
         HashMap<String, CrashableFunction<ComponentIdentifier, String, IOException>> kernelNamespace = new HashMap<>();
         kernelNamespace.put(KERNEL_ROOT_PATH, (id) -> nucleusPaths.rootPath().toAbsolutePath().toString());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add `{[component]:work:path}` to available `systemParamters` in KernelConfigResolver to support recipe variable interpolation of work paths.

**Why is this change necessary:**
Enable recipes to specify work path of dependency components through variable interpolation.

**How was this change tested:**
Unit test

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
