### PR TITLE
feat(AwsIotMqttClient): resubscribe robust retry

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -291,7 +291,7 @@ class AwsIotMqttClient implements Closeable {
                             .log("Subscription interrupted. Cancelling subscriptions");
                     allSubFutures.cancel(true);
                 } catch (ExecutionException e) {
-                    // Do nothing. Errors already handled in the above whenComplete stage
+                    // Do nothing. Errors already handled in individual subscription future's whenComplete stage
                 }
             }, delayMillis, TimeUnit.MILLISECONDS);
 

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -259,7 +259,6 @@ class AwsIotMqttClient implements Closeable {
                 droppedSubscriptionTopics.putAll(subscriptionTopics);
             }
             if (!droppedSubscriptionTopics.isEmpty() && (resubscribeFuture == null || resubscribeFuture.isDone())) {
-                logger.info("ignoring");
                 resubscribeFuture = executorService.submit(this::resubscribeDroppedTopicsTask);
             }
         }

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -259,6 +259,7 @@ class AwsIotMqttClient implements Closeable {
                 droppedSubscriptionTopics.putAll(subscriptionTopics);
             }
             if (!droppedSubscriptionTopics.isEmpty() && (resubscribeFuture == null || resubscribeFuture.isDone())) {
+                logger.info("ignoring");
                 resubscribeFuture = executorService.submit(this::resubscribeDroppedTopicsTask);
             }
         }

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -108,6 +108,7 @@ public class MqttClient implements Closeable {
     private final CallbackEventManager callbackEventManager = new CallbackEventManager();
     private final Spool spool;
     private final ExecutorService executorService;
+    private ScheduledExecutorService ses;
     private final AtomicReference<Future<?>> spoolingFuture = new AtomicReference<>();
     private final int maxInFlightPublishes = DEFAULT_MAX_IN_FLIGHT_PUBLISHES;
 
@@ -201,6 +202,7 @@ public class MqttClient implements Closeable {
                          ScheduledExecutorService ses, ExecutorService executorService) {
         this.deviceConfiguration = deviceConfiguration;
         this.executorService = executorService;
+        this.ses = ses;
 
         mqttTopics = this.deviceConfiguration.getMQTTNamespace();
         this.builderProvider = builderProvider;
@@ -597,7 +599,7 @@ public class MqttClient implements Closeable {
         String clientId = Coerce.toString(deviceConfiguration.getThingName()) + (connections.isEmpty() ? ""
                 : "#" + (connections.size() + 1));
         return new AwsIotMqttClient(() -> builderProvider.apply(clientBootstrap), this::getMessageHandlerForClient,
-                clientId, mqttTopics, callbackEventManager, executorService);
+                clientId, mqttTopics, callbackEventManager, executorService, ses);
     }
 
     public boolean connected() {

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -597,7 +597,7 @@ public class MqttClient implements Closeable {
         String clientId = Coerce.toString(deviceConfiguration.getThingName()) + (connections.isEmpty() ? ""
                 : "#" + (connections.size() + 1));
         return new AwsIotMqttClient(() -> builderProvider.apply(clientBootstrap), this::getMessageHandlerForClient,
-                clientId, mqttTopics, callbackEventManager);
+                clientId, mqttTopics, callbackEventManager, executorService);
     }
 
     public boolean connected() {

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.mqttclient;
 
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -81,8 +81,8 @@ class AwsIotMqttClientTest {
 
     @AfterAll
     static void cleanup() {
-        executorService.shutdown();
-        ses.shutdown();
+        executorService.shutdownNow();
+        ses.shutdownNow();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.mqttclient;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,8 +69,8 @@ class AwsIotMqttClientTest {
     Topics mockTopic;
 
     // same as what we use in Kernel
-    private static final ExecutorService executorService = Executors.newCachedThreadPool();
-    private static final ScheduledExecutorService ses = Executors.newScheduledThreadPool(4);
+    private ExecutorService executorService;
+    private ScheduledExecutorService ses;
 
     @BeforeEach
     void beforeEach() {
@@ -77,12 +78,16 @@ class AwsIotMqttClientTest {
         callbackEventManager.addToCallbackEvents(mockCallback1);
         callbackEventManager.addToCallbackEvents(mockCallback2);
         mockTopic = mock(Topics.class);
+        executorService = Executors.newCachedThreadPool();
+        ses = Executors.newScheduledThreadPool(4);
     }
 
-    @AfterAll
-    static void cleanup() {
+    @AfterEach
+    void cleanup() throws InterruptedException {
         executorService.shutdownNow();
         ses.shutdownNow();
+        ses.awaitTermination(2, TimeUnit.SECONDS);
+        executorService.awaitTermination(2, TimeUnit.SECONDS);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -80,15 +81,15 @@ class AwsIotMqttClientTest {
         callbackEventManager.addToCallbackEvents(mockCallback2);
         mockTopic = mock(Topics.class);
         executorService = Executors.newCachedThreadPool();
-        ses = Executors.newScheduledThreadPool(4);
+        ses = new ScheduledThreadPoolExecutor(4);
     }
 
     @AfterEach
     void cleanup() throws InterruptedException {
         executorService.shutdownNow();
         ses.shutdownNow();
-        ses.awaitTermination(2, TimeUnit.SECONDS);
-        executorService.awaitTermination(2, TimeUnit.SECONDS);
+        ses.awaitTermination(5, TimeUnit.SECONDS);
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -53,7 +53,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 class AwsIotMqttClientTest {
 
-    public static final int VERIFY_TIMEOUT_MILLIS = 1000;
+    private static final int VERIFY_TIMEOUT_MILLIS = 1000;
+
     @Mock
     AwsIotMqttConnectionBuilder builder;
 

--- a/src/test/java/com/aws/greengrass/mqttclient/WrapperMqttClientConnectionTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/WrapperMqttClientConnectionTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient;
+
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.crt.mqtt.MqttMessage;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+class WrapperMqttClientConnectionTest {
+
+    @Mock
+    MqttClient mockMqttClient;
+    @Captor
+    ArgumentCaptor<SubscribeRequest> subRequestCaptor;
+    @Captor
+    ArgumentCaptor<PublishRequest> pubRequestCaptor;
+    @Captor
+    ArgumentCaptor<UnsubscribeRequest> unsubRequestCaptor;
+
+    public static final String TEST_TOPIC = "testTopic";
+
+    @BeforeEach
+    void beforeEach() throws InterruptedException, ExecutionException, TimeoutException {
+        lenient().doNothing().when(mockMqttClient).subscribe(subRequestCaptor.capture());
+        lenient().doNothing().when(mockMqttClient).unsubscribe(unsubRequestCaptor.capture());
+        lenient().when(mockMqttClient.publish(pubRequestCaptor.capture()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+    }
+
+    @Test
+    void GIVEN_wrapper_connection_WHEN_do_unsupported_operation_THEN_exception_thrown() {
+        try (WrapperMqttClientConnection wrapperConnection = new WrapperMqttClientConnection(mockMqttClient)) {
+            assertThrows(UnsupportedOperationException.class, wrapperConnection::connect);
+            assertThrows(UnsupportedOperationException.class, wrapperConnection::disconnect);
+            assertThrows(UnsupportedOperationException.class, () -> wrapperConnection.onMessage((message) -> {}));
+            assertThrows(UnsupportedOperationException.class,
+                    () -> wrapperConnection.subscribe(TEST_TOPIC, QualityOfService.AT_MOST_ONCE));
+        }
+    }
+
+    @Test
+    void GIVEN_wrapper_connection_WHEN_send_requests_THEN_delegated_to_mqtt_client()
+            throws ExecutionException, InterruptedException {
+        try (WrapperMqttClientConnection wrapperConnection = new WrapperMqttClientConnection(mockMqttClient)) {
+            wrapperConnection.subscribe(TEST_TOPIC, QualityOfService.AT_MOST_ONCE, (m) -> {
+            }).get();
+            SubscribeRequest subRequest = subRequestCaptor.getValue();
+            assertEquals(TEST_TOPIC, subRequest.getTopic());
+            assertEquals(QualityOfService.AT_MOST_ONCE, subRequest.getQos());
+
+            wrapperConnection.publish(new MqttMessage(TEST_TOPIC, new byte[0]), QualityOfService.AT_MOST_ONCE, false).get();
+            PublishRequest pubRequest = pubRequestCaptor.getValue();
+            assertEquals(TEST_TOPIC, pubRequest.getTopic());
+            assertEquals(QualityOfService.AT_MOST_ONCE, pubRequest.getQos());
+
+            wrapperConnection.unsubscribe(TEST_TOPIC);
+            UnsubscribeRequest unsubRequest = unsubRequestCaptor.getValue();
+            assertEquals(TEST_TOPIC, unsubRequest.getTopic());
+
+            // should throw exception if unsubscribe an unknown topic
+            assertThrows(ExecutionException.class, () -> wrapperConnection.unsubscribe("unknown").get());
+        }
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/mqttclient/WrapperMqttClientConnectionTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/WrapperMqttClientConnectionTest.java
@@ -36,7 +36,7 @@ class WrapperMqttClientConnectionTest {
     @Captor
     ArgumentCaptor<UnsubscribeRequest> unsubRequestCaptor;
 
-    public static final String TEST_TOPIC = "testTopic";
+    private static final String TEST_TOPIC = "testTopic";
 
     @BeforeEach
     void beforeEach() throws InterruptedException, ExecutionException, TimeoutException {

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -129,8 +129,10 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         TelemetryConfig.getInstance().closeContext();
         telemetryAgent.shutdown();
         ses.shutdownNow();
+        executorService.shutdownNow();
         context.close();
-        ses.awaitTermination(2, TimeUnit.SECONDS);
+        ses.awaitTermination(5, TimeUnit.SECONDS);
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
         TestFeatureParameters.internalDisableTestingFeatureParameters();
     }
 

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -133,6 +133,8 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         context.close();
         ses.awaitTermination(5, TimeUnit.SECONDS);
         executorService.awaitTermination(5, TimeUnit.SECONDS);
+        TestFeatureParameters.unRegisterHandlerCallback(serviceFullName);
+        TestFeatureParameters.internalDisableTestingFeatureParameters();
     }
 
     @Test
@@ -237,7 +239,5 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         verify(mockMqttClient, times(0)).publish(publishRequestArgumentCaptor.capture());
         // aggregation is continued irrespective of the mqtt connection
         verify(ma, timeout(timeoutMs).atLeastOnce()).aggregateMetrics(anyLong(), anyLong());
-
-        TestFeatureParameters.internalDisableTestingFeatureParameters();
     }
 }

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -192,11 +192,11 @@ class TelemetryAgentTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_Telemetry_Agent_WHEN_starts_up_THEN_periodically_schedule_operations() {
-        TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any()))
                 .thenReturn(1);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any()))
                 .thenReturn(3);
+        TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
         telemetryAgent.postInject();
         long milliSeconds = 4000;
         telemetryAgent.getCurrentConfiguration().set(TelemetryConfiguration.builder()
@@ -219,11 +219,11 @@ class TelemetryAgentTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_Telemetry_Agent_WHEN_mqtt_is_interrupted_THEN_aggregation_continues_but_publishing_stops() {
-        TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any()))
                 .thenReturn(1);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any()))
                 .thenReturn(2);
+        TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
         Map<Long, List<AggregatedNamespaceData>> metricsToPublishMap = new HashMap<>();
         List<AggregatedNamespaceData> data = new ArrayList<>();
         data.add(AggregatedNamespaceData.builder().namespace("SomeNameSpace").build());

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -58,6 +58,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -133,7 +134,6 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         context.close();
         ses.awaitTermination(5, TimeUnit.SECONDS);
         executorService.awaitTermination(5, TimeUnit.SECONDS);
-        TestFeatureParameters.internalDisableTestingFeatureParameters();
     }
 
     @Test
@@ -192,10 +192,10 @@ class TelemetryAgentTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_Telemetry_Agent_WHEN_starts_up_THEN_periodically_schedule_operations() {
-        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any()))
-                .thenReturn(1);
-        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any()))
-                .thenReturn(3);
+        doReturn(1).when(DEFAULT_HANDLER)
+                .retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any());
+        doReturn(3).when(DEFAULT_HANDLER)
+                .retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any());
         TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
         telemetryAgent.postInject();
         long milliSeconds = 4000;
@@ -219,10 +219,10 @@ class TelemetryAgentTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_Telemetry_Agent_WHEN_mqtt_is_interrupted_THEN_aggregation_continues_but_publishing_stops() {
-        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any()))
-                .thenReturn(1);
-        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any()))
-                .thenReturn(2);
+        doReturn(1).when(DEFAULT_HANDLER)
+                .retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any());
+        doReturn(2).when(DEFAULT_HANDLER)
+                .retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any());
         TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
         Map<Long, List<AggregatedNamespaceData>> metricsToPublishMap = new HashMap<>();
         List<AggregatedNamespaceData> data = new ArrayList<>();

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -215,6 +215,8 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         telemetryAgent.schedulePeriodicAggregateMetrics(false);
         // aggregation starts at least at the 2nd sec
         verify(ma, timeout(milliSeconds).atLeastOnce()).aggregateMetrics(anyLong(), anyLong());
