### PR TITLE
fix(spooler): poison pill protection

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.spool.Spool;
+import com.aws.greengrass.mqttclient.spool.SpoolMessage;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.LockScope;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 import java.io.Closeable;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +58,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 
@@ -68,6 +71,7 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROO
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.mqttclient.AwsIotMqttClient.TOPIC_KEY;
 
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals"})
 public class MqttClient implements Closeable {
     private static final Logger logger = LogManager.getLogger(MqttClient.class);
     private static final String MQTT_KEEP_ALIVE_TIMEOUT_KEY = "keepAliveTimeoutMs";
@@ -83,10 +87,20 @@ public class MqttClient implements Closeable {
     static final String MQTT_OPERATION_TIMEOUT_KEY = "operationTimeoutMs";
     static final int DEFAULT_MQTT_OPERATION_TIMEOUT = (int) Duration.ofSeconds(30).toMillis();
     static final String MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY = "maxInFlightPublishes";
-    static final int DEFAULT_MAX_IN_FLIGHT_PUBLISHES = 1;
+    static final int DEFAULT_MAX_IN_FLIGHT_PUBLISHES = 5;
     public static final int MAX_SUBSCRIPTIONS_PER_CONNECTION = 50;
     public static final String CLIENT_ID_KEY = "clientId";
     public static final int EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS = 2;
+    static final String MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES_KEY = "maxMessageSizeInBytes";
+    static final String MQTT_MAX_OF_PUBLISH_RETRY_COUNT_KEY = "maxPublishRetry";
+    static final int DEFAULT_MQTT_MAX_OF_PUBLISH_RETRY_COUNT = 100;
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718023
+    static final int MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES = 256 * 1024 * 1024; // 256 MB
+    // https://docs.aws.amazon.com/general/latest/gr/iot-core.html#limits_iot
+    static final int DEFAULT_MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES = 128 * 1024; // 128 kB
+    static final int MAX_NUMBER_OF_FORWARD_SLASHES = 7;
+    static final int MAX_LENGTH_OF_TOPIC = 256;
+    static final int IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES = 100;
 
     // Use read lock for MQTT operations and write lock when changing the MQTT connection
     private final ReadWriteLock connectionLock = new ReentrantReadWriteLock(true);
@@ -109,7 +123,9 @@ public class MqttClient implements Closeable {
     private final Spool spool;
     private final ExecutorService executorService;
     private final AtomicReference<Future<?>> spoolingFuture = new AtomicReference<>();
-    private final int maxInFlightPublishes = DEFAULT_MAX_IN_FLIGHT_PUBLISHES;
+    private int maxInFlightPublishes;
+    private int maxPublishRetryCount;
+    private int maxPublishMessageSize;
 
     @Getter(AccessLevel.PROTECTED)
     private final MqttClientConnectionEvents callbacks = new MqttClientConnectionEvents() {
@@ -204,6 +220,7 @@ public class MqttClient implements Closeable {
 
         mqttTopics = this.deviceConfiguration.getMQTTNamespace();
         this.builderProvider = builderProvider;
+        validateAndSetMqttPublishConfiguration();
 
         eventLoopGroup = new EventLoopGroup(Coerce.toInt(mqttTopics.findOrDefault(1, MQTT_THREAD_POOL_SIZE_KEY)));
         hostResolver = new HostResolver(eventLoopGroup);
@@ -237,6 +254,10 @@ public class MqttClient implements Closeable {
                         .childOf(DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node.childOf(DEVICE_PARAM_ROOT_CA_PATH) || node
                         .childOf(DEVICE_PARAM_AWS_REGION))) {
                     return;
+                }
+
+                if (node.childOf(DEVICE_MQTT_NAMESPACE)) {
+                    validateAndSetMqttPublishConfiguration();
                 }
 
                 // Only reconnect when the region changed if the proxy exists
@@ -293,6 +314,39 @@ public class MqttClient implements Closeable {
         this.mqttOnline.set(mqttOnline);
         this.builderProvider = builderProvider;
         this.executorService = executorService;
+        validateAndSetMqttPublishConfiguration();
+    }
+
+    private void validateAndSetMqttPublishConfiguration() {
+        maxInFlightPublishes = Coerce.toInt(mqttTopics
+                .findOrDefault(DEFAULT_MAX_IN_FLIGHT_PUBLISHES,
+                        MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY));
+        if (maxInFlightPublishes > IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES) {
+            logger.atWarn()
+                    .kv(MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY, maxInFlightPublishes)
+                    .kv("Max acceptable configuration", IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES)
+                    .log(String.format("The configuration of %s may hit the AWS IoT Core restricting number of "
+                                    + "unacknowledged QoS=1 publish requests per client. "
+                                    + "Will change to the maximum allowed setting: %d",
+                            MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY, IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES));
+
+            maxInFlightPublishes = IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES;
+        }
+
+        maxPublishMessageSize = Coerce.toInt(mqttTopics.findOrDefault(DEFAULT_MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES,
+                MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES_KEY));
+        if (maxPublishMessageSize > MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES) {
+            logger.atWarn()
+                    .kv(MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES_KEY, maxPublishMessageSize)
+                    .kv("Max acceptable configuration", MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES)
+                    .log(String.format("The configuration of %s exceeds the max limit and will change to "
+                                    + "the maximum allowed setting: %d bytes", MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES_KEY,
+                            MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES));
+            maxPublishMessageSize = MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES;
+        }
+
+        maxPublishRetryCount =  Coerce.toInt(mqttTopics.findOrDefault(DEFAULT_MQTT_MAX_OF_PUBLISH_RETRY_COUNT,
+                MQTT_MAX_OF_PUBLISH_RETRY_COUNT_KEY));
     }
 
     /**
@@ -434,6 +488,14 @@ public class MqttClient implements Closeable {
             return future;
         }
 
+        try {
+            isValidPublishRequest(request);
+        } catch (SpoolerStoreException e) {
+            logger.atError().kv("topic", request.getTopic()).log("Invalid publish request: {}", e.getMessage());
+            future.completeExceptionally(e);
+            return future;
+        }
+
         boolean willDropTheRequest = !mqttOnline.get() && request.getQos().getValue() == 0 && !spool.getSpoolConfig()
                 .isKeepQos0WhenOffline();
 
@@ -455,12 +517,53 @@ public class MqttClient implements Closeable {
         return CompletableFuture.completedFuture(0);
     }
 
+    protected void isValidPublishRequest(PublishRequest request) throws SpoolerStoreException {
+        // Payload size should be smaller than MQTT maximum message size
+        int messageSize = request.getPayload().length;
+        if (messageSize >= maxPublishMessageSize) {
+            throw new SpoolerStoreException(String.format("The publishing message size %d bytes exceeds the "
+                            + "configured limit of %d bytes", messageSize, maxPublishMessageSize));
+        }
+
+        // Topic should not contain wildcard characters
+        String topic = request.getTopic();
+        if (topic.contains("#") || topic.contains("+")) {
+            throw new SpoolerStoreException("The topic of publish request should not contain wildcard "
+                    + "characters of '#' or '+'");
+        }
+
+        String reservedTopicTemplate = "^\\$aws/rules/\\S+/\\S+";
+        String prefixOfReservedTopic = "^\\$aws/rules/\\S+?/";
+        if (Pattern.matches(reservedTopicTemplate, topic.toLowerCase())) {
+            // remove the prefix of "$aws/rules/rule-name/"
+            topic = topic.toLowerCase().split(prefixOfReservedTopic, 2)[1];
+        }
+
+        // Topic should not have no more than maximum number of forward slashes (/)
+        if (topic.chars().filter(num -> num == '/').count() > MAX_NUMBER_OF_FORWARD_SLASHES) {
+            String errMsg = String.format("The topic of publish request must have no"
+                    + "more than %d forward slashes (/). This excludes the first 3 slashes in the mandatory segments "
+                    + "for Basic Ingest topics ($AWS/rules/rule-name/).", MAX_NUMBER_OF_FORWARD_SLASHES);
+            throw new SpoolerStoreException(errMsg);
+        }
+
+        // Check the topic size
+        if (topic.getBytes(StandardCharsets.UTF_8).length > MAX_LENGTH_OF_TOPIC) {
+            String errMsg = String.format("The topic size of publish request must be no "
+                            + "larger than {} bytes of UTF-8 encoded characters. This excludes the first "
+                            + "3 mandatory segments for Basic Ingest topics ($AWS/rules/rule-name/).",
+                    MAX_LENGTH_OF_TOPIC);
+            throw new SpoolerStoreException(errMsg);
+        }
+    }
+
     @SuppressWarnings({"PMD.AvoidCatchingThrowable", "PMD.PreserveStackTrace"})
     protected CompletableFuture<Integer> publishSingleSpoolerMessage() throws InterruptedException {
         long id = -1L;
         try {
             id = spool.popId();
-            PublishRequest request = spool.getMessageById(id);
+            SpoolMessage spooledMessage = spool.getMessageById(id);
+            PublishRequest request = spooledMessage.getRequest();
             MqttMessage m = new MqttMessage(request.getTopic(), request.getPayload());
 
             long finalId = id;
@@ -472,9 +575,17 @@ public class MqttClient implements Closeable {
                             logger.atDebug().kv("id", finalId).kv("topic", request.getTopic())
                                     .log("Successfully published message");
                         } else {
-                            spool.addId(finalId);
-                            logger.atError().log("Failed to publish the message via Spooler and will retry",
-                                    throwable);
+                            if (maxPublishRetryCount == -1 || spooledMessage.getRetried().getAndIncrement()
+                                    < maxPublishRetryCount) {
+                                spool.addId(finalId);
+                                logger.atError().log("Failed to publish the message via Spooler and will retry",
+                                        throwable);
+                            } else {
+                                logger.atError().log("Failed to publish the message via Spooler"
+                                                + " after retried {} times and will drop the message",
+                                        DEFAULT_MQTT_MAX_OF_PUBLISH_RETRY_COUNT, throwable);
+                            }
+
                         }
                     });
         } catch (Throwable t) {

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/CloudMessageSpool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/CloudMessageSpool.java
@@ -5,13 +5,11 @@
 
 package com.aws.greengrass.mqttclient.spool;
 
-import com.aws.greengrass.mqttclient.PublishRequest;
-
 public interface CloudMessageSpool {
 
-    PublishRequest getMessageById(long id);
+    SpoolMessage getMessageById(long id);
 
     void removeMessageById(long id);
 
-    void add(long id, PublishRequest request);
+    void add(long id, SpoolMessage message);
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/InMemorySpool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/InMemorySpool.java
@@ -5,17 +5,15 @@
 
 package com.aws.greengrass.mqttclient.spool;
 
-import com.aws.greengrass.mqttclient.PublishRequest;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class InMemorySpool implements CloudMessageSpool {
 
-    private final Map<Long, PublishRequest> messages = new ConcurrentHashMap<>();
+    private final Map<Long, SpoolMessage> messages = new ConcurrentHashMap<>();
 
     @Override
-    public PublishRequest getMessageById(long messageId) {
+    public SpoolMessage getMessageById(long messageId) {
         return messages.get(messageId);
     }
 
@@ -25,8 +23,8 @@ public class InMemorySpool implements CloudMessageSpool {
     }
 
     @Override
-    public void add(long id, PublishRequest request) {
-        messages.put(id, request);
+    public void add(long id, SpoolMessage message) {
+        messages.put(id, message);
     }
 
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -102,11 +102,12 @@ public class Spool {
      * If there is still no room after deleting QoS 0 PublishRequests, then an exception will be thrown.
      *
      * @param request publish request
-     * @return MessageID identifying the spooled PublishRequest
+     * @return SpoolMessage spool message
      * @throws InterruptedException result from the queue implementation
      * @throws SpoolerStoreException  if the message cannot be inserted into the message spool
      */
-    public synchronized long addMessage(PublishRequest request) throws InterruptedException, SpoolerStoreException {
+    public synchronized SpoolMessage addMessage(PublishRequest request) throws InterruptedException,
+            SpoolerStoreException {
         int messageSizeInBytes = request.getPayload().length;
         if (messageSizeInBytes > getSpoolConfig().getSpoolSizeInBytes()) {
             throw new SpoolerStoreException("Message is larger than the size of message spool.");
@@ -123,14 +124,15 @@ public class Spool {
         }
 
         long id = nextId.getAndIncrement();
-        addMessageToSpooler(id, request);
+        SpoolMessage message = SpoolMessage.builder().id(id).request(request).build();
+        addMessageToSpooler(id, message);
         queueOfMessageId.putLast(id);
 
-        return id;
+        return message;
     }
 
-    private void addMessageToSpooler(long id, PublishRequest request) {
-        spooler.add(id, request);
+    private void addMessageToSpooler(long id, SpoolMessage message) {
+        spooler.add(id, message);
     }
 
     /**
@@ -140,16 +142,19 @@ public class Spool {
      * @throws InterruptedException the thread is interrupted while popping the first id from the queue
      */
     public long popId() throws InterruptedException {
-        PublishRequest request;
+        SpoolMessage message;
         long id;
-        do {
+        while (true) {
             id = queueOfMessageId.takeFirst();
-            request = getMessageById(id);
-        } while (request == null);
+            message = getMessageById(id);
+            if (message != null) {
+                break;
+            }
+        }
         return id;
     }
 
-    public PublishRequest getMessageById(long messageId) {
+    public SpoolMessage getMessageById(long messageId) {
         return spooler.getMessageById(messageId);
     }
 
@@ -159,10 +164,10 @@ public class Spool {
      * @param messageId  message id
      */
     public void removeMessageById(long messageId) {
-        PublishRequest toBeRemovedRequest = getMessageById(messageId);
-        if (toBeRemovedRequest != null) {
+        SpoolMessage toBeRemovedMessage = getMessageById(messageId);
+        if (toBeRemovedMessage != null) {
             spooler.removeMessageById(messageId);
-            int messageSize = toBeRemovedRequest.getPayload().length;
+            int messageSize = toBeRemovedMessage.getRequest().getPayload().length;
             curMessageQueueSizeInBytes.getAndAdd(-1 * messageSize);
         }
     }
@@ -179,7 +184,7 @@ public class Spool {
         Iterator<Long> messageIdIterator = queueOfMessageId.iterator();
         while (messageIdIterator.hasNext() && addJudgementWithCurrentSpoolerSize(needToCheckCurSpoolerSize)) {
             long id = messageIdIterator.next();
-            PublishRequest request = getMessageById(id);
+            PublishRequest request = getMessageById(id).getRequest();
             int qos = request.getQos().getValue();
             if (qos == 0) {
                 removeMessageById(id);

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/SpoolMessage.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/SpoolMessage.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.spool;
+
+import com.aws.greengrass.mqttclient.PublishRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Builder
+@Getter
+public class SpoolMessage {
+    private long id;
+    @Builder.Default @Setter
+    private AtomicInteger retried = new AtomicInteger(0);
+    private PublishRequest request;
+}

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.mqttclient.spool.Spool;
+import com.aws.greengrass.mqttclient.spool.SpoolMessage;
 import com.aws.greengrass.mqttclient.spool.SpoolerConfig;
 import com.aws.greengrass.mqttclient.spool.SpoolerStorageType;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
@@ -31,6 +32,7 @@ import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
+import java.util.Collections;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
@@ -43,6 +45,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_MQTT_NAMESPACE;
+import static com.aws.greengrass.mqttclient.MqttClient.IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES;
+import static com.aws.greengrass.mqttclient.MqttClient.MAX_LENGTH_OF_TOPIC;
+import static com.aws.greengrass.mqttclient.MqttClient.MAX_NUMBER_OF_FORWARD_SLASHES;
+import static com.aws.greengrass.mqttclient.MqttClient.DEFAULT_MQTT_MAX_OF_PUBLISH_RETRY_COUNT;
+import static com.aws.greengrass.mqttclient.MqttClient.MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
@@ -88,12 +95,17 @@ class MqttClientTest {
     Configuration config = new Configuration(new Context());
     private final Consumer<MqttMessage> cb = (m) -> {
     };
+    private final static String reservedTopicPrefix = "$AWS/rules/rule_name/";
 
     @BeforeEach
     void beforeEach() {
         Topics mqttNamespace = config.lookupTopics("mqtt");
         Topics spoolerNamespace = config.lookupTopics("spooler");
         mqttNamespace.lookup(MqttClient.MQTT_OPERATION_TIMEOUT_KEY).withValue(0);
+        mqttNamespace.lookup(MqttClient.MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES_KEY)
+                .withValue(MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES + 1);
+        mqttNamespace.lookup(MqttClient.MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY).
+                withValue(IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES + 1);
         when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttNamespace);
         lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         lenient().when(deviceConfiguration.getSpoolerNamespace()).thenReturn(spoolerNamespace);
@@ -356,7 +368,9 @@ class MqttClientTest {
         MqttClient client = spy(new MqttClient(deviceConfiguration, spool, true, (c) -> builder, executorService));
         PublishRequest request = PublishRequest.builder().topic("spool").payload(new byte[0])
                 .qos(QualityOfService.AT_MOST_ONCE).build();
-        when(spool.addMessage(request)).thenReturn(0L);
+        SpoolMessage message = SpoolMessage.builder().id(0L).request(request).build();
+
+        when(spool.addMessage(request)).thenReturn(message);
         when(spool.popId()).thenThrow(InterruptedException.class);
 
         CompletableFuture<Integer> future = client.publish(request);
@@ -372,6 +386,8 @@ class MqttClientTest {
         MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
         PublishRequest request = PublishRequest.builder().topic("spool").payload(new byte[0])
                 .qos(QualityOfService.AT_LEAST_ONCE).build();
+        SpoolMessage message = SpoolMessage.builder().id(0L).request(request).build();
+        when(spool.addMessage(request)).thenReturn(message);
 
         CompletableFuture<Integer> future = client.publish(request);
 
@@ -423,7 +439,8 @@ class MqttClientTest {
         PublishRequest request = PublishRequest.builder().topic("spool")
                 .payload("What's up".getBytes(StandardCharsets.UTF_8))
                 .qos(QualityOfService.AT_LEAST_ONCE).build();
-        when(spool.getMessageById(id)).thenReturn(request);
+        SpoolMessage message = SpoolMessage.builder().id(id).request(request).build();
+        when(spool.getMessageById(id)).thenReturn(message);
         AwsIotMqttClient awsIotMqttClient = mock(AwsIotMqttClient.class);
         when(client.getNewMqttClient()).thenReturn(awsIotMqttClient);
         when(awsIotMqttClient.publish(any(), any(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(0));
@@ -436,7 +453,7 @@ class MqttClientTest {
     }
 
     @Test
-    void GIVEN_publish_request_unsuccessfully_WHEN_spool_single_message_THEN_add_id_back_to_spooler(ExtensionContext context)
+    void GIVEN_publish_request_unsuccessfully_WHEN_spool_single_message_THEN_add_id_back_to_spooler_if_will_retry(ExtensionContext context)
             throws InterruptedException {
 
         ignoreExceptionOfType(context, ExecutionException.class);
@@ -449,7 +466,8 @@ class MqttClientTest {
         PublishRequest request = PublishRequest.builder().topic("spool")
                 .payload("What's up".getBytes(StandardCharsets.UTF_8))
                 .qos(QualityOfService.AT_LEAST_ONCE).build();
-        when(spool.getMessageById(id)).thenReturn(request);
+        SpoolMessage message = SpoolMessage.builder().id(id).request(request).build();
+        when(spool.getMessageById(id)).thenReturn(message);
         AwsIotMqttClient awsIotMqttClient = mock(AwsIotMqttClient.class);
         when(client.getNewMqttClient()).thenReturn(awsIotMqttClient);
         CompletableFuture<Integer> future = new CompletableFuture<>();
@@ -460,7 +478,37 @@ class MqttClientTest {
 
         verify(awsIotMqttClient).publish(any(), any(), anyBoolean());
         verify(spool, never()).removeMessageById(anyLong());
-        verify(spool, times(1)).addId(anyLong());
+        verify(spool).addId(anyLong());
+    }
+
+    @Test
+    void GIVEN_publish_request_unsuccessfully_WHEN_spool_single_message_THEN_not_retry_if_have_retried_max_times(ExtensionContext context)
+            throws InterruptedException {
+
+        ignoreExceptionOfType(context, ExecutionException.class);
+
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, true, (c) -> builder,
+                executorService));
+
+        long id = 1L;
+        when(spool.popId()).thenReturn(id);
+        PublishRequest request = PublishRequest.builder().topic("spool")
+                .payload("What's up".getBytes(StandardCharsets.UTF_8))
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+        SpoolMessage message = SpoolMessage.builder().id(id).request(request).build();
+        message.getRetried().set(DEFAULT_MQTT_MAX_OF_PUBLISH_RETRY_COUNT);
+        when(spool.getMessageById(id)).thenReturn(message);
+        AwsIotMqttClient awsIotMqttClient = mock(AwsIotMqttClient.class);
+        when(client.getNewMqttClient()).thenReturn(awsIotMqttClient);
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        future.completeExceptionally(new ExecutionException("exception", new Throwable()));
+        when(awsIotMqttClient.publish(any(), any(), anyBoolean())).thenReturn(future);
+
+        client.publishSingleSpoolerMessage();
+
+        verify(awsIotMqttClient).publish(any(), any(), anyBoolean());
+        verify(spool, never()).removeMessageById(anyLong());
+        verify(spool, never()).addId(anyLong());
     }
 
     @Test
@@ -476,7 +524,8 @@ class MqttClientTest {
         PublishRequest request = PublishRequest.builder().topic("spool")
                 .payload("What's up".getBytes(StandardCharsets.UTF_8))
                 .qos(QualityOfService.AT_LEAST_ONCE).build();
-        when(spool.getMessageById(id)).thenReturn(request);
+        SpoolMessage message = SpoolMessage.builder().id(id).request(request).build();
+        when(spool.getMessageById(id)).thenReturn(message);
 
         AwsIotMqttClient awsIotMqttClient = mock(AwsIotMqttClient.class);
         when(client.getNewMqttClient()).thenReturn(awsIotMqttClient);
@@ -509,7 +558,8 @@ class MqttClientTest {
         PublishRequest request = PublishRequest.builder().topic("spool")
                 .payload("What's up".getBytes(StandardCharsets.UTF_8))
                 .qos(QualityOfService.AT_LEAST_ONCE).build();
-        when(spool.getMessageById(id)).thenReturn(request);
+        SpoolMessage message = SpoolMessage.builder().id(id).request(request).build();
+        when(spool.getMessageById(id)).thenReturn(message);
 
         AwsIotMqttClient awsIotMqttClient = mock(AwsIotMqttClient.class);
         when(client.getNewMqttClient()).thenReturn(awsIotMqttClient);
@@ -544,7 +594,8 @@ class MqttClientTest {
         PublishRequest request = PublishRequest.builder().topic("spool")
                 .payload("What's up".getBytes(StandardCharsets.UTF_8))
                 .qos(QualityOfService.AT_LEAST_ONCE).build();
-        when(spool.getMessageById(id)).thenReturn(request);
+        SpoolMessage message = SpoolMessage.builder().id(id).request(request).build();
+        when(spool.getMessageById(id)).thenReturn(message);
         // Throw an InterruptedException to break the while loop in the client.spoolMessages()
         when(spool.popId()).thenReturn(id).thenThrow(new InterruptedException("interrupted"));
 
@@ -578,5 +629,132 @@ class MqttClientTest {
 
         verify(spool).getSpoolConfig();
         verify(spool).popOutMessagesWithQosZero();
+    }
+
+    @Test
+    void GIVEN_message_size_exceeds_max_limit_WHEN_publish_THEN_future_complete_exceptionally() throws SpoolerStoreException, InterruptedException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        PublishRequest request = PublishRequest.builder().topic("spool")
+                .payload(new byte[MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES + 1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertTrue(future.isCompletedExceptionally());
+        verify(spool, never()).addMessage(request);
+        verify(client).isValidPublishRequest(request);
+    }
+
+    @Test
+    void GIVEN_message_topic_have_wildcard_WHEN_publish_THEN_future_complete_exceptionally() throws SpoolerStoreException, InterruptedException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        PublishRequest request = PublishRequest.builder().topic("abc/+")
+                .payload(new byte[1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertTrue(future.isCompletedExceptionally());
+        verify(spool, never()).addMessage(request);
+        verify(client).isValidPublishRequest(request);
+    }
+
+    @Test
+    void GIVEN_unreserved_topic_have_8_forward_slashes_WHEN_publish_THEN_future_complete_exceptionally() throws SpoolerStoreException, InterruptedException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        String topic = String.join("/", Collections.nCopies(MAX_NUMBER_OF_FORWARD_SLASHES + 2, "a"));
+        assertEquals(8, topic.chars().filter(num -> num == '/').count());
+        PublishRequest request = PublishRequest.builder().topic(topic)
+                .payload(new byte[1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertTrue(future.isCompletedExceptionally());
+        verify(spool, never()).addMessage(request);
+        verify(client).isValidPublishRequest(request);
+    }
+
+    @Test
+    void GIVEN_reserved_topic_have_9_forward_slashes_WHEN_publish_THEN_future_complete() throws SpoolerStoreException, InterruptedException, ExecutionException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        String topic = reservedTopicPrefix + String.join("/", Collections.nCopies(MAX_NUMBER_OF_FORWARD_SLASHES, "a"));
+        assertEquals(9, topic.chars().filter(num -> num == '/').count());
+        PublishRequest request = PublishRequest.builder().topic(topic)
+                .payload(new byte[1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        SpoolMessage message = SpoolMessage.builder().id(0L).request(request).build();
+        when(spool.addMessage(request)).thenReturn(message);
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertEquals(0, future.get());
+        verify(spool, times(1)).addMessage(request);
+        verify(spool, never()).getSpoolConfig();
+    }
+
+    @Test
+    void GIVEN_reserved_topic_have_11_forward_slashes_WHEN_publish_THEN_future_complete_exceptionally() throws SpoolerStoreException, InterruptedException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        String topic = reservedTopicPrefix + String.join("/", Collections.nCopies(MAX_NUMBER_OF_FORWARD_SLASHES + 2, "a"));
+        assertEquals(11, topic.chars().filter(num -> num == '/').count());
+        PublishRequest request = PublishRequest.builder().topic(topic)
+                .payload(new byte[1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertTrue(future.isCompletedExceptionally());
+        verify(spool, never()).addMessage(request);
+        verify(client).isValidPublishRequest(request);
+    }
+
+    @Test
+    void GIVEN_unreserved_topic_exceeds_topic_size_limit_WHEN_publish_THEN_future_complete_exceptionally() throws SpoolerStoreException, InterruptedException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        String topic = String.join("", Collections.nCopies(MAX_LENGTH_OF_TOPIC + 1, "a"));
+        PublishRequest request = PublishRequest.builder().topic(topic)
+                .payload(new byte[1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertTrue(future.isCompletedExceptionally());
+        verify(spool, never()).addMessage(request);
+        verify(client).isValidPublishRequest(request);
+    }
+
+    @Test
+    void GIVEN_reserved_topic_including_prefix_equal_to_topic_size_limit_WHEN_publish_THEN_future_complete() throws SpoolerStoreException, InterruptedException, ExecutionException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        String topic = String.join("", Collections.nCopies(MAX_LENGTH_OF_TOPIC, "a"));
+        PublishRequest request = PublishRequest.builder().topic(reservedTopicPrefix + topic)
+                .payload(new byte[1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        SpoolMessage message = SpoolMessage.builder().id(0L).request(request).build();
+        when(spool.addMessage(request)).thenReturn(message);
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertEquals(0, future.get());
+        verify(spool, times(1)).addMessage(request);
+        verify(spool, never()).getSpoolConfig();
+    }
+
+    @Test
+    void GIVEN_reserved_topic_excluding_prefix_exceeds_topic_size_limit_WHEN_publish_THEN_future_complete_exceptionally() throws SpoolerStoreException, InterruptedException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        String topic = String.join("", Collections.nCopies(MAX_LENGTH_OF_TOPIC + 1, "a"));
+        PublishRequest request = PublishRequest.builder().topic(reservedTopicPrefix + topic)
+                .payload(new byte[1])
+                .qos(QualityOfService.AT_LEAST_ONCE).build();
+
+        CompletableFuture<Integer> future = client.publish(request);
+
+        assertTrue(future.isCompletedExceptionally());
+        verify(spool, never()).addMessage(request);
+        verify(client).isValidPublishRequest(request);
     }
 }

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -45,7 +45,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_MQTT_NAMESPACE;
-import static com.aws.greengrass.mqttclient.MqttClient.IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES;
 import static com.aws.greengrass.mqttclient.MqttClient.MAX_LENGTH_OF_TOPIC;
 import static com.aws.greengrass.mqttclient.MqttClient.MAX_NUMBER_OF_FORWARD_SLASHES;
 import static com.aws.greengrass.mqttclient.MqttClient.DEFAULT_MQTT_MAX_OF_PUBLISH_RETRY_COUNT;
@@ -104,8 +103,6 @@ class MqttClientTest {
         mqttNamespace.lookup(MqttClient.MQTT_OPERATION_TIMEOUT_KEY).withValue(0);
         mqttNamespace.lookup(MqttClient.MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES_KEY)
                 .withValue(MQTT_MAX_LIMIT_OF_MESSAGE_SIZE_IN_BYTES + 1);
-        mqttNamespace.lookup(MqttClient.MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY).
-                withValue(IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES + 1);
         when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttNamespace);
         lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         lenient().when(deviceConfiguration.getSpoolerNamespace()).thenReturn(spoolerNamespace);


### PR DESCRIPTION
**Issue #, if available:**
Currently, the MqttClient.publish would complete the future immediately if the message has been added to the spooler and does not provide the information whether the messages have been really published out. 

**Description of changes:**
1. Check whether the publish request is valid 
2. Set the maximum retried limit to the message published and make this setting configurable

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
