### PR TITLE
refactor(deviceconfiguration): isDeviceConfiguredToTalkToCloud validates only cloud related settings

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
@@ -66,7 +66,7 @@ public class GreengrassComponentServiceClientFactory {
     @Inject
     public GreengrassComponentServiceClientFactory(DeviceConfiguration deviceConfiguration) {
         try {
-            deviceConfiguration.validate();
+            deviceConfiguration.validate(true);
         } catch (DeviceConfigurationException e) {
             configValidationError = e.getMessage();
             return;

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -624,6 +624,16 @@ public class DeviceConfiguration {
      * @throws DeviceConfigurationException when configuration parameters are not valid
      */
     public void validate() throws DeviceConfigurationException {
+        validate(false);
+    }
+
+    /**
+     * Validates the device configuration parameters.
+     *
+     * @param cloudOnly true to only check cloud related settings
+     * @throws DeviceConfigurationException when configuration parameters are not valid
+     */
+    public void validate(boolean cloudOnly) throws DeviceConfigurationException {
         String thingName = Coerce.toString(getThingName());
         String certificateFilePath = Coerce.toString(getCertificateFilePath());
         String privateKeyPath = Coerce.toString(getPrivateKeyFilePath());
@@ -633,7 +643,7 @@ public class DeviceConfiguration {
         String awsRegion = Coerce.toString(getAWSRegion());
 
         validateDeviceConfiguration(thingName, certificateFilePath, privateKeyPath, rootCAPath, iotDataEndpoint,
-                iotCredEndpoint, awsRegion);
+                iotCredEndpoint, awsRegion, cloudOnly);
     }
 
     /**
@@ -647,7 +657,7 @@ public class DeviceConfiguration {
             return cachedValue;
         }
         try {
-            validate();
+            validate(true);
             deviceConfigValidateCachedResult.set(true);
         } catch (DeviceConfigurationException e) {
             deviceConfigValidateCachedResult.set(false);
@@ -709,7 +719,7 @@ public class DeviceConfiguration {
 
     private void validateDeviceConfiguration(String thingName, String certificateFilePath, String privateKeyPath,
                                              String rootCAPath, String iotDataEndpoint, String iotCredEndpoint,
-                                             String awsRegion)
+                                             String awsRegion, boolean cloudOnly)
             throws DeviceConfigurationException {
         List<String> errors = new ArrayList<>();
         if (Utils.isEmpty(thingName)) {
@@ -736,7 +746,9 @@ public class DeviceConfiguration {
 
         try {
             validateEndpoints(awsRegion, iotCredEndpoint, iotDataEndpoint);
-            Platform.getInstance().getRunWithGenerator().validateDefaultConfiguration(this);
+            if (!cloudOnly) {
+                Platform.getInstance().getRunWithGenerator().validateDefaultConfiguration(this);
+            }
         } catch (DeviceConfigurationException | ComponentConfigurationValidationException e) {
             errors.add(e.getMessage());
         }

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -38,7 +38,7 @@ public class S3SdkClientFactory {
     public S3SdkClientFactory(DeviceConfiguration deviceConfiguration, LazyCredentialProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
         try {
-            deviceConfiguration.validate();
+            deviceConfiguration.validate(true);
         } catch (DeviceConfigurationException e) {
             configValidationError = e.getMessage();
         }

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -107,11 +107,11 @@ class DeviceConfigurationTest {
     @Test
     void WHEN_isDeviceConfiguredToTalkToCloud_THEN_validate_called_when_cache_is_null() throws DeviceConfigurationException {
         deviceConfiguration = spy(new DeviceConfiguration(mockKernel));
-        doNothing().when(deviceConfiguration).validate();
+        doNothing().when(deviceConfiguration).validate(true);
         deviceConfiguration.isDeviceConfiguredToTalkToCloud();
-        verify(deviceConfiguration, times(1)).validate();
+        verify(deviceConfiguration, times(1)).validate(true);
         deviceConfiguration.isDeviceConfiguredToTalkToCloud();
-        verify(deviceConfiguration, times(1)).validate();
+        verify(deviceConfiguration, times(1)).validate(true);
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactor `isDeviceConfiguredToTalkToCloud` so that it only checks cloud related settings instead of all device settings.

**Why is this change necessary:**
Removes unnecessary calls to the OS to validate users.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
