### PR TITLE
fix(dependencyresolver): fail fast when circular dependency is detected

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -275,7 +275,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
             if (status.get(DEPLOYMENT_ID_KEY_NAME).equals("firstDeployment")
                     && status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("FAILED")) {
                 Map<String, String> detailedStatus = (Map<String, String>) status.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
-                if (detailedStatus.get("deployment-failure-cause").equals("Circular dependency detected for Component ComponentWithCircularDependency")
+                if (detailedStatus.get("deployment-failure-cause").equals("Circular dependency detected for component ComponentWithCircularDependency")
                         && detailedStatus.get("detailed-deployment-status").equals("FAILED_NO_STATE_CHANGE")) {
                     firstErroredCDL.countDown();
                 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -275,7 +275,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
             if (status.get(DEPLOYMENT_ID_KEY_NAME).equals("firstDeployment")
                     && status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("FAILED")) {
                 Map<String, String> detailedStatus = (Map<String, String>) status.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
-                if (detailedStatus.get("deployment-failure-cause").equals("Circular dependency detected for component ComponentWithCircularDependency")
+                if (detailedStatus.get("deployment-failure-cause").contains("Circular dependency detected")
                         && detailedStatus.get("detailed-deployment-status").equals("FAILED_NO_STATE_CHANGE")) {
                     firstErroredCDL.countDown();
                 }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentWithCircularDependency-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentWithCircularDependency-1.0.0.yaml
@@ -1,0 +1,17 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: ComponentWithCircularDependency
+ComponentDescription: A simple test app
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentDependencies:
+  ComponentWithCircularDependency:
+    VersionRequirement: 1.0.0
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:
+        echo "Hello From App"
+    Artifacts:
+      - URI: s3://mock-bucket/simpleApp.txt

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -226,7 +226,7 @@ public class DependencyResolver {
             for (Map.Entry<String, String> dependency : resolvedVersion.getDependencies().entrySet()) {
                 // A circular dependency is present if the dependency is already resolved.
                 if (resolvedComponents.containsKey(dependency.getKey())) {
-                    throw new ComponentVersionNegotiationException("Circular dependency detected for Component "
+                    throw new ComponentVersionNegotiationException("Circular dependency detected for component "
                             + dependency.getKey());
                 }
                 componentNameToVersionConstraints.putIfAbsent(dependency.getKey(), new HashMap<>());

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -307,7 +307,8 @@ public class DependencyResolver {
                 componentDependencyMap.keySet(), componentDependencyMap::get);
 
         if (result.size() != componentCount) {
-            throw new ComponentVersionNegotiationException("Circular dependency detected for component " + targetComponent);
+            throw new ComponentVersionNegotiationException("Circular dependency detected for component "
+                    + targetComponent);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.DependencyOrder;
 import com.aws.greengrass.util.Utils;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -82,12 +84,25 @@ public class DependencyResolver {
         // dependency tree.
         Map<String, Map<String, Requirement>> componentNameToVersionConstraints = new HashMap<>();
 
-        // populate the other groups dependencies version requirement.
-        Map<String, ComponentIdentifier> otherGroupsComponents =
-                populateOtherGroupsComponentsDependencies(groupToTargetComponentDetails, document.getGroupName(),
-                        componentNameToVersionConstraints);
+        // A map of component name to count of components that depend on it
+        Map<String, Integer> componentIncomingReferenceCount = new HashMap<>();
 
-        Map<String, ComponentIdentifier> resolvedComponents = new HashMap<>(otherGroupsComponents);
+        // A map of component name to its resolved version.
+        Map<String, ComponentMetadata> resolvedComponents = new HashMap<>();
+
+        Set<String> otherGroupTargetComponents =
+                getOtherGroupsTargetComponents(groupToTargetComponentDetails, document.getGroupName(),
+                        componentNameToVersionConstraints);
+        logger.atDebug().kv("otherGroupTargets", otherGroupTargetComponents)
+                .log("Found the other group target components");
+        // populate other groups target components dependencies
+        // retrieve only dependency active version, update version requirement map
+        for (String targetComponent : otherGroupTargetComponents) {
+            resolveComponentDependencies(targetComponent, componentNameToVersionConstraints,
+                    resolvedComponents, componentIncomingReferenceCount,
+                    (name, requirements) ->
+                            componentManager.getActiveAndSatisfiedComponentMetadata(name, requirements));
+        }
 
         // Get the target components with version requirements in the deployment document
         List<String> targetComponentsToResolve = new ArrayList<>();
@@ -107,18 +122,27 @@ public class DependencyResolver {
                 .log("Start to resolve group dependencies");
         // resolve target components dependencies
         for (String component : targetComponentsToResolve) {
-            resolvedComponents.putAll(resolveComponentDependencies(component, componentNameToVersionConstraints,
+            resolveComponentDependencies(component, componentNameToVersionConstraints,
+                    resolvedComponents, componentIncomingReferenceCount,
                     (name, requirements) -> componentManager.resolveComponentVersion(name, requirements,
-                            document.getDeploymentId())));
+                            document.getDeploymentId()));
         }
 
-        checkNonExplicitNucleusUpdate(targetComponentsToResolve,
-                resolvedComponents.entrySet().stream().map(Map.Entry::getValue).collect(Collectors.toList()));
+        // detect circular dependencies for target components from the current deployment
+        for (String component : targetComponentsToResolve) {
+            detectCircularDependency(component, resolvedComponents);
+        }
+
+        List<ComponentIdentifier> resolvedComponentIdentifiers =  resolvedComponents.entrySet()
+                .stream().map(Map.Entry::getValue).map(md -> md.getComponentIdentifier())
+                .collect(Collectors.toList());
+
+        checkNonExplicitNucleusUpdate(targetComponentsToResolve, resolvedComponentIdentifiers);
 
         logger.atInfo().setEventType("resolve-group-dependencies-finish").kv("resolvedComponents", resolvedComponents)
                 .kv(COMPONENT_VERSION_REQUIREMENT_KEY, componentNameToVersionConstraints)
                 .log("Finish resolving group dependencies");
-        return new ArrayList<>(resolvedComponents.values());
+        return new ArrayList<>(resolvedComponentIdentifiers);
     }
 
     void checkNonExplicitNucleusUpdate(List<String> targetComponents,
@@ -183,30 +207,11 @@ public class DependencyResolver {
         return targetComponents;
     }
 
-    private Map<String, ComponentIdentifier> populateOtherGroupsComponentsDependencies(
-            Topics groupToTargetComponentDetails, String deploymentGroupName,
-            Map<String, Map<String, Requirement>> componentNameToVersionConstraints)
-            throws PackagingException, InterruptedException {
-        Set<String> otherGroupTargetComponents =
-                getOtherGroupsTargetComponents(groupToTargetComponentDetails, deploymentGroupName,
-                        componentNameToVersionConstraints);
-        logger.atDebug().kv("otherGroupTargets", otherGroupTargetComponents)
-                .log("Found the other group target components");
-        // populate other groups target components dependencies
-        // retrieve only dependency active version, update version requirement map
-        Map<String, ComponentIdentifier> resolvedComponent = new HashMap<>();
-        for (String targetComponent : otherGroupTargetComponents) {
-            resolvedComponent.putAll(resolveComponentDependencies(targetComponent, componentNameToVersionConstraints,
-                    (name, requirements) -> componentManager
-                            .getActiveAndSatisfiedComponentMetadata(name, requirements)));
-        }
-
-        return resolvedComponent;
-    }
-
     // Breadth first traverse of dependency tree, use component resolve to resolve every component
-    private Map<String, ComponentIdentifier> resolveComponentDependencies(
+    private void resolveComponentDependencies(
             String targetComponentName, Map<String, Map<String, Requirement>> componentNameToVersionConstraints,
+            Map<String, ComponentMetadata> resolvedComponents,
+            Map<String, Integer> componentIncomingReferenceCount,
             ComponentResolver componentResolver) throws PackagingException, InterruptedException {
         logger.atDebug().setEventType("traverse-dependencies-start").kv("targetComponent", targetComponentName)
                 .kv(COMPONENT_VERSION_REQUIREMENT_KEY, componentNameToVersionConstraints)
@@ -214,21 +219,29 @@ public class DependencyResolver {
         Queue<String> componentsToResolve = new LinkedList<>();
         componentsToResolve.add(targetComponentName);
 
-        Map<String, ComponentIdentifier> resolvedComponents = new HashMap<>();
         while (!componentsToResolve.isEmpty()) {
             String componentToResolve = componentsToResolve.poll();
             Map<String, Requirement> versionConstraints =
                     new HashMap<>(componentNameToVersionConstraints.get(componentToResolve));
             ComponentMetadata resolvedVersion = componentResolver.resolve(componentToResolve, versionConstraints);
+            // Incrementing the incoming reference count
+            componentIncomingReferenceCount.compute(resolvedVersion.getComponentIdentifier().getName(),
+                    (key, value) -> value == null ? 1 : value + 1);
             logger.atDebug().kv("resolvedVersion", resolvedVersion).log("Resolved component");
-            resolvedComponents.put(componentToResolve, resolvedVersion.getComponentIdentifier());
 
+            ComponentMetadata previousVersion = resolvedComponents.put(componentToResolve, resolvedVersion);
+
+            if (previousVersion != null && !previousVersion.equals(resolvedVersion)) {
+                logger.atDebug().kv("previousVersion", previousVersion).kv("newVersion", resolvedVersion)
+                        .log("The resolved version of the component changed, updating the dependency tree");
+                removeDependencies(previousVersion, resolvedComponents, componentIncomingReferenceCount,
+                        componentNameToVersionConstraints);
+            }
+            // Skipping dependency resolution for the component as there is no change in the version.
+            if (resolvedVersion.equals(previousVersion)) {
+                continue;
+            }
             for (Map.Entry<String, String> dependency : resolvedVersion.getDependencies().entrySet()) {
-                // A circular dependency is present if the dependency is already resolved.
-                if (resolvedComponents.containsKey(dependency.getKey())) {
-                    throw new ComponentVersionNegotiationException("Circular dependency detected for component "
-                            + dependency.getKey());
-                }
                 componentNameToVersionConstraints.putIfAbsent(dependency.getKey(), new HashMap<>());
                 componentNameToVersionConstraints.get(dependency.getKey()).put(componentToResolve,
                         Requirement.buildNPM(dependency.getValue()));
@@ -238,8 +251,66 @@ public class DependencyResolver {
 
         logger.atDebug().setEventType("traverse-dependencies-finish").kv("resolvedComponents", resolvedComponents)
                 .log("Finish traversing dependencies");
-        return resolvedComponents;
     }
+
+    /*
+     A component version is removed from the dependency tree, remove all dependencies of this version
+     which has an incoming reference count of 1 (i.e no other component has depends on them)
+     */
+    private void removeDependencies(ComponentMetadata removedComponentVersion,
+                                    Map<String, ComponentMetadata> resolvedComponents,
+                                    Map<String, Integer> componentIncomingReferenceCount,
+                                    Map<String, Map<String, Requirement>> componentNameToVersionConstraints) {
+
+        Queue<ComponentMetadata> componentsToRemove = new LinkedList<>();
+        componentsToRemove.add(removedComponentVersion);
+        while (!componentsToRemove.isEmpty()) {
+            ComponentMetadata removedComponent = componentsToRemove.poll();
+            for (Map.Entry<String, String> dependency : removedComponent.getDependencies().entrySet()) {
+                // removing version constraints from removed component
+                componentNameToVersionConstraints.get(dependency.getKey())
+                        .remove(removedComponent.getComponentIdentifier().getName());
+                componentIncomingReferenceCount.compute(dependency.getKey(),
+                        (key, value) -> {
+                            if (value == null) {
+                                return null;
+                            } else if (value == 1) {
+                                // only removedComponent depend on this component. This component can be removed.
+                                ComponentMetadata component = resolvedComponents.remove(key);
+                                logger.atDebug().kv("version", component).log("Removing component");
+                                // adding the component to componentsToRemove, to clean up its dependencies
+                                componentsToRemove.add(component);
+                                return null;
+                            } else {
+                                // count down the incoming reference count for the dependency
+                                return value - 1;
+                            }
+                        });
+            }
+        }
+    }
+
+    private void detectCircularDependency(String targetComponent, Map<String, ComponentMetadata> resolvedComponents)
+            throws ComponentVersionNegotiationException {
+        Map<String, Set<String>> componentDependencyMap = new HashMap();
+        Queue<String> componentsToVisit = new LinkedList<>();
+        componentsToVisit.add(targetComponent);
+        while (!componentsToVisit.isEmpty()) {
+            String componentName = componentsToVisit.poll();
+            Set<String> dependencies = resolvedComponents.get(componentName).getDependencies().keySet();
+            componentDependencyMap.put(componentName, dependencies);
+            dependencies.stream().filter(dependency -> !componentDependencyMap.containsKey(dependency))
+                    .forEach(componentsToVisit::add);
+        }
+        int componentCount = componentDependencyMap.keySet().size();
+        LinkedHashSet<String> result = new DependencyOrder<String>().computeOrderedDependencies(
+                componentDependencyMap.keySet(), componentDependencyMap::get);
+
+        if (result.size() != componentCount) {
+            throw new ComponentVersionNegotiationException("Circular dependency detected for component " + targetComponent);
+        }
+    }
+
 
     @FunctionalInterface
     public interface ComponentResolver {

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -308,7 +308,7 @@ public class DependencyResolver {
 
         if (result.size() != componentCount) {
             throw new ComponentVersionNegotiationException("Circular dependency detected for component "
-                    + targetComponent);
+                    + resolvedComponents.get(targetComponent).getComponentIdentifier().toString());
         }
     }
 

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -140,7 +140,7 @@ class DependencyResolverTest {
 
         Exception e = assertThrows(PackagingException.class,
                 () -> dependencyResolver.resolveDependencies(doc, groupToTargetComponentsTopics));
-        assertEquals("Circular dependency detected for Component A", e.getMessage());
+        assertEquals("Circular dependency detected for component A", e.getMessage());
     }
 
 
@@ -207,7 +207,7 @@ class DependencyResolverTest {
 
         Exception e = assertThrows(PackagingException.class,
                 () -> dependencyResolver.resolveDependencies(doc, groupToTargetComponentsTopics));
-        assertEquals("Circular dependency detected for Component B1", e.getMessage());
+        assertEquals("Circular dependency detected for component B1", e.getMessage());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -150,7 +150,7 @@ class DependencyResolverTest {
 
         Exception e = assertThrows(PackagingException.class,
                 () -> dependencyResolver.resolveDependencies(doc, groupToTargetComponentsTopics));
-        assertTrue( e.getMessage().contains("Circular dependency detected for component A"));
+        assertTrue( e.getMessage().contains("Circular dependency detected for component A-v1.0.0"));
     }
 
 
@@ -217,7 +217,7 @@ class DependencyResolverTest {
 
         Exception e = assertThrows(PackagingException.class,
                 () -> dependencyResolver.resolveDependencies(doc, groupToTargetComponentsTopics));
-        assertTrue( e.getMessage().contains("Circular dependency detected for component A"));
+        assertTrue( e.getMessage().contains("Circular dependency detected for component A-v1.0.0"));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -72,10 +72,13 @@ class DependencyResolverTest {
     private static final Semver v1_1_0 = new Semver("1.1.0");
     private static final Semver v1_0_0 = new Semver("1.0.0");
     private static final String componentA = "A";
+    private static final String componentB = "B";
     private static final String componentB1 = "B1";
     private static final String componentB2 = "B2";
     private static final String componentC1 = "C1";
+    private static final String componentD = "D";
     private static final String componentX = "X";
+    private static final String componentY = "Y";
 
     @InjectMocks
     private DependencyResolver dependencyResolver;
@@ -129,6 +132,12 @@ class DependencyResolverTest {
                 new ComponentMetadata(new ComponentIdentifier(componentA, v1_0_0), dependenciesA_1_x);
         when(componentManager.resolveComponentVersion(eq(componentA), any(), anyString())).thenReturn(componentA_1_0_0);
 
+
+        ComponentMetadata componentB2_1_1_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentB2, v1_1_0), Collections.emptyMap());
+        when(componentManager.resolveComponentVersion(eq(componentB2), any(), anyString()))
+                .thenReturn(componentB2_1_1_0);
+
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
                         new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
@@ -140,7 +149,7 @@ class DependencyResolverTest {
 
         Exception e = assertThrows(PackagingException.class,
                 () -> dependencyResolver.resolveDependencies(doc, groupToTargetComponentsTopics));
-        assertEquals("Circular dependency detected for component A", e.getMessage());
+        assertTrue( e.getMessage().contains("Circular dependency detected for component A"));
     }
 
 
@@ -207,7 +216,108 @@ class DependencyResolverTest {
 
         Exception e = assertThrows(PackagingException.class,
                 () -> dependencyResolver.resolveDependencies(doc, groupToTargetComponentsTopics));
-        assertEquals("Circular dependency detected for component B1", e.getMessage());
+        assertTrue( e.getMessage().contains("Circular dependency detected for component A"));
+    }
+
+    @Test
+    void GIVEN_component_B_WHEN_version_is_bumped_up_from_1_to_2_THEN_dependencies_of_1_are_removed() throws Exception {
+        /*
+         *      group1
+         *         \(1.0.0)
+         *          A
+         (>=1.0.0)/   \(1.0)
+         *       B     D
+                      / (>=2.0.0)
+         *           /
+         *          B
+         *
+         *   B will be first resolved to version 1.0.0 which depends on X=2.0.0
+         *   X=2.0.0 depends on Y=1.0.0
+         *
+         *   B will then be resolved to version 2.0.0 which depends on Y=2.0.0
+         *   For the test to succeed X should be removed from the dependency tree and the constraint X puts on Y should be removed.
+         */
+
+        // prepare A
+        Map<String, String> dependenciesA_1_x = new HashMap<>();
+        dependenciesA_1_x.put(componentB, ">=1.0.0");
+        dependenciesA_1_x.put(componentD, "1.0.0");
+        ComponentMetadata componentA_1_0_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentA, v1_0_0), dependenciesA_1_x);
+        when(componentManager.resolveComponentVersion(eq(componentA), any(), anyString())).thenReturn(componentA_1_0_0);
+
+
+        // prepare D
+        Map<String, String> dependenciesD_1_0_0 = new HashMap<>();
+        dependenciesD_1_0_0.put(componentB, ">=2.0.0");
+        ComponentMetadata componentD_1_0_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentD, v1_0_0), dependenciesD_1_0_0);
+        when(componentManager.resolveComponentVersion(eq(componentD), any(), anyString()))
+                .thenReturn(componentD_1_0_0);
+
+        // prepare B version 1
+        Map<String, String> dependenciesB_1_0_0 = new HashMap<>();
+        dependenciesB_1_0_0.put("X", "2.0.0");
+        ComponentMetadata componentB_1_0_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentB, v1_0_0), dependenciesB_1_0_0);
+        Map<String, Requirement> versionRequirementsForB_1_0_0 = new HashMap<>();
+        versionRequirementsForB_1_0_0.put(componentA, Requirement.buildNPM(">=1.0.0"));
+        when(componentManager.resolveComponentVersion(eq(componentB), eq(versionRequirementsForB_1_0_0), anyString()))
+                .thenReturn(componentB_1_0_0);
+
+
+        // prepare B version 1
+        Map<String, String> dependenciesB_2_0_0 = new HashMap<>();
+        dependenciesB_2_0_0.put("Y", "2.0.0");
+        ComponentMetadata componentB_2_0_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentB, v2_0_0), dependenciesB_2_0_0);
+        Map<String, Requirement> versionRequirementsForB_2_0_0 = new HashMap<>();
+        versionRequirementsForB_2_0_0.put(componentA, Requirement.buildNPM(">=1.0.0"));
+        versionRequirementsForB_2_0_0.put(componentD, Requirement.buildNPM(">=2.0.0"));
+        when(componentManager.resolveComponentVersion(eq(componentB), eq(versionRequirementsForB_2_0_0), anyString()))
+                .thenReturn(componentB_2_0_0);
+
+        // prepare X
+        Map<String, String> dependenciesX_2_0_0 = new HashMap<>();
+        dependenciesX_2_0_0.put("Y", "1.0.0");
+        ComponentMetadata componentX_2_0_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentX, v2_0_0), dependenciesX_2_0_0);
+        when(componentManager.resolveComponentVersion(eq(componentX), any(), anyString()))
+                .thenReturn(componentX_2_0_0);
+
+        // prepare Y version 1
+        ComponentMetadata componentY_1_0_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentY, v1_0_0), Collections.emptyMap());
+        Map<String, Requirement> versionRequirementsForY_1_0_0 = new HashMap<>();
+        versionRequirementsForY_1_0_0.put(componentX, Requirement.buildNPM("=1.0.0"));
+        lenient().when(componentManager.resolveComponentVersion(eq(componentY), eq(versionRequirementsForY_1_0_0), anyString()))
+                .thenReturn(componentY_1_0_0);
+
+
+        // prepare Y version 2
+        ComponentMetadata componentY_2_0_0 =
+                new ComponentMetadata(new ComponentIdentifier(componentY, v2_0_0), Collections.emptyMap());
+        Map<String, Requirement> versionRequirementsForY_2_0_0 = new HashMap<>();
+        versionRequirementsForY_2_0_0.put(componentB, Requirement.buildNPM("=2.0.0"));
+        lenient().when(componentManager.resolveComponentVersion(eq(componentY), eq(versionRequirementsForY_2_0_0), anyString()))
+                .thenReturn(componentY_2_0_0);
+
+
+        DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
+                .singletonList(
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+
+        groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
+                .replaceAndWait(ImmutableMap.of(GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
+
+        List<ComponentIdentifier> result = dependencyResolver.resolveDependencies(doc, groupToTargetComponentsTopics);
+
+        assertThat(result.size(), is(4));
+        assertThat(result, containsInAnyOrder(new ComponentIdentifier(componentA, v1_0_0),
+                new ComponentIdentifier(componentB, v2_0_0), new ComponentIdentifier(componentD, v1_0_0),
+                new ComponentIdentifier(componentY, v2_0_0)));
     }
 
     @Test
@@ -218,8 +328,8 @@ class DependencyResolverTest {
          *          A
          * (1.0.0)/   \(>1.0)
          *      B1     B2
-         *       \(1.0.0)
-         *        C1
+         * (=1.0.0)\  / (=1.0.0)
+         *          C1
          */
 
         // prepare A
@@ -239,8 +349,10 @@ class DependencyResolverTest {
                 .thenReturn(componentB1_1_0_0);
 
         // prepare B2
+        Map<String, String> dependenciesB2_1_x = new HashMap<>();
+        dependenciesB2_1_x.put(componentC1, "1.0.0");
         ComponentMetadata componentB2_1_2_0 =
-                new ComponentMetadata(new ComponentIdentifier(componentB2, v1_2_0), Collections.emptyMap());
+                new ComponentMetadata(new ComponentIdentifier(componentB2, v1_2_0), dependenciesB2_1_x);
         when(componentManager.resolveComponentVersion(eq(componentB2), any(), anyString()))
                 .thenReturn(componentB2_1_2_0);
 


### PR DESCRIPTION
**Issue #, if available:**
1.  Circular dependencies causes deployment to go into an infinite loop.
2. During dependency resolution, if the resolved version of a component changes. Say during the initial stage of dependency resolution B got resolved to version 1.0.0 and at a later stage  B got resolved to 2.0.0. Current implementation does not remove the dependencies of B=1.0.0.

**Description of changes:**
1. Dependency resolver will detect circular dependency during dependency resolution and fail the deployment. The detailed deployment status will mention circular dependency as the reason.

2. When the version of a component is bumped from v1 to v2. Dependency resolver will remove dependencies of v1. All version constraints placed by the removed components will also be removed.

**How was this change tested:**
Unit and Integration tests.

Test Plan:
Testing:
Issue 1:
when root component has circular dependency, deployment completes with status FAILED
```
     /*
     *      group1
     *         \(1.0.0)
     *     |--> A
     *  1.0.0  / \
     *     |__/   \(>1.0)
     *             B2
     */
```

when non-root component has circular dependency, deployment completes with status FAILED
```
    /*
     *      group1
     *         \(1.0.0)
     *          A
     *           \
     *            \(=1.0.0)
     *         |-> B1
     *         |    \
     *         |     \(=1.0.0)
     *      (=1.0.0)  B2
     *         |       \(<=1.1.0)
     *         |        \
     *         |--------C1
     */
```
when a component has more than one depender but there is no cycle in the dependency tree, the deployment completes successfully.
```
        /*
         *       group1
         *          |(1.0.0)
         *          A
         * (1.0.0)/ |  \(>1.0)
         *     B1   |   B2
         *(=1.0.0)\ |  / (=1.0.0)
         *          C1
         */
```

Issue 2:
When a component version is bumped from v1 to v2, all the dependencies of v1 should be removed. All version constraints places by the removed components should also be removed. 

    /*
     *      group1
     *         \(1.0.0)
     *          A
     (>=1.0.0)/   \(1.0)
     *       B     D
                  / (>=2.0.0)
     *           /
     *          B
     *
     *   B will be first resolved to version 1.0.0 which depends on X=2.0.0
     *   X=2.0.0 depends on Y=1.0.0
     *
     *   B will then be resolved to version 2.0.0 which depends on Y=2.0.0
     *   For the test to succeed X should be removed from the dependency tree and the constraint X puts on Y should also be removed.
     */ 

 When a component version is resolved to v1 when resolving dependency tree of group 1 and gets re-resolved to v2 when resolving the dependency tree of group2. All the dependencies of v1 should be removed. 
All version constraints places by the removed components should also be removed. 

    /*
     *      group1                         group2
     *         \(1.0.0)                       \(1.0)
     *          A                              D  
     (>=1.0.0)/                               / (>=2.0.0)
     *       B                               /
     *                                      B          
     *
     *   B will be first resolved to version 1.0.0 which depends on X=2.0.0
     *   X=2.0.0 depends on Y=1.0.0
     *
     *   B will then be resolved to version 2.0.0 which depends on Y=2.0.0
     *   For the test to succeed X should be removed from the dependency tree and the constraint X puts on Y should also be removed.
     */ 

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ X] Updated or added new unit tests
 - [ X] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
