### PR TITLE
fix(mqttclient): validate subscribe request

### DIFF
--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -800,4 +800,17 @@ class MqttClientTest {
         verify(spool, never()).addMessage(request);
         verify(client).isValidPublishRequest(request);
     }
+
+    @Test
+    void unreserved_topic_have_8_forward_slashes_WHEN_subscribe_THEN_throw_exception() throws MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+        String topic = String.join("/", Collections.nCopies(MAX_NUMBER_OF_FORWARD_SLASHES + 2, "a"));
+        assertEquals(8, topic.chars().filter(num -> num == '/').count());
+        SubscribeRequest request = SubscribeRequest.builder().topic(topic).callback(cb).build();
+
+        assertThrows(ExecutionException.class, () -> client.subscribe(request));
+
+        verify(client).isValidRequestTopic(topic);
+        verify(mockConnection, never()).subscribe(any(), any());
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

If the subscribe topic is not valid, the MqttClient is impossible to finish the operation successfully.
For the details,  please refer to ***topic size***  and ***Maximum number of slashes in topic and topic filter*** at https://docs.aws.amazon.com/general/latest/gr/iot-core.html#limits_iot

**Description of changes:**

check the request topic before doing the operation of subscription.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
