### PR TITLE
fix(startup): don't crash nucleus on service load exceptions

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/UnloadableServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/UnloadableServiceIntegTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.lifecyclemanager;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.lifecyclemanager.KernelCommandLine;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.aws.greengrass.integrationtests.lifecyclemanager.PluginComponentTest.componentId;
+import static com.aws.greengrass.integrationtests.lifecyclemanager.PluginComponentTest.setDigestInConfig;
+import static com.aws.greengrass.integrationtests.lifecyclemanager.PluginComponentTest.setupPackageStore;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessageSubstring;
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class UnloadableServiceIntegTest extends BaseITCase {
+
+    private Kernel kernel;
+
+    @BeforeEach
+    void beforeEach() {
+        kernel = new Kernel();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (kernel != null) {
+            kernel.shutdown();
+        }
+    }
+
+    @Test
+    void GIVEN_unloadable_service_missing_config_WHEN_nucleus_launch_THEN_nucleus_starts_and_other_services_running(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionWithMessage(context, "No matching definition in system model for: MissingConfigService");
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                this.getClass().getResource("unloadable_service_missing_config.yaml"));
+        kernel.launch();
+
+        assertThat(kernel.locate("ServiceA")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("MissingConfigService")::getState, eventuallyEval(is(State.BROKEN)));
+        assertThat(kernel.locate("CustomerApp")::getState, eventuallyEval(is(State.INSTALLED)));
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.INSTALLED)));
+        assertEquals(4, kernel.orderedDependencies().stream().filter(s -> !s.isBuiltin()).count());
+    }
+
+    @Test
+    void GIVEN_unloadable_plugin_missing_jar_WHEN_nucleus_launch_THEN_nucleus_starts_and_other_services_running(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionWithMessageSubstring(context, "Unable to find plugin");
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                this.getClass().getResource("unloadable_plugin.yaml"));
+        kernel.launch();
+
+        assertThat(kernel.locate("ServiceA")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceB")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceC")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("plugin")::getState, eventuallyEval(is(State.BROKEN)));
+        assertThat(kernel.locate("CustomerApp")::getState, eventuallyEval(is(State.INSTALLED)));
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.INSTALLED)));
+        assertEquals(6, kernel.orderedDependencies().stream().filter(s -> !s.isBuiltin()).count());
+
+        // Fix plugin by adding jar to component store and restart Nucleus
+        setupPackageStore(kernel, componentId);
+        setDigestInConfig(kernel);
+        kernel.shutdown();
+        kernel = new Kernel().parseArgs();
+        kernel.launch();
+
+        assertThat(kernel.locate("ServiceA")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceB")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceC")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("plugin")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("CustomerApp")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.FINISHED)));
+    }
+
+    @Test
+    void GIVEN_unloadable_plugin_digest_missing_WHEN_nucleus_launch_THEN_nucleus_starts_and_other_services_running(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionWithMessage(context, "Custom plugins is not supported by this greengrass version");
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                this.getClass().getResource("unloadable_plugin.yaml"));
+        setupPackageStore(kernel, componentId);
+        kernel.launch();
+
+        assertThat(kernel.locate("ServiceA")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceB")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceC")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("plugin")::getState, eventuallyEval(is(State.BROKEN)));
+        assertThat(kernel.locate("CustomerApp")::getState, eventuallyEval(is(State.INSTALLED)));
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.INSTALLED)));
+        assertEquals(6, kernel.orderedDependencies().stream().filter(s -> !s.isBuiltin()).count());
+
+        // Fix plugin by adding digest in config and restart Nucleus
+        setDigestInConfig(kernel);
+        kernel.shutdown();
+        kernel = new Kernel().parseArgs();
+        kernel.launch();
+
+        assertThat(kernel.locate("ServiceA")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceB")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceC")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("plugin")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("CustomerApp")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.FINISHED)));
+    }
+
+    @Test
+    void GIVEN_unloadable_plugin_digest_mismatch_WHEN_nucleus_launch_THEN_nucleus_starts_and_other_services_running(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionWithMessage(context, "Plugin has been modified after it was downloaded");
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                this.getClass().getResource("unloadable_plugin.yaml"));
+        setupPackageStore(kernel, componentId);
+        kernel.getConfig()
+                .lookupTopics(GreengrassService.SERVICES_NAMESPACE_TOPIC,
+                        KernelCommandLine.MAIN_SERVICE_NAME,
+                        GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC)
+                .lookup(Kernel.SERVICE_DIGEST_TOPIC_KEY, componentId.toString())
+                .withValue("wrong-digest");
+
+        kernel.launch();
+
+        assertThat(kernel.locate("ServiceA")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceB")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceC")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("plugin")::getState, eventuallyEval(is(State.BROKEN)));
+        assertThat(kernel.locate("CustomerApp")::getState, eventuallyEval(is(State.INSTALLED)));
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.INSTALLED)));
+        assertEquals(6, kernel.orderedDependencies().stream().filter(s -> !s.isBuiltin()).count());
+
+        // Fix plugin by correcting digest in config and restart Nucleus
+        setDigestInConfig(kernel);
+        kernel.shutdown();
+        kernel = new Kernel().parseArgs();
+        kernel.launch();
+
+        assertThat(kernel.locate("ServiceA")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceB")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("ServiceC")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("plugin")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.locate("CustomerApp")::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.FINISHED)));
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/unloadable_plugin.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/unloadable_plugin.yaml
@@ -1,0 +1,48 @@
+---
+services:
+  plugin:
+    dependencies:
+      - ServiceB
+      - ServiceC
+    version: 1.0.0
+    componentType: PLUGIN
+  ServiceA:
+    dependencies:
+      - ServiceB
+    lifecycle:
+      posix:
+        run:
+          script: while true; do sleep 1000; done
+      windows:
+        run:
+          script: powershell -command while(1) { sleep 1000 }
+  ServiceB:
+    lifecycle:
+      posix:
+        run:
+          script: while true; do sleep 1000; done
+      windows:
+        run:
+          script: powershell -command while(1) { sleep 1000 }
+  ServiceC:
+    lifecycle:
+      posix:
+        run:
+          script: while true; do sleep 1000; done
+      windows:
+        run:
+          script: powershell -command while(1) { sleep 1000 }
+  CustomerApp:
+    dependencies:
+      - ServiceA
+      - plugin
+    lifecycle:
+      posix:
+        run:
+          script: while true; do sleep 1000; done
+      windows:
+        run:
+          script: powershell -command while(1) { sleep 1000 }
+  main:
+    dependencies:
+      - CustomerApp:HARD

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/unloadable_service_missing_config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/unloadable_service_missing_config.yaml
@@ -1,0 +1,24 @@
+---
+services:
+  ServiceA:
+    lifecycle:
+      posix:
+        run:
+          script: while true; do sleep 1000; done
+      windows:
+        run:
+          script: powershell -command while(1) { sleep 1000 }
+  CustomerApp:
+    dependencies:
+      - ServiceA:HARD
+      - MissingConfigService:HARD
+    lifecycle:
+      posix:
+        run:
+          script: while true; do sleep 1000; done
+      windows:
+        run:
+          script: powershell -command while(1) { sleep 1000 }
+  main:
+    dependencies:
+      - CustomerApp:HARD

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -65,6 +65,8 @@ public class DefaultActivator extends DeploymentActivator {
         Throwable setDesiredStateFailureCause = kernel.getContext().runOnPublishQueueAndWait(() -> {
             // polling to wait for all services to be started.
             servicesChangeManager.startNewServices();
+            // Close unloadable service instances and initiate with new config
+            servicesChangeManager.replaceUnloadableService();
             // Restart any services that may have been broken before this deployment
             // This is added to allow deployments to fix broken services
             servicesChangeManager.reinstallBrokenServices();
@@ -120,6 +122,7 @@ public class DefaultActivator extends DeploymentActivator {
         // wait until topic listeners finished processing read changes.
         Throwable setDesiredStateFailureCause = kernel.getContext().runOnPublishQueueAndWait(() -> {
                 rollbackManager.startNewServices();
+                rollbackManager.replaceUnloadableService();
                 rollbackManager.reinstallBrokenServices();
         });
         if (setDesiredStateFailureCause != null) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -105,13 +105,7 @@ public class KernelLifecycle {
         // referenced by main/dependencies of main
         final Queue<String> autostart = findBuiltInServicesAndPlugins(); //NOPMD
 
-        try {
-            mainService = kernel.locate(KernelCommandLine.MAIN_SERVICE_NAME);
-        } catch (ServiceLoadException sle) {
-            RuntimeException rte = new RuntimeException("Cannot load main service", sle);
-            logger.atError("system-boot-error", rte).log();
-            throw rte;
-        }
+        mainService = kernel.locateIgnoreError(KernelCommandLine.MAIN_SERVICE_NAME);
 
         autostart.forEach(s -> {
             try {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/UnloadableService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/UnloadableService.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.lifecyclemanager;
+
+import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.NucleusPaths;
+import com.aws.greengrass.util.Utils;
+import com.vdurmont.semver4j.Semver;
+import com.vdurmont.semver4j.SemverException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.amazon.aws.iot.greengrass.component.common.ComponentType.PLUGIN;
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
+import static com.aws.greengrass.dependency.EZPlugins.JAR_FILE_EXTENSION;
+import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
+import static com.aws.greengrass.lifecyclemanager.Kernel.SERVICE_TYPE_TOPIC_KEY;
+
+public class UnloadableService extends GreengrassService {
+    ServiceLoadException serviceLoadException;
+    long exceptionTimestamp;
+
+    /**
+     * Create a new instance for unloadable service.
+     *
+     * @param topics root topic for this service
+     * @param e the original exception while loading the service
+     */
+    public UnloadableService(Topics topics, ServiceLoadException e) {
+        super(topics);
+        this.serviceLoadException = e;
+        this.exceptionTimestamp = Instant.now().toEpochMilli();
+        logger.atError().log(exceptionTimestamp);
+    }
+
+    @Override
+    protected void install() {
+        serviceErrored(serviceLoadException.getMessage());
+    }
+
+    @Override
+    public int bootstrap() {
+        return REQUEST_RESTART;
+    }
+
+    @Override
+    public boolean isBootstrapRequired(Map<String, Object> newServiceConfig) {
+        if (!PLUGIN.name().equals(newServiceConfig.get(SERVICE_TYPE_TOPIC_KEY))) {
+            logger.atInfo().log("Bootstrap is not required: component type is not Plugin");
+            return false;
+        }
+        if (!newServiceConfig.containsKey(VERSION_CONFIG_KEY)) {
+            logger.atInfo().log("Bootstrap is not required: config incomplete with no version");
+            return false;
+        }
+        String newVersion = newServiceConfig.get(VERSION_CONFIG_KEY).toString();
+        if (Utils.stringHasChanged(Coerce.toString(getConfig().find(VERSION_CONFIG_KEY)), newVersion)) {
+            logger.atInfo().log("Bootstrap is required: plugin version changed");
+            return true;
+        }
+        try {
+            Path pluginJar = config.getContext().get(NucleusPaths.class).artifactPath(new ComponentIdentifier(getName(),
+                    new Semver(newVersion))).resolve(getName() + JAR_FILE_EXTENSION);
+
+            if (!pluginJar.toFile().exists() || !pluginJar.toFile().isFile()) {
+                logger.atInfo().kv("pluginJar", pluginJar).log("Bootstrap is not required: plugin JAR not found");
+                return false;
+            }
+
+            if (Files.getLastModifiedTime(pluginJar).toMillis() > exceptionTimestamp) {
+                logger.atInfo().kv("pluginJar", pluginJar).log("Bootstrap is required: plugin JAR was modified");
+                return true;
+            }
+            logger.atInfo().kv("pluginJar", pluginJar).log("Bootstrap is not required: no change in plugin JAR");
+        } catch (IOException | SemverException e) {
+            logger.atError().log("Bootstrap is not required: unable to locate plugin JAR", e);
+        }
+        return false;
+    }
+
+    /**
+     * Moves the service to finished state and shuts down lifecycle thread.
+     * Since the service has loading exceptions, don't expect depending services to exit before itself.
+     *
+     * @return future completes when the lifecycle thread shuts down.
+     */
+    @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public CompletableFuture<Void> close() {
+        return close(false);
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -115,6 +115,7 @@ class DeploymentConfigMergerTest {
         GreengrassService newService = mock(GreengrassService.class);
         when(kernel.locate("oldService")).thenReturn(newService);
         when(kernel.locate("newService")).thenReturn(newService);
+        when(kernel.locateIgnoreError("newService")).thenReturn(newService);
 
         Map<String, Object> newConfig = new HashMap<>();
         newConfig.put("newService", new Object());
@@ -213,11 +214,11 @@ class DeploymentConfigMergerTest {
             throws Exception {
         // setup
         GreengrassService builtinService = mock(GreengrassService.class);
-        when(kernel.locate("builtinService")).thenReturn(builtinService);
+        when(kernel.locateIgnoreError("builtinService")).thenReturn(builtinService);
         when(builtinService.shouldAutoStart()).thenReturn(true);
 
         GreengrassService userLambdaService = mock(GreengrassService.class);
-        when(kernel.locate("userLambdaService")).thenReturn(userLambdaService);
+        when(kernel.locateIgnoreError("userLambdaService")).thenReturn(userLambdaService);
         when(userLambdaService.shouldAutoStart()).thenReturn(false);
 
         Collection<GreengrassService> orderedDependencies = Arrays.asList();

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
@@ -102,6 +102,31 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     }
 
     @Test
+    void GIVEN_nested_bootstrap_definition_WHEN_isBootstrapRequired_THEN_return_false() {
+        Topics bootstrap = Topics.of(context, Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC, null);
+        bootstrap.createLeafChild("script").withValue("\necho complete\n");
+        doReturn(bootstrap).when(config)
+                .findNode(eq(SERVICE_LIFECYCLE_NAMESPACE_TOPIC), eq(Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC));
+
+        assertFalse(ges.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "1.0.0");
+            put(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                put(Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                    put("script", "\necho complete\n");
+                }});
+            }});
+        }}));
+        assertFalse(ges.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "1.0.0");
+            put(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                put("Bootstrap", new HashMap<String, Object>() {{
+                    put("script", "\necho complete\n");
+                }});
+            }});
+        }}));
+    }
+
+    @Test
     void GIVEN_runwith_info_WHEN_exec_add_group_THEN_use_runwith() throws Exception {
         ges.runWith = RunWith.builder().user("foo").group("bar").build();
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/GreengrassServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/GreengrassServiceTest.java
@@ -64,10 +64,10 @@ class GreengrassServiceTest {
         cService = new GreengrassService(root.findTopics(SERVICES_NAMESPACE_TOPIC, "C"));
         dService = new GreengrassService(root.findTopics(SERVICES_NAMESPACE_TOPIC, "D"));
         eService = new GreengrassService(root.findTopics(SERVICES_NAMESPACE_TOPIC, "E"));
-        when(kernel.locate("B")).thenReturn(bService);
-        when(kernel.locate("C")).thenReturn(cService);
-        when(kernel.locate("D")).thenReturn(dService);
-        lenient().when(kernel.locate("E")).thenReturn(eService);
+        when(kernel.locateIgnoreError("B")).thenReturn(bService);
+        when(kernel.locateIgnoreError("C")).thenReturn(cService);
+        when(kernel.locateIgnoreError("D")).thenReturn(dService);
+        lenient().when(kernel.locateIgnoreError("E")).thenReturn(eService);
         aService = spy(new GreengrassService(root.findTopics(SERVICES_NAMESPACE_TOPIC, "A")));
 
     }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
@@ -112,7 +112,7 @@ class KernelLifecycleTest {
             throws Exception {
         GreengrassService mockMain = mock(GreengrassService.class);
         GreengrassService mockOthers = mock(GreengrassService.class);
-        doReturn(mockMain).when(mockKernel).locate(eq("main"));
+        doReturn(mockMain).when(mockKernel).locateIgnoreError(eq("main"));
         doReturn(mockOthers).when(mockKernel).locate(not(eq("main")));
 
         // Mock out EZPlugins so I can return a deterministic set of services to be added as auto-start
@@ -212,7 +212,7 @@ class KernelLifecycleTest {
     @Test
     void GIVEN_kernel_WHEN_launch_with_config_THEN_effective_config_written() throws Exception {
         GreengrassService mockMain = mock(GreengrassService.class);
-        doReturn(mockMain).when(mockKernel).locate(eq("main"));
+        doReturn(mockMain).when(mockKernel).locateIgnoreError(eq("main"));
 
         kernelLifecycle.initConfigAndTlog();
         verify(mockKernel).writeEffectiveConfig();

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/SetupDependencyTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/SetupDependencyTest.java
@@ -80,9 +80,9 @@ class SetupDependencyTest extends GGServiceTestUtil {
         GreengrassService svcA = mock(GreengrassService.class);
         GreengrassService svcB = mock(GreengrassService.class);
         GreengrassService svcC = mock(GreengrassService.class);
-        when(mockKernel.locate("svcA")).thenReturn(svcA);
-        when(mockKernel.locate("svcB")).thenReturn(svcB);
-        when(mockKernel.locate("svcC")).thenReturn(svcC);
+        when(mockKernel.locateIgnoreError("svcA")).thenReturn(svcA);
+        when(mockKernel.locateIgnoreError("svcB")).thenReturn(svcB);
+        when(mockKernel.locateIgnoreError("svcC")).thenReturn(svcC);
 
         Map<GreengrassService, DependencyType> dependencyMap = greengrassService.getDependencyTypeMap(Arrays
                 .asList("svcA", "svcB:Hard", "svcC:sOFT"));

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/UnloadableServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/UnloadableServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.lifecyclemanager;
+
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
+import com.aws.greengrass.util.NucleusPaths;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
+import static com.aws.greengrass.lifecyclemanager.Kernel.SERVICE_TYPE_TOPIC_KEY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+public class UnloadableServiceTest extends GGServiceTestUtil {
+
+    private UnloadableService unloadableService;
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    NucleusPaths nucleusPaths;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        unloadableService = new UnloadableService(initializeMockedConfig(), new ServiceLoadException("mock error"));
+        lenient().doReturn(nucleusPaths).when(context).get(NucleusPaths.class);
+        lenient().doReturn(tempDir).when(nucleusPaths).artifactPath(any());
+    }
+
+    @Test
+    void GIVEN_new_config_missing_information_WHEN_isBootstrapRequired_THEN_return_false() {
+        doReturn(Topic.of(context, VERSION_CONFIG_KEY, "1.0.0")).when(config).find(eq(VERSION_CONFIG_KEY));
+
+        assertFalse(unloadableService.isBootstrapRequired(Collections.emptyMap()));
+
+        assertFalse(unloadableService.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(SERVICE_TYPE_TOPIC_KEY, "PLUGIN");
+        }}));
+
+        // Plugin jar not found
+        assertFalse(unloadableService.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(SERVICE_TYPE_TOPIC_KEY, "PLUGIN");
+            put(VERSION_CONFIG_KEY, "1.0.0");
+        }}));
+    }
+
+    @Test
+    void GIVEN_new_config_with_plugin_version_change_WHEN_isBootstrapRequired_THEN_return_true() {
+        doReturn(Topic.of(context, VERSION_CONFIG_KEY, "1.0.0")).when(config).find(eq(VERSION_CONFIG_KEY));
+
+        assertTrue(unloadableService.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "1.0.1");
+            put(SERVICE_TYPE_TOPIC_KEY, "PLUGIN");
+        }}));
+    }
+
+    @Test
+    void GIVEN_new_config_with_plugin_jar_change_WHEN_isBootstrapRequired_THEN_return_true() throws Exception {
+        doReturn(Topic.of(context, VERSION_CONFIG_KEY, "1.0.0")).when(config).find(eq(VERSION_CONFIG_KEY));
+
+        // Sleep 1 second here before modifying file, because last modified timestamp gives 1 second precision
+        Thread.sleep(1_000L);
+        Files.createFile(tempDir.resolve("GreengrassServiceFullName.jar"));
+        assertTrue(unloadableService.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(SERVICE_TYPE_TOPIC_KEY, "PLUGIN");
+            put(VERSION_CONFIG_KEY, "1.0.0");
+        }}));
+    }
+}

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -33,6 +34,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -160,8 +162,9 @@ class AwsIotMqttClientTest {
     }
 
     @Test
