### PR TITLE
fix(platform resolver): determine if on macos using os.name instead of uname -a

### DIFF
--- a/src/main/java/com/aws/greengrass/config/PlatformResolver.java
+++ b/src/main/java/com/aws/greengrass/config/PlatformResolver.java
@@ -94,22 +94,22 @@ public class PlatformResolver {
         return platform;
     }
 
+    /**
+     * Get the OS type for this system.
+     *
+     * @return one of our supported identified OSes
+     */
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-    private static String getOSInfo() {
+    public static String getOSInfo() {
         if (isWindows) {
             return OS_WINDOWS;
         }
-        try {
-            String sysver = Exec.sh("uname -a").toLowerCase();
-
-            if (sysver.contains("darwin")) {
-                return OS_DARWIN;
-            }
-            if (Files.exists(Paths.get("/proc"))) {
-                return OS_LINUX;
-            }
-        } catch (IOException | InterruptedException e) {
-            logger.error("Error trying to determine OS", e);
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.contains("mac os")) {
+            return OS_DARWIN;
+        }
+        if (Files.exists(Paths.get("/proc"))) {
+            return OS_LINUX;
         }
         return UNKNOWN_KEYWORD;
     }

--- a/src/main/java/com/aws/greengrass/util/platforms/Platform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/Platform.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.util.platforms;
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.FileSystemPermission;
 import com.aws.greengrass.util.FileSystemPermission.Option;
 import com.aws.greengrass.util.platforms.unix.DarwinPlatform;
@@ -21,24 +20,12 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
 
+import static com.aws.greengrass.config.PlatformResolver.OS_DARWIN;
+
 public abstract class Platform implements UserPlatform {
     public static final Logger logger = LogManager.getLogger(Platform.class);
 
     private static Platform INSTANCE;
-
-    private static final String UNIX_SYS_VER = getUnixSysVer();
-
-    private static String getUnixSysVer() {
-        if (PlatformResolver.isWindows) {
-            return "";
-        }
-        try {
-            return Exec.sh("uname -a").toLowerCase();
-        } catch (InterruptedException | IOException e) {
-            logger.atError().setCause(e).log("Error in running uname -a");
-        }
-        return "";
-    }
 
     /**
      * Get the appropriate instance of Platform for the current platform.
@@ -52,10 +39,10 @@ public abstract class Platform implements UserPlatform {
 
         if (PlatformResolver.isWindows) {
             INSTANCE = new WindowsPlatform();
-        } else if (UNIX_SYS_VER.contains("qnx")) {
-            INSTANCE = new QNXPlatform();
-        } else if (UNIX_SYS_VER.contains("darwin") || UNIX_SYS_VER.contains("macos")) {
+        } else if (OS_DARWIN.equals(PlatformResolver.getOSInfo())) {
             INSTANCE = new DarwinPlatform();
+        } else if (System.getProperty("os.name").toLowerCase().contains("qnx")) {
+            INSTANCE = new QNXPlatform();
         } else {
             INSTANCE = new UnixPlatform();
         }


### PR DESCRIPTION
**Issue #, if available:**
Closes #837 

**Description of changes:**
Instead of using `uname -a` to determine the platform, switch to using `os.name` from the Java system properties.

**Why is this change necessary:**
`uname -a` contains the hostname in the output, so if the hostname was "darwin" or "macos" we were incorrectly identifying the machine as a mac.

**How was this change tested:**
Validate that on macos the os.name property is "Mac OS X"

Verified that we detect macos and linux correctly, and even after setting the hostname to "darwin" it still detects correctly.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
