### PR TITLE
refactor: exposing methods for setting the client certificates to call the data plane api

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager;
+
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.EncryptionUtils;
+import com.aws.greengrass.util.IotSdkClientFactory;
+import com.aws.greengrass.util.ProxyUtils;
+import com.aws.greengrass.util.RegionUtils;
+import com.aws.greengrass.util.Utils;
+import com.aws.greengrass.util.exceptions.InvalidEnvironmentStageException;
+import com.aws.greengrass.util.exceptions.TLSAuthException;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
+
+public final class ClientConfigurationUtils {
+
+    private static final Logger logger = LogManager.getLogger(ClientConfigurationUtils.class);
+
+    private ClientConfigurationUtils() {
+    }
+
+    /**
+     * Get the greengrass service endpoint.
+     *
+     * @param deviceConfiguration    {@link DeviceConfiguration}
+     * @return service end point
+     */
+    public static String getGreengrassServiceEndpoint(DeviceConfiguration deviceConfiguration) {
+        IotSdkClientFactory.EnvironmentStage stage;
+        try {
+            stage = IotSdkClientFactory.EnvironmentStage
+                    .fromString(Coerce.toString(deviceConfiguration.getEnvironmentStage()));
+        } catch (InvalidEnvironmentStageException e) {
+            logger.atError().setCause(e).log("Caught exception while parsing Nucleus args");
+            throw new RuntimeException(e);
+        }
+        return RegionUtils.getGreengrassDataPlaneEndpoint(Coerce.toString(deviceConfiguration.getAWSRegion()), stage,
+                Coerce.toInt(deviceConfiguration.getGreengrassDataPlanePort()));
+    }
+
+    /**
+     * Configure the http client builder with the required certificates for the mutual auth connection.
+     *
+     * @param deviceConfiguration    {@link DeviceConfiguration}
+     * @return configured http client
+     */
+    public static ApacheHttpClient.Builder getConfiguredClientBuilder(DeviceConfiguration deviceConfiguration) {
+        ApacheHttpClient.Builder httpClient = ProxyUtils.getSdkHttpClientBuilder();
+        httpClient = httpClient == null ? ApacheHttpClient.builder() : httpClient;
+
+        try {
+            configureClientMutualTLS(httpClient, deviceConfiguration);
+        } catch (TLSAuthException e) {
+            logger.atWarn("configure-greengrass-mutual-auth")
+                    .log("Error during configure greengrass client mutual auth", e);
+        }
+        return httpClient;
+    }
+
+    private static void configureClientMutualTLS(ApacheHttpClient.Builder httpBuilder,
+                                          DeviceConfiguration deviceConfiguration) throws TLSAuthException {
+        String certificatePath = Coerce.toString(deviceConfiguration.getCertificateFilePath());
+        String privateKeyPath = Coerce.toString(deviceConfiguration.getPrivateKeyFilePath());
+        String rootCAPath = Coerce.toString(deviceConfiguration.getRootCAFilePath());
+        if (Utils.isEmpty(certificatePath) || Utils.isEmpty(privateKeyPath) || Utils.isEmpty(rootCAPath)) {
+            return;
+        }
+
+        TrustManager[] trustManagers = createTrustManagers(rootCAPath);
+        KeyManager[] keyManagers = createKeyManagers(privateKeyPath, certificatePath);
+
+        httpBuilder.tlsKeyManagersProvider(() -> keyManagers).tlsTrustManagersProvider(() -> trustManagers);
+    }
+
+    private static TrustManager[] createTrustManagers(String rootCAPath) throws TLSAuthException {
+        try {
+            List<X509Certificate> trustCertificates = EncryptionUtils.loadX509Certificates(rootCAPath);
+
+            KeyStore tmKeyStore = KeyStore.getInstance("JKS");
+            tmKeyStore.load(null, null);
+            for (X509Certificate certificate : trustCertificates) {
+                X500Principal principal = certificate.getSubjectX500Principal();
+                String name = principal.getName("RFC2253");
+                tmKeyStore.setCertificateEntry(name, certificate);
+            }
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("X509");
+            trustManagerFactory.init(tmKeyStore);
+            return trustManagerFactory.getTrustManagers();
+        } catch (GeneralSecurityException | IOException e) {
+            throw new TLSAuthException("Failed to get trust manager", e);
+        }
+    }
+
+    private static KeyManager[] createKeyManagers(String privateKeyPath, String certificatePath)
+            throws TLSAuthException {
+        try {
+            List<X509Certificate> certificateChain = EncryptionUtils.loadX509Certificates(certificatePath);
+
+            PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
+
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            keyStore.load(null);
+            keyStore.setKeyEntry("private-key", privateKey, null, certificateChain.toArray(new Certificate[0]));
+
+            KeyManagerFactory keyManagerFactory =
+                    KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(keyStore, null);
+            return keyManagerFactory.getKeyManagers();
+        } catch (GeneralSecurityException | IOException e) {
+            throw new TLSAuthException("Failed to get key manager", e);
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/GreengrassComponentServiceClientFactory.java
@@ -11,13 +11,7 @@ import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.EncryptionUtils;
-import com.aws.greengrass.util.IotSdkClientFactory;
-import com.aws.greengrass.util.ProxyUtils;
-import com.aws.greengrass.util.RegionUtils;
 import com.aws.greengrass.util.Utils;
-import com.aws.greengrass.util.exceptions.InvalidEnvironmentStageException;
-import com.aws.greengrass.util.exceptions.TLSAuthException;
 import lombok.Getter;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -27,22 +21,10 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
 import software.amazon.awssdk.services.greengrassv2.GreengrassV2ClientBuilder;
 
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
-import java.security.PrivateKey;
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
-import java.util.List;
 import javax.inject.Inject;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.security.auth.x500.X500Principal;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_CERTIFICATE_FILE_PATH;
@@ -90,14 +72,8 @@ public class GreengrassComponentServiceClientFactory {
     }
 
     private void configureClient(DeviceConfiguration deviceConfiguration) {
-        ApacheHttpClient.Builder httpClient = ProxyUtils.getSdkHttpClientBuilder();
-        httpClient = httpClient == null ? ApacheHttpClient.builder() : httpClient;
-        try {
-            configureClientMutualTLS(httpClient, deviceConfiguration);
-        } catch (TLSAuthException e) {
-            logger.atWarn("configure-greengrass-mutual-auth")
-                    .log("Error during configure greengrass client mutual auth", e);
-        }
+
+        ApacheHttpClient.Builder httpClient = ClientConfigurationUtils.getConfiguredClientBuilder(deviceConfiguration);
         GreengrassV2ClientBuilder clientBuilder = GreengrassV2Client.builder()
                 // Use an empty credential provider because our requests don't need SigV4
                 // signing, as they are going through IoT Core instead
@@ -107,7 +83,9 @@ public class GreengrassComponentServiceClientFactory {
         String region = Coerce.toString(deviceConfiguration.getAWSRegion());
 
         if (!Utils.isEmpty(region)) {
-            String greengrassServiceEndpoint = getGreengrassServiceEndpoint(deviceConfiguration);
+            String greengrassServiceEndpoint = ClientConfigurationUtils
+                    .getGreengrassServiceEndpoint(deviceConfiguration);
+
             if (!Utils.isEmpty(greengrassServiceEndpoint)) {
                 // Region and endpoint are both required when updating endpoint config
                 logger.atInfo("initialize-greengrass-client").addKeyValue("service-endpoint", greengrassServiceEndpoint)
@@ -120,73 +98,6 @@ public class GreengrassComponentServiceClientFactory {
                 clientBuilder.region(Region.of(region));
             }
         }
-
         this.cmsClient = clientBuilder.build();
-    }
-
-    private String getGreengrassServiceEndpoint(DeviceConfiguration deviceConfiguration) {
-        IotSdkClientFactory.EnvironmentStage stage;
-        try {
-            stage = IotSdkClientFactory.EnvironmentStage
-                    .fromString(Coerce.toString(deviceConfiguration.getEnvironmentStage()));
-        } catch (InvalidEnvironmentStageException e) {
-            logger.atError().setCause(e).log("Caught exception while parsing Nucleus args");
-            throw new RuntimeException(e);
-        }
-        return RegionUtils.getGreengrassDataPlaneEndpoint(Coerce.toString(deviceConfiguration.getAWSRegion()), stage,
-                Coerce.toInt(deviceConfiguration.getGreengrassDataPlanePort()));
-    }
-
-    private void configureClientMutualTLS(ApacheHttpClient.Builder httpBuilder,
-                                          DeviceConfiguration deviceConfiguration) throws TLSAuthException {
-        String certificatePath = Coerce.toString(deviceConfiguration.getCertificateFilePath());
-        String privateKeyPath = Coerce.toString(deviceConfiguration.getPrivateKeyFilePath());
-        String rootCAPath = Coerce.toString(deviceConfiguration.getRootCAFilePath());
-        if (Utils.isEmpty(certificatePath) || Utils.isEmpty(privateKeyPath) || Utils.isEmpty(rootCAPath)) {
-            return;
-        }
-
-        TrustManager[] trustManagers = createTrustManagers(rootCAPath);
-        KeyManager[] keyManagers = createKeyManagers(privateKeyPath, certificatePath);
-
-        httpBuilder.tlsKeyManagersProvider(() -> keyManagers).tlsTrustManagersProvider(() -> trustManagers);
-    }
-
-    private TrustManager[] createTrustManagers(String rootCAPath) throws TLSAuthException {
-        try {
-            List<X509Certificate> trustCertificates = EncryptionUtils.loadX509Certificates(rootCAPath);
-
-            KeyStore tmKeyStore = KeyStore.getInstance("JKS");
-            tmKeyStore.load(null, null);
-            for (X509Certificate certificate : trustCertificates) {
-                X500Principal principal = certificate.getSubjectX500Principal();
-                String name = principal.getName("RFC2253");
-                tmKeyStore.setCertificateEntry(name, certificate);
-            }
-            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("X509");
-            trustManagerFactory.init(tmKeyStore);
-            return trustManagerFactory.getTrustManagers();
-        } catch (GeneralSecurityException | IOException e) {
-            throw new TLSAuthException("Failed to get trust manager", e);
-        }
-    }
-
-    private KeyManager[] createKeyManagers(String privateKeyPath, String certificatePath) throws TLSAuthException {
-        try {
-            List<X509Certificate> certificateChain = EncryptionUtils.loadX509Certificates(certificatePath);
-
-            PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
-
-            KeyStore keyStore = KeyStore.getInstance("PKCS12");
-            keyStore.load(null);
-            keyStore.setKeyEntry("private-key", privateKey, null, certificateChain.toArray(new Certificate[0]));
-
-            KeyManagerFactory keyManagerFactory =
-                    KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            keyManagerFactory.init(keyStore, null);
-            return keyManagerFactory.getKeyManagers();
-        } catch (GeneralSecurityException | IOException e) {
-            throw new TLSAuthException("Failed to get key manager", e);
-        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Creating client configuration utility to set the necessary certificates for calling the data plane api.

**Why is this change necessary:**
This will avoid the duplication of the code in ip detector

**How was this change tested:**

Manually 

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
