### PR TITLE
fix(spooler): fix memory leak due to CompletableFuture.anyOf

### DIFF
--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -149,6 +149,7 @@ class AwsIotMqttClientTest {
         verify(connection, times(2)).close();
         verify(connection, times(2)).disconnect();
         assertTrue(client.connected());
+        verify(connection, timeout(1_000).times(2)).subscribe(any(), any());
 
         // Ensure that we track connection state through the callbacks
         events.getValue().onConnectionInterrupted(0);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove usage of `CompletableFuture.anyOf` in order to resolve memory leak due to JDK-8160402. This JDK bug, which has been fixed in Java 9, results in extraneous futures which never complete if any of the future inside of the `anyOf` don't complete.

**Why is this change necessary:**
Without this change, after approximately 1 hour we had ~400MB of CompletableFutures which could not be garbage collected.

**How was this change tested:**
Verified with jprofiler that memory no longer increases over time and the number of CompletableFuture objects stays reasonable.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
