### PR TITLE
fix(proxy): support 1p component artifact download with proxy

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -11,17 +11,25 @@ import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.util.ProxyUtils;
 import com.aws.greengrass.util.RetryUtils;
 import lombok.AccessLevel;
 import lombok.Setter;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.greengrassv2.model.GetComponentVersionArtifactRequest;
 import software.amazon.awssdk.services.greengrassv2.model.GetComponentVersionArtifactResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
@@ -31,6 +39,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class GreengrassRepositoryDownloader extends ArtifactDownloader {
+    static final String CONTENT_LENGTH_HEADER = "content-length";
     private final ComponentStore componentStore;
     private final GreengrassComponentServiceClientFactory clientFactory;
     private Long artifactSize = null;
@@ -78,14 +87,18 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     }
 
     private Long getDownloadSizeWithoutRetry() throws InterruptedException, PackageDownloadException, IOException {
-        URL url = getArtifactDownloadURL(identifier, artifact.getArtifactUri().getSchemeSpecificPart());
+        String url = getArtifactDownloadURL(identifier, artifact.getArtifactUri().getSchemeSpecificPart());
 
-        HttpURLConnection httpConn = null;
-        try {
-            httpConn = connect(url);
-            int responseCode = httpConn.getResponseCode();
+        try (SdkHttpClient client = getSdkHttpClient()) {
+            HttpExecuteRequest executeRequest = HttpExecuteRequest.builder()
+                    .request(SdkHttpFullRequest.builder().uri(URI.create(url)).method(SdkHttpMethod.GET).build())
+                    .build();
+            HttpExecuteResponse executeResponse = client.prepareRequest(executeRequest).call();
+
+            int responseCode = executeResponse.httpResponse().statusCode();
             if (responseCode == HttpURLConnection.HTTP_OK) {
-                long length = httpConn.getContentLengthLong();
+                long length = getContentLengthLong(executeResponse.httpResponse());
+
                 if (length == -1) {
                     throw new PackageDownloadException(getErrorString("Failed to get download size"));
                 }
@@ -94,10 +107,6 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
                 throw new PackageDownloadException(
                         getErrorString("Failed to get download size. HTTP response: " + responseCode));
             }
-        } finally {
-            if (httpConn != null) {
-                httpConn.disconnect();
-            }
         }
     }
 
@@ -105,58 +114,60 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     @Override
     protected long download(long rangeStart, long rangeEnd, MessageDigest messageDigest)
             throws PackageDownloadException, InterruptedException {
-        URL url = getArtifactDownloadURL(identifier, artifact.getArtifactUri().getSchemeSpecificPart());
+        String url = getArtifactDownloadURL(identifier, artifact.getArtifactUri().getSchemeSpecificPart());
 
         try {
             return RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
-                HttpURLConnection httpConn = null;
-                try {
-                    // establish http connection
-                    httpConn = connect(url);
-                    httpConn.setRequestProperty(HTTP_RANGE_HEADER_KEY,
-                            String.format(HTTP_RANGE_HEADER_FORMAT, rangeStart, rangeEnd));
-                    int responseCode = httpConn.getResponseCode();
+                try (SdkHttpClient client = getSdkHttpClient()) {
+                    HttpExecuteRequest executeRequest = HttpExecuteRequest.builder()
+                            .request(SdkHttpFullRequest.builder().uri(URI.create(url)).method(SdkHttpMethod.GET)
+                                    .putHeader(HTTP_RANGE_HEADER_KEY,
+                                            String.format(HTTP_RANGE_HEADER_FORMAT, rangeStart, rangeEnd)).build())
+                            .build();
+                    HttpExecuteResponse executeResponse = client.prepareRequest(executeRequest).call();
+
+                    int responseCode = executeResponse.httpResponse().statusCode();
 
                     // check response code
                     if (responseCode == HttpURLConnection.HTTP_PARTIAL) {
-                        long downloaded = download(httpConn.getInputStream(), messageDigest);
-                        if (downloaded == 0) {
-                            // If 0 byte is read, it's fairly certain that the input stream is closed.
-                            // Therefore throw IOException to trigger the retry logic.
-                            throw new IOException(getErrorString("Failed to read any byte from the stream"));
-                        } else {
-                            return downloaded;
+                        try (InputStream inputStream = executeResponse.responseBody().get()) {
+                            long downloaded = download(inputStream, messageDigest);
+                            if (downloaded == 0) {
+                                // If 0 byte is read, it's fairly certain that the input stream is closed.
+                                // Therefore throw IOException to trigger the retry logic.
+                                throw new IOException(getErrorString("Failed to read any byte from the stream"));
+                            } else {
+                                return downloaded;
+                            }
                         }
                     } else if (responseCode == HttpURLConnection.HTTP_OK) {
-                        if (httpConn.getContentLengthLong() < rangeEnd) {
+                        long length = getContentLengthLong(executeResponse.httpResponse());
+                        if (length < rangeEnd) {
                             String errMsg = String.format(
                                     "Artifact size mismatch. Expected artifact size %d. HTTP contentLength %d",
-                                    rangeEnd, httpConn.getContentLengthLong());
+                                    rangeEnd, length);
                             throw new PackageDownloadException(getErrorString(errMsg));
                         }
                         // 200 means server doesn't recognize the Range header and returns all contents.
                         // try to discard the offset number of bytes.
-                        InputStream inputStream = httpConn.getInputStream();
-                        long byteSkipped = inputStream.skip(rangeStart);
-                        // If number of bytes skipped is less than declared, throw error.
-                        if (byteSkipped != rangeStart) {
-                            throw new PackageDownloadException(getErrorString("Reach the end of the stream"));
-                        }
-                        long downloaded = download(inputStream, messageDigest);
-                        if (downloaded == 0) {
-                            // If 0 byte is read, it's fairly certain that the inputStream is closed.
-                            // Therefore throw IOException to trigger the retry logic.
-                            throw new IOException("Failed to read any byte from the inputStream");
-                        } else {
-                            return downloaded;
+                        try (InputStream inputStream = executeResponse.responseBody().get()) {
+                            long byteSkipped = inputStream.skip(rangeStart);
+                            // If number of bytes skipped is less than declared, throw error.
+                            if (byteSkipped != rangeStart) {
+                                throw new PackageDownloadException(getErrorString("Reach the end of the stream"));
+                            }
+                            long downloaded = download(inputStream, messageDigest);
+                            if (downloaded == 0) {
+                                // If 0 byte is read, it's fairly certain that the inputStream is closed.
+                                // Therefore throw IOException to trigger the retry logic.
+                                throw new IOException("Failed to read any byte from the inputStream");
+                            } else {
+                                return downloaded;
+                            }
                         }
                     } else {
                         throw new PackageDownloadException(getErrorString(
                                 "Unable to download Greengrass artifact. HTTP Error: " + responseCode));
-                    }
-                } finally {
-                    if (httpConn != null) {
-                        httpConn.disconnect();
                     }
                 }
             }, "download-artifact", logger);
@@ -173,7 +184,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
-    private URL getArtifactDownloadURL(ComponentIdentifier componentIdentifier, String artifactName)
+    private String getArtifactDownloadURL(ComponentIdentifier componentIdentifier, String artifactName)
             throws InterruptedException, PackageDownloadException {
         String arn;
         try {
@@ -189,7 +200,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
                         GetComponentVersionArtifactRequest.builder().artifactName(artifactName).arn(arn).build();
                 GetComponentVersionArtifactResponse getComponentArtifactResult =
                         clientFactory.getCmsClient().getComponentVersionArtifact(getComponentArtifactRequest);
-                return new URL(getComponentArtifactResult.preSignedUrl());
+                return getComponentArtifactResult.preSignedUrl();
             }, "get-artifact-size", logger);
         } catch (InterruptedException e) {
             throw e;
@@ -198,7 +209,21 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
         }
     }
 
-    HttpURLConnection connect(URL url) throws IOException {
-        return (HttpURLConnection) url.openConnection();
+    SdkHttpClient getSdkHttpClient() {
+        SdkHttpClient proxyClient = ProxyUtils.getSdkHttpClient();
+        return proxyClient == null ? ApacheHttpClient.builder().build() : proxyClient;
+    }
+
+    private long getContentLengthLong(SdkHttpResponse sdkHttpResponse) {
+        long length = -1L;
+        Optional<String> value = sdkHttpResponse.firstMatchingHeader(CONTENT_LENGTH_HEADER);
+        try {
+            if (value.isPresent()) {
+                length = Long.parseLong(value.get());
+            }
+        } catch (NumberFormatException e) {
+            logger.atError().log("Failed to parse content-length from http response", e);
+        }
+        return length;
     }
 }

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
@@ -24,12 +24,16 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
 import software.amazon.awssdk.services.greengrassv2.model.GetComponentVersionArtifactRequest;
 import software.amazon.awssdk.services.greengrassv2.model.GetComponentVersionArtifactResponse;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +41,11 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Base64;
 
+import static com.aws.greengrass.componentmanager.builtins.GreengrassRepositoryDownloader.CONTENT_LENGTH_HEADER;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_PARTIAL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.core.Is.is;
@@ -58,7 +66,9 @@ class GreengrassRepositoryDownloaderTest {
     @Captor
     ArgumentCaptor<GetComponentVersionArtifactRequest> getComponentVersionArtifactRequestArgumentCaptor;
     @Mock
-    private HttpURLConnection connection;
+    private ExecutableHttpRequest request;
+    @Mock
+    private SdkHttpClient httpClient;
     @Mock
     private GreengrassV2Client client;
     @Mock
@@ -102,11 +112,19 @@ class GreengrassRepositoryDownloaderTest {
                 .thenReturn(result);
 
         // mock requests to return partial stream
-        doReturn(connection).when(downloader).connect(any());
-        when(connection.getContentLengthLong()).thenReturn(Files.size(mockArtifactPath));
-        when(connection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK)
-                .thenReturn(HttpURLConnection.HTTP_PARTIAL);
-        when(connection.getInputStream()).thenReturn(Files.newInputStream(mockArtifactPath));
+        doReturn(httpClient).when(downloader).getSdkHttpClient();
+        doReturn(request).when(httpClient).prepareRequest(any());
+        when(request.call())
+                .thenReturn(HttpExecuteResponse.builder()
+                        .response(SdkHttpResponse.builder().statusCode(HTTP_OK)
+                                .putHeader(CONTENT_LENGTH_HEADER, String.valueOf(Files.size(mockArtifactPath))).build())
+                        .responseBody(AbortableInputStream.create(Files.newInputStream(mockArtifactPath)))
+                        .build())
+                .thenReturn(HttpExecuteResponse.builder()
+                        .response(SdkHttpResponse.builder().statusCode(HTTP_PARTIAL)
+                                .putHeader(CONTENT_LENGTH_HEADER, String.valueOf(Files.size(mockArtifactPath))).build())
+                        .responseBody(AbortableInputStream.create(Files.newInputStream(mockArtifactPath)))
+                        .build());
 
         downloader.download();
 
@@ -134,8 +152,10 @@ class GreengrassRepositoryDownloaderTest {
         lenient().when(componentStore.getRecipeMetadata(pkgId)).thenReturn(new RecipeMetadata(TEST_ARN));
         GreengrassRepositoryDownloader downloader = spy(new GreengrassRepositoryDownloader(clientFactory, pkgId,
                 ComponentArtifact.builder().artifactUri(new URI("greengrass:binary")).build(), null, componentStore));
-        doReturn(connection).when(downloader).connect(any());
-        when(connection.getResponseCode()).thenThrow(IOException.class);
+
+        doReturn(httpClient).when(downloader).getSdkHttpClient();
+        doReturn(request).when(httpClient).prepareRequest(any());
+        when(request.call()).thenThrow(IOException.class);
 
         downloader.setClientExceptionRetryConfig(RetryUtils.RetryConfig.builder().maxAttempt(2)
                 .retryableExceptions(Arrays.asList(SdkClientException.class, IOException.class)).build());
@@ -144,8 +164,7 @@ class GreengrassRepositoryDownloaderTest {
                 () -> downloader.download(0, 100, MessageDigest.getInstance("SHA-256")));
 
         // assert retry called
-        verify(connection, times(2)).getResponseCode();
-        verify(connection, times(2)).disconnect();
+        verify(request, times(2)).call();
         assertThat(e.getLocalizedMessage(), containsStringIgnoringCase("Failed to download artifact"));
     }
 
@@ -159,15 +178,18 @@ class GreengrassRepositoryDownloaderTest {
         lenient().when(componentStore.getRecipeMetadata(pkgId)).thenReturn(new RecipeMetadata(TEST_ARN));
         GreengrassRepositoryDownloader downloader = spy(new GreengrassRepositoryDownloader(clientFactory, pkgId,
                 ComponentArtifact.builder().artifactUri(new URI("greengrass:binary")).build(), null, componentStore));
-        doReturn(connection).when(downloader).connect(any());
-        when(connection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
+
+        doReturn(httpClient).when(downloader).getSdkHttpClient();
+        doReturn(request).when(httpClient).prepareRequest(any());
+        doReturn(HttpExecuteResponse.builder()
+                .response(SdkHttpResponse.builder().statusCode(HTTP_BAD_REQUEST).build())
+                .build()).when(request).call();
 
         PackageDownloadException e = assertThrows(PackageDownloadException.class,
                 () -> downloader.download(0, 100, MessageDigest.getInstance("SHA-256")));
 
         // assert retry called
-        verify(connection, times(1)).getResponseCode();
-        verify(connection, times(1)).disconnect();
+        verify(request, times(1)).call();
         assertThat(e.getLocalizedMessage(), containsStringIgnoringCase("Failed to download the artifact"));
     }
 

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -126,8 +127,9 @@ class AwsIotMqttClientTest {
     }
 
     @Test
-    void GIVEN_individual_client_THEN_it_tracks_connection_state_correctly()
+    void GIVEN_individual_client_THEN_it_tracks_connection_state_correctly(ExtensionContext ec)
             throws ExecutionException, InterruptedException, TimeoutException {
+        ignoreExceptionUltimateCauseOfType(ec, RejectedExecutionException.class);
         when(mockTopic.findOrDefault(any(), any())).thenReturn(1000);
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
         when(connection.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -50,6 +52,7 @@ import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_LAST_PERIODI
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_LAST_PERIODIC_PUBLISH_TIME_TOPIC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -93,7 +96,8 @@ class TelemetryAgentTest extends GGServiceTestUtil {
     private MetricsAggregator ma;
 
     @BeforeEach
-    void setup() {
+    void setup(ExtensionContext ec) {
+        ignoreExceptionUltimateCauseOfType(ec, RejectedExecutionException.class);
         serviceFullName = "MetricsAgent";
         initializeMockedConfig();
         TelemetryConfig.getInstance().setRoot(tempRootDir);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add proxy support while downloading 1P component artifact with pre-signed URL.

**Why is this change necessary:**
Without this change, customer running Nucleus behind a proxy cannot deploy 1P components.

**How was this change tested:**
Tested end-to-end deploying 1P public components to Nucleus.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
