### PR TITLE
fix(shadowdeployment): handle out of order shadow updates

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/ShadowDeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/ShadowDeploymentE2ETest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.e2e.deployment;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.integrationtests.e2e.BaseE2ETestCase;
+import com.aws.greengrass.logging.impl.GreengrassLogMessage;
+import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.WrapperMqttClientConnection;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
+import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
+import software.amazon.awssdk.iot.iotshadow.IotShadowClient;
+import software.amazon.awssdk.iot.iotshadow.model.GetNamedShadowSubscriptionRequest;
+import software.amazon.awssdk.iot.iotshadow.model.ShadowState;
+import software.amazon.awssdk.iot.iotshadow.model.UpdateNamedShadowRequest;
+import software.amazon.awssdk.iot.iotshadow.model.UpdateNamedShadowSubscriptionRequest;
+import software.amazon.awssdk.services.greengrassv2.model.ComponentConfigurationUpdate;
+import software.amazon.awssdk.services.greengrassv2.model.ComponentDeploymentSpecification;
+import software.amazon.awssdk.services.greengrassv2.model.CreateDeploymentRequest;
+
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static com.aws.greengrass.deployment.ShadowDeploymentListener.DEPLOYMENT_SHADOW_NAME;
+import static com.aws.greengrass.status.DeploymentInformation.STATUS_KEY;
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(GGExtension.class)
+@Tag("E2E")
+public class ShadowDeploymentE2ETest extends BaseE2ETestCase {
+    protected ShadowDeploymentE2ETest() throws Exception {
+        super();
+    }
+    @AfterEach
+    void afterEach() {
+        if (kernel != null) {
+            kernel.shutdown();
+        }
+        // Cleanup all IoT thing resources we created
+        cleanup();
+    }
+
+    @BeforeEach
+    void launchKernel() throws Exception {
+        initKernel();
+        kernel.launch();
+    }
+
+    @Test
+    void GIVEN_kernel_running_WHEN_device_deployment_adds_packages_THEN_new_services_should_be_running()
+            throws Exception {
+        CountDownLatch cdlDeploymentFinished = new CountDownLatch(1);
+        Consumer<GreengrassLogMessage> listener = m -> {
+            if (m.getMessage() != null && m.getMessage().contains("Current deployment finished")) {
+                cdlDeploymentFinished.countDown();
+            }
+        };
+        Slf4jLogAdapter.addGlobalListener(listener);
+        CreateDeploymentRequest createDeploymentRequest =
+                CreateDeploymentRequest.builder().targetArn(thingInfo.getThingArn()).components(
+                        Utils.immutableMap("CustomerApp",
+                                ComponentDeploymentSpecification.builder().componentVersion("1.0.0")
+                                        .configurationUpdate(ComponentConfigurationUpdate.builder()
+                                                .merge("{\"sampleText\":\"FCS integ test\"}").build()).build(),
+                                "SomeService",
+                                ComponentDeploymentSpecification.builder().componentVersion("1.0.0").build())).build();
+        draftAndCreateDeployment(createDeploymentRequest);
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.FINISHED)));
+
+        IotShadowClient shadowClient =
+                new IotShadowClient(new WrapperMqttClientConnection(kernel.getContext().get(MqttClient.class)));
+
+        UpdateNamedShadowSubscriptionRequest req = new UpdateNamedShadowSubscriptionRequest();
+        req.shadowName = DEPLOYMENT_SHADOW_NAME;
+        req.thingName = thingInfo.getThingName();
+        CountDownLatch reportInProgressCdl = new CountDownLatch(1);
+        CountDownLatch reportSucceededCdl = new CountDownLatch(1);
+        shadowClient.SubscribeToUpdateNamedShadowAccepted(req, QualityOfService.AT_LEAST_ONCE, (response) -> {
+            try {
+                logger.info("Got shadow update: {}", new ObjectMapper().writeValueAsString(response));
+            } catch (JsonProcessingException e) {
+                // ignore
+            }
+            if (response.state.reported == null) {
+                return;
+            }
+            String reportedStatus = (String) response.state.reported.get(STATUS_KEY);
+            if (JobStatus.IN_PROGRESS.toString().equals(reportedStatus)) {
+                reportInProgressCdl.countDown();
+            } else if (JobStatus.SUCCEEDED.toString().equals(reportedStatus)) {
+                reportSucceededCdl.countDown();
+            }
+        });
+        // wait for the shadow's reported section to be updated
+        assertTrue(reportInProgressCdl.await(30, TimeUnit.SECONDS));
+        assertTrue(reportSucceededCdl.await(30, TimeUnit.SECONDS));
+
+        // deployment should succeed
+        assertTrue(cdlDeploymentFinished.await(30, TimeUnit.SECONDS));
+        Slf4jLogAdapter.removeGlobalListener(listener);
+        assertThat(getCloudDeployedComponent("CustomerApp")::getState, eventuallyEval(is(State.FINISHED)));
+        assertThat(getCloudDeployedComponent("SomeService")::getState, eventuallyEval(is(State.FINISHED)));
+    }
+
+    @Test
+    void GIVEN_device_deployment_WHEN_shadow_update_messages_gets_delivered_out_of_order_THEN_shadow_updated_with_latest_deployment_status()
+            throws Exception {
+        CreateDeploymentRequest createDeploymentRequest =
+                CreateDeploymentRequest.builder().targetArn(thingInfo.getThingArn()).components(
+                        Utils.immutableMap("CustomerApp",
+                                ComponentDeploymentSpecification.builder().componentVersion("1.0.0").build(),
+                                "SomeService",
+                                ComponentDeploymentSpecification.builder().componentVersion("1.0.0").build())).build();
+        draftAndCreateDeployment(createDeploymentRequest);
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.FINISHED)));
+
+        IotShadowClient shadowClient =
+                new IotShadowClient(new WrapperMqttClientConnection(kernel.getContext().get(MqttClient.class)));
+
+        UpdateNamedShadowSubscriptionRequest req = new UpdateNamedShadowSubscriptionRequest();
+        req.shadowName = DEPLOYMENT_SHADOW_NAME;
+        req.thingName = thingInfo.getThingName();
+        CountDownLatch reportSucceededCdl = new CountDownLatch(1);
+        CountDownLatch deviceSyncedStateToSucceededCdl = new CountDownLatch(1);
+        AtomicReference<HashMap<String, Object>> reportedSection = new AtomicReference<>();
+        AtomicReference<Integer> shadowVersionWhenDeviceFirstReportedSuccess = new AtomicReference<>();
+        AtomicReference<Integer> shadowVersionWhenDeviceReportedInProgress = new AtomicReference<>();
+        shadowClient.SubscribeToUpdateNamedShadowAccepted(req, QualityOfService.AT_LEAST_ONCE, (response) -> {
+            try {
+                logger.info("Got shadow update: {}", new ObjectMapper().writeValueAsString(response));
+            } catch (JsonProcessingException e) {
+                // ignore
+            }
+            if (response.state.reported == null) {
+                return;
+            }
+            String reportedStatus = (String) response.state.reported.get(STATUS_KEY);
+            if (JobStatus.IN_PROGRESS.toString().equals(reportedStatus)) {
+                reportedSection.set(response.state.reported);
+                shadowVersionWhenDeviceReportedInProgress.set(response.version);
+            } else if (JobStatus.SUCCEEDED.toString().equals(reportedStatus)) {
+                // when device first reports success reportSucceededCdl is counted down, when the device syncs the shadow
+                // state to SUCCESS second time the shadow version
+                if(reportSucceededCdl.getCount() == 0 && response.version > shadowVersionWhenDeviceFirstReportedSuccess.get()){
+                    deviceSyncedStateToSucceededCdl.countDown();
+                }
+                shadowVersionWhenDeviceFirstReportedSuccess.set(response.version);
+                reportSucceededCdl.countDown();
+            }
+        });
+        //waiting for the device to report success
+        assertTrue(reportSucceededCdl.await(30, TimeUnit.SECONDS));
+
+        //Updating the shadow with deployment status IN_PROGRESS to simulate out-of-order update of shadow
+        ShadowState shadowState = new ShadowState();
+        shadowState.reported = reportedSection.get();
+        UpdateNamedShadowRequest updateNamedShadowRequest = new UpdateNamedShadowRequest();
+        updateNamedShadowRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
+        updateNamedShadowRequest.thingName = thingInfo.getThingName();
+        updateNamedShadowRequest.state = shadowState;
+        shadowClient.PublishUpdateNamedShadow(updateNamedShadowRequest, QualityOfService.AT_LEAST_ONCE)
+                .get(30, TimeUnit.SECONDS);
+
+        // verify that the device updates shadow state to SUCCEEDED
+        assertTrue(deviceSyncedStateToSucceededCdl.await(30, TimeUnit.SECONDS));
+
+
+        //Updating the shadow with a lower version number to trigger a message to /update/rejected event
+        shadowState = new ShadowState();
+        shadowState.reported = reportedSection.get();
+        updateNamedShadowRequest = new UpdateNamedShadowRequest();
+        updateNamedShadowRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
+        updateNamedShadowRequest.thingName = thingInfo.getThingName();
+        updateNamedShadowRequest.state = shadowState;
+        updateNamedShadowRequest.version = shadowVersionWhenDeviceReportedInProgress.get();
+        shadowClient.PublishUpdateNamedShadow(updateNamedShadowRequest, QualityOfService.AT_LEAST_ONCE)
+                .get(30, TimeUnit.SECONDS);
+
+
+        CountDownLatch deviceRetrievedShadowCdl = new CountDownLatch(1);
+        GetNamedShadowSubscriptionRequest getNamedShadowSubscriptionRequest
+                = new GetNamedShadowSubscriptionRequest();
+        getNamedShadowSubscriptionRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
+        getNamedShadowSubscriptionRequest.thingName = thingInfo.getThingName();
+        shadowClient.SubscribeToGetNamedShadowAccepted(getNamedShadowSubscriptionRequest,
+                QualityOfService.AT_MOST_ONCE,
+                getShadowResponse -> {
+                    deviceRetrievedShadowCdl.countDown();
+                }).get(30, TimeUnit.SECONDS);
+
+        // verify that the device retrieved the shadow when an update operation was rejected.
+        assertTrue(deviceRetrievedShadowCdl.await(30, TimeUnit.SECONDS));
+    }
+
+}

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -334,9 +334,8 @@ public class ShadowDeploymentListener implements InjectionActions {
         if (lastDeploymentStatus.get() == null) {
             return;
         }
-        HashMap<String, Object> latestDeploymentStatus = populateReportedSectionOfShadow(lastDeploymentStatus.get());
-        if (!reported.get(ARN_FOR_STATUS_KEY).equals(latestDeploymentStatus.get(ARN_FOR_STATUS_KEY))
-                || !reported.get(STATUS_KEY).equals(latestDeploymentStatus.get(STATUS_KEY))) {
+        if (!reported.get(ARN_FOR_STATUS_KEY).equals(lastDeploymentStatus.get().get(DEPLOYMENT_ID_KEY_NAME))
+                || !reported.get(STATUS_KEY).equals(lastDeploymentStatus.get().get(DEPLOYMENT_STATUS_KEY_NAME))) {
             logger.info("Updating reported section of shadow with the latest deployment status");
             updateReportedSectionOfShadowWithDeploymentStatus();
         }

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -120,6 +120,7 @@ public class ShadowDeploymentListener implements InjectionActions {
 
     /*
         Subscribe to "$aws/things/{thingName}/shadow/update/accepted" topic to get notified when shadow is updated
+        Subscribe to "$aws/things/{thingName}/shadow/update/rejected" topic to get notified when an update is rejected
         Subscribe to "$aws/things/{thingName}/shadow/get/accepted" topic to retrieve shadow by publishing to get topic
      */
     private void subscribeToShadowTopics() {
@@ -149,7 +150,7 @@ public class ShadowDeploymentListener implements InjectionActions {
                 getNamedShadowSubscriptionRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
                 getNamedShadowSubscriptionRequest.thingName = thingName;
                 iotShadowClient.SubscribeToGetNamedShadowAccepted(getNamedShadowSubscriptionRequest,
-                        QualityOfService.AT_MOST_ONCE,
+                        QualityOfService.AT_LEAST_ONCE,
                         getShadowResponse -> shadowUpdated(getShadowResponse.state.desired,
                                 getShadowResponse.state.reported, getShadowResponse.version),
                         (e) -> logger.atError().log("Error processing getShadowResponse", e))

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;
@@ -95,6 +96,7 @@ public class ShadowDeploymentListener implements InjectionActions {
     };
     private String lastConfigurationArn;
     private Integer lastVersion;
+    private final AtomicReference<Map<String, Object>> lastDeploymentStatus = new AtomicReference();
     protected static final Random JITTER = new Random();
 
     @Override
@@ -116,7 +118,6 @@ public class ShadowDeploymentListener implements InjectionActions {
         });
     }
 
-
     /*
         Subscribe to "$aws/things/{thingName}/shadow/update/accepted" topic to get notified when shadow is updated
         Subscribe to "$aws/things/{thingName}/shadow/get/accepted" topic to retrieve shadow by publishing to get topic
@@ -135,6 +136,14 @@ public class ShadowDeploymentListener implements InjectionActions {
                         (e) -> logger.atError().log("Error processing updateShadowResponse", e))
                         .get(TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
                 logger.info("Subscribed to update named shadow accepted topic");
+
+                iotShadowClient.SubscribeToUpdateNamedShadowRejected(updateNamedShadowSubscriptionRequest,
+                        QualityOfService.AT_LEAST_ONCE,
+                        updateShadowRejected -> handleNamedShadowRejectedEvent(),
+                        (e) -> logger.atError().log("Error processing named shadow update rejected response", e))
+                        .get(TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
+                logger.info("Subscribed to update named shadow rejected topic");
+
                 GetNamedShadowSubscriptionRequest getNamedShadowSubscriptionRequest
                         = new GetNamedShadowSubscriptionRequest();
                 getNamedShadowSubscriptionRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
@@ -176,6 +185,13 @@ public class ShadowDeploymentListener implements InjectionActions {
         }
     }
 
+    private void handleNamedShadowRejectedEvent() {
+        // A shadow update was rejected, publishing to get device shadow topic to retrieve the latest shadow document.
+        // Once the latest shadow document is received, device will update the reported section with the
+        // the latest deployment status.
+        publishToGetDeviceShadowTopic();
+    }
+
     private void publishToGetDeviceShadowTopic() {
         GetNamedShadowRequest getNamedShadowRequest = new GetNamedShadowRequest();
         getNamedShadowRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
@@ -186,17 +202,24 @@ public class ShadowDeploymentListener implements InjectionActions {
 
     @SuppressFBWarnings
     private Boolean deploymentStatusChanged(Map<String, Object> deploymentDetails) {
-        String configurationArn = (String) deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME);
+        lastDeploymentStatus.set(deploymentDetails);
+        return updateReportedSectionOfShadowWithDeploymentStatus();
+    }
+
+    private boolean updateReportedSectionOfShadowWithDeploymentStatus() {
+        Map<String, Object> deploymentDetails = lastDeploymentStatus.get();
         try {
             ShadowState shadowState = new ShadowState();
-            shadowState.reported = getReportedShadowState(deploymentDetails);
+            shadowState.reported = populateReportedSectionOfShadow(deploymentDetails);
             UpdateNamedShadowRequest updateNamedShadowRequest = new UpdateNamedShadowRequest();
             updateNamedShadowRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
             updateNamedShadowRequest.thingName = thingName;
             updateNamedShadowRequest.state = shadowState;
+            updateNamedShadowRequest.version = lastVersion;
             iotShadowClient.PublishUpdateNamedShadow(updateNamedShadowRequest, QualityOfService.AT_LEAST_ONCE)
                     .get(TIMEOUT_FOR_PUBLISHING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
-            logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, configurationArn)
+
+            logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME))
                     .kv(STATUS_KEY, shadowState.reported.get(STATUS_KEY))
                     .log("Updated reported state for deployment");
             return true;
@@ -212,7 +235,8 @@ public class ShadowDeploymentListener implements InjectionActions {
     }
 
     @SuppressWarnings("PMD.LooseCoupling")
-    private HashMap<String, Object> getReportedShadowState(Map<String, Object> deploymentDetails) {
+    private HashMap<String, Object> populateReportedSectionOfShadow(Map<String, Object> deploymentDetails) {
+
         Map<String, Object> deploymentStatusDetails =
                 (Map<String, Object>) deploymentDetails.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
 
@@ -225,13 +249,22 @@ public class ShadowDeploymentListener implements InjectionActions {
         reported.put(STATUS_KEY, deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME));
         reported.put(STATUS_DETAILS_KEY, statusDetails);
         reported.put(GGC_VERSION_KEY, deviceConfiguration.getNucleusVersion());
-
         return reported;
     }
 
     protected void shadowUpdated(Map<String, Object> desired, Map<String, Object> reported, Integer version) {
+        if (lastVersion != null && lastVersion > version) {
+            logger.atInfo().kv("SHADOW_VERSION", version)
+                    .log("Received an older version of shadow. Ignoring...");
+            return;
+        }
+        lastVersion = version;
+        //the reported section of the shadow was updated
+        if (reported != null && !reported.isEmpty()) {
+            syncShadowDeploymentStatus(reported);
+        }
         if (desired == null || desired.isEmpty()) {
-            logger.debug("Empty desired state, no device deployments created yet");
+            logger.debug("Empty desired state, no update to desired section or no device deployments created yet");
             return;
         }
         String fleetConfigStr = (String) desired.get(FLEET_CONFIG_KEY);
@@ -255,12 +288,10 @@ public class ShadowDeploymentListener implements InjectionActions {
             return;
         }
         boolean cancelDeployment = DESIRED_STATUS_CANCELED.equals(desiredStatus);
-
         synchronized (ShadowDeploymentListener.class) {
             // If lastConfigurationArn is null, this is the first shadow update since startup
             if (lastConfigurationArn == null) {
                 lastConfigurationArn = configurationArn;
-                lastVersion = version;
                 // Ignore if the latest deployment was canceled
                 if (cancelDeployment) {
                     logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, configurationArn)
@@ -276,19 +307,12 @@ public class ShadowDeploymentListener implements InjectionActions {
                     return;
                 }
             } else {
-                if (lastVersion > version) {
-                    logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, configurationArn)
-                            .kv("SHADOW_VERSION", version)
-                            .log("Old deployment notification. Ignoring shadow update");
-                    return;
-                }
                 if (lastConfigurationArn.equals(configurationArn) && !cancelDeployment) {
                     logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, configurationArn)
                             .log("Duplicate deployment notification. Ignoring shadow update");
                     return;
                 }
                 lastConfigurationArn = configurationArn;
-                lastVersion = version;
             }
         }
 
@@ -300,6 +324,19 @@ public class ShadowDeploymentListener implements InjectionActions {
         }
         if (deploymentQueue.offer(deployment)) {
             logger.atInfo().kv("ID", deployment.getId()).log("Added shadow deployment job");
+        }
+    }
+
+    private void syncShadowDeploymentStatus(Map<String, Object> reported) {
+        // device does not have anything to report
+        if (lastDeploymentStatus.get() == null) {
+            return;
+        }
+        HashMap<String, Object> latestDeploymentStatus = populateReportedSectionOfShadow(lastDeploymentStatus.get());
+        if (!reported.get(ARN_FOR_STATUS_KEY).equals(latestDeploymentStatus.get(ARN_FOR_STATUS_KEY))
+                || !reported.get(STATUS_KEY).equals(latestDeploymentStatus.get(STATUS_KEY))) {
+            logger.info("Updating reported section of shadow with the latest deployment status");
+            updateReportedSectionOfShadowWithDeploymentStatus();
         }
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -332,6 +332,7 @@ public class ShadowDeploymentListener implements InjectionActions {
     private void syncShadowDeploymentStatus(Map<String, Object> reported) {
         // device does not have anything to report
         if (lastDeploymentStatus.get() == null) {
+            logger.info("Last known deployment status is empty, nothing to report");
             return;
         }
         if (!reported.get(ARN_FOR_STATUS_KEY).equals(lastDeploymentStatus.get().get(DEPLOYMENT_ID_KEY_NAME))

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -96,7 +96,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         }
     };
     private String lastConfigurationArn;
-    private AtomicInteger lastVersion = new AtomicInteger();
+    private final AtomicInteger lastVersion = new AtomicInteger();
     private final AtomicReference<Map<String, Object>> lastDeploymentStatus = new AtomicReference();
     protected static final Random JITTER = new Random();
 


### PR DESCRIPTION
**Issue #, if available:**

We update the shadow when a deployment completes which will queue the MQTT message to be delivered eventually. If multiple changes happen, then the messages may be processed out of order, thus causing the shadow to be in an inconsistent state.

**Description of changes:**
Update the shadow using optimistic locking, which adds a version field to the update. The shadow will only be updated in the case that the current shadow version matches the version provided in the update. If a shadow update is rejected, device will fetch the latest shadow and retry the update with the updated shadow version.  This will ensure that the shadow is always in a consistent state and will eventually show the current state.

**How was this change tested:**
E2E tests.

Tests:
When a shadow update is rejected, device fetches the latest shadow document.
When a shadow document with outdated deployment status is received, device updates the reported section with the latest deployment status.

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ X] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