-    void GIVEN_individual_client_THEN_it_tracks_subscriptions_correctly()
+    void GIVEN_individual_client_THEN_it_tracks_subscriptions_correctly(ExtensionContext context)
             throws ExecutionException, InterruptedException, TimeoutException {
+        ignoreExceptionOfType(context, CompletionException.class);
         when(mockTopic.findOrDefault(any(), any())).thenReturn(1000);
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
         when(connection.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle service load exception on Nucleus launch
1. Refactor `public GreengrassService locate(String name)` to `locate` which surface exceptions and `locateIgnoreError` which proceeds exceptions using surrogates.
    1. `locateIgnoreError` are used during Nucleus launch, loading new services in deployments, and service setting up dependencies.
1. Deployments are required to fix unloadable services. 
    1. Fixes to plugin services will trigger Nucleus restart. 
    1. Non-plugin services will not restart Nucleus, but old instance will be closed and new one created with new config. When closing unloadable service, its depending services will not block the shutdown.

Minor improvements
1. Track group to root components information if deployment is configured to not rollback on failure
2. Fix error details for Nucleus restart workflow, which should be the persisted error messages during Nucleus activate stage. If missing, there must be errors launching Nucleus in activate stage. 

**Why is this change necessary:**
To prevent such error cases bricking devices.

**How was this change tested:**
End-to-end test scenarios:
1. Nucleus can launch successfully under different ServiceLoadExceptions.
2. Unloadable service can be fixed with deployments.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [x] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
