### PR TITLE
improvement(DeviceConfiguration): Cache the result of validate operation on device configuration 

### DIFF
--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -16,6 +16,7 @@ import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.exceptions.ComponentConfigurationValidationException;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -62,13 +63,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class DeviceConfigurationTest {
@@ -95,9 +90,21 @@ class DeviceConfigurationTest {
         lenient().when(mockKernel.getNucleusPaths()).thenReturn(nucleusPaths);
 
         Topics topics = Topics.of(mock(Context.class), SERVICES_NAMESPACE_TOPIC, mock(Topics.class));
+        when(mockTopics.subscribe(any())).thenReturn(mockTopics);
+        when(configuration.lookupTopics(anyString(), anyString(), anyString())).thenReturn(mockTopics);
         when(configuration.lookupTopics(anyString(), anyString(), anyString(), anyString())).thenReturn(mockTopics);
         when(configuration.lookupTopics(anyString())).thenReturn(topics);
         lenient().when(configuration.lookupTopics(anyString())).thenReturn(topics);
+    }
+
+    @Test
+    void WHEN_isDeviceConfiguredToTalkToCloud_THEN_validate_called_when_cache_is_null() throws DeviceConfigurationException {
+        deviceConfiguration = spy(new DeviceConfiguration(mockKernel));
+        doNothing().when(deviceConfiguration).validate();
+        deviceConfiguration.isDeviceConfiguredToTalkToCloud();
+        verify(deviceConfiguration, times(1)).validate();
+        deviceConfiguration.isDeviceConfiguredToTalkToCloud();
+        verify(deviceConfiguration, times(1)).validate();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -63,7 +63,14 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class DeviceConfigurationTest {

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.NUCLEUS_CONFIG_LOGGING_TOPICS;
+import static com.aws.greengrass.deployment.DeviceConfiguration.SYSTEM_NAMESPACE_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.telemetry.impl.MetricFactory.METRIC_LOGGER_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -143,6 +144,8 @@ class LogManagerHelperTest {
         Topics topics = Topics.of(mock(Context.class), SERVICES_NAMESPACE_TOPIC, mock(Topics.class));
         when(configuration.lookupTopics(anyString(), anyString(), anyString(), anyString())).thenReturn(loggingConfig);
         when(configuration.lookupTopics(anyString())).thenReturn(topics);
+        when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY)).thenReturn(topics);
+        when(configuration.lookupTopics(SYSTEM_NAMESPACE_KEY)).thenReturn(topics);
         DeviceConfiguration deviceConfiguration = new DeviceConfiguration(kernel);
         deviceConfiguration.handleLoggingConfigurationChanges(WhatHappened.childChanged, loggingConfig);
 
@@ -177,6 +180,8 @@ class LogManagerHelperTest {
         when(topic.subscribe(childChangedArgumentCaptor.capture())).thenReturn(topic);
         when(configuration.lookupTopics(anyString(), anyString(), anyString(), anyString())).thenReturn(topic);
         when(configuration.lookupTopics(anyString())).thenReturn(topics);
+        when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY)).thenReturn(topics);
+        when(configuration.lookupTopics(SYSTEM_NAMESPACE_KEY)).thenReturn(topics);
         DeviceConfiguration deviceConfiguration = new DeviceConfiguration(kernel);
         deviceConfiguration.handleLoggingConfigurationChanges(WhatHappened.childChanged, null);
 

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -91,6 +91,9 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
     @Mock
     Context context;
 
+    @Mock
+    Topics topics;
+
     ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
 
     ArgumentCaptor<Set<String>> operationsCaptor = ArgumentCaptor.forClass(Set.class);
@@ -133,6 +136,10 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, MAIN_SERVICE_NAME, SERVICE_DEPENDENCIES_NAMESPACE_TOPIC))
                 .thenReturn(mainDependenciesTopic);
         when(configuration.lookup(SETENV_CONFIG_NAMESPACE, AWS_IOT_THING_NAME_ENV)).thenReturn(thingNameEnv);
+
+        when(topics.subscribe(any())).thenReturn(topics);
+        when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY)).thenReturn(topics);
+        when(configuration.lookupTopics(SYSTEM_NAMESPACE_KEY)).thenReturn(topics);
     }
 
     @AfterEach


### PR DESCRIPTION
**Issue #, if available:**
High throughput operations like mqtt publish checks if the device is configured to talk to cloud. Currently this check is performed every time a message needs to be published.  

**Description of changes:**
This change caches the results of a validate() call on device configuration. The cache is invalidated when the device configuration changes.

**How was this change tested:**
Unit tests.

Test Plan:
1. Verified validate() is called if cache is empty
2. Verified validate() is not called when cache is not empty

**Checklist:**
 - [ ] Updated the README if applicable
 - [ X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
