### PR TITLE
fix: region validation avoid NPE

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -127,11 +127,11 @@ public class DeviceConfiguration {
     private static final String DEFAULT_ENV_STAGE = "prod";
     private static final String CANNOT_BE_EMPTY = " cannot be empty";
     private static final Logger logger = LogManager.getLogger(DeviceConfiguration.class);
-    public static final String FALLBACK_DEFAULT_REGION = "us-east-1";
     public static final String AWS_IOT_THING_NAME_ENV = "AWS_IOT_THING_NAME";
     public static final String GGC_VERSION_ENV = "GGC_VERSION";
     public static final String NUCLEUS_BUILD_METADATA_DIRECTORY = "conf";
     public static final String NUCLEUS_RECIPE_FILENAME = "recipe.yaml";
+    protected static final String FALLBACK_DEFAULT_REGION = "us-east-1";
     protected static final String FALLBACK_VERSION = "0.0.0";
     private final Kernel kernel;
 
@@ -470,6 +470,7 @@ public class DeviceConfiguration {
                     logger.atWarn().log("Error looking up AWS region", ex);
                 }
             }
+            // Snow* devices have a null region
             if (Utils.isEmpty(region) || !Region.regions().contains(Region.of(region))) {
                 logger.atWarn().log("No valid AWS region found, falling back to default: {}", FALLBACK_DEFAULT_REGION);
                 region = FALLBACK_DEFAULT_REGION;

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -127,7 +127,7 @@ public class DeviceConfiguration {
     private static final String DEFAULT_ENV_STAGE = "prod";
     private static final String CANNOT_BE_EMPTY = " cannot be empty";
     private static final Logger logger = LogManager.getLogger(DeviceConfiguration.class);
-    private static final String FALLBACK_DEFAULT_REGION = "us-east-1";
+    public static final String FALLBACK_DEFAULT_REGION = "us-east-1";
     public static final String AWS_IOT_THING_NAME_ENV = "AWS_IOT_THING_NAME";
     public static final String GGC_VERSION_ENV = "GGC_VERSION";
     public static final String NUCLEUS_BUILD_METADATA_DIRECTORY = "conf";
@@ -470,9 +470,8 @@ public class DeviceConfiguration {
                     logger.atWarn().log("Error looking up AWS region", ex);
                 }
             }
-            // Snow* devices have a null region
-            if (Utils.isEmpty(region) || "null".equals(region)) {
-                logger.atWarn().log("No AWS region found, falling back to default: {}", FALLBACK_DEFAULT_REGION);
+            if (Utils.isEmpty(region) || !Region.regions().contains(Region.of(region))) {
+                logger.atWarn().log("No valid AWS region found, falling back to default: {}", FALLBACK_DEFAULT_REGION);
                 region = FALLBACK_DEFAULT_REGION;
             }
 

--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -275,7 +275,7 @@ public class GreengrassSetup {
         if (Utils.isEmpty(awsRegion)) {
             throw new RuntimeException("Required input for aws region not provided");
         }
-        if (Region.of(awsRegion) == null) {
+        if (!Region.regions().contains(Region.of(awsRegion))) {
             throw new RuntimeException(String.format("%s is invalid AWS region", awsRegion));
         }
 

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -47,6 +47,7 @@ import static com.amazon.aws.iot.greengrass.component.common.SerializerFactory.g
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.config.Topic.DEFAULT_VALUE_TIMESTAMP;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
+import static com.aws.greengrass.deployment.DeviceConfiguration.FALLBACK_DEFAULT_REGION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.GGC_VERSION_ENV;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
@@ -137,6 +138,18 @@ class DeviceConfigurationTest {
                 () -> deviceConfiguration.validateEndpoints("us-east-1", "xxxxxx.credentials.iot.us-east-1.amazonaws.com",
                         "xxxxxx-ats.iot.us-east-2.amazonaws.com"));
         assertEquals("IoT data endpoint region xxxxxx-ats.iot.us-east-2.amazonaws.com does not match the AWS region us-east-1 of the device", ex.getMessage());
+    }
+
+    @Test
+    void GIVEN_config_WHEN_set_bad_aws_region_THEN_fallback_to_default(@Mock Context mockContext) {
+        Topic testingTopic = Topic.of(mockContext, "testing", null);
+        when(configuration.lookup(anyString(), anyString(), anyString(), anyString())).thenReturn(testingTopic);
+        when(mockTopic.withValue(anyString())).thenReturn(mockTopic);
+        when(configuration.lookup(eq(SETENV_CONFIG_NAMESPACE), anyString())).thenReturn(mockTopic);
+
+        deviceConfiguration = new DeviceConfiguration(mockKernel);
+        deviceConfiguration.setAWSRegion("nowhere-south-42");
+        assertEquals(FALLBACK_DEFAULT_REGION, testingTopic.getOnce());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -308,7 +307,7 @@ class GreengrassSetupTest {
                 "-ss", "false");
         greengrassSetup.parseArgs();
         Exception e = assertThrows(RuntimeException.class, greengrassSetup::performSetup);
-        assertTrue(e.getMessage().contains("aws region not provided"));
+        assertThat(e.getMessage(), containsString("aws region not provided"));
     }
 
     @Test
@@ -319,7 +318,7 @@ class GreengrassSetupTest {
                 "-ss", "false", "--aws-region", "nowhere");
         greengrassSetup.parseArgs();
         Exception e = assertThrows(RuntimeException.class, greengrassSetup::performSetup);
-        assertTrue(e.getMessage().contains("is invalid AWS region"));
+        assertThat(e.getMessage(), containsString("is invalid AWS region"));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -300,15 +301,25 @@ class GreengrassSetupTest {
     }
 
     @Test
-    void GIVEN_setup_script_WHEN_no_region_provided_THEN_fail(ExtensionContext context) throws Exception {
+    void GIVEN_setup_script_WHEN_no_region_provided_THEN_fail() {
         GreengrassSetup greengrassSetup = new GreengrassSetup(System.out, System.err, deviceProvisioningHelper,
                 platform, kernel, "-i",
                 "mock_config_path", "-r", "mock_root", "-tn", "mock_thing_name", "-trn", "mock_tes_role_name",
                 "-ss", "false");
-        Topic regionTopic = Topic.of(this.context, DeviceConfiguration.DEVICE_PARAM_AWS_REGION, null);
-        lenient().doReturn(regionTopic).when(deviceConfiguration).getAWSRegion();
         greengrassSetup.parseArgs();
-        assertThrows(RuntimeException.class, greengrassSetup::performSetup);
+        Exception e = assertThrows(RuntimeException.class, greengrassSetup::performSetup);
+        assertTrue(e.getMessage().contains("aws region not provided"));
+    }
+
+    @Test
+    void GIVEN_setup_script_WHEN_bad_region_provided_THEN_fail() {
+        GreengrassSetup greengrassSetup = new GreengrassSetup(System.out, System.err, deviceProvisioningHelper,
+                platform, kernel, "-i",
+                "mock_config_path", "-r", "mock_root", "-tn", "mock_thing_name", "-trn", "mock_tes_role_name",
+                "-ss", "false", "--aws-region", "nowhere");
+        greengrassSetup.parseArgs();
+        Exception e = assertThrows(RuntimeException.class, greengrassSetup::performSetup);
+        assertTrue(e.getMessage().contains("is invalid AWS region"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Properly validate AWS region.

**Why is this change necessary:**
Currently we are letting bad region through and causing NullPointerException later on.

**How was this change tested:**
Added new unit tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
