### PR TITLE
fix(mqttclient): remove synchronization deadlock in reconnect

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -162,12 +162,9 @@ class AwsIotMqttClient implements Closeable {
     }
 
     void reconnect() throws TimeoutException, ExecutionException, InterruptedException {
-        // Synchronize here instead of method signature to make mockito work without deadlocking
-        synchronized (this) {
-            logger.atInfo().log("Reconnecting MQTT client most likely due to device configuration change");
-            disconnect().get(getTimeout(), TimeUnit.MILLISECONDS);
-            connect().get(getTimeout(), TimeUnit.MILLISECONDS);
-        }
+        logger.atInfo().log("Reconnecting MQTT client most likely due to device configuration change");
+        disconnect().get(getTimeout(), TimeUnit.MILLISECONDS);
+        connect().get(getTimeout(), TimeUnit.MILLISECONDS);
     }
 
     protected synchronized CompletableFuture<Boolean> connect() {

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -293,7 +293,7 @@ public class MqttClient implements Closeable {
                             }
                         }
                     } while (!brokenConnections.isEmpty());
-                }, 2, TimeUnit.SECONDS));
+                }, 1, TimeUnit.SECONDS));
 
                 // If a reconfiguration task already existed, then kill it and create a new one
                 if (oldFuture != null) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
There was a deadlock in `reconnect()` due to the synchronized block there and in the `whenComplete` callback of `disconnect()`. Removed the synchronized block so that we don't deadlock and modified the reconnect test to fail if it does deadlock.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
