### PR TITLE
feat(docker): initial implementation for docker image artifact do…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
+        <!-- Temporary, need to remove when docker image downloading moves out of the Nucleus -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ecr</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-process-killer</artifactId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
@@ -7,10 +7,10 @@ package com.aws.greengrass.integrationtests.componentmanager;
 
 import com.aws.greengrass.componentmanager.ComponentManager;
 import com.aws.greengrass.componentmanager.ComponentStore;
+import com.aws.greengrass.componentmanager.builtins.ArtifactDownloader;
+import com.aws.greengrass.componentmanager.builtins.ArtifactDownloaderFactory;
 import com.aws.greengrass.componentmanager.converter.RecipeLoader;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
-import com.aws.greengrass.componentmanager.plugins.ArtifactDownloader;
-import com.aws.greengrass.componentmanager.plugins.ArtifactDownloaderFactory;
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.helper.PreloadComponentStoreHelper;
 import com.aws.greengrass.integrationtests.BaseITCase;
@@ -73,7 +73,10 @@ class ComponentManagerIntegTest extends BaseITCase {
         when(mockDownloader.downloadRequired()).thenReturn(true);
         when(mockDownloader.checkDownloadable()).thenReturn(Optional.empty());
         when(mockDownloader.getArtifactFile()).thenReturn(artifactFile);
-        when(mockDownloader.downloadToPath()).thenAnswer(downloadToPath("zip.zip", artifactFile));
+        when(mockDownloader.canUnarchiveArtifact()).thenReturn(true);
+        when(mockDownloader.canSetFilePermissions()).thenReturn(true);
+        when(mockDownloader.checkComponentStoreSize()).thenReturn(true);
+        when(mockDownloader.download()).thenAnswer(downloadToPath("zip.zip", artifactFile));
 
         ArtifactDownloaderFactory mockDownloaderFactory = mock(ArtifactDownloaderFactory.class);
         when(mockDownloaderFactory.getArtifactDownloader(any(), any(), any())).thenReturn(mockDownloader);
@@ -122,7 +125,10 @@ class ComponentManagerIntegTest extends BaseITCase {
         when(mockDownloader.downloadRequired()).thenReturn(true);
         when(mockDownloader.checkDownloadable()).thenReturn(Optional.empty());
         when(mockDownloader.getArtifactFile()).thenReturn(scriptFile).thenReturn(emptyFile);
-        when(mockDownloader.downloadToPath()).thenAnswer(downloadToPath("script.sh", scriptFile))
+        when(mockDownloader.canUnarchiveArtifact()).thenReturn(true);
+        when(mockDownloader.canSetFilePermissions()).thenReturn(true);
+        when(mockDownloader.checkComponentStoreSize()).thenReturn(true);
+        when(mockDownloader.download()).thenAnswer(downloadToPath("script.sh", scriptFile))
                 .thenAnswer(downloadToPath("empty.txt", emptyFile));
 
         ArtifactDownloaderFactory mockDownloaderFactory = mock(ArtifactDownloaderFactory.class);
@@ -132,7 +138,6 @@ class ComponentManagerIntegTest extends BaseITCase {
         Files.copy(Paths.get(this.getClass().getResource("aws.iot.gg.test.integ.perm-1.0.0.yaml").toURI()),
                 nucleusPaths.recipePath().resolve(PreloadComponentStoreHelper
                         .getRecipeStorageFilenameFromTestSource("aws.iot.gg.test.integ.perm-1.0.0.yaml")));
-
         // THEN
         kernel.getContext().get(ComponentManager.class).preparePackages(Collections.singletonList(ident))
                 .get(10, TimeUnit.SECONDS);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/DockerImageArtifactDownloadTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/DockerImageArtifactDownloadTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.componentmanager.plugins;
+
+import com.aws.greengrass.componentmanager.ComponentManager;
+import com.aws.greengrass.componentmanager.ComponentStore;
+import com.aws.greengrass.componentmanager.converter.RecipeLoader;
+import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.componentmanager.plugins.DefaultDockerClient;
+import com.aws.greengrass.componentmanager.plugins.EcrAccessor;
+import com.aws.greengrass.componentmanager.plugins.Image;
+import com.aws.greengrass.componentmanager.plugins.Registry;
+import com.aws.greengrass.config.PlatformResolver;
+import com.aws.greengrass.helper.PreloadComponentStoreHelper;
+import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.NucleusPaths;
+import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
+import com.vdurmont.semver4j.Semver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.AuthorizationData;
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest;
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenResponse;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class DockerImageArtifactDownloadTest extends BaseITCase {
+
+    private final PlatformResolver platformResolver = new PlatformResolver(null);
+    private final RecipeLoader recipeLoader = new RecipeLoader(platformResolver);
+    @Mock
+    private EcrClient ecrClient;
+    @Mock
+    private DefaultDockerClient dockerClient;
+    @Mock
+    private MqttClient mqttClient;
+    private ComponentManager componentManager;
+    private Kernel kernel;
+
+    @BeforeEach
+    void before() throws Exception {
+        Instant credentialsExpiry = Instant.now().plusSeconds(10);
+        AuthorizationData authorizationData = AuthorizationData.builder()
+                .authorizationToken(Base64.encode("username:password".getBytes(StandardCharsets.UTF_8)))
+                .expiresAt(credentialsExpiry).build();
+        GetAuthorizationTokenResponse response =
+                GetAuthorizationTokenResponse.builder().authorizationData(authorizationData).build();
+        lenient().when(ecrClient.getAuthorizationToken(any(GetAuthorizationTokenRequest.class))).thenReturn(response);
+
+        lenient().when(dockerClient.dockerInstalled()).thenReturn(true);
+        lenient().when(dockerClient.login(any(Registry.class))).thenReturn(true);
+        lenient().when(dockerClient.pullImage(any(Image.class))).thenReturn(true);
+
+        AtomicBoolean mqttOnline = new AtomicBoolean(true);
+        lenient().when(mqttClient.getMqttOnline()).thenReturn(mqttOnline);
+
+        kernel = new Kernel();
+
+        NucleusPaths nucleusPaths = kernel.getNucleusPaths();
+        nucleusPaths.setComponentStorePath(tempRootDir);
+        ComponentStore store = new ComponentStore(nucleusPaths, platformResolver, recipeLoader);
+
+        EcrAccessor ecrAccessor = new EcrAccessor(ecrClient);
+
+        kernel.getContext().put(ComponentStore.class, store);
+        kernel.getContext().put(EcrAccessor.class, ecrAccessor);
+        kernel.getContext().put(DefaultDockerClient.class, dockerClient);
+        kernel.getContext().put(MqttClient.class, mqttClient);
+
+        preloadLocalStoreContent();
+
+        componentManager = kernel.getContext().get(ComponentManager.class);
+    }
+
+    @AfterEach
+    void afterEach() {
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_component_with_ecr_private_image_as_artifact_WHEN_prepare_packages_THEN_download_image()
+            throws Exception {
+        ComponentIdentifier componentId =
+                new ComponentIdentifier("docker.image.from.ecr.private.registry", new Semver("1.0.0"));
+        componentManager.preparePackages(Collections.singletonList(componentId)).get();
+
+        verify(ecrClient, times(3)).getAuthorizationToken(any(GetAuthorizationTokenRequest.class));
+        verify(dockerClient, times(3)).dockerInstalled();
+        verify(dockerClient, times(3)).login(any(Registry.class));
+        verify(dockerClient, times(3)).pullImage(any(Image.class));
+    }
+
+    @Test
+    void GIVEN_component_with_ecr_public_image_as_artifact_WHEN_prepare_packages_THEN_download_image()
+            throws Exception {
+        ComponentIdentifier componentId =
+                new ComponentIdentifier("docker.image.from.ecr.public.registry", new Semver("1.0.0"));
+        componentManager.preparePackages(Collections.singletonList(componentId)).get();
+
+        verify(ecrClient, never()).getAuthorizationToken(any(GetAuthorizationTokenRequest.class));
+        verify(dockerClient, times(3)).dockerInstalled();
+        verify(dockerClient, never()).login(any(Registry.class));
+        verify(dockerClient, times(3)).pullImage(any(Image.class));
+    }
+
+    @Test
+    void GIVEN_component_with_dockerhub_image_as_artifact_WHEN_prepare_packages_THEN_download_image() throws Exception {
+        ComponentIdentifier componentId = new ComponentIdentifier("docker.image.from.dockerhub", new Semver("1.0.0"));
+        componentManager.preparePackages(Collections.singletonList(componentId)).get();
+
+        verify(ecrClient, never()).getAuthorizationToken(any(GetAuthorizationTokenRequest.class));
+        verify(dockerClient, times(3)).dockerInstalled();
+        verify(dockerClient, never()).login(any(Registry.class));
+        verify(dockerClient, times(3)).pullImage(any(Image.class));
+    }
+
+    private void preloadLocalStoreContent() throws URISyntaxException, IOException {
+        Path localStoreContentPath =
+                Paths.get(DockerImageArtifactDownloadTest.class.getResource("dockerdownloader").toURI());
+        System.out.println(localStoreContentPath.toString());
+        PreloadComponentStoreHelper.preloadRecipesFromTestResourceDir(localStoreContentPath.resolve("recipes"),
+                kernel.getNucleusPaths().recipePath());
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/componentmanager/plugins/dockerdownloader/recipes/docker.image.from.dockerhub-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/componentmanager/plugins/dockerdownloader/recipes/docker.image.from.dockerhub-1.0.0.yaml
@@ -1,0 +1,11 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: docker.image.from.dockerhub
+ComponentVersion: '1.0.0'
+Manifests:
+  - Platform:
+      os: all
+    Artifacts:
+      - URI: "docker:registry.hub.docker.com/library/alpine@sha256:5442792a-752c-11eb-9439-0242ac130002"
+      - URI: "docker:registry.hub.docker.com/library/alpine:sometag"
+      - URI: "docker:registry.hub.docker.com/library/alpine"

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/componentmanager/plugins/dockerdownloader/recipes/docker.image.from.ecr.private.registry-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/componentmanager/plugins/dockerdownloader/recipes/docker.image.from.ecr.private.registry-1.0.0.yaml
@@ -1,0 +1,11 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: docker.image.from.ecr.private.registry
+ComponentVersion: '1.0.0'
+Manifests:
+  - Platform:
+      os: all
+    Artifacts:
+      - URI: "docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage@sha256:5442792a-752c-11eb-9439-0242ac130002"
+      - URI: "docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage:sometag"
+      - URI: "docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage"

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/componentmanager/plugins/dockerdownloader/recipes/docker.image.from.ecr.public.registry-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/componentmanager/plugins/dockerdownloader/recipes/docker.image.from.ecr.public.registry-1.0.0.yaml
@@ -1,0 +1,11 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: docker.image.from.ecr.public.registry
+ComponentVersion: '1.0.0'
+Manifests:
+  - Platform:
+      os: all
+    Artifacts:
+      - URI: "docker:public.ecr.aws/a1b2c3d4/testimage@sha256:5442792a-752c-11eb-9439-0242ac130002"
+      - URI: "docker:public.ecr.aws/a1b2c3d4/testimage:sometag"
+      - URI: "docker:public.ecr.aws/a1b2c3d4/testimage"

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -7,8 +7,11 @@ package com.aws.greengrass.componentmanager;
 
 import com.amazon.aws.iot.greengrass.component.common.ComponentType;
 import com.amazon.aws.iot.greengrass.component.common.Unarchive;
+import com.aws.greengrass.componentmanager.builtins.ArtifactDownloader;
+import com.aws.greengrass.componentmanager.builtins.ArtifactDownloaderFactory;
 import com.aws.greengrass.componentmanager.converter.RecipeLoader;
 import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriException;
+import com.aws.greengrass.componentmanager.exceptions.MissingRequiredComponentsException;
 import com.aws.greengrass.componentmanager.exceptions.NoAvailableComponentVersionException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
@@ -19,8 +22,7 @@ import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.ComponentMetadata;
 import com.aws.greengrass.componentmanager.models.ComponentRecipe;
 import com.aws.greengrass.componentmanager.models.RecipeMetadata;
-import com.aws.greengrass.componentmanager.plugins.ArtifactDownloader;
-import com.aws.greengrass.componentmanager.plugins.ArtifactDownloaderFactory;
+import com.aws.greengrass.componentmanager.plugins.Image;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.InjectionActions;
 import com.aws.greengrass.deployment.DeviceConfiguration;
@@ -64,7 +66,9 @@ import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.PREV_VERSION_CONFIG_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
+import static com.aws.greengrass.componentmanager.plugins.DockerManagerService.DOCKER_MANAGER_PLUGIN_SERVICE_NAME;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.ANY_VERSION;
+import static com.aws.greengrass.tes.TokenExchangeService.TOKEN_EXCHANGE_SERVICE_TOPICS;
 import static org.apache.commons.io.FileUtils.ONE_MB;
 
 public class ComponentManager implements InjectionActions {
@@ -335,6 +339,45 @@ public class ComponentManager implements InjectionActions {
         });
     }
 
+    /**
+     * Check if all plugins that are required to execute pre-merge steps like download for other components are included
+     * in the deployment.
+     *
+     * @param componentIds deployment dependency closure
+     * @throws MissingRequiredComponentsException when any required plugins are not included
+     * @throws PackageLoadingException            when other errors occur
+     */
+    public void checkPreparePackagesPrerequisites(List<ComponentIdentifier> componentIds)
+            throws MissingRequiredComponentsException, PackageLoadingException {
+        List<String> componentNames =
+                componentIds.stream().map(ComponentIdentifier::getName).collect(Collectors.toList());
+        for (ComponentIdentifier componentId : componentIds) {
+            Optional<ComponentRecipe> recipeOption = componentStore.findPackageRecipe(componentId);
+            if (!recipeOption.isPresent()) {
+                throw new PackageLoadingException(
+                        String.format("Unexpected error - cannot find recipe for a component to be prepared - %s",
+                                componentId));
+            }
+            for (ComponentArtifact artifact : recipeOption.get().getArtifacts()) {
+                // TODO : Make this more generic & use dedicated component type
+                if (artifact.getArtifactUri().getScheme().equalsIgnoreCase(ArtifactDownloaderFactory.DOCKER_SCHEME)) {
+                    if (!componentNames.contains(DOCKER_MANAGER_PLUGIN_SERVICE_NAME)) {
+                        throw new MissingRequiredComponentsException(String.format(
+                                "Special components with docker artifacts must include the "
+                                        + "%s download plugin in the deployment", DOCKER_MANAGER_PLUGIN_SERVICE_NAME));
+                    }
+                    Image image = Image.fromArtifactUri(artifact.getArtifactUri());
+                    if (image.getRegistry().isEcrRegistry() && image.getRegistry().isPrivateRegistry()
+                            && !componentNames.contains(TOKEN_EXCHANGE_SERVICE_TOPICS)) {
+                        throw new MissingRequiredComponentsException(String.format(
+                                "Components with private ECR docker artifacts must include "
+                                        + "the %s plugin in the deployment", TOKEN_EXCHANGE_SERVICE_TOPICS));
+                    }
+                }
+            }
+        }
+    }
+
     private void preparePackage(ComponentIdentifier componentIdentifier)
             throws PackageLoadingException, PackageDownloadException, InvalidArtifactUriException,
             InterruptedException {
@@ -383,55 +426,64 @@ public class ComponentManager implements InjectionActions {
                             String.format("Disk space critical: %d bytes usable, %d bytes minimum allowed",
                                     usableSpaceBytes, DEFAULT_MIN_DISK_AVAIL_BYTES));
                 }
-                long downloadSize = downloader.getDownloadSize();
-                long storeContentSize = componentStore.getContentSize();
-                if (storeContentSize + downloadSize > getConfiguredMaxSize()) {
-                    throw new SizeLimitException(String.format(
-                            "Component store size limit reached: %d bytes existing, %d bytes needed"
-                                    + ", %d bytes maximum allowed total", storeContentSize, downloadSize,
-                            getConfiguredMaxSize()));
+                if (downloader.checkComponentStoreSize()) {
+                    long downloadSize = downloader.getDownloadSize();
+                    long storeContentSize = componentStore.getContentSize();
+                    if (storeContentSize + downloadSize > getConfiguredMaxSize()) {
+                        throw new SizeLimitException(String.format(
+                                "Component store size limit reached: %d bytes existing, %d bytes needed"
+                                        + ", %d bytes maximum allowed total", storeContentSize, downloadSize,
+                                getConfiguredMaxSize()));
+                    }
                 }
                 try {
-                    downloader.downloadToPath();
+                    downloader.download();
                 } catch (IOException e) {
                     throw new PackageDownloadException(
                             String.format("Failed to download component %s artifact %s", componentIdentifier, artifact),
                             e);
                 }
             }
-            File artifactFile = downloader.getArtifactFile();
-            if (artifactFile != null) {
-                try {
-                    Permissions.setArtifactPermission(artifactFile.toPath(),
-                            artifact.getPermission().toFileSystemPermission());
-                } catch (IOException e) {
-                    throw new PackageDownloadException(
-                            String.format("Failed to change permissions of component %s artifact %s",
-                                    componentIdentifier, artifact), e);
-                }
-            }
-            Unarchive unarchive = artifact.getUnarchive();
-            if (unarchive == null) {
-                unarchive = Unarchive.NONE;
-            }
-
-            if (artifactFile != null && !unarchive.equals(Unarchive.NONE)) {
-                try {
-                    Path unarchivePath =
-                            nucleusPaths.unarchiveArtifactPath(componentIdentifier, getFileName(artifactFile));
-                    unarchiver.unarchive(unarchive, artifactFile, unarchivePath);
+            if (downloader.canSetFilePermissions()) {
+                File artifactFile = downloader.getArtifactFile();
+                if (artifactFile != null) {
                     try {
-                        Permissions.setArtifactPermission(unarchivePath,
+                        Permissions.setArtifactPermission(artifactFile.toPath(),
                                 artifact.getPermission().toFileSystemPermission());
                     } catch (IOException e) {
                         throw new PackageDownloadException(
                                 String.format("Failed to change permissions of component %s artifact %s",
                                         componentIdentifier, artifact), e);
                     }
-                } catch (IOException e) {
-                    throw new PackageDownloadException(
-                            String.format("Failed to unarchive component %s artifact %s", componentIdentifier,
-                                    artifact), e);
+                }
+            }
+            if (downloader.canUnarchiveArtifact()) {
+                Unarchive unarchive = artifact.getUnarchive();
+                if (unarchive == null) {
+                    unarchive = Unarchive.NONE;
+                }
+
+                File artifactFile = downloader.getArtifactFile();
+                if (artifactFile != null && !unarchive.equals(Unarchive.NONE)) {
+                    try {
+                        Path unarchivePath =
+                                nucleusPaths.unarchiveArtifactPath(componentIdentifier, getFileName(artifactFile));
+                        unarchiver.unarchive(unarchive, artifactFile, unarchivePath);
+                        if (downloader.canSetFilePermissions()) {
+                            try {
+                                Permissions.setArtifactPermission(unarchivePath,
+                                        artifact.getPermission().toFileSystemPermission());
+                            } catch (IOException e) {
+                                throw new PackageDownloadException(
+                                        String.format("Failed to change permissions of component %s artifact %s",
+                                                componentIdentifier, artifact), e);
+                            }
+                        }
+                    } catch (IOException e) {
+                        throw new PackageDownloadException(
+                                String.format("Failed to unarchive component %s artifact %s", componentIdentifier,
+                                        artifact), e);
+                    }
                 }
             }
         }

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.componentmanager.plugins;
+package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.exceptions.ArtifactChecksumMismatchException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
@@ -43,6 +43,7 @@ public abstract class ArtifactDownloader {
     protected final ComponentIdentifier identifier;
     protected final ComponentArtifact artifact;
     protected final Path artifactDir;
+
     @Setter(AccessLevel.PACKAGE)
     private RetryUtils.RetryConfig checksumMismatchRetryConfig =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1L))
@@ -83,7 +84,7 @@ public abstract class ArtifactDownloader {
      * @throws PackageDownloadException if error occurred in download process
      */
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
-    public final File downloadToPath() throws PackageDownloadException, IOException, InterruptedException {
+    public File download() throws PackageDownloadException, IOException, InterruptedException {
         MessageDigest messageDigest;
         try {
             if (artifact.getAlgorithm() == null) {
@@ -249,6 +250,36 @@ public abstract class ArtifactDownloader {
     protected String getErrorString(String reason) {
         return String.format(ARTIFACT_DOWNLOAD_EXCEPTION_FMT, artifact.getArtifactUri(),
                 identifier.getName(), identifier.getVersion().toString()) + reason;
+    }
+
+    /**
+     * Check if an instance of implemented class supports checking component store size depending on
+     * if the artifact is located in greengrass artifact store or third party.
+     *
+     * @return evaluation result
+     */
+    public boolean checkComponentStoreSize() {
+        return true;
+    }
+
+    /**
+     * Check if an instance of implemented class supports setting file permissions depending on
+     * if the artifact is located in greengrass artifact store or third party.
+     *
+     * @return evaluation result
+     */
+    public boolean canSetFilePermissions() {
+        return true;
+    }
+
+    /**
+     * Check if an instance of implemented class supports unarchiving the artifact depending on
+     * if the artifact is located in greengrass artifact store or third party.
+     *
+     * @return evaluation result
+     */
+    public boolean canUnarchiveArtifact() {
+        return true;
     }
 }
 

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.componentmanager.plugins;
+package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.GreengrassComponentServiceClientFactory;
@@ -11,6 +11,8 @@ import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriExceptio
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.componentmanager.plugins.DockerImageDownloader;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.util.S3SdkClientFactory;
 
 import java.net.URI;
@@ -20,6 +22,7 @@ import javax.inject.Inject;
 public class ArtifactDownloaderFactory {
     private static final String GREENGRASS_SCHEME = "GREENGRASS";
     private static final String S3_SCHEME = "S3";
+    public static final String DOCKER_SCHEME = "DOCKER";
 
     private final S3SdkClientFactory s3ClientFactory;
 
@@ -27,20 +30,25 @@ public class ArtifactDownloaderFactory {
 
     private final ComponentStore componentStore;
 
+    private final Context context;
+
     /**
      * ArtifactDownloaderFactory constructor.
      *
      * @param s3SdkClientFactory                      s3SdkClientFactory
      * @param greengrassComponentServiceClientFactory greengrassComponentServiceClientFactory
      * @param componentStore                          componentStore
+     * @param context                                 context
      */
     @Inject
     public ArtifactDownloaderFactory(S3SdkClientFactory s3SdkClientFactory,
                                      GreengrassComponentServiceClientFactory greengrassComponentServiceClientFactory,
-                                     ComponentStore componentStore) {
+                                     ComponentStore componentStore,
+                                     Context context) {
         this.s3ClientFactory = s3SdkClientFactory;
         this.greengrassComponentServiceClientFactory = greengrassComponentServiceClientFactory;
         this.componentStore = componentStore;
+        this.context = context;
     }
 
     /**
@@ -63,6 +71,11 @@ public class ArtifactDownloaderFactory {
         }
         if (S3_SCHEME.equals(scheme)) {
             return new S3Downloader(s3ClientFactory, identifier, artifact, artifactDir);
+        }
+        // TODO : Needs to be moved out into a different mechanism where when loaded via a plugin,
+        //  an artifact downloader can register itself and be discoverable here.
+        if (DOCKER_SCHEME.equals(scheme)) {
+            return new DockerImageDownloader(identifier, artifact, artifactDir, context);
         }
         throw new PackageLoadingException(String.format("artifact URI scheme %s is not supported yet", scheme));
     }

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.componentmanager.plugins;
+package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.GreengrassComponentServiceClientFactory;

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.componentmanager.plugins;
+package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;

--- a/src/main/java/com/aws/greengrass/componentmanager/exceptions/MissingRequiredComponentsException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/exceptions/MissingRequiredComponentsException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package com.aws.greengrass.componentmanager.exceptions;
+
+public class MissingRequiredComponentsException extends Exception {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public MissingRequiredComponentsException(String message) {
+        super(message);
+    }
+
+    public MissingRequiredComponentsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/DefaultDockerClient.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import com.aws.greengrass.componentmanager.plugins.exceptions.DockerLoginException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.DockerServiceUnavailableException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.InvalidImageOrAccessDeniedException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.UserNotAuthorizedForDockerException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.Exec;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Docker CLI wrapper that communicates with Docker Engine to execute user commands.
+ */
+@NoArgsConstructor
+public class DefaultDockerClient {
+    public static final Logger logger = LogManager.getLogger(DefaultDockerClient.class);
+
+    /**
+     * Sanity check for installation.
+     *
+     * @return if docker is installed on the host
+     */
+    public boolean dockerInstalled() {
+        CliResponse response = runDockerCmd("docker -v");
+        return response.exit.isPresent() && response.exit.get() == 0;
+    }
+
+    /**
+     * Login to given docker registry.
+     *
+     * @param registry Registry to log into, with credentials encapsulated
+     * @return if docker login was successful
+     * @throws DockerLoginException                error in authenticating with the registry
+     * @throws UserNotAuthorizedForDockerException when current user is not authorized to use docker
+     * @throws DockerServiceUnavailableException   an error that can be potentially fixed through retries
+     * @throws IOException                         unexpected error
+     */
+    public boolean login(Registry registry)
+            throws DockerLoginException, UserNotAuthorizedForDockerException, DockerServiceUnavailableException,
+            IOException {
+        // TODO : [Blocker] Ensure credentials in command to be run do not get logged
+        CliResponse response = runDockerCmd(String.format("docker login %s -u %s -p %s", registry.getEndpoint(),
+                registry.getCredentials().getUsername(), registry.getCredentials().getPassword()));
+
+        Optional userAuthorizationError = checkUserAuthorizationError(response);
+        if (userAuthorizationError.isPresent()) {
+            throw (UserNotAuthorizedForDockerException) userAuthorizationError.get();
+        }
+
+        if (response.exit.isPresent()) {
+            if (response.exit.get() == 0) {
+                return true;
+            } else {
+                if (response.getOut().contains("Service Unavailable")) {
+                    // This error can be thrown when disconnected/issue with docker cloud service, or when the docker
+                    // engine has issues or proxy config is bad etc. Not entirely reliable to determine retry behavior
+                    throw new DockerServiceUnavailableException(
+                            String.format("Error logging into the registry using credentials - %s", response.out));
+                }
+                throw new DockerLoginException(
+                        String.format("Error logging into the registry using credentials - %s", response.out));
+            }
+        } else {
+            throw new IOException("Unexpected error while trying to perform docker login", response.failureCause);
+        }
+    }
+
+    /**
+     * Pull given docker image.
+     *
+     * @param image Image to download
+     * @return if docker pull was successful
+     * @throws DockerServiceUnavailableException   an error that can be potentially fixed through retries
+     * @throws InvalidImageOrAccessDeniedException an error indicating incorrect image specification or auth issues with
+     *                                             the registry
+     * @throws UserNotAuthorizedForDockerException when current user is not authorized to use docker
+     * @throws IOException                         unexpected error
+     */
+    public boolean pullImage(Image image) throws DockerServiceUnavailableException, InvalidImageOrAccessDeniedException,
+            UserNotAuthorizedForDockerException, IOException {
+        CliResponse response = runDockerCmd(String.format("docker pull %s", image.getImageFullName()));
+
+        Optional userAuthorizationError = checkUserAuthorizationError(response);
+        if (userAuthorizationError.isPresent()) {
+            throw (UserNotAuthorizedForDockerException) userAuthorizationError.get();
+        }
+
+        if (response.exit.isPresent()) {
+            if (response.exit.get() == 0) {
+                return true;
+            } else {
+                if (response.getOut().contains("Service Unavailable")) {
+                    // This error can be thrown when disconnected/issue with docker cloud service, or when the docker
+                    // engine has issues or proxy config is bad etc. Not entirely reliable to determine retry behavior
+                    throw new DockerServiceUnavailableException(
+                            String.format("Error logging into the registry using credentials - %s", response.out));
+                }
+                if (response.getOut().contains("repository does not exist or may require 'docker login'")) {
+                    throw new InvalidImageOrAccessDeniedException(
+                            String.format("Invalid image or login - %s", response.out));
+                }
+                throw new IOException("Unexpected error while trying to perform docker login", response.failureCause);
+            }
+        } else {
+            throw new IOException("Unexpected error while trying to perform docker login", response.failureCause);
+        }
+    }
+
+    private CliResponse runDockerCmd(String cmd) {
+        Throwable cause = null;
+        StringBuilder output = new StringBuilder();
+        StringBuilder error = new StringBuilder();
+        Optional<Integer> exit = Optional.empty();
+        try (Exec exec = new Exec()) {
+            exit = exec.withExec(cmd.split(" ")).withShell().withOut(output::append).withErr(error::append).exec();
+        } catch (InterruptedException e) {
+            Arrays.stream(e.getSuppressed()).forEach((t) -> {
+                logger.atError().setCause(e).log("interrupted");
+            });
+            cause = e;
+        } catch (IOException e) {
+            cause = e;
+        }
+        return new CliResponse(exit, output.toString(), error.toString(), cause);
+    }
+
+    private Optional<UserNotAuthorizedForDockerException> checkUserAuthorizationError(CliResponse response) {
+        UserNotAuthorizedForDockerException error = null;
+        if (response.exit.isPresent() && response.exit.get() != 0 && response.err
+                .contains("Got permission denied while trying to connect to the Docker daemon socket")) {
+            error = new UserNotAuthorizedForDockerException("User not authorized to use docker, if you're "
+                    + "not running greengrass as root, please add the user you're running with to docker group "
+                    + "and redo the deployment");
+        }
+        return Optional.ofNullable(error);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class CliResponse {
+        Optional<Integer> exit;
+        String out;
+        String err;
+        Throwable failureCause;
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/DockerImageDownloader.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import com.aws.greengrass.componentmanager.builtins.ArtifactDownloader;
+import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+import com.aws.greengrass.componentmanager.models.ComponentArtifact;
+import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.componentmanager.plugins.exceptions.ConnectionException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.DockerLoginException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.DockerServiceUnavailableException;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.util.CrashableSupplier;
+import com.aws.greengrass.util.RetryUtils;
+import lombok.AccessLevel;
+import lombok.Setter;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.ecr.model.ServerException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.AvoidCatchingGenericException",
+        "PMD.AvoidInstanceofChecksInCatchClause", "PMD.AvoidRethrowingException"})
+public class DockerImageDownloader extends ArtifactDownloader {
+
+    private final EcrAccessor ecrAccessor;
+    private final DefaultDockerClient dockerClient;
+    private final MqttClient mqttClient;
+
+    @Setter(AccessLevel.PACKAGE)
+    private RetryUtils.RetryConfig networkIssuesRetryConfig =
+            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1L))
+                    .maxRetryInterval(Duration.ofMinutes(1L)).maxAttempt(Integer.MAX_VALUE).retryableExceptions(
+                    Arrays.asList(ConnectionException.class, SdkClientException.class, ServerException.class)).build();
+    @Setter(AccessLevel.PACKAGE)
+    private RetryUtils.RetryConfig nonNetworkIssuesRetryConfig =
+            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1L))
+                    .maxRetryInterval(Duration.ofMinutes(1L)).maxAttempt(30).retryableExceptions(
+                    Arrays.asList(DockerServiceUnavailableException.class, DockerLoginException.class,
+                            SdkClientException.class, ServerException.class)).build();
+
+    /**
+     * Constructor.
+     *
+     * @param identifier  component identifier
+     * @param artifact    artifact to download
+     * @param artifactDir artifact store path
+     * @param context     context
+     */
+    public DockerImageDownloader(ComponentIdentifier identifier, ComponentArtifact artifact, Path artifactDir,
+                                 Context context) {
+        super(identifier, artifact, artifactDir);
+        ecrAccessor = context.get(EcrAccessor.class);
+        dockerClient = context.get(DefaultDockerClient.class);
+        mqttClient = context.get(MqttClient.class);
+    }
+
+    DockerImageDownloader(ComponentIdentifier identifier, ComponentArtifact artifact, Path artifactDir,
+                          DefaultDockerClient dockerClient, EcrAccessor ecrAccessor, MqttClient mqttClient) {
+        super(identifier, artifact, artifactDir);
+        this.dockerClient = dockerClient;
+        this.ecrAccessor = ecrAccessor;
+        this.mqttClient = mqttClient;
+    }
+
+    @Override
+    protected long download(long rangeStart, long rangeEnd, MessageDigest messageDigest)
+            throws PackageDownloadException, InterruptedException {
+        // N/A since handling partial download is managed by docker engine
+        return 0;
+    }
+
+    @Override
+    public File download() throws PackageDownloadException, IOException, InterruptedException {
+        // Check that Docker engine is installed
+        if (!dockerClient.dockerInstalled()) {
+            throw new PackageDownloadException("Docker engine is not installed on the device, please ensure it's "
+                    + "installed and redo the deployment");
+        }
+
+        Image image = Image.fromArtifactUri(artifact.getArtifactUri());
+        if (image.getRegistry().isEcrRegistry() && image.getRegistry().isPrivateRegistry()) {
+            // Get auth token for ECR
+            try {
+                RetryUtils.runWithRetry(networkIssuesRetryConfig, () -> {
+                    Registry.Credentials credentials = ecrAccessor.getCredentials(image.getRegistry().getRegistryId());
+                    image.getRegistry().setCredentials(credentials);
+                    return null;
+                }, "get-ecr-auth-token", logger);
+            } catch (InterruptedException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new PackageDownloadException(getErrorString("Failed to get auth token for docker login"), e);
+            }
+
+            // Login to registry
+            run(() -> dockerClient.login(image.getRegistry()), "docker-login", "Failed to login to docker registry");
+        }
+
+        // Docker pull
+        // TODO : Redo credential fetching and login if ECR registry credentials expire by the time pull is attempted
+        run(() -> dockerClient.pullImage(image), "docker-pull-image", "Failed to download docker image");
+
+        // No file resources available since image artifacts are stored in docker's image store
+        return null;
+    }
+
+    private <T> void run(CrashableSupplier<T, Exception> task, String description, String message)
+            throws PackageDownloadException, InterruptedException {
+        try {
+            // Retry with relevant config for errors that are not due to connectivity issues
+            RetryUtils.runWithRetry(nonNetworkIssuesRetryConfig, () -> RetryUtils
+                    // Retry with relevant config for errors that are due to connectivity issues
+                    .runWithRetry(networkIssuesRetryConfig, () -> runWithConnectionErrorCheck(task), description,
+                            logger), description, logger);
+        } catch (InterruptedException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new PackageDownloadException(getErrorString(message), e);
+        }
+    }
+
+    private <T> T runWithConnectionErrorCheck(CrashableSupplier<T, Exception> task) throws Exception {
+        try {
+            return task.apply();
+        } catch (Exception e) {
+            // Since docker engine can throw service unavailable error that may or may not indicate a problem that
+            // can be fixed with retries, explicitly check if an error could be due to connectivity problem
+            // we infer that based on Mqtt connection, even though not perfect, it should accurately represent if
+            // device is having connectivity issues most of the times.
+            if (e instanceof DockerServiceUnavailableException && !mqttClient.getMqttOnline().get()) {
+                throw new ConnectionException(String.format("Device appears to be offline, should retry the task "), e);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean downloadRequired() {
+        // TODO : Consider executing `docker image ls` to see if the required image version(tag/digest) already
+        //  exists to save a download attempt
+        return true;
+    }
+
+    @Override
+    public Optional<String> checkDownloadable() {
+        // TODO : Maybe worth checking if device is configured such that it can get TES credentials for ECR.
+        // N/A for images from other registries
+        return Optional.empty();
+    }
+
+    @Override
+    public Long getDownloadSize() throws PackageDownloadException, InterruptedException {
+        // Not supported for docker images
+        return null;
+    }
+
+    @Override
+    public String getArtifactFilename() {
+        // Not applicable for docker images since docker engine abstracts this
+        return null;
+    }
+
+    @Override
+    public boolean checkComponentStoreSize() {
+        // Not applicable for docker images since docker has its own image store
+        return false;
+    }
+
+    @Override
+    public boolean canSetFilePermissions() {
+        // Not applicable for docker images since docker has its own image store
+        return false;
+    }
+
+    @Override
+    public boolean canUnarchiveArtifact() {
+        // Not applicable for docker images since docker engine abstracts this
+        return false;
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/DockerManagerService.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/DockerManagerService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.ImplementsService;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Loads docker image artifact downloader. Currently just a placeholder since the downloader is part of the nucleus but
+ * when the downloader needs to be moved out into its own plugin, this service will be instantiated for the plugin.
+ */
+@ImplementsService(name = DockerManagerService.DOCKER_MANAGER_PLUGIN_SERVICE_NAME)
+@Singleton
+public class DockerManagerService extends GreengrassService {
+    public static final String DOCKER_MANAGER_PLUGIN_SERVICE_NAME = "aws.greengrass.DockerManager";
+
+    /**
+     * Constructor for injection.
+     *
+     * @param topics topics root
+     */
+    @Inject
+    public DockerManagerService(Topics topics) {
+        super(topics);
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/EcrAccessor.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/EcrAccessor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import com.aws.greengrass.componentmanager.plugins.exceptions.RegistryAuthException;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.tes.LazyCredentialProvider;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.ProxyUtils;
+import lombok.AllArgsConstructor;
+import org.apache.commons.codec.binary.Base64;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.AuthorizationData;
+import software.amazon.awssdk.services.ecr.model.EcrException;
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest;
+import software.amazon.awssdk.services.ecr.model.ServerException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import javax.inject.Inject;
+
+/**
+ * AWS ECR SDK client wrapper.
+ *
+ */
+@AllArgsConstructor
+public class EcrAccessor {
+    private EcrClient ecrClient;
+
+    /**
+     * Constructor.
+     *
+     * @param deviceConfiguration Device config
+     * @param lazyCredentialProvider AWS credentials provider
+     */
+    @Inject
+    public EcrAccessor(DeviceConfiguration deviceConfiguration, LazyCredentialProvider lazyCredentialProvider) {
+        configureClient(deviceConfiguration, lazyCredentialProvider);
+        deviceConfiguration.getAWSRegion()
+                .subscribe((what, node) -> configureClient(deviceConfiguration, lazyCredentialProvider));
+    }
+
+    private void configureClient(DeviceConfiguration deviceConfiguration,
+                                 LazyCredentialProvider lazyCredentialProvider) {
+        this.ecrClient = EcrClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
+                .region(Region.of(Coerce.toString(deviceConfiguration.getAWSRegion())))
+                .credentialsProvider(lazyCredentialProvider).build();
+    }
+
+    /**
+     * Get credentials(auth token) for a private docker registry in ECR.
+     *
+     * @param registryId Registry id
+     * @return Registry.Credentials - Registry's authorization information
+     * @throws RegistryAuthException When authentication fails
+     */
+    @SuppressWarnings("PMD.AvoidRethrowingException")
+    public Registry.Credentials getCredentials(String registryId) throws RegistryAuthException {
+        try {
+            AuthorizationData authorizationData = ecrClient.getAuthorizationToken(
+                    GetAuthorizationTokenRequest.builder().registryIds(Collections.singletonList(registryId)).build())
+                    .authorizationData().get(0);
+            // Decoded auth token is of the format <username>:<password>
+            String[] authTokenParts =
+                    new String(Base64.decodeBase64(authorizationData.authorizationToken()), StandardCharsets.UTF_8)
+                            .split(":");
+            return new Registry.Credentials(authTokenParts[0], authTokenParts[1],
+                    authorizationData.expiresAt());
+        } catch (ServerException | SdkClientException e) {
+            // Errors we can retry on
+            throw e;
+        } catch (EcrException e) {
+            throw new RegistryAuthException(String.format("Failed to get credentials for ECR registry - %s",
+                    registryId), e);
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/Image.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/Image.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.Pair;
+import com.aws.greengrass.util.Utils;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.net.URI;
+
+/**
+ * Represents a docker image derived from a component artifact specification.
+ */
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Image {
+    public static final Logger logger = LogManager.getLogger(Image.class);
+
+    private Registry registry;
+    private String name;
+    private String tag;
+    private String digest;
+    @EqualsAndHashCode.Include
+    private URI artifactUri;
+
+
+    /**
+     * Build an instance from a component artifact.
+     *
+     * @param uri Artifact uri
+     * @return Image instance
+     */
+    public static Image fromArtifactUri(URI uri) {
+        // Format - <docker:registry/host:port/image:tag|@digest>, everything except for the image name is optional
+        // TODO : Add more validation/use regex per docker's official grammar - https://github
+        //  .com/distribution/distribution/blob/main/reference/reference.go#L6
+        String rawId = uri.getSchemeSpecificPart();
+        String digest = null;
+        String tag = null;
+        String endpointAndImage;
+
+        // Look for digest first
+        Pair<String, String> digestParts = splitBySeparator(rawId, '@', true, null);
+        if (Utils.isNotEmpty(digestParts.getRight())) {
+            endpointAndImage = digestParts.getLeft();
+            digest = digestParts.getRight();
+        } else {
+            // If no digest specified, look for tag
+            Pair<String, String> tagParts = splitBySeparator(rawId, ':', true, null);
+            if (Utils.isNotEmpty(tagParts.getRight())) {
+                endpointAndImage = tagParts.getLeft();
+                tag = tagParts.getRight();
+            } else {
+                // No digest/tag specified, docker engine will pull the latest image
+                logger.atWarn().kv("artifact-uri", uri).log("It appears that you are not using a specific version of "
+                        + "the image with your component, for ensuring component immutability, it is advised that you "
+                        + "use a specific image version in your component version using image tag/digest");
+                tag = "latest";
+                endpointAndImage = rawId;
+            }
+        }
+        // No registry specified, the default is docker hub's registry server
+        // e.g. ubuntu == library/ubuntu == docker.io/library/ubuntu == registry.hub.docker.com/library/ubuntu
+        Pair<String, String> endpointAndImageParsed =
+                splitBySeparator(endpointAndImage, '/', false, "registry.hub.docker.com/library");
+
+        return new Image(new Registry(endpointAndImageParsed.getLeft()), endpointAndImageParsed.getRight(), tag, digest,
+                uri);
+    }
+
+    /**
+     * Split a string, docker registry+image spec within this class, by given separator that identifies unique parts of
+     * the specified string.
+     *
+     * @param toSplit                       String to split
+     * @param separator                     Separator to split by
+     * @param setAllLeftWhenSeparatorAbsent When provided separator is not present in source string, state if the whole
+     *                                      source string should be set as the first return value. If false, the
+     *                                      opposite will happen, i.e. it will be set as the second return value
+     *                                      instead.
+     * @param defaultWhenSeparatorAbsent    When provided separator is not present in source string, use this
+     *                                      as default value for the missing part
+     * @return Pair of first and second value as split result
+     */
+    private static Pair<String, String> splitBySeparator(String toSplit, char separator,
+                                                         boolean setAllLeftWhenSeparatorAbsent,
+                                                         String defaultWhenSeparatorAbsent) {
+        String left;
+        String right;
+
+        if (toSplit.indexOf(separator) > -1) {
+            int separatorIndex = toSplit.lastIndexOf(separator);
+            left = toSplit.substring(0, separatorIndex);
+            right = toSplit.substring(separatorIndex + 1);
+        } else if (setAllLeftWhenSeparatorAbsent) {
+            left = toSplit;
+            right = defaultWhenSeparatorAbsent;
+        } else {
+            left = defaultWhenSeparatorAbsent;
+            right = toSplit;
+        }
+
+        return new Pair<>(left, right);
+    }
+
+    /**
+     * Derive the full name of the image in docker-defined format that can be used with the docker engine.
+     *
+     * @return full docker image name in the docker-specific format
+     */
+    public String getImageFullName() {
+        return this.artifactUri.getSchemeSpecificPart();
+    }
+
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/Registry.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/Registry.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a docker registry derived from a component artifact specification.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Registry {
+    private static List<String> PRIVATE_ECR_REGISTRY_IDENTIFIERS = Arrays.asList("dkr.ecr", "amazonaws");
+    private static String PUBLIC_ECR_REGISTRY_IDENTIFIER = "public.ecr.aws";
+
+    @EqualsAndHashCode.Include
+    private String endpoint;
+    private ImageType type;
+    private ImageSource source;
+    @Setter
+    private Credentials credentials;
+
+    /**
+     * Constructor.
+     *
+     * @param endpoint Registry endpoint
+     */
+    public Registry(String endpoint) {
+        this.endpoint = endpoint;
+
+        if (endpoint.contains(PUBLIC_ECR_REGISTRY_IDENTIFIER)) {
+            this.source = ImageSource.ECR;
+            this.type = ImageType.PUBLIC;
+        } else if (containsAll(endpoint, PRIVATE_ECR_REGISTRY_IDENTIFIERS)) {
+            this.source = ImageSource.ECR;
+            this.type = ImageType.PRIVATE;
+        } else {
+            this.source = ImageSource.OTHER;
+            this.type = ImageType.PUBLIC;
+        }
+    }
+
+    private boolean containsAll(String str, List<String> subStrs) {
+        for (String subStr : subStrs) {
+            if (!str.contains(subStr)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get registry id.
+     *
+     * @return registry id
+     */
+    public String getRegistryId() {
+        return this.isEcrRegistry() && this.isPrivateRegistry() ? this.endpoint.split("\\.")[0] : this.endpoint;
+    }
+
+    /**
+     * Check if the registry is from ECR.
+     *
+     * @return evaluation result
+     */
+    public boolean isEcrRegistry() {
+        return Registry.ImageSource.ECR.equals(source);
+    }
+
+    /**
+     * Check if the image is private.
+     *
+     * @return evaluation result
+     */
+    public boolean isPrivateRegistry() {
+        return Registry.ImageType.PRIVATE.equals(type);
+    }
+
+    public enum ImageType {
+        PRIVATE, PUBLIC
+    }
+
+    public enum ImageSource {
+        ECR, OTHER
+    }
+
+    /**
+     * Registry credentials.
+     */
+    @Getter
+    @AllArgsConstructor
+    public static class Credentials {
+        @NonNull
+        private String username;
+        @NonNull
+        private String password;
+        // For ECR, credential validity is 12 hrs, for other registries, credentials should be static
+        private Instant expiresAt;
+
+        /**
+         * Check if credentials are valid at any point in time, if not they need to be refreshed.
+         *
+         * @return validity
+         */
+        public boolean stillValid() {
+            return Objects.isNull(expiresAt) || Instant.now().compareTo(expiresAt) < 0;
+        }
+
+        /**
+         * Refresh credential values with latest valid ones.
+         *
+         * @param username  username
+         * @param password  password
+         * @param expiresAt expiresAt
+         */
+        public void refresh(String username, String password, Instant expiresAt) {
+            this.username = username;
+            this.password = password;
+            this.expiresAt = expiresAt;
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/ConnectionException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/ConnectionException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins.exceptions;
+
+public class ConnectionException extends Exception {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public ConnectionException(String message) {
+        super(message);
+    }
+
+    public ConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/DockerLoginException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/DockerLoginException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package com.aws.greengrass.componentmanager.plugins.exceptions;
+
+import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+
+public class DockerLoginException extends PackageDownloadException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public DockerLoginException(String message) {
+        super(message);
+    }
+
+    public DockerLoginException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/DockerServiceUnavailableException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/DockerServiceUnavailableException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package com.aws.greengrass.componentmanager.plugins.exceptions;
+
+import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+
+public class DockerServiceUnavailableException extends PackageDownloadException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public DockerServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    public DockerServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/InvalidImageOrAccessDeniedException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/InvalidImageOrAccessDeniedException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package com.aws.greengrass.componentmanager.plugins.exceptions;
+
+import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+
+public class InvalidImageOrAccessDeniedException extends PackageDownloadException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public InvalidImageOrAccessDeniedException(String message) {
+        super(message);
+    }
+
+    public InvalidImageOrAccessDeniedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/RegistryAuthException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/RegistryAuthException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package com.aws.greengrass.componentmanager.plugins.exceptions;
+
+import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+
+public class RegistryAuthException extends PackageDownloadException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public RegistryAuthException(String message) {
+        super(message);
+    }
+
+    public RegistryAuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/UserNotAuthorizedForDockerException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/exceptions/UserNotAuthorizedForDockerException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins.exceptions;
+
+public class UserNotAuthorizedForDockerException extends Exception {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public UserNotAuthorizedForDockerException(String message) {
+        super(message);
+    }
+
+    public UserNotAuthorizedForDockerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -100,6 +100,7 @@ public class MqttClient implements Closeable {
     private final Map<SubscribeRequest, AwsIotMqttClient> subscriptions = new ConcurrentHashMap<>();
     private final Map<MqttTopic, AwsIotMqttClient> subscriptionTopics = new ConcurrentHashMap<>();
     private final AtomicInteger connectionRoundRobin = new AtomicInteger(0);
+    @Getter
     private final AtomicBoolean mqttOnline = new AtomicBoolean(false);
 
     private final EventLoopGroup eventLoopGroup;

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.componentmanager.plugins;
+package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.GreengrassComponentServiceClientFactory;
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.S3SdkClientFactory;
 import com.vdurmont.semver4j.Semver;
@@ -42,12 +43,15 @@ class ArtifactDownloaderFactoryTest {
     @Mock
     ComponentStore componentStore;
 
+    @Mock
+    Context context;
+
     ArtifactDownloaderFactory artifactDownloaderFactory;
 
     @BeforeEach
     public void setup() {
         artifactDownloaderFactory = new ArtifactDownloaderFactory(
-                s3SdkClientFactory, greengrassComponentServiceClientFactory, componentStore);
+                s3SdkClientFactory, greengrassComponentServiceClientFactory, componentStore, context);
     }
 
     @Test
@@ -92,9 +96,9 @@ class ArtifactDownloaderFactoryTest {
     void GIVEN_artifact_provider_not_supported_WHEN_attempt_download_THEN_throw_package_exception()
             throws Exception {
         ComponentIdentifier pkgId = new ComponentIdentifier("CoolService", new Semver("1.0.0"));
-        ComponentArtifact artifact = ComponentArtifact.builder().artifactUri(new URI("docker:image1")).build();
+        ComponentArtifact artifact = ComponentArtifact.builder().artifactUri(new URI("foo:bar")).build();
         Exception exception = assertThrows(PackageLoadingException.class,
                 () -> artifactDownloaderFactory.getArtifactDownloader(pkgId, artifact, testDir));
-        assertThat(exception.getMessage(), is("artifact URI scheme DOCKER is not supported yet"));
+        assertThat(exception.getMessage(), is("artifact URI scheme FOO is not supported yet"));
     }
 }

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.componentmanager.plugins;
+package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.ComponentTestResourceHelper;
@@ -108,7 +108,7 @@ class GreengrassRepositoryDownloaderTest {
                 .thenReturn(HttpURLConnection.HTTP_PARTIAL);
         when(connection.getInputStream()).thenReturn(Files.newInputStream(mockArtifactPath));
 
-        downloader.downloadToPath();
+        downloader.download();
 
         GetComponentVersionArtifactRequest generatedRequest =
                 getComponentVersionArtifactRequestArgumentCaptor.getValue();

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/S3DownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/S3DownloaderTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.componentmanager.plugins;
+package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentTestResourceHelper;
 import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriException;
@@ -121,7 +121,7 @@ class S3DownloaderTest {
                     ComponentArtifact.builder().artifactUri(new URI(VALID_ARTIFACT_URI))
                             .checksum(checksum).algorithm(VALID_ALGORITHM).build(),
                     saveToPath);
-            s3Downloader.downloadToPath();
+            s3Downloader.download();
             byte[] downloadedFile = Files.readAllBytes(saveToPath.resolve("artifact.txt"));
             assertThat("Content of downloaded file should be same as the artifact content",
                     Arrays.equals(Files.readAllBytes(artifactFilePath), downloadedFile));
@@ -166,7 +166,7 @@ class S3DownloaderTest {
                     ComponentArtifact.builder().artifactUri(new URI(VALID_ARTIFACT_URI))
                             .checksum(VALID_ARTIFACT_CHECKSUM).algorithm(VALID_ALGORITHM).build(),
                     saveToPath);
-            Exception e = assertThrows(PackageDownloadException.class, () -> s3Downloader.downloadToPath());
+            Exception e = assertThrows(PackageDownloadException.class, () -> s3Downloader.download());
             assertThat(e.getMessage(), containsString("Failed to download artifact"));
         } finally {
             ComponentTestResourceHelper.cleanDirectory(testCache);

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/DockerImageDownloaderTest.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+import com.aws.greengrass.componentmanager.models.ComponentArtifact;
+import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.componentmanager.plugins.exceptions.ConnectionException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.DockerLoginException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.DockerServiceUnavailableException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.InvalidImageOrAccessDeniedException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.RegistryAuthException;
+import com.aws.greengrass.componentmanager.plugins.exceptions.UserNotAuthorizedForDockerException;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.RetryUtils;
+import com.vdurmont.semver4j.Semver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.ecr.model.ServerException;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class DockerImageDownloaderTest {
+    private static ComponentIdentifier TEST_COMPONENT_ID =
+            new ComponentIdentifier("test.container.component", new Semver("1.0.0"));
+    // Using distinct retry attempts to use as means of verification
+    private final RetryUtils.RetryConfig networkIssuesRetryConfig =
+            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(50L))
+                    .maxRetryInterval(Duration.ofMillis(50L)).maxAttempt(5).retryableExceptions(
+                    Arrays.asList(ConnectionException.class, SdkClientException.class, ServerException.class)).build();
+    private final RetryUtils.RetryConfig nonNetworkIssuesRetryConfig =
+            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(50L))
+                    .maxRetryInterval(Duration.ofMillis(50L)).maxAttempt(2).retryableExceptions(
+                    Arrays.asList(DockerServiceUnavailableException.class, DockerLoginException.class,
+                            SdkClientException.class, ServerException.class)).build();
+
+    @Mock
+    private DefaultDockerClient dockerClient;
+    @Mock
+    private EcrAccessor ecrAccessor;
+    @Mock
+    private MqttClient mqttClient;
+    @Mock
+    private Path artifactDir;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        // AtomicBoolean mqttOnline = new AtomicBoolean(true);
+        lenient().when(mqttClient.getMqttOnline()).thenReturn(new AtomicBoolean(true));
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_an_ecr_image_with_digest_WHEN_deployed_THEN_download_image_artifact()
+            throws Exception {
+        URI artifactUri =
+                new URI("docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage@sha256:5442792a-752c-11eb-9439-0242ac130002");
+        Image image = Image.fromArtifactUri(artifactUri);
+
+        when(ecrAccessor.getCredentials("012345678910"))
+                .thenReturn(new Registry.Credentials("username", "password", Instant.now().plusSeconds(60)));
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.login(image.getRegistry())).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("testimage", image.getName());
+        assertEquals("sha256:5442792a-752c-11eb-9439-0242ac130002", image.getDigest());
+        assertNull(image.getTag());
+        assertTrue(image.getRegistry().isEcrRegistry());
+        assertTrue(image.getRegistry().isPrivateRegistry());
+        assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
+        assertEquals("012345678910", image.getRegistry().getRegistryId());
+
+        verify(ecrAccessor).getCredentials("012345678910");
+        verify(dockerClient).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_an_ecr_image_with_tag_WHEN_deployed_THEN_download_image_artifact()
+            throws Exception {
+        URI artifactUri = new URI("docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(ecrAccessor.getCredentials("012345678910"))
+                .thenReturn(new Registry.Credentials("username", "password", Instant.now().plusSeconds(60)));
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.login(image.getRegistry())).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("testimage", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertTrue(image.getRegistry().isEcrRegistry());
+        assertTrue(image.getRegistry().isPrivateRegistry());
+        assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
+        assertEquals("012345678910", image.getRegistry().getRegistryId());
+
+        verify(ecrAccessor).getCredentials("012345678910");
+        verify(dockerClient).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_a_public_ecr_image_WHEN_deployed_THEN_download_image_artifact()
+            throws Exception {
+        URI artifactUri = new URI("docker:public.ecr.aws/a1b2c3d4/testimage:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("testimage", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertTrue(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("public.ecr.aws/a1b2c3d4", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient).pullImage(image);
+        verify(dockerClient, never()).login(any());
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_a_public_dockerhub_image_WHEN_deployed_THEN_download_image_artifact()
+            throws Exception {
+        URI artifactUri = new URI("docker:registry.hub.docker.com/library/alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_a_container_component_in_deployment_WHEN_docker_not_installed_THEN_fail_deployment() throws Exception {
+        URI artifactUri = new URI("docker:registry.hub.docker.com/library/alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(false);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        Throwable err = assertThrows(PackageDownloadException.class, () -> downloader.download());
+        assertThat(err.getMessage(), containsString("Docker engine is not installed on the device"));
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        verify(dockerClient, never()).pullImage(any());
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_image_in_dockerhub_WHEN_image_not_public_THEN_fail_deployment()
+            throws Exception {
+        URI artifactUri = new URI("docker:registry.hub.docker.com/library/alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenThrow(new InvalidImageOrAccessDeniedException(
+                "Invalid image or login - repository does not exist or may require 'docker login'"));
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        Throwable err = assertThrows(PackageDownloadException.class, () -> downloader.download());
+        assertThat(err.getMessage(), containsString("Failed to download docker image"));
+        assertTrue(err.getCause() instanceof InvalidImageOrAccessDeniedException);
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        verify(dockerClient).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_image_in_ecr_WHEN_when_failed_to_get_credentials_THEN_fail_deployment()
+            throws Exception {
+        URI artifactUri = new URI("docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(ecrAccessor.getCredentials("012345678910"))
+                .thenThrow(new RegistryAuthException("Failed to get " + "credentials for ECR registry"));
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        Throwable err = assertThrows(PackageDownloadException.class, () -> downloader.download());
+        assertThat(err.getMessage(), containsString("Failed to get auth token for docker login"));
+        assertTrue(err.getCause() instanceof RegistryAuthException);
+
+        assertEquals("testimage", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertTrue(image.getRegistry().isEcrRegistry());
+        assertTrue(image.getRegistry().isPrivateRegistry());
+        assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
+        assertEquals("012345678910", image.getRegistry().getRegistryId());
+
+        verify(ecrAccessor).getCredentials("012345678910");
+        verify(dockerClient, never()).login(any());
+        verify(dockerClient, never()).pullImage(any());
+    }
+
+    @Test
+    void GIVEN_a_container_component_WHENn_failed_to_pull_image_THEN_fail_deployment(ExtensionContext extensionContext)
+            throws Exception {
+        ignoreExceptionOfType(extensionContext, DockerServiceUnavailableException.class);
+
+        URI artifactUri = new URI("docker:registry.hub.docker.com/library/alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        // fail all retries
+        when(dockerClient.pullImage(image)).thenThrow(new DockerServiceUnavailableException("Service Unavailable"));
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        Throwable err = assertThrows(PackageDownloadException.class, () -> downloader.download());
+        assertThat(err.getMessage(), containsString("Failed to download docker image"));
+        assertTrue(err.getCause() instanceof DockerServiceUnavailableException);
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        // Invocations as many as the retry count should be expected
+        verify(dockerClient, times(2)).pullImage(any());
+    }
+
+    @Test
+    void GIVEN_connectivity_missing_WHEN_failed_to_pull_and_connectivity_is_back_THEN_retry_and_succeed(
+            ExtensionContext extensionContext) throws Exception {
+        ignoreExceptionOfType(extensionContext, DockerServiceUnavailableException.class);
+        ignoreExceptionOfType(extensionContext, ConnectionException.class);
+
+        URI artifactUri = new URI("docker:registry.hub.docker.com/library/alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(mqttClient.getMqttOnline()).thenReturn(new AtomicBoolean(false));
+        // Fail on first 3 attempts, succeed on fourth attempt to simulate that pull would succeed when connectivity
+        // comes back
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenThrow(new DockerServiceUnavailableException("Service Unavailable"))
+                .thenThrow(new DockerServiceUnavailableException("Service Unavailable"))
+                .thenThrow(new DockerServiceUnavailableException("Service Unavailable"))
+                .thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        // Invocations as many as the retry attempts should be expected
+        verify(dockerClient, times(4)).pullImage(any());
+        verify(mqttClient, times(3)).getMqttOnline();
+    }
+
+    @Test
+    void GIVEN_connectivity_available_WHEN_failed_to_pull_image_intermittently_THEN_succeed_on_retries(
+            ExtensionContext extensionContext) throws Exception {
+        ignoreExceptionOfType(extensionContext, DockerServiceUnavailableException.class);
+
+        URI artifactUri = new URI("docker:registry.hub.docker.com/library/alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        // fail first attempt, succeed on next retry attempt, device is connected the whole time but there could be
+        // temporary issues with docker cloud which can get resolved in a short span
+        when(dockerClient.pullImage(image)).thenThrow(new DockerServiceUnavailableException("Service Unavailable"))
+                .thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        // Invocations as many as the retry count should be expected
+        verify(dockerClient, times(2)).pullImage(any());
+        // Connectivity will be checked on failures which is only once for this test
+        verify(mqttClient, times(1)).getMqttOnline();
+    }
+
+    @Test
+    void GIVEN_connectivity_available_WHEN_failed_to_pull_image_consistently_THEN_fail_after_finite_retries(
+            ExtensionContext extensionContext) throws Exception {
+        ignoreExceptionOfType(extensionContext, DockerServiceUnavailableException.class);
+
+        URI artifactUri = new URI("docker:registry.hub.docker.com/library/alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        // fail first attempt, succeed on next retry attempt, device is connected the whole time
+        when(dockerClient.pullImage(image)).thenThrow(new DockerServiceUnavailableException("Service Unavailable"));
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        Throwable err = assertThrows(PackageDownloadException.class, () -> downloader.download());
+        assertThat(err.getMessage(), containsString("Failed to download docker image"));
+        assertTrue(err.getCause() instanceof DockerServiceUnavailableException);
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        // Invocations as many as the retry count should be expected
+        verify(dockerClient, times(2)).pullImage(any());
+        verify(mqttClient, times(2)).getMqttOnline();
+    }
+
+    @Test
+    void GIVEN_a_container_component_WHEN_greengrass_does_not_have_permissions_to_use_docker_daemon_THEN_fail_deployment()
+            throws Exception {
+        URI artifactUri = new URI("docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.login(any())).thenThrow(new UserNotAuthorizedForDockerException(
+                "Got permission denied while trying to connect to the Docker daemon socket"));
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        Throwable err = assertThrows(PackageDownloadException.class, () -> downloader.download());
+        assertThat(err.getMessage(), containsString("Failed to login to docker registry"));
+        assertTrue(err.getCause() instanceof UserNotAuthorizedForDockerException);
+
+        assertEquals("testimage", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertTrue(image.getRegistry().isEcrRegistry());
+        assertTrue(image.getRegistry().isPrivateRegistry());
+        assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
+        assertEquals("012345678910", image.getRegistry().getRegistryId());
+
+        verify(ecrAccessor).getCredentials("012345678910");
+        verify(dockerClient).login(any());
+        verify(dockerClient, never()).pullImage(any());
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_no_registry_in_uri_WHEN_deployed_THEN_download_image_artifact_from_dockerhub()
+            throws Exception {
+        URI artifactUri = new URI("docker:alpine:sometag");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("alpine", image.getName());
+        assertEquals("sometag", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        verify(dockerClient).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_a_container_component_with_no_digest_or_tag_in_uri_WHEN_deployed_THEN_assume_latest_image_version()
+            throws Exception {
+        URI artifactUri = new URI("docker:alpine");
+        Image image = Image.fromArtifactUri(artifactUri);
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        when(dockerClient.pullImage(image)).thenReturn(true);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        assertEquals("alpine", image.getName());
+        assertEquals("latest", image.getTag());
+        assertNull(image.getDigest());
+        assertFalse(image.getRegistry().isEcrRegistry());
+        assertFalse(image.getRegistry().isPrivateRegistry());
+        assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
+
+        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(dockerClient, never()).login(any());
+        verify(dockerClient).pullImage(image);
+    }
+
+    private DockerImageDownloader getDownloader(URI artifactUri) {
+        DockerImageDownloader downloader = new DockerImageDownloader(TEST_COMPONENT_ID,
+                ComponentArtifact.builder().artifactUri(artifactUri).build(), artifactDir, dockerClient, ecrAccessor,
+                mqttClient);
+        downloader.setNetworkIssuesRetryConfig(networkIssuesRetryConfig);
+        downloader.setNonNetworkIssuesRetryConfig(nonNetworkIssuesRetryConfig);
+        return downloader;
+    }
+}

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/EcrAccessorTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/EcrAccessorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins;
+
+import com.aws.greengrass.componentmanager.plugins.exceptions.RegistryAuthException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.AuthorizationData;
+import software.amazon.awssdk.services.ecr.model.EcrException;
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest;
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class EcrAccessorTest {
+    @Mock
+    private EcrClient ecrClient;
+
+    private EcrAccessor ecrAccessor;
+
+    @BeforeEach
+    public void setup() {
+        ecrAccessor = new EcrAccessor(ecrClient);
+    }
+
+    @Test
+    void GIVEN_ecr_accessor_WHEN_get_credentials_success_THEN_return_registry_credentials() throws Exception {
+        Instant credentialsExpiry = Instant.now().plusSeconds(10);
+        AuthorizationData authorizationData = AuthorizationData.builder()
+                .authorizationToken(Base64.encode("username:password".getBytes(StandardCharsets.UTF_8)))
+                .expiresAt(credentialsExpiry).build();
+        GetAuthorizationTokenResponse response =
+                GetAuthorizationTokenResponse.builder().authorizationData(authorizationData).build();
+        when(ecrClient.getAuthorizationToken(any(GetAuthorizationTokenRequest.class))).thenReturn(response);
+
+        Registry.Credentials credentials = ecrAccessor.getCredentials("some_registry_id");
+
+        assertEquals("username", credentials.getUsername());
+        assertEquals("password", credentials.getPassword());
+        assertEquals(credentialsExpiry, credentials.getExpiresAt());
+        verify(ecrClient).getAuthorizationToken(any(GetAuthorizationTokenRequest.class));
+    }
+
+    @Test
+    void GIVEN_ecr_accessor_WHEN_get_credentials_failure_THEN_throw_auth_error() throws Exception {
+        EcrException ecrException = (EcrException) EcrException.builder().message("Something went wrong").build();
+        when(ecrClient.getAuthorizationToken(any(GetAuthorizationTokenRequest.class))).thenThrow(ecrException);
+
+        Throwable err = assertThrows(RegistryAuthException.class, () -> ecrAccessor.getCredentials("some_registry_id"));
+        assertThat(err.getMessage(), containsString("Failed to get credentials for ECR registry - some_registry_id"));
+        assertThat(err.getCause(), is(instanceOf(EcrException.class)));
+        verify(ecrClient).getAuthorizationToken(any(GetAuthorizationTokenRequest.class));
+    }
+}


### PR DESCRIPTION
…wnloader

**Issue #, if available:**

**Description of changes:**
Implement an artifact downloader which performs docker registry login if applicable and downloads images during the deployment download step. 

*Immediate follow up items outside this PR*
- Add more robustness to intermittent network, close out TODOs etc

*Further fast follow changes planned in this area* 
- This is intended to be a plugin, the code will be moved out of nucleus as soon as time permits, and checks around the plugin dependency being required have been added to make it possible to move this code out as fast follow.
-  Further support for registries

**Why is this change necessary:**

**How was this change tested:**
New tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
