### PR TITLE
fix(loader): make loader script executable immediately on startup

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v2.1.6
+      - uses: wagoid/commitlint-github-action@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/src/main/java/com/aws/greengrass/util/Permissions.java
+++ b/src/main/java/com/aws/greengrass/util/Permissions.java
@@ -20,7 +20,7 @@ public final class Permissions {
 
     static final FileSystemPermission OWNER_RWX_ONLY =  FileSystemPermission.builder()
             .ownerRead(true).ownerWrite(true).ownerExecute(true).build();
-    static final FileSystemPermission OWNER_RWX_EVERYONE_RX = FileSystemPermission.builder()
+    public static final FileSystemPermission OWNER_RWX_EVERYONE_RX = FileSystemPermission.builder()
             .ownerRead(true).ownerWrite(true).ownerExecute(true)
             .groupRead(true).groupExecute(true)
             .otherRead(true).otherExecute(true)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set the loader script to be executable immediately when the Nucleus starts up if it isn't already set as executable. This is required so that we can `exec` the loader when restarting the Nucleus.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
