### PR TITLE
test: fix NPE in test setup when mock isn't initialized first

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
@@ -77,13 +77,13 @@ class TelemetryAgentTest extends BaseITCase {
     @BeforeEach
     void before() {
         kernel = new Kernel();
-        TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any()))
                 .thenReturn(aggregateInterval);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any()))
                 .thenReturn(publishInterval);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC), any()))
                 .thenReturn(DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC);
+        TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
     }
 
     @AfterEach


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Some tests were failing with a NPE because the mock was only setup after calling the `internalEnableTestingFeatureParameters` so this simply flips the order.

**Why is this change necessary:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/runs/1787744563

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
