### PR TITLE
fix(startup): handle special case for greengrass data plane endpoint i…

### DIFF
--- a/src/main/java/com/aws/greengrass/util/RegionUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RegionUtils.java
@@ -19,6 +19,12 @@ public final class RegionUtils {
             IotSdkClientFactory.EnvironmentStage.BETA, "https://greengrass-ats.beta.%s.iot.%s:%s"
     );
     private static final Map<IotSdkClientFactory.EnvironmentStage, String>
+            GREENGRASS_DATA_PLANE_STAGE_TO_ENDPOINT_FORMAT_CN_NORTH_1 = ImmutableMap.of(
+            IotSdkClientFactory.EnvironmentStage.PROD, "https://greengrass.ats.iot.%s.%s:%s",
+            IotSdkClientFactory.EnvironmentStage.GAMMA, "https://greengrass.ats.gamma.%s.iot.%s:%s",
+            IotSdkClientFactory.EnvironmentStage.BETA, "https://greengrass.ats.beta.%s.iot.%s:%s"
+    );
+    private static final Map<IotSdkClientFactory.EnvironmentStage, String>
             GREENGRASS_CONTROL_PLANE_STAGE_TO_ENDPOINT_FORMAT = ImmutableMap.of(
             IotSdkClientFactory.EnvironmentStage.PROD, "https://greengrass.%s.%s",
             IotSdkClientFactory.EnvironmentStage.GAMMA, "https://greengrass-gamma.%s.%s",
@@ -47,10 +53,15 @@ public final class RegionUtils {
      * @param port endpoint port
      * @return Greengrass ServiceEndpoint
      */
-    public static String getGreengrassDataPlaneEndpoint(String awsRegion,
-                                                        IotSdkClientFactory.EnvironmentStage stage,
+    public static String getGreengrassDataPlaneEndpoint(String awsRegion, IotSdkClientFactory.EnvironmentStage stage,
                                                         int port) {
         String dnsSuffix = Region.of(awsRegion).metadata().partition().dnsSuffix();
+        if (Region.CN_NORTH_1.equals(Region.of(awsRegion))) {
+            // CN_NORTH_1 has a special endpoint format
+            return String
+                    .format(GREENGRASS_DATA_PLANE_STAGE_TO_ENDPOINT_FORMAT_CN_NORTH_1.get(stage), awsRegion, dnsSuffix,
+                            port);
+        }
         return String.format(GREENGRASS_DATA_PLANE_STAGE_TO_ENDPOINT_FORMAT.get(stage), awsRegion, dnsSuffix, port);
     }
 


### PR DESCRIPTION
…n cn-north-1

**Issue #, if available:**

**Description of changes:**
Greengrass data plane endpoint format is different in cn-north-1 due to historical reasons, so current logic to infer the endpoint doesn't quite work there, need to use special format for cn-north-1

**Why is this change necessary:**
Without this, devices in cn-north-1 will not be able to communicate with the Greengrass data plane endpoint and will fail deployments.

**How was this change tested:**
Since cn-north-1 requires special infrastructure, this was manually tested with a test build out of this change

**Any additional information or context required to review the change:**
After this patch flows through, we will need to merge this to the main branch as well

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
