### PR TITLE
fix(startup): ensure nucleus version config is always available

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/onlyMain.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/onlyMain.yaml
@@ -7,3 +7,4 @@ services:
 
   main:
     dependencies:
+      - aws.greengrass.Nucleus

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.Utils;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
 import lombok.NoArgsConstructor;
@@ -43,6 +44,7 @@ public class DependencyResolver {
             + "nucleus from %s-%s to %s-%s but no component of type nucleus was included as target component, please "
             + "add the desired nucleus version as top level component if you wish to update the nucleus to a different "
             + "minor/major version";
+    static final String NO_ACTIVE_NUCLEUS_VERSION_ERROR_MSG = "Nucleus version config is required but not found";
     private static final Logger logger = LogManager.getLogger(DependencyResolver.class);
     private static final String VERSION_KEY = "version";
     private static final String COMPONENT_NAME_KEY = "componentName";
@@ -139,7 +141,11 @@ public class DependencyResolver {
             return;
         }
         GreengrassService activeNucleus = activeNucleusOption.get();
-        Semver activeNucleusVersion = new Semver(Coerce.toString(activeNucleus.getServiceConfig().find(VERSION_KEY)));
+        String activeNucleusVersionConfig = Coerce.toString(activeNucleus.getServiceConfig().find(VERSION_KEY));
+        if (Utils.isEmpty(activeNucleusVersionConfig)) {
+            throw new PackagingException(NO_ACTIVE_NUCLEUS_VERSION_ERROR_MSG);
+        }
+        Semver activeNucleusVersion = new Semver(activeNucleusVersionConfig);
         ComponentIdentifier activeNucleusId = new ComponentIdentifier(activeNucleus.getServiceName(),
                 activeNucleusVersion);
         ComponentIdentifier resolvedNucleusId = resolvedNucleusComponents.get(0);

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -227,22 +227,21 @@ public class DeviceConfiguration {
                 kernel.getConfig().lookupTopics(SERVICES_NAMESPACE_TOPIC).children.keySet().stream()
                         .filter(s -> ComponentType.NUCLEUS.name().equals(getComponentType(s.toString())))
                         .findAny();
-        if (nucleusComponent.isPresent()) {
-            return nucleusComponent.get().toString();
-        } else {
-            initializeNucleusComponentConfig();
-            return DEFAULT_NUCLEUS_COMPONENT_NAME;
-        }
+        String nucleusComponentName = nucleusComponent.isPresent() ? nucleusComponent.get().toString() :
+                DEFAULT_NUCLEUS_COMPONENT_NAME;
+        // Initialize default/inferred required config if it doesn't exist
+        initializeNucleusComponentConfig(nucleusComponentName);
+        return nucleusComponentName;
     }
 
-    private void initializeNucleusComponentConfig() {
-        kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, SERVICE_TYPE_TOPIC_KEY)
-                .withValue(ComponentType.NUCLEUS.name());
+    private void initializeNucleusComponentConfig(String nucleusComponentName) {
+        kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, nucleusComponentName, SERVICE_TYPE_TOPIC_KEY)
+                .dflt(ComponentType.NUCLEUS.name());
 
         ArrayList<String> mainDependencies = (ArrayList) kernel.getConfig().getRoot()
                 .findOrDefault(new ArrayList<>(), SERVICES_NAMESPACE_TOPIC, MAIN_SERVICE_NAME,
                         SERVICE_DEPENDENCIES_NAMESPACE_TOPIC);
-        mainDependencies.add(DEFAULT_NUCLEUS_COMPONENT_NAME);
+        mainDependencies.add(nucleusComponentName);
         kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, MAIN_SERVICE_NAME, SERVICE_DEPENDENCIES_NAMESPACE_TOPIC)
                 .dflt(mainDependencies);
     }


### PR DESCRIPTION
**Issue #, if available:**
If a config file is manually provided at startup with certain nucleus component config but no component version config(or other required keys for nucleus component), inferred version from build file or fallback version if even that's not present(which shouldn't happen in real usage) should be used instead of forcing user to include version in manually created config or finding out too late that it's needed
Also adds a null check in dependency resolution which depends on the version config and and fails without proper message if it's missing

**Description of changes:**

**Why is this change necessary:**
See description

**How was this change tested:**
Added unit tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
