### PR TITLE
improvement(spooler): reintroduce the parameter of maxInFlightPublishes

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -310,10 +310,10 @@ public class MqttClient implements Closeable {
             logger.atWarn()
                     .kv(MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY, maxInFlightPublishes)
                     .kv("Max acceptable configuration", IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES)
-                    .log(String.format("The configuration of %s may hit the AWS IoT Core restricting number of "
+                    .log("The configuration of {} may hit the AWS IoT Core restricting number of "
                                     + "unacknowledged QoS=1 publish requests per client. "
-                                    + "Will change to the maximum allowed setting: %d",
-                            MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY, IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES));
+                                    + "Will change to the maximum allowed setting: {}",
+                            MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY, IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES);
 
             maxInFlightPublishes = IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES;
         }

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -94,6 +94,8 @@ class MqttClientTest {
         Topics mqttNamespace = config.lookupTopics("mqtt");
         Topics spoolerNamespace = config.lookupTopics("spooler");
         mqttNamespace.lookup(MqttClient.MQTT_OPERATION_TIMEOUT_KEY).withValue(0);
+        mqttNamespace.lookup(MqttClient.MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY)
+                .withValue(MqttClient.IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES + 1);
         when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttNamespace);
         lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         lenient().when(deviceConfiguration.getSpoolerNamespace()).thenReturn(spoolerNamespace);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, the spooler could only use singe thread for message publishing and result in publish tps as 13-15. Right now, re-introduce the parameter of "maxInFlightPublishes" to increase the tps. 

Because IoT has restriction of Inbound/Outbound publish requests per second per account as 100, "maxInFlightPublishes" will limit to 100. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
