### PR TITLE
feat: handle RPC server initialization on Windows

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
@@ -5,10 +5,7 @@
 
 package com.aws.greengrass.integrationtests.ipc;
 
-import com.aws.greengrass.config.Subscriber;
-import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeploymentStatusKeeper;
 import com.aws.greengrass.deployment.model.Deployment;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
@@ -136,8 +136,8 @@ public final class IPCTestUtils {
             InterruptedException {
 
         try (EventLoopGroup elGroup = new EventLoopGroup(1); ClientBootstrap clientBootstrap = new ClientBootstrap(elGroup, null)) {
-
-            final String ipcServerSocketPath = (String)kernel.getConfig().getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT).getOnce();
+            final String ipcServerSocketPath = Coerce.toString(kernel.getConfig().getRoot()
+                    .lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT));
             final EventStreamRPCConnectionConfig config = new EventStreamRPCConnectionConfig(clientBootstrap, elGroup,
                     socketOptions, null, ipcServerSocketPath, DEFAULT_PORT_NUMBER,
                     GreengrassConnectMessageSupplier.connectMessageSupplier(authToken));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
@@ -47,7 +47,9 @@ import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ST
 import static com.aws.greengrass.ipc.AuthenticationHandler.SERVICE_UNIQUE_ID_KEY;
 import static com.aws.greengrass.ipc.IPCEventStreamService.DEFAULT_PORT_NUMBER;
 import static com.aws.greengrass.ipc.IPCEventStreamService.NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT;
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.*;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.PRIVATE_STORE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
@@ -13,7 +13,6 @@ import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeploymentStatusKeeper;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
-import com.aws.greengrass.ipc.IPCEventStreamService;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
@@ -139,18 +138,9 @@ public final class IPCTestUtils {
 
         try (EventLoopGroup elGroup = new EventLoopGroup(1); ClientBootstrap clientBootstrap = new ClientBootstrap(elGroup, null)) {
 
-            //String ipcServerSocketPath = kernel.getContext().get(IPCEventStreamService.class).getIpcServerSocketPath();
-            final String[] ipcServerSocketPath = new String[1];
-            kernel.getConfig().getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT)
-                    .subscribe(new Subscriber() {
-                                   @Override
-                                   public void published(WhatHappened what, Topic t) {
-                                       ipcServerSocketPath[0] = (String)t.getOnce();
-                                   }
-                               });
-
+            final String ipcServerSocketPath = (String)kernel.getConfig().getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT).getOnce();
             final EventStreamRPCConnectionConfig config = new EventStreamRPCConnectionConfig(clientBootstrap, elGroup,
-                    socketOptions, null, ipcServerSocketPath[0], DEFAULT_PORT_NUMBER,
+                    socketOptions, null, ipcServerSocketPath, DEFAULT_PORT_NUMBER,
                     GreengrassConnectMessageSupplier.connectMessageSupplier(authToken));
             final CompletableFuture<Void> connected = new CompletableFuture<>();
             final EventStreamRPCConnection connection = new EventStreamRPCConnection(config);

--- a/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
@@ -16,7 +16,6 @@ import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.Platform;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCServiceModel;
@@ -30,9 +29,6 @@ import software.amazon.awssdk.eventstreamrpc.RpcServer;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Paths;
 import java.util.List;
 import javax.inject.Inject;
 

--- a/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
@@ -12,8 +12,8 @@ import com.aws.greengrass.ipc.exceptions.UnauthenticatedException;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.util.Permissions;
 import com.aws.greengrass.util.Utils;
+import com.aws.greengrass.util.platforms.Platform;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
@@ -32,7 +32,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import javax.inject.Inject;
@@ -46,22 +45,22 @@ public class IPCEventStreamService implements Startable, Closeable {
     private static final ObjectMapper OBJECT_MAPPER =
             new ObjectMapper().configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false)
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME = "ipc.socket";
-    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK = "./nucleusRoot/ipc.socket";
-    public static final String NUCLEUS_ROOT_PATH_SYMLINK = "./nucleusRoot";
+//    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME = "ipc.socket";
+//    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK = "./nucleusRoot/ipc.socket";
+//    public static final String NUCLEUS_ROOT_PATH_SYMLINK = "./nucleusRoot";
     // This is relative to component's CWD
     // components CWD is <kernel-root-path>/work/component
-    public static final String IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME = "../../ipc.socket";
+//    public static final String IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME = "../../ipc.socket";
 
     public static final String NUCLEUS_DOMAIN_SOCKET_FILEPATH = "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH";
     public static final String NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT =
             "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT";
 
-    // https://www.gnu.org/software/libc/manual/html_node/Local-Namespace-Details.html
-    private static final int UDS_SOCKET_PATH_MAX_LEN = 108;
+//    // https://www.gnu.org/software/libc/manual/html_node/Local-Namespace-Details.html
+//    private static final int UDS_SOCKET_PATH_MAX_LEN = 108;
 
-    private static final int MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS = 30;
-    public static final int SOCKET_CREATE_POLL_INTERVAL_MS = 200;
+//    private static final int MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS = 30;
+//    public static final int SOCKET_CREATE_POLL_INTERVAL_MS = 200;
 
     private static final Logger logger = LogManager.getLogger(IPCEventStreamService.class);
 
@@ -81,8 +80,8 @@ public class IPCEventStreamService implements Startable, Closeable {
 
     private SocketOptions socketOptions;
     private EventLoopGroup eventLoopGroup;
-    @Getter
-    private String ipcServerSocketAbsolutePath;
+//    @Getter
+//    private String ipcServerSocketPath;
 
     IPCEventStreamService(Kernel kernel,
                                  GreengrassCoreIPCService greengrassCoreIPCService,
@@ -110,55 +109,21 @@ public class IPCEventStreamService implements Startable, Closeable {
             socketOptions.domain = SocketOptions.SocketDomain.LOCAL;
             socketOptions.type = SocketOptions.SocketType.STREAM;
             eventLoopGroup = new EventLoopGroup(1);
-//            ipcServerSocketAbsolutePath =
-//                    kernel.getNucleusPaths().rootPath().resolve(IPC_SERVER_DOMAIN_SOCKET_FILENAME).toString();
 
-            ipcServerSocketAbsolutePath = "\\\\.\\pipe\\NucleusNamedPipe";
-
-//            if (Files.exists(Paths.get(ipcServerSocketAbsolutePath))) {
-//                try {
-//                    logger.atDebug().log("Deleting the ipc server socket descriptor file");
-//                    Files.delete(Paths.get(ipcServerSocketAbsolutePath));
-//                } catch (IOException e) {
-//                    logger.atError().setCause(e).kv("path", ipcServerSocketAbsolutePath)
-//                            .log("Failed to delete the ipc server socket descriptor file");
-//                }
-//            }
-
-
+            String domainSocketFilepath = Platform.getInstance().prepareDomainSocketFilepath();
+            String domainSocketFilepathForComponent = Platform.getInstance().prepareDomainSocketFilepathForComponent();
 
             Topic kernelUri = config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH);
-            kernelUri.withValue(ipcServerSocketAbsolutePath);
+            kernelUri.withValue(domainSocketFilepath);
             Topic kernelRelativeUri =
                     config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
-            kernelRelativeUri.withValue(ipcServerSocketAbsolutePath);
-
-            boolean symLinkCreated = false;
-
-//            try {
-//                // Usually we do not want to write outside of kernel root. Because of socket path length limitations we
-//                // will create a symlink only if needed
-//                if (ipcServerSocketAbsolutePath.length() >= UDS_SOCKET_PATH_MAX_LEN) {
-//                    Files.createSymbolicLink(Paths.get(NUCLEUS_ROOT_PATH_SYMLINK), kernel.getNucleusPaths().rootPath());
-//                    kernelRelativeUri = config.getRoot()
-//                            .lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
-//                    kernelRelativeUri.withValue(IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME);
-//                    symLinkCreated = true;
-//                }
-//
-//            } catch (IOException e) {
-//                logger.atError().setCause(e).log("Cannot setup symlinks for the ipc server socket path. Cannot start "
-//                        + "IPC server as the long nucleus root path is making socket filepath greater than 108 chars. "
-//                        + "Shorten root path and start nucleus again");
-//                close();
-//                throw new RuntimeException(e);
-//            }
+            kernelRelativeUri.withValue(domainSocketFilepathForComponent);
 
             // For domain sockets:
             // 1. Port number is ignored. RpcServer does not accept a null value so we are using a default value.
             // 2. The hostname parameter expects the socket filepath
             rpcServer = new RpcServer(eventLoopGroup, socketOptions, null,
-                    symLinkCreated ? IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK : ipcServerSocketAbsolutePath,
+                    domainSocketFilepathForComponent,
                     DEFAULT_PORT_NUMBER, greengrassCoreIPCService);
             rpcServer.runServer();
         } catch (RuntimeException e) {
@@ -167,30 +132,8 @@ public class IPCEventStreamService implements Startable, Closeable {
             throw e;
         }
 
-        // IPC socket does not get created immediately after runServer returns
-        // Wait up to 30s for it to exist
-//        Path ipcPath = Paths.get(ipcServerSocketAbsolutePath);
-//        long maxTime = System.currentTimeMillis() + MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS * 1000;
-//        while (System.currentTimeMillis() < maxTime && Files.notExists(ipcPath)) {
-//            logger.atDebug().log("Waiting for server socket file");
-//            try {
-//                Thread.sleep(SOCKET_CREATE_POLL_INTERVAL_MS);
-//            } catch (InterruptedException e) {
-//                logger.atWarn().setCause(e).log("Service interrupted before server socket exists");
-//                close();
-//                throw new RuntimeException(e);
-//            }
-//        }
-//        // set permissions on IPC socket so that everyone can read/write
-//        try {
-//            Permissions.setIpcSocketPermission(ipcPath);
-//        } catch (IOException e) {
-//            logger.atError().setCause(e).log("Error while setting permissions for IPC server socket");
-//            close();
-//            throw new RuntimeException(e);
-//        }
+        Platform.getInstance().setIpcBackingFilePermissions();
     }
-
 
     @SuppressWarnings("PMD.UnusedFormalParameter")
     private Authorization ipcAuthorizationHandler(AuthenticationData authenticationData) {
@@ -243,31 +186,7 @@ public class IPCEventStreamService implements Startable, Closeable {
             socketOptions.close();
         }
 
-        // fufranci: refactor
-        if (Files.exists(Paths.get(IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK), LinkOption.NOFOLLOW_LINKS)) {
-            try {
-                logger.atDebug().log("Deleting the ipc server socket descriptor file symlink");
-                Files.delete(Paths.get(IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK));
-            } catch (IOException e) {
-                logger.atError().setCause(e).log("Failed to delete the ipc server socket descriptor file symlink");
-            }
-        }
-        // Removing it during close as CWD might change on next run
-        if (Files.exists(Paths.get(NUCLEUS_ROOT_PATH_SYMLINK), LinkOption.NOFOLLOW_LINKS)) {
-            try {
-                logger.atDebug().log("Deleting the nucleus root path symlink");
-                Files.delete(Paths.get(NUCLEUS_ROOT_PATH_SYMLINK));
-            } catch (IOException e) {
-                logger.atError().setCause(e).log("Failed to delete the ipc server socket descriptor file symlink");
-            }
-        }
-        if (Files.exists(Paths.get(ipcServerSocketAbsolutePath))) {
-            try {
-                logger.atDebug().log("Deleting the ipc server socket descriptor file");
-                Files.delete(Paths.get(ipcServerSocketAbsolutePath));
-            } catch (IOException e) {
-                logger.atError().setCause(e).log("Failed to delete the ipc server socket descriptor file");
-            }
-        }
+
+        Platform.getInstance().cleanupIpcBackingFile();
     }
 }

--- a/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
@@ -110,18 +110,22 @@ public class IPCEventStreamService implements Startable, Closeable {
             socketOptions.domain = SocketOptions.SocketDomain.LOCAL;
             socketOptions.type = SocketOptions.SocketType.STREAM;
             eventLoopGroup = new EventLoopGroup(1);
-            ipcServerSocketAbsolutePath =
-                    kernel.getNucleusPaths().rootPath().resolve(IPC_SERVER_DOMAIN_SOCKET_FILENAME).toString();
+//            ipcServerSocketAbsolutePath =
+//                    kernel.getNucleusPaths().rootPath().resolve(IPC_SERVER_DOMAIN_SOCKET_FILENAME).toString();
 
-            if (Files.exists(Paths.get(ipcServerSocketAbsolutePath))) {
-                try {
-                    logger.atDebug().log("Deleting the ipc server socket descriptor file");
-                    Files.delete(Paths.get(ipcServerSocketAbsolutePath));
-                } catch (IOException e) {
-                    logger.atError().setCause(e).kv("path", ipcServerSocketAbsolutePath)
-                            .log("Failed to delete the ipc server socket descriptor file");
-                }
-            }
+            ipcServerSocketAbsolutePath = "\\\\.\\pipe\\NucleusNamedPipe";
+
+//            if (Files.exists(Paths.get(ipcServerSocketAbsolutePath))) {
+//                try {
+//                    logger.atDebug().log("Deleting the ipc server socket descriptor file");
+//                    Files.delete(Paths.get(ipcServerSocketAbsolutePath));
+//                } catch (IOException e) {
+//                    logger.atError().setCause(e).kv("path", ipcServerSocketAbsolutePath)
+//                            .log("Failed to delete the ipc server socket descriptor file");
+//                }
+//            }
+
+
 
             Topic kernelUri = config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH);
             kernelUri.withValue(ipcServerSocketAbsolutePath);
@@ -131,24 +135,24 @@ public class IPCEventStreamService implements Startable, Closeable {
 
             boolean symLinkCreated = false;
 
-            try {
-                // Usually we do not want to write outside of kernel root. Because of socket path length limitations we
-                // will create a symlink only if needed
-                if (ipcServerSocketAbsolutePath.length() >= UDS_SOCKET_PATH_MAX_LEN) {
-                    Files.createSymbolicLink(Paths.get(NUCLEUS_ROOT_PATH_SYMLINK), kernel.getNucleusPaths().rootPath());
-                    kernelRelativeUri = config.getRoot()
-                            .lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
-                    kernelRelativeUri.withValue(IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME);
-                    symLinkCreated = true;
-                }
-
-            } catch (IOException e) {
-                logger.atError().setCause(e).log("Cannot setup symlinks for the ipc server socket path. Cannot start "
-                        + "IPC server as the long nucleus root path is making socket filepath greater than 108 chars. "
-                        + "Shorten root path and start nucleus again");
-                close();
-                throw new RuntimeException(e);
-            }
+//            try {
+//                // Usually we do not want to write outside of kernel root. Because of socket path length limitations we
+//                // will create a symlink only if needed
+//                if (ipcServerSocketAbsolutePath.length() >= UDS_SOCKET_PATH_MAX_LEN) {
+//                    Files.createSymbolicLink(Paths.get(NUCLEUS_ROOT_PATH_SYMLINK), kernel.getNucleusPaths().rootPath());
+//                    kernelRelativeUri = config.getRoot()
+//                            .lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
+//                    kernelRelativeUri.withValue(IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME);
+//                    symLinkCreated = true;
+//                }
+//
+//            } catch (IOException e) {
+//                logger.atError().setCause(e).log("Cannot setup symlinks for the ipc server socket path. Cannot start "
+//                        + "IPC server as the long nucleus root path is making socket filepath greater than 108 chars. "
+//                        + "Shorten root path and start nucleus again");
+//                close();
+//                throw new RuntimeException(e);
+//            }
 
             // For domain sockets:
             // 1. Port number is ignored. RpcServer does not accept a null value so we are using a default value.
@@ -165,26 +169,26 @@ public class IPCEventStreamService implements Startable, Closeable {
 
         // IPC socket does not get created immediately after runServer returns
         // Wait up to 30s for it to exist
-        Path ipcPath = Paths.get(ipcServerSocketAbsolutePath);
-        long maxTime = System.currentTimeMillis() + MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS * 1000;
-        while (System.currentTimeMillis() < maxTime && Files.notExists(ipcPath)) {
-            logger.atDebug().log("Waiting for server socket file");
-            try {
-                Thread.sleep(SOCKET_CREATE_POLL_INTERVAL_MS);
-            } catch (InterruptedException e) {
-                logger.atWarn().setCause(e).log("Service interrupted before server socket exists");
-                close();
-                throw new RuntimeException(e);
-            }
-        }
-        // set permissions on IPC socket so that everyone can read/write
-        try {
-            Permissions.setIpcSocketPermission(ipcPath);
-        } catch (IOException e) {
-            logger.atError().setCause(e).log("Error while setting permissions for IPC server socket");
-            close();
-            throw new RuntimeException(e);
-        }
+//        Path ipcPath = Paths.get(ipcServerSocketAbsolutePath);
+//        long maxTime = System.currentTimeMillis() + MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS * 1000;
+//        while (System.currentTimeMillis() < maxTime && Files.notExists(ipcPath)) {
+//            logger.atDebug().log("Waiting for server socket file");
+//            try {
+//                Thread.sleep(SOCKET_CREATE_POLL_INTERVAL_MS);
+//            } catch (InterruptedException e) {
+//                logger.atWarn().setCause(e).log("Service interrupted before server socket exists");
+//                close();
+//                throw new RuntimeException(e);
+//            }
+//        }
+//        // set permissions on IPC socket so that everyone can read/write
+//        try {
+//            Permissions.setIpcSocketPermission(ipcPath);
+//        } catch (IOException e) {
+//            logger.atError().setCause(e).log("Error while setting permissions for IPC server socket");
+//            close();
+//            throw new RuntimeException(e);
+//        }
     }
 
 
@@ -239,6 +243,7 @@ public class IPCEventStreamService implements Startable, Closeable {
             socketOptions.close();
         }
 
+        // fufranci: refactor
         if (Files.exists(Paths.get(IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK), LinkOption.NOFOLLOW_LINKS)) {
             try {
                 logger.atDebug().log("Deleting the ipc server socket descriptor file symlink");

--- a/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
@@ -96,16 +96,16 @@ public class IPCEventStreamService implements Startable, Closeable {
             eventLoopGroup = new EventLoopGroup(1);
 
             Topic kernelUri = config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH);
-            kernelUri.withValue(Platform.getInstance().prepareDomainSocketFilepath(rootPath));
+            kernelUri.withValue(Platform.getInstance().prepareIpcFilepath(rootPath));
             Topic kernelRelativeUri =
                     config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
-            kernelRelativeUri.withValue(Platform.getInstance().prepareDomainSocketFilepathForComponent(rootPath));
+            kernelRelativeUri.withValue(Platform.getInstance().prepareIpcFilepathForComponent(rootPath));
 
             // For domain sockets:
             // 1. Port number is ignored. RpcServer does not accept a null value so we are using a default value.
             // 2. The hostname parameter expects the socket filepath
             rpcServer = new RpcServer(eventLoopGroup, socketOptions, null,
-                    Platform.getInstance().prepareDomainSocketFilepathForRpcServer(rootPath),
+                    Platform.getInstance().prepareIpcFilepathForRpcServer(rootPath),
                     DEFAULT_PORT_NUMBER, greengrassCoreIPCService);
             rpcServer.runServer();
         } catch (RuntimeException e) {
@@ -114,7 +114,7 @@ public class IPCEventStreamService implements Startable, Closeable {
             throw e;
         }
 
-        Platform.getInstance().setIpcBackingFilePermissions(rootPath);
+        Platform.getInstance().setIpcFilePermissions(rootPath);
     }
 
     @SuppressWarnings("PMD.UnusedFormalParameter")
@@ -168,6 +168,6 @@ public class IPCEventStreamService implements Startable, Closeable {
             socketOptions.close();
         }
 
-        Platform.getInstance().cleanupIpcBackingFile(kernel.getNucleusPaths().rootPath());
+        Platform.getInstance().cleanupIpcFiles(kernel.getNucleusPaths().rootPath());
     }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/Platform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/Platform.java
@@ -113,7 +113,12 @@ public abstract class Platform implements UserPlatform {
             throws IOException;
 
     public abstract String prepareDomainSocketFilepath();
+
     public abstract String prepareDomainSocketFilepathForComponent();
+
+    public abstract String prepareDomainSocketFilepathForRpcServer();
+
     public abstract void setIpcBackingFilePermissions();
+
     public abstract void cleanupIpcBackingFile();
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/Platform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/Platform.java
@@ -112,13 +112,13 @@ public abstract class Platform implements UserPlatform {
     protected abstract void setPermissions(FileSystemPermission permission, Path path, EnumSet<Option> options)
             throws IOException;
 
-    public abstract String prepareDomainSocketFilepath(Path rootPath);
+    public abstract String prepareIpcFilepath(Path rootPath);
 
-    public abstract String prepareDomainSocketFilepathForComponent(Path rootPath);
+    public abstract String prepareIpcFilepathForComponent(Path rootPath);
 
-    public abstract String prepareDomainSocketFilepathForRpcServer(Path rootPath);
+    public abstract String prepareIpcFilepathForRpcServer(Path rootPath);
 
-    public abstract void setIpcBackingFilePermissions(Path rootPath);
+    public abstract void setIpcFilePermissions(Path rootPath);
 
-    public abstract void cleanupIpcBackingFile(Path rootPath);
+    public abstract void cleanupIpcFiles(Path rootPath);
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/Platform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/Platform.java
@@ -111,4 +111,10 @@ public abstract class Platform implements UserPlatform {
      */
     protected abstract void setPermissions(FileSystemPermission permission, Path path, EnumSet<Option> options)
             throws IOException;
+
+    public abstract String provideIpcBackingFile();
+
+    public abstract void setIpcBackingFilePermissions();
+
+    public abstract void cleanupIpcBackingFile();
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/Platform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/Platform.java
@@ -112,9 +112,8 @@ public abstract class Platform implements UserPlatform {
     protected abstract void setPermissions(FileSystemPermission permission, Path path, EnumSet<Option> options)
             throws IOException;
 
-    public abstract String provideIpcBackingFile();
-
+    public abstract String prepareDomainSocketFilepath();
+    public abstract String prepareDomainSocketFilepathForComponent();
     public abstract void setIpcBackingFilePermissions();
-
     public abstract void cleanupIpcBackingFile();
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/Platform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/Platform.java
@@ -112,13 +112,13 @@ public abstract class Platform implements UserPlatform {
     protected abstract void setPermissions(FileSystemPermission permission, Path path, EnumSet<Option> options)
             throws IOException;
 
-    public abstract String prepareDomainSocketFilepath();
+    public abstract String prepareDomainSocketFilepath(Path rootPath);
 
-    public abstract String prepareDomainSocketFilepathForComponent();
+    public abstract String prepareDomainSocketFilepathForComponent(Path rootPath);
 
-    public abstract String prepareDomainSocketFilepathForRpcServer();
+    public abstract String prepareDomainSocketFilepathForRpcServer(Path rootPath);
 
-    public abstract void setIpcBackingFilePermissions();
+    public abstract void setIpcBackingFilePermissions(Path rootPath);
 
-    public abstract void cleanupIpcBackingFile();
+    public abstract void cleanupIpcBackingFile(Path rootPath);
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -153,4 +153,22 @@ public class WindowsPlatform extends Platform {
             throw new UnsupportedOperationException("changing shell is not supported");
         }
     }
+
+    @Override
+    public String provideIpcBackingFile() {
+//        ipcServerSocketAbsolutePath = "\\\\.\\pipe\\NucleusNamedPipe";
+
+
+        return "";
+    }
+
+    @Override
+    public void setIpcBackingFilePermissions() {
+
+    }
+
+    @Override
+    public void cleanupIpcBackingFile() {
+
+    }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -5,6 +5,8 @@
 
 package com.aws.greengrass.util.platforms;
 
+import com.aws.greengrass.config.Configuration;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
@@ -16,6 +18,7 @@ import org.zeroturnaround.process.PidProcess;
 import org.zeroturnaround.process.Processes;
 import org.zeroturnaround.process.WindowsProcess;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -23,6 +26,8 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 
 public class WindowsPlatform extends Platform {
     @Override
@@ -154,12 +159,30 @@ public class WindowsPlatform extends Platform {
         }
     }
 
+    @Inject
+    private Configuration config;
+
+//    public static final String NUCLEUS_DOMAIN_SOCKET_FILEPATH = "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH";
+//    public static final String NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT =
+//            "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT";
+
+
     @Override
-    public String provideIpcBackingFile() {
-//        ipcServerSocketAbsolutePath = "\\\\.\\pipe\\NucleusNamedPipe";
+    public String prepareDomainSocketFilepath() {
+        String ipcServerSocketAbsolutePath = "\\\\.\\pipe\\NucleusNamedPipe";
 
+//        Topic kernelUri = config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH);
+//        kernelUri.withValue(ipcServerSocketAbsolutePath);
+//        Topic kernelRelativeUri =
+//                config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
+//        kernelRelativeUri.withValue(ipcServerSocketAbsolutePath);
 
-        return "";
+        return ipcServerSocketAbsolutePath;
+    }
+
+    @Override
+    public String prepareDomainSocketFilepathForComponent() {
+        return "\\\\.\\pipe\\NucleusNamedPipe";
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -157,25 +157,25 @@ public class WindowsPlatform extends Platform {
     }
 
     @Override
-    public String prepareDomainSocketFilepath() {
+    public String prepareDomainSocketFilepath(Path rootPath) {
         return NAMED_PIPE;
     }
 
     @Override
-    public String prepareDomainSocketFilepathForComponent() {
+    public String prepareDomainSocketFilepathForComponent(Path rootPath) {
         return NAMED_PIPE;
     }
 
     @Override
-    public String prepareDomainSocketFilepathForRpcServer() {
+    public String prepareDomainSocketFilepathForRpcServer(Path rootPath) {
         return NAMED_PIPE;
     }
 
     @Override
-    public void setIpcBackingFilePermissions() {
+    public void setIpcBackingFilePermissions(Path rootPath) {
     }
 
     @Override
-    public void cleanupIpcBackingFile() {
+    public void cleanupIpcBackingFile(Path rootPath) {
     }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -23,9 +23,10 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 public class WindowsPlatform extends Platform {
-    private static final String NAMED_PIPE = "\\\\.\\pipe\\NucleusNamedPipe";
+    private static final String NAMED_PIPE = "\\\\.\\pipe\\NucleusNamedPipe" + UUID.randomUUID().toString();
 
     @Override
     public Set<Integer> killProcessAndChildren(Process process, boolean force, Set<Integer> additionalPids,

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -5,8 +5,6 @@
 
 package com.aws.greengrass.util.platforms;
 
-import com.aws.greengrass.config.Configuration;
-import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
@@ -25,11 +23,10 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.inject.Inject;
-
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 
 public class WindowsPlatform extends Platform {
+    private static final String NAMED_PIPE = "\\\\.\\pipe\\NucleusNamedPipe";
+
     @Override
     public Set<Integer> killProcessAndChildren(Process process, boolean force, Set<Integer> additionalPids,
                                                UserDecorator decorator)
@@ -159,31 +156,24 @@ public class WindowsPlatform extends Platform {
         }
     }
 
-    @Inject
-    private Configuration config;
-
     @Override
     public String prepareDomainSocketFilepath() {
-        return "\\\\.\\pipe\\NucleusNamedPipe";
+        return NAMED_PIPE;
     }
 
     @Override
     public String prepareDomainSocketFilepathForComponent() {
-        return "\\\\.\\pipe\\NucleusNamedPipe";
+        return NAMED_PIPE;
     }
 
     @Override
     public String prepareDomainSocketFilepathForRpcServer() {
-        return "\\\\.\\pipe\\NucleusNamedPipe";
+        return NAMED_PIPE;
     }
 
     @Override
-    public void setIpcBackingFilePermissions() {
-
-    }
+    public void setIpcBackingFilePermissions() {}
 
     @Override
-    public void cleanupIpcBackingFile() {
-
-    }
+    public void cleanupIpcBackingFile() {}
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -158,25 +158,25 @@ public class WindowsPlatform extends Platform {
     }
 
     @Override
-    public String prepareDomainSocketFilepath(Path rootPath) {
+    public String prepareIpcFilepath(Path rootPath) {
         return NAMED_PIPE;
     }
 
     @Override
-    public String prepareDomainSocketFilepathForComponent(Path rootPath) {
+    public String prepareIpcFilepathForComponent(Path rootPath) {
         return NAMED_PIPE;
     }
 
     @Override
-    public String prepareDomainSocketFilepathForRpcServer(Path rootPath) {
+    public String prepareIpcFilepathForRpcServer(Path rootPath) {
         return NAMED_PIPE;
     }
 
     @Override
-    public void setIpcBackingFilePermissions(Path rootPath) {
+    public void setIpcFilePermissions(Path rootPath) {
     }
 
     @Override
-    public void cleanupIpcBackingFile(Path rootPath) {
+    public void cleanupIpcFiles(Path rootPath) {
     }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -172,8 +172,10 @@ public class WindowsPlatform extends Platform {
     }
 
     @Override
-    public void setIpcBackingFilePermissions() {}
+    public void setIpcBackingFilePermissions() {
+    }
 
     @Override
-    public void cleanupIpcBackingFile() {}
+    public void cleanupIpcBackingFile() {
+    }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -18,7 +18,6 @@ import org.zeroturnaround.process.PidProcess;
 import org.zeroturnaround.process.Processes;
 import org.zeroturnaround.process.WindowsProcess;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -26,6 +25,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.inject.Inject;
 
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 
@@ -162,26 +162,18 @@ public class WindowsPlatform extends Platform {
     @Inject
     private Configuration config;
 
-//    public static final String NUCLEUS_DOMAIN_SOCKET_FILEPATH = "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH";
-//    public static final String NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT =
-//            "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT";
-
-
     @Override
     public String prepareDomainSocketFilepath() {
-        String ipcServerSocketAbsolutePath = "\\\\.\\pipe\\NucleusNamedPipe";
-
-//        Topic kernelUri = config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH);
-//        kernelUri.withValue(ipcServerSocketAbsolutePath);
-//        Topic kernelRelativeUri =
-//                config.getRoot().lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
-//        kernelRelativeUri.withValue(ipcServerSocketAbsolutePath);
-
-        return ipcServerSocketAbsolutePath;
+        return "\\\\.\\pipe\\NucleusNamedPipe";
     }
 
     @Override
     public String prepareDomainSocketFilepathForComponent() {
+        return "\\\\.\\pipe\\NucleusNamedPipe";
+    }
+
+    @Override
+    public String prepareDomainSocketFilepathForRpcServer() {
         return "\\\\.\\pipe\\NucleusNamedPipe";
     }
 

--- a/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/WindowsPlatform.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.UUID;
 
 public class WindowsPlatform extends Platform {
-    private static final String NAMED_PIPE = "\\\\.\\pipe\\NucleusNamedPipe" + UUID.randomUUID().toString();
+    private static final String NAMED_PIPE = "\\\\.\\pipe\\NucleusNamedPipe-" + UUID.randomUUID().toString();
 
     @Override
     public Set<Integer> killProcessAndChildren(Process process, boolean force, Set<Integer> additionalPids,

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -542,7 +542,6 @@ public class UnixPlatform extends Platform {
             // will create a symlink only if needed
             if (isSocketPathTooLong(ipcServerSocketAbsolutePath)) {
                 Files.createSymbolicLink(Paths.get(NUCLEUS_ROOT_PATH_SYMLINK), rootPath);
-
                 symLinkCreated = true;
             }
         } catch (IOException e) {
@@ -553,7 +552,7 @@ public class UnixPlatform extends Platform {
             throw new RuntimeException(e);
         }
 
-        return symLinkCreated ? IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK : ipcServerSocketAbsolutePath;
+        return symLinkCreated ? IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME : ipcServerSocketAbsolutePath;
     }
 
     @Override
@@ -594,7 +593,6 @@ public class UnixPlatform extends Platform {
 
     @Override
     public void cleanupIpcBackingFile(Path rootPath) {
-        // fufranci: refactor
         if (Files.exists(Paths.get(IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK), LinkOption.NOFOLLOW_LINKS)) {
             try {
                 logger.atDebug().log("Deleting the ipc server socket descriptor file symlink");

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.util.platforms.unix;
 
-import com.aws.greengrass.config.Configuration;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.LogEventBuilder;
 import com.aws.greengrass.util.CrashableFunction;
@@ -71,10 +70,26 @@ public class UnixPlatform extends Platform {
     public static final String SET_PERMISSIONS_EVENT = "set-permissions";
     public static final String PATH = "path";
 
+    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME = "ipc.socket";
+    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK = "./nucleusRoot/ipc.socket";
+    public static final String NUCLEUS_ROOT_PATH_SYMLINK = "./nucleusRoot";
+    // This is relative to component's CWD
+    // components CWD is <kernel-root-path>/work/component
+    public static final String IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME = "../../ipc.socket";
+
+    // https://www.gnu.org/software/libc/manual/html_node/Local-Namespace-Details.html
+    private static final int UDS_SOCKET_PATH_MAX_LEN = 108;
+
+    private static final int MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS = 30;
+    public static final int SOCKET_CREATE_POLL_INTERVAL_MS = 200;
+
     private static UnixUserAttributes CURRENT_USER;
     private static UnixGroupAttributes CURRENT_USER_PRIMARY_GROUP;
 
     private final UnixRunWithGenerator runWithGenerator;
+
+    @Inject
+    private Kernel kernel;
 
     /**
      * Construct a new instance.
@@ -495,27 +510,6 @@ public class UnixPlatform extends Platform {
         }
         return ret;
     }
-
-    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME = "ipc.socket";
-    public static final String IPC_SERVER_DOMAIN_SOCKET_FILENAME_SYMLINK = "./nucleusRoot/ipc.socket";
-    public static final String NUCLEUS_ROOT_PATH_SYMLINK = "./nucleusRoot";
-    // This is relative to component's CWD
-    // components CWD is <kernel-root-path>/work/component
-    public static final String IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME = "../../ipc.socket";
-
-    // https://www.gnu.org/software/libc/manual/html_node/Local-Namespace-Details.html
-    private static final int UDS_SOCKET_PATH_MAX_LEN = 108;
-
-    private static final int MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS = 30;
-    public static final int SOCKET_CREATE_POLL_INTERVAL_MS = 200;
-
-
-    @Inject
-    private Kernel kernel;
-
-    @Inject
-    private Configuration config;
-
 
     private String getIpcServerSocketAbsolutePath() {
         return kernel.getNucleusPaths().rootPath().resolve(IPC_SERVER_DOMAIN_SOCKET_FILENAME).toString();

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -488,6 +488,79 @@ public class UnixPlatform extends Platform {
         return ret;
     }
 
+    @Override
+    public String provideIpcBackingFile() {
+//        ipcServerSocketAbsolutePath =
+//                    kernel.getNucleusPaths().rootPath().resolve(IPC_SERVER_DOMAIN_SOCKET_FILENAME).toString();
+
+
+//            if (Files.exists(Paths.get(ipcServerSocketAbsolutePath))) {
+//                try {
+//                    logger.atDebug().log("Deleting the ipc server socket descriptor file");
+//                    Files.delete(Paths.get(ipcServerSocketAbsolutePath));
+//                } catch (IOException e) {
+//                    logger.atError().setCause(e).kv("path", ipcServerSocketAbsolutePath)
+//                            .log("Failed to delete the ipc server socket descriptor file");
+//                }
+//            }
+
+
+//            try {
+//                // Usually we do not want to write outside of kernel root. Because of socket path length limitations we
+//                // will create a symlink only if needed
+//                if (ipcServerSocketAbsolutePath.length() >= UDS_SOCKET_PATH_MAX_LEN) {
+//                    Files.createSymbolicLink(Paths.get(NUCLEUS_ROOT_PATH_SYMLINK), kernel.getNucleusPaths().rootPath());
+//                    kernelRelativeUri = config.getRoot()
+//                            .lookup(SETENV_CONFIG_NAMESPACE, NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT);
+//                    kernelRelativeUri.withValue(IPC_SERVER_DOMAIN_SOCKET_RELATIVE_FILENAME);
+//                    symLinkCreated = true;
+//                }
+//
+//            } catch (IOException e) {
+//                logger.atError().setCause(e).log("Cannot setup symlinks for the ipc server socket path. Cannot start "
+//                        + "IPC server as the long nucleus root path is making socket filepath greater than 108 chars. "
+//                        + "Shorten root path and start nucleus again");
+//                close();
+//                throw new RuntimeException(e);
+//            }
+
+
+        return "";
+    }
+
+    @Override
+    public void setIpcBackingFilePermissions() {
+
+        // IPC socket does not get created immediately after runServer returns
+        // Wait up to 30s for it to exist
+//        Path ipcPath = Paths.get(ipcServerSocketAbsolutePath);
+//        long maxTime = System.currentTimeMillis() + MAX_IPC_SOCKET_CREATION_WAIT_TIME_SECONDS * 1000;
+//        while (System.currentTimeMillis() < maxTime && Files.notExists(ipcPath)) {
+//            logger.atDebug().log("Waiting for server socket file");
+//            try {
+//                Thread.sleep(SOCKET_CREATE_POLL_INTERVAL_MS);
+//            } catch (InterruptedException e) {
+//                logger.atWarn().setCause(e).log("Service interrupted before server socket exists");
+//                close();
+//                throw new RuntimeException(e);
+//            }
+//        }
+//        // set permissions on IPC socket so that everyone can read/write
+//        try {
+//            Permissions.setIpcSocketPermission(ipcPath);
+//        } catch (IOException e) {
+//            logger.atError().setCause(e).log("Error while setting permissions for IPC server socket");
+//            close();
+//            throw new RuntimeException(e);
+//        }
+
+    }
+
+    @Override
+    public void cleanupIpcBackingFile() {
+
+    }
+
     private enum IdOption {
         User, Group
     }

--- a/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.aws.greengrass.ipc.IPCEventStreamService.DEFAULT_PORT_NUMBER;
-import static com.aws.greengrass.ipc.IPCEventStreamService.IPC_SERVER_DOMAIN_SOCKET_FILENAME;
+import static com.aws.greengrass.util.platforms.unix.UnixPlatform.IPC_SERVER_DOMAIN_SOCKET_FILENAME;
 import static com.aws.greengrass.ipc.IPCEventStreamService.NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT;
 import static com.aws.greengrass.ipc.IPCEventStreamService.NUCLEUS_DOMAIN_SOCKET_FILEPATH;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* Define a few methods in `Platform` for the IPC backing file.
* On Unix, the implementation is to provide a domain socket.
* On Windows, the implementation is to provide a named pipe.
* When providing the name of the named pipe, append an UUID to make the name unique so that multiple instances of Nucleus can be started.

**Why is this change necessary:**
* When running on Windows, RPC server expects the `hostname` in the form of a named pipe.

**How was this change tested:**
* Unit tests and integration tests on Linux
* On Windows, manually start Nucleus and observe the following log:
```
2021-02-03T22:49:21.632Z [INFO] (main) com.aws.greengrass.lifecyclemanager.KernelLifecycle: system-start. Launch Nucleus. {configPath=C:\Users\Administrator\my_greengrass_env\root\config, rootPath=C:\Users\Administrator\my_greengrass_env\root, version=0.0.0}
2021-02-03T22:49:21.732Z [INFO] (main) software.amazon.awssdk.eventstreamrpc.RpcServer: IpcServer started.... {}
```

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