+
+        TestFeatureParameters.internalDisableTestingFeatureParameters();
     }
 
     @Test
@@ -250,5 +252,7 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         verify(mockMqttClient, times(0)).publish(publishRequestArgumentCaptor.capture());
         // aggregation is continued irrespective of the mqtt connection
         verify(ma, timeout(timeoutMs).atLeastOnce()).aggregateMetrics(anyLong(), anyLong());
+
+        TestFeatureParameters.internalDisableTestingFeatureParameters();
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`AwsIotMqttClient`: Implement MQTT continuous subscription retry upon connection recovery.

Before: when MQTT connection resumed, retry all subscribed topics once only if session persisted.
After: when MQTT connection resumed, retry failed subscriptions. Keep retrying until succeeded or connection interrupted again, with backoff delay.

- Add unit tests for resubscribe logic.
- Add unit tests for `WrapperMqttClientConnection` and `MqttClient` to increase test coverage.
- Fix flaky `TelemetryAgentTest`:
    - [Link to failed run](https://github.com/aws-greengrass/aws-greengrass-nucleus/runs/1891190361). Null pointer exception because `TestFeatureParameters.internalEnableTestingFeatureParameters` was called before mock was fully setup. Fixed by reordering.
    - [Link to failed run](https://github.com/aws-greengrass/aws-greengrass-nucleus/runs/1906728743). `RejectedExecutionException` because `internalDisableTestingFeatureParameters` was called after executor was shutdown. Because TA [registers the callback async-ly](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/3b2350aec4dcacca2e88c06401e63b0078dd051b/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java#L293), the callback could be registered after TA itself is shutdown if the test is really short. Fixed by moving `internalDisableTestingFeatureParameters` from `AfterEach` to individual test cases that changed the default handler. Also removed unnecessary code from one test case.
- [Link to failed run](https://github.com/aws-greengrass/aws-greengrass-nucleus/runs/1891370493). Fix flaky `PeriodicFleetStatusServiceTest`: was not waiting until all services started. FSS status could miss some services. Fixed by waiting for `main service` to finish.

**Why is this change necessary:**
Making MQTT network recovery more robust.
Fix flaky tests.

**How was this change tested:**
- Unit test
- Smoke UATs
- UAT `Deployment-3-T6`: deploy to a group with intermittent connectivity

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
