### PR TITLE
fix(mqttclient): add rate limiting for publish request at 100TPS/512KBPS

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -1,6 +1,7 @@
 ** aws-iot-device-sdk; version 1.2.8 --
 https://github.com/aws/aws-iot-device-sdk-java-v2
 ** aws-java-sdk; version 2.15.17 -- https://github.com/aws/aws-sdk-java-v2
+** Google Guava; version 27 -- https://github.com/google/guava
 ** Jackson; version 2.11 -- https://github.com/FasterXML/jackson
 ** JNA; version 5.5.0 -- https://github.com/java-native-access/jna
 ** zt-process-killer; version 1.10 --
@@ -211,6 +212,8 @@ limitations under the License.
 * For aws-java-sdk see also this required NOTICE:
     AWS SDK for Java 2.0
     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For Google Guava see also this required NOTICE:
+    Copyright (C) 2020 The Guava Authors
 * For Jackson see also this required NOTICE:
     Copyright © 2012-2020 FasterXML. All Rights Reserved.
 * For JNA see also this required NOTICE:

--- a/codestyle/findbugs-exclude.xml
+++ b/codestyle/findbugs-exclude.xml
@@ -19,11 +19,8 @@
     </Match>
     <Match>
         <Or>
-            <Package name="software.amazon.awssdk.aws.greengrass"/>
-            <Package name="software.amazon.awssdk.aws.greengrass.model"/>
-            <Package name="software.amazon.awssdk.eventstreamrpc"/>
-            <Package name="software.amazon.awssdk.eventstreamrpc.model"/>
-            <Package name="software.amazon.awssdk.http.apache.internal.conn"/>
+            <Package name="~software.amazon.awssdk.*"/>
+            <Package name="~vendored.*"/>
         </Or>
     </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
                         <ruleset>codestyle/pmd-eg-tests-ruleset.xml</ruleset>
                     </rulesets>
                     <includeTests>true</includeTests>
-                    <excludes>**/awssdk/**, **/eventstream/**</excludes>
+                    <excludes>**/awssdk/**, **/eventstream/**, **/vendored/**</excludes>
                     <skip>${skipTests}</skip>
                 </configuration>
                 <executions>
@@ -339,6 +339,7 @@
                                 <exclude>codestyle/**</exclude>
                                 <exclude>src/test/greengrass-nucleus-benchmark/**</exclude>
                                 <exclude>src/*/resources/**</exclude>
+                                <exclude>src/**/vendored/**</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>
@@ -392,7 +393,7 @@
                     <configLocation>codestyle/checkstyle.xml</configLocation>
                     <violationSeverity>warning</violationSeverity>
                     <maxAllowedViolations>0</maxAllowedViolations>
-                    <excludes>**/awssdk/**, **/eventstream/**</excludes>
+                    <excludes>**/awssdk/**, **/eventstream/**, **/vendored/**</excludes>
                     <skip>${skipTests}</skip>
                 </configuration>
                 <executions>

--- a/src/main/java/vendored/com/google/common/base/Stopwatch.java
+++ b/src/main/java/vendored/com/google/common/base/Stopwatch.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package vendored.com.google.common.base;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * An object that accurately measures <i>elapsed time</i>: the measured duration between two
+ * successive readings of "now" in the same process.
+ *
+ * <p>In contrast, <i>wall time</i> is a reading of "now" as given by a method like
+ * {@link System#currentTimeMillis()}, best represented as an {@link Instant}. Such values
+ * <i>can</i> be subtracted to obtain a {@code Duration} (such as by {@code Duration.between}), but
+ * doing so does <i>not</i> give a reliable measurement of elapsed time, because wall time readings
+ * are inherently approximate, routinely affected by periodic clock corrections. Because this class
+ * (by default) uses {@link System#nanoTime}, it is unaffected by these changes.
+ *
+ * <p>Use this class instead of direct calls to {@link System#nanoTime} for two reasons:
+ *
+ * <ul>
+ *   <li>The raw {@code long} values returned by {@code nanoTime} are meaningless and unsafe to use
+ *       in any other way than how {@code Stopwatch} uses them.
+ *   <li>An alternative source of nanosecond ticks can be substituted, for example for testing or
+ *       performance reasons, without affecting most of your code.
+ * </ul>
+ *
+ * <p>Basic usage:
+ *
+ * <pre>{@code
+ * Stopwatch stopwatch = Stopwatch.createStarted();
+ * doSomething();
+ * stopwatch.stop(); // optional
+ *
+ * Duration duration = stopwatch.elapsed();
+ *
+ * log.info("time: " + stopwatch); // formatted string like "12.3 ms"
+ * }</pre>
+ *
+ * <p>The state-changing methods are not idempotent; it is an error to start or stop a stopwatch
+ * that is already in the desired state.
+ *
+ * <p>When testing code that uses this class, use {@link #createUnstarted(Ticker)} or {@link
+ * #createStarted(Ticker)} to supply a fake or mock ticker. This allows you to simulate any valid
+ * behavior of the stopwatch.
+ *
+ * <p><b>Note:</b> This class is not thread-safe.
+ *
+ * <p><b>Warning for Android users:</b> a stopwatch with default behavior may not continue to keep
+ * time while the device is asleep. Instead, create one like this:
+ *
+ * <pre>{@code
+ * Stopwatch.createStarted(
+ *      new Ticker() {
+ *        public long read() {
+ *          return android.os.SystemClock.elapsedRealtimeNanos();
+ *        }
+ *      });
+ * }</pre>
+ *
+ * @author Kevin Bourrillion
+ * @since 10.0
+ */
+@SuppressWarnings("GoodTime") // lots of violations
+public final class Stopwatch {
+    private final Ticker ticker;
+    private boolean isRunning;
+    private long elapsedNanos;
+    private long startTick;
+
+    /**
+     * Creates (but does not start) a new stopwatch using {@link System#nanoTime} as its time source.
+     *
+     * @since 15.0
+     */
+    public static Stopwatch createUnstarted() {
+        return new Stopwatch();
+    }
+
+    /**
+     * Creates (but does not start) a new stopwatch, using the specified time source.
+     *
+     * @since 15.0
+     */
+    public static Stopwatch createUnstarted(Ticker ticker) {
+        return new Stopwatch(ticker);
+    }
+
+    /**
+     * Creates (and starts) a new stopwatch using {@link System#nanoTime} as its time source.
+     *
+     * @since 15.0
+     */
+    public static Stopwatch createStarted() {
+        return new Stopwatch().start();
+    }
+
+    /**
+     * Creates (and starts) a new stopwatch, using the specified time source.
+     *
+     * @since 15.0
+     */
+    public static Stopwatch createStarted(Ticker ticker) {
+        return new Stopwatch(ticker).start();
+    }
+
+    Stopwatch() {
+        this.ticker = Ticker.systemTicker();
+    }
+
+    Stopwatch(Ticker ticker) {
+        this.ticker = ticker;
+    }
+
+    /**
+     * Returns {@code true} if {@link #start()} has been called on this stopwatch, and {@link #stop()}
+     * has not been called since the last call to {@code start()}.
+     */
+    public boolean isRunning() {
+        return isRunning;
+    }
+
+    /**
+     * Starts the stopwatch.
+     *
+     * @return this {@code Stopwatch} instance
+     * @throws IllegalStateException if the stopwatch is already running.
+     */
+    public Stopwatch start() {
+        isRunning = true;
+        startTick = ticker.read();
+        return this;
+    }
+
+    /**
+     * Stops the stopwatch. Future reads will return the fixed duration that had elapsed up to this
+     * point.
+     *
+     * @return this {@code Stopwatch} instance
+     * @throws IllegalStateException if the stopwatch is already stopped.
+     */
+    public Stopwatch stop() {
+        long tick = ticker.read();
+        isRunning = false;
+        elapsedNanos += tick - startTick;
+        return this;
+    }
+
+    /**
+     * Sets the elapsed time for this stopwatch to zero, and places it in a stopped state.
+     *
+     * @return this {@code Stopwatch} instance
+     */
+    public Stopwatch reset() {
+        elapsedNanos = 0;
+        isRunning = false;
+        return this;
+    }
+
+    private long elapsedNanos() {
+        return isRunning ? ticker.read() - startTick + elapsedNanos : elapsedNanos;
+    }
+
+    /**
+     * Returns the current elapsed time shown on this stopwatch, expressed in the desired time unit,
+     * with any fraction rounded down.
+     *
+     * <p><b>Note:</b> the overhead of measurement can be more than a microsecond, so it is generally
+     * not useful to specify {@link TimeUnit#NANOSECONDS} precision here.
+     *
+     * <p>It is generally not a good idea to use an ambiguous, unitless {@code long} to represent
+     * elapsed time. Therefore, we recommend using {@link #elapsed()} instead, which returns a
+     * strongly-typed {@code Duration} instance.
+     *
+     * @since 14.0 (since 10.0 as {@code elapsedTime()})
+     */
+    public long elapsed(TimeUnit desiredUnit) {
+        return desiredUnit.convert(elapsedNanos(), NANOSECONDS);
+    }
+
+    /**
+     * Returns the current elapsed time shown on this stopwatch as a {@link Duration}. Unlike {@link
+     * #elapsed(TimeUnit)}, this method does not lose any precision due to rounding.
+     *
+     * @since 22.0
+     */
+    public Duration elapsed() {
+        return Duration.ofNanos(elapsedNanos());
+    }
+
+}

--- a/src/main/java/vendored/com/google/common/base/Ticker.java
+++ b/src/main/java/vendored/com/google/common/base/Ticker.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package vendored.com.google.common.base;
+
+
+/**
+ * A time source; returns a time value representing the number of nanoseconds elapsed since some
+ * fixed but arbitrary point in time. Note that most users should use {@link Stopwatch} instead of
+ * interacting with this class directly.
+ *
+ * <p><b>Warning:</b> this interface can only be used to measure elapsed time, not wall time.
+ *
+ * @author Kevin Bourrillion
+ * @since 10.0 (<a href="https://github.com/google/guava/wiki/Compatibility">mostly
+ *     source-compatible</a> since 9.0)
+ */
+public abstract class Ticker {
+    /** Constructor for use by subclasses. */
+    protected Ticker() {}
+
+    /** Returns the number of nanoseconds elapsed since this ticker's fixed point of reference. */
+    public abstract long read();
+
+    /**
+     * A ticker that reads the current time using {@link System#nanoTime}.
+     *
+     * @since 10.0
+     */
+    public static Ticker systemTicker() {
+        return SYSTEM_TICKER;
+    }
+
+    private static final Ticker SYSTEM_TICKER =
+            new Ticker() {
+                @Override
+                public long read() {
+                    return System.nanoTime();
+                }
+            };
+}

--- a/src/main/java/vendored/com/google/common/util/concurrent/RateLimiter.java
+++ b/src/main/java/vendored/com/google/common/util/concurrent/RateLimiter.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright (C) 2012 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package vendored.com.google.common.util.concurrent;
+
+import vendored.com.google.common.base.Stopwatch;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Math.max;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * A rate limiter. Conceptually, a rate limiter distributes permits at a configurable rate. Each
+ * {@link #acquire()} blocks if necessary until a permit is available, and then takes it. Once
+ * acquired, permits need not be released.
+ *
+ * <p>{@code RateLimiter} is safe for concurrent use: It will restrict the total rate of calls from
+ * all threads. Note, however, that it does not guarantee fairness.
+ *
+ * <p>Rate limiters are often used to restrict the rate at which some physical or logical resource
+ * is accessed. This is in contrast to {@link java.util.concurrent.Semaphore} which restricts the
+ * number of concurrent accesses instead of the rate (note though that concurrency and rate are
+ * closely related, e.g. see <a href="http://en.wikipedia.org/wiki/Little%27s_law">Little's
+ * Law</a>).
+ *
+ * <p>A {@code RateLimiter} is defined primarily by the rate at which permits are issued. Absent
+ * additional configuration, permits will be distributed at a fixed rate, defined in terms of
+ * permits per second. Permits will be distributed smoothly, with the delay between individual
+ * permits being adjusted to ensure that the configured rate is maintained.
+ *
+ * <p>It is possible to configure a {@code RateLimiter} to have a warmup period during which time
+ * the permits issued each second steadily increases until it hits the stable rate.
+ *
+ * <p>As an example, imagine that we have a list of tasks to execute, but we don't want to submit
+ * more than 2 per second:
+ *
+ * <pre>{@code
+ * final RateLimiter rateLimiter = RateLimiter.create(2.0); // rate is "2 permits per second"
+ * void submitTasks(List<Runnable> tasks, Executor executor) {
+ *   for (Runnable task : tasks) {
+ *     rateLimiter.acquire(); // may wait
+ *     executor.execute(task);
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>As another example, imagine that we produce a stream of data, and we want to cap it at 5kb per
+ * second. This could be accomplished by requiring a permit per byte, and specifying a rate of 5000
+ * permits per second:
+ *
+ * <pre>{@code
+ * final RateLimiter rateLimiter = RateLimiter.create(5000.0); // rate = 5000 permits per second
+ * void submitPacket(byte[] packet) {
+ *   rateLimiter.acquire(packet.length);
+ *   networkService.send(packet);
+ * }
+ * }</pre>
+ *
+ * <p>It is important to note that the number of permits requested <i>never</i> affects the
+ * throttling of the request itself (an invocation to {@code acquire(1)} and an invocation to {@code
+ * acquire(1000)} will result in exactly the same throttling, if any), but it affects the throttling
+ * of the <i>next</i> request. I.e., if an expensive task arrives at an idle RateLimiter, it will be
+ * granted immediately, but it is the <i>next</i> request that will experience extra throttling,
+ * thus paying for the cost of the expensive task.
+ *
+ * @author Dimitris Andreou
+ * @since 13.0
+ */
+// TODO(user): switch to nano precision. A natural unit of cost is "bytes", and a micro precision
+// would mean a maximum rate of "1MB/s", which might be small in some cases.
+@SuppressWarnings("GoodTime") // lots of violations - also how should we model a rate?
+public abstract class RateLimiter {
+  /**
+   * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per
+   * second" (commonly referred to as <i>QPS</i>, queries per second).
+   *
+   * <p>The returned {@code RateLimiter} ensures that on average no more than {@code
+   * permitsPerSecond} are issued during any given second, with sustained requests being smoothly
+   * spread over each second. When the incoming request rate exceeds {@code permitsPerSecond} the
+   * rate limiter will release one permit every {@code (1.0 / permitsPerSecond)} seconds. When the
+   * rate limiter is unused, bursts of up to {@code permitsPerSecond} permits will be allowed, with
+   * subsequent requests being smoothly limited at the stable rate of {@code permitsPerSecond}.
+   *
+   * @param permitsPerSecond the rate of the returned {@code RateLimiter}, measured in how many
+   *     permits become available per second
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero
+   */
+  // TODO(user): "This is equivalent to
+  // {@code createWithCapacity(permitsPerSecond, 1, TimeUnit.SECONDS)}".
+  public static RateLimiter create(double permitsPerSecond) {
+    /*
+     * The default RateLimiter configuration can save the unused permits of up to one second. This
+     * is to avoid unnecessary stalls in situations like this: A RateLimiter of 1qps, and 4 threads,
+     * all calling acquire() at these moments:
+     *
+     * T0 at 0 seconds
+     * T1 at 1.05 seconds
+     * T2 at 2 seconds
+     * T3 at 3 seconds
+     *
+     * Due to the slight delay of T1, T2 would have to sleep till 2.05 seconds, and T3 would also
+     * have to sleep till 3.05 seconds.
+     */
+    return create(permitsPerSecond, SleepingStopwatch.createFromSystemTimer());
+  }
+
+  static RateLimiter create(double permitsPerSecond, SleepingStopwatch stopwatch) {
+    RateLimiter rateLimiter = new SmoothRateLimiter.SmoothBursty(stopwatch, 1.0 /* maxBurstSeconds */);
+    rateLimiter.setRate(permitsPerSecond);
+    return rateLimiter;
+  }
+
+  /**
+   * The underlying timer; used both to measure elapsed time and sleep as necessary. A separate
+   * object to facilitate testing.
+   */
+  private final SleepingStopwatch stopwatch;
+
+  // Can't be initialized in the constructor because mocks don't call the constructor.
+  private volatile Object mutexDoNotUseDirectly;
+
+  private Object mutex() {
+    Object mutex = mutexDoNotUseDirectly;
+    if (mutex == null) {
+      synchronized (this) {
+        mutex = mutexDoNotUseDirectly;
+        if (mutex == null) {
+          mutexDoNotUseDirectly = mutex = new Object();
+        }
+      }
+    }
+    return mutex;
+  }
+
+  RateLimiter(SleepingStopwatch stopwatch) {
+    this.stopwatch = stopwatch;
+  }
+
+  /**
+   * Updates the stable rate of this {@code RateLimiter}, that is, the {@code permitsPerSecond}
+   * argument provided in the factory method that constructed the {@code RateLimiter}. Currently
+   * throttled threads will <b>not</b> be awakened as a result of this invocation, thus they do not
+   * observe the new rate; only subsequent requests will.
+   *
+   * <p>Note though that, since each request repays (by waiting, if necessary) the cost of the
+   * <i>previous</i> request, this means that the very next request after an invocation to {@code
+   * setRate} will not be affected by the new rate; it will pay the cost of the previous request,
+   * which is in terms of the previous rate.
+   *
+   * <p>The behavior of the {@code RateLimiter} is not modified in any other way, e.g. if the {@code
+   * RateLimiter} was configured with a warmup period of 20 seconds, it still has a warmup period of
+   * 20 seconds after this method invocation.
+   *
+   * @param permitsPerSecond the new stable rate of this {@code RateLimiter}
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero
+   */
+  public final void setRate(double permitsPerSecond) {
+    synchronized (mutex()) {
+      doSetRate(permitsPerSecond, stopwatch.readMicros());
+    }
+  }
+
+  abstract void doSetRate(double permitsPerSecond, long nowMicros);
+
+  /**
+   * Returns the stable rate (as {@code permits per seconds}) with which this {@code RateLimiter} is
+   * configured with. The initial value of this is the same as the {@code permitsPerSecond} argument
+   * passed in the factory method that produced this {@code RateLimiter}, and it is only updated
+   * after invocations to {@linkplain #setRate}.
+   */
+  public final double getRate() {
+    synchronized (mutex()) {
+      return doGetRate();
+    }
+  }
+
+  abstract double doGetRate();
+
+  /**
+   * Acquires a single permit from this {@code RateLimiter}, blocking until the request can be
+   * granted. Tells the amount of time slept, if any.
+   *
+   * <p>This method is equivalent to {@code acquire(1)}.
+   *
+   * @return time spent sleeping to enforce rate, in seconds; 0.0 if not rate-limited
+   * @since 16.0 (present in 13.0 with {@code void} return type})
+   */
+  public double acquire() {
+    return acquire(1);
+  }
+
+  /**
+   * Acquires the given number of permits from this {@code RateLimiter}, blocking until the request
+   * can be granted. Tells the amount of time slept, if any.
+   *
+   * @param permits the number of permits to acquire
+   * @return time spent sleeping to enforce rate, in seconds; 0.0 if not rate-limited
+   * @throws IllegalArgumentException if the requested number of permits is negative or zero
+   * @since 16.0 (present in 13.0 with {@code void} return type})
+   */
+  public double acquire(int permits) {
+    long microsToWait = reserve(permits);
+    stopwatch.sleepMicrosUninterruptibly(microsToWait);
+    return 1.0 * microsToWait / SECONDS.toMicros(1L);
+  }
+
+  /**
+   * Reserves the given number of permits from this {@code RateLimiter} for future use, returning
+   * the number of microseconds until the reservation can be consumed.
+   *
+   * @return time in microseconds to wait until the resource can be acquired, never negative
+   */
+  final long reserve(int permits) {
+    synchronized (mutex()) {
+      return reserveAndGetWaitLength(permits, stopwatch.readMicros());
+    }
+  }
+
+  /**
+   * Acquires a permit from this {@code RateLimiter} if it can be obtained without exceeding the
+   * specified {@code timeout}, or returns {@code false} immediately (without waiting) if the permit
+   * would not have been granted before the timeout expired.
+   *
+   * <p>This method is equivalent to {@code tryAcquire(1, timeout, unit)}.
+   *
+   * @param timeout the maximum time to wait for the permit. Negative values are treated as zero.
+   * @param unit the time unit of the timeout argument
+   * @return {@code true} if the permit was acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is negative or zero
+   */
+  public boolean tryAcquire(long timeout, TimeUnit unit) {
+    return tryAcquire(1, timeout, unit);
+  }
+
+  /**
+   * Acquires permits from this {@link RateLimiter} if it can be acquired immediately without delay.
+   *
+   * <p>This method is equivalent to {@code tryAcquire(permits, 0, anyUnit)}.
+   *
+   * @param permits the number of permits to acquire
+   * @return {@code true} if the permits were acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is negative or zero
+   * @since 14.0
+   */
+  public boolean tryAcquire(int permits) {
+    return tryAcquire(permits, 0, MICROSECONDS);
+  }
+
+  /**
+   * Acquires a permit from this {@link RateLimiter} if it can be acquired immediately without
+   * delay.
+   *
+   * <p>This method is equivalent to {@code tryAcquire(1)}.
+   *
+   * @return {@code true} if the permit was acquired, {@code false} otherwise
+   * @since 14.0
+   */
+  public boolean tryAcquire() {
+    return tryAcquire(1, 0, MICROSECONDS);
+  }
+
+  /**
+   * Acquires the given number of permits from this {@code RateLimiter} if it can be obtained
+   * without exceeding the specified {@code timeout}, or returns {@code false} immediately (without
+   * waiting) if the permits would not have been granted before the timeout expired.
+   *
+   * @param permits the number of permits to acquire
+   * @param timeout the maximum time to wait for the permits. Negative values are treated as zero.
+   * @param unit the time unit of the timeout argument
+   * @return {@code true} if the permits were acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is negative or zero
+   */
+  public boolean tryAcquire(int permits, long timeout, TimeUnit unit) {
+    long timeoutMicros = max(unit.toMicros(timeout), 0);
+    long microsToWait;
+    synchronized (mutex()) {
+      long nowMicros = stopwatch.readMicros();
+      if (!canAcquire(nowMicros, timeoutMicros)) {
+        return false;
+      } else {
+        microsToWait = reserveAndGetWaitLength(permits, nowMicros);
+      }
+    }
+    stopwatch.sleepMicrosUninterruptibly(microsToWait);
+    return true;
+  }
+
+  /**
+   * Get time in microseconds until the next permit of any size is guaranteed not to block.
+   *
+   * @return time in microseconds until the next permit of any size is guaranteed not to block.
+   */
+  public long microTimeToNextPermit() {
+    long nowMicros = stopwatch.readMicros();
+    return max(queryEarliestAvailable(nowMicros) - nowMicros, 0);
+  }
+
+  private boolean canAcquire(long nowMicros, long timeoutMicros) {
+    return queryEarliestAvailable(nowMicros) - timeoutMicros <= nowMicros;
+  }
+
+  /**
+   * Reserves next ticket and returns the wait time that the caller must wait for.
+   *
+   * @return the required wait time, never negative
+   */
+  final long reserveAndGetWaitLength(int permits, long nowMicros) {
+    long momentAvailable = reserveEarliestAvailable(permits, nowMicros);
+    return max(momentAvailable - nowMicros, 0);
+  }
+
+  /**
+   * Returns the earliest time that permits are available (with one caveat).
+   *
+   * @return the time that permits are available, or, if permits are available immediately, an
+   *     arbitrary past or present time
+   */
+  abstract long queryEarliestAvailable(long nowMicros);
+
+  /**
+   * Reserves the requested number of permits and returns the time that those permits can be used
+   * (with one caveat).
+   *
+   * @return the time that the permits may be used, or, if the permits may be used immediately, an
+   *     arbitrary past or present time
+   */
+  abstract long reserveEarliestAvailable(int permits, long nowMicros);
+
+  @Override
+  public String toString() {
+    return String.format(Locale.ROOT, "RateLimiter[stableRate=%3.1fqps]", getRate());
+  }
+
+  abstract static class SleepingStopwatch {
+    /** Constructor for use by subclasses. */
+    protected SleepingStopwatch() {}
+
+    /*
+     * We always hold the mutex when calling this. TODO(cpovirk): Is that important? Perhaps we need
+     * to guarantee that each call to reserveEarliestAvailable, etc. sees a value >= the previous?
+     * Also, is it OK that we don't hold the mutex when sleeping?
+     */
+    protected abstract long readMicros();
+
+    protected abstract void sleepMicrosUninterruptibly(long micros);
+
+    public static SleepingStopwatch createFromSystemTimer() {
+      return new SleepingStopwatch() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+
+        @Override
+        protected long readMicros() {
+          return stopwatch.elapsed(MICROSECONDS);
+        }
+
+        @Override
+        protected void sleepMicrosUninterruptibly(long micros) {
+          if (micros > 0) {
+            try {
+              MICROSECONDS.sleep(micros);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        }
+      };
+    }
+  }
+}

--- a/src/main/java/vendored/com/google/common/util/concurrent/SmoothRateLimiter.java
+++ b/src/main/java/vendored/com/google/common/util/concurrent/SmoothRateLimiter.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2012 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package vendored.com.google.common.util.concurrent;
+
+import static java.lang.Math.min;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+abstract class SmoothRateLimiter extends RateLimiter {
+    /*
+     * How is the RateLimiter designed, and why?
+     *
+     * The primary feature of a RateLimiter is its "stable rate", the maximum rate that it should
+     * allow in normal conditions. This is enforced by "throttling" incoming requests as needed. For
+     * example, we could compute the appropriate throttle time for an incoming request, and make the
+     * calling thread wait for that time.
+     *
+     * The simplest way to maintain a rate of QPS is to keep the timestamp of the last granted
+     * request, and ensure that (1/QPS) seconds have elapsed since then. For example, for a rate of
+     * QPS=5 (5 tokens per second), if we ensure that a request isn't granted earlier than 200ms after
+     * the last one, then we achieve the intended rate. If a request comes and the last request was
+     * granted only 100ms ago, then we wait for another 100ms. At this rate, serving 15 fresh permits
+     * (i.e. for an acquire(15) request) naturally takes 3 seconds.
+     *
+     * It is important to realize that such a RateLimiter has a very superficial memory of the past:
+     * it only remembers the last request. What if the RateLimiter was unused for a long period of
+     * time, then a request arrived and was immediately granted? This RateLimiter would immediately
+     * forget about that past underutilization. This may result in either underutilization or
+     * overflow, depending on the real world consequences of not using the expected rate.
+     *
+     * Past underutilization could mean that excess resources are available. Then, the RateLimiter
+     * should speed up for a while, to take advantage of these resources. This is important when the
+     * rate is applied to networking (limiting bandwidth), where past underutilization typically
+     * translates to "almost empty buffers", which can be filled immediately.
+     *
+     * On the other hand, past underutilization could mean that "the server responsible for handling
+     * the request has become less ready for future requests", i.e. its caches become stale, and
+     * requests become more likely to trigger expensive operations (a more extreme case of this
+     * example is when a server has just booted, and it is mostly busy with getting itself up to
+     * speed).
+     *
+     * To deal with such scenarios, we add an extra dimension, that of "past underutilization",
+     * modeled by "storedPermits" variable. This variable is zero when there is no underutilization,
+     * and it can grow up to maxStoredPermits, for sufficiently large underutilization. So, the
+     * requested permits, by an invocation acquire(permits), are served from:
+     *
+     * - stored permits (if available)
+     *
+     * - fresh permits (for any remaining permits)
+     *
+     * How this works is best explained with an example:
+     *
+     * For a RateLimiter that produces 1 token per second, every second that goes by with the
+     * RateLimiter being unused, we increase storedPermits by 1. Say we leave the RateLimiter unused
+     * for 10 seconds (i.e., we expected a request at time X, but we are at time X + 10 seconds before
+     * a request actually arrives; this is also related to the point made in the last paragraph), thus
+     * storedPermits becomes 10.0 (assuming maxStoredPermits >= 10.0). At that point, a request of
+     * acquire(3) arrives. We serve this request out of storedPermits, and reduce that to 7.0 (how
+     * this is translated to throttling time is discussed later). Immediately after, assume that an
+     * acquire(10) request arriving. We serve the request partly from storedPermits, using all the
+     * remaining 7.0 permits, and the remaining 3.0, we serve them by fresh permits produced by the
+     * rate limiter.
+     *
+     * We already know how much time it takes to serve 3 fresh permits: if the rate is
+     * "1 token per second", then this will take 3 seconds. But what does it mean to serve 7 stored
+     * permits? As explained above, there is no unique answer. If we are primarily interested to deal
+     * with underutilization, then we want stored permits to be given out /faster/ than fresh ones,
+     * because underutilization = free resources for the taking. If we are primarily interested to
+     * deal with overflow, then stored permits could be given out /slower/ than fresh ones. Thus, we
+     * require a (different in each case) function that translates storedPermits to throttling time.
+     *
+     * This role is played by storedPermitsToWaitTime(double storedPermits, double permitsToTake). The
+     * underlying model is a continuous function mapping storedPermits (from 0.0 to maxStoredPermits)
+     * onto the 1/rate (i.e. intervals) that is effective at the given storedPermits. "storedPermits"
+     * essentially measure unused time; we spend unused time buying/storing permits. Rate is
+     * "permits / time", thus "1 / rate = time / permits". Thus, "1/rate" (time / permits) times
+     * "permits" gives time, i.e., integrals on this function (which is what storedPermitsToWaitTime()
+     * computes) correspond to minimum intervals between subsequent requests, for the specified number
+     * of requested permits.
+     *
+     * Here is an example of storedPermitsToWaitTime: If storedPermits == 10.0, and we want 3 permits,
+     * we take them from storedPermits, reducing them to 7.0, and compute the throttling for these as
+     * a call to storedPermitsToWaitTime(storedPermits = 10.0, permitsToTake = 3.0), which will
+     * evaluate the integral of the function from 7.0 to 10.0.
+     *
+     * Using integrals guarantees that the effect of a single acquire(3) is equivalent to {
+     * acquire(1); acquire(1); acquire(1); }, or { acquire(2); acquire(1); }, etc, since the integral
+     * of the function in [7.0, 10.0] is equivalent to the sum of the integrals of [7.0, 8.0], [8.0,
+     * 9.0], [9.0, 10.0] (and so on), no matter what the function is. This guarantees that we handle
+     * correctly requests of varying weight (permits), /no matter/ what the actual function is - so we
+     * can tweak the latter freely. (The only requirement, obviously, is that we can compute its
+     * integrals).
+     *
+     * Note well that if, for this function, we chose a horizontal line, at height of exactly (1/QPS),
+     * then the effect of the function is non-existent: we serve storedPermits at exactly the same
+     * cost as fresh ones (1/QPS is the cost for each). We use this trick later.
+     *
+     * If we pick a function that goes /below/ that horizontal line, it means that we reduce the area
+     * of the function, thus time. Thus, the RateLimiter becomes /faster/ after a period of
+     * underutilization. If, on the other hand, we pick a function that goes /above/ that horizontal
+     * line, then it means that the area (time) is increased, thus storedPermits are more costly than
+     * fresh permits, thus the RateLimiter becomes /slower/ after a period of underutilization.
+     *
+     * Last, but not least: consider a RateLimiter with rate of 1 permit per second, currently
+     * completely unused, and an expensive acquire(100) request comes. It would be nonsensical to just
+     * wait for 100 seconds, and /then/ start the actual task. Why wait without doing anything? A much
+     * better approach is to /allow/ the request right away (as if it was an acquire(1) request
+     * instead), and postpone /subsequent/ requests as needed. In this version, we allow starting the
+     * task immediately, and postpone by 100 seconds future requests, thus we allow for work to get
+     * done in the meantime instead of waiting idly.
+     *
+     * This has important consequences: it means that the RateLimiter doesn't remember the time of the
+     * _last_ request, but it remembers the (expected) time of the _next_ request. This also enables
+     * us to tell immediately (see tryAcquire(timeout)) whether a particular timeout is enough to get
+     * us to the point of the next scheduling time, since we always maintain that. And what we mean by
+     * "an unused RateLimiter" is also defined by that notion: when we observe that the
+     * "expected arrival time of the next request" is actually in the past, then the difference (now -
+     * past) is the amount of time that the RateLimiter was formally unused, and it is that amount of
+     * time which we translate to storedPermits. (We increase storedPermits with the amount of permits
+     * that would have been produced in that idle time). So, if rate == 1 permit per second, and
+     * arrivals come exactly one second after the previous, then storedPermits is _never_ increased --
+     * we would only increase it for arrivals _later_ than the expected one second.
+     */
+
+    /**
+     * This implements a "bursty" RateLimiter, where storedPermits are translated to zero throttling.
+     * The maximum number of permits that can be saved (when the RateLimiter is unused) is defined in
+     * terms of time, in this sense: if a RateLimiter is 2qps, and this time is specified as 10
+     * seconds, we can save up to 2 * 10 = 20 permits.
+     */
+    static final class SmoothBursty extends SmoothRateLimiter {
+        /** The work (permits) of how many seconds can be saved up if this RateLimiter is unused? */
+        final double maxBurstSeconds;
+
+        SmoothBursty(SleepingStopwatch stopwatch, double maxBurstSeconds) {
+            super(stopwatch);
+            this.maxBurstSeconds = maxBurstSeconds;
+        }
+
+        @Override
+        void doSetRate(double permitsPerSecond, double stableIntervalMicros) {
+            double oldMaxPermits = this.maxPermits;
+            maxPermits = maxBurstSeconds * permitsPerSecond;
+            if (oldMaxPermits == Double.POSITIVE_INFINITY) {
+                // if we don't special-case this, we would get storedPermits == NaN, below
+                storedPermits = maxPermits;
+            } else {
+                storedPermits =
+                        (oldMaxPermits == 0.0)
+                                ? 0.0 // initial state
+                                : storedPermits * maxPermits / oldMaxPermits;
+            }
+        }
+
+        @Override
+        long storedPermitsToWaitTime(double storedPermits, double permitsToTake) {
+            return 0L;
+        }
+
+        @Override
+        double coolDownIntervalMicros() {
+            return stableIntervalMicros;
+        }
+    }
+
+    /** The currently stored permits. */
+    double storedPermits;
+
+    /** The maximum number of stored permits. */
+    double maxPermits;
+
+    /**
+     * The interval between two unit requests, at our stable rate. E.g., a stable rate of 5 permits
+     * per second has a stable interval of 200ms.
+     */
+    double stableIntervalMicros;
+
+    /**
+     * The time when the next request (no matter its size) will be granted. After granting a request,
+     * this is pushed further in the future. Large requests push this further than small requests.
+     */
+    private long nextFreeTicketMicros = 0L; // could be either in the past or future
+
+    private SmoothRateLimiter(SleepingStopwatch stopwatch) {
+        super(stopwatch);
+    }
+
+    @Override
+    final void doSetRate(double permitsPerSecond, long nowMicros) {
+        resync(nowMicros);
+        double stableIntervalMicros = SECONDS.toMicros(1L) / permitsPerSecond;
+        this.stableIntervalMicros = stableIntervalMicros;
+        doSetRate(permitsPerSecond, stableIntervalMicros);
+    }
+
+    abstract void doSetRate(double permitsPerSecond, double stableIntervalMicros);
+
+    @Override
+    final double doGetRate() {
+        return SECONDS.toMicros(1L) / stableIntervalMicros;
+    }
+
+    @Override
+    final long queryEarliestAvailable(long nowMicros) {
+        return nextFreeTicketMicros;
+    }
+
+    @Override
+    final long reserveEarliestAvailable(int requiredPermits, long nowMicros) {
+        resync(nowMicros);
+        long returnValue = nextFreeTicketMicros;
+        double storedPermitsToSpend = min(requiredPermits, this.storedPermits);
+        double freshPermits = requiredPermits - storedPermitsToSpend;
+        long waitMicros =
+                storedPermitsToWaitTime(this.storedPermits, storedPermitsToSpend)
+                        + (long) (freshPermits * stableIntervalMicros);
+
+        this.nextFreeTicketMicros = saturatedAdd(nextFreeTicketMicros, waitMicros);
+        this.storedPermits -= storedPermitsToSpend;
+        return returnValue;
+    }
+
+    public static long saturatedAdd(long a, long b) {
+        long naiveSum = a + b;
+        if ((a ^ b) < 0 | (a ^ naiveSum) >= 0) {
+            // If a and b have different signs or a has the same sign as the result then there was no
+            // overflow, return.
+            return naiveSum;
+        }
+        // we did over/under flow, if the sign is negative we should return MAX otherwise MIN
+        return Long.MAX_VALUE + ((naiveSum >>> (Long.SIZE - 1)) ^ 1);
+    }
+
+    /**
+     * Translates a specified portion of our currently stored permits which we want to spend/acquire,
+     * into a throttling time. Conceptually, this evaluates the integral of the underlying function we
+     * use, for the range of [(storedPermits - permitsToTake), storedPermits].
+     *
+     * <p>This always holds: {@code 0 <= permitsToTake <= storedPermits}
+     */
+    abstract long storedPermitsToWaitTime(double storedPermits, double permitsToTake);
+
+    /**
+     * Returns the number of microseconds during cool down that we have to wait to get a new permit.
+     */
+    abstract double coolDownIntervalMicros();
+
+    /** Updates {@code storedPermits} and {@code nextFreeTicketMicros} based on the current time. */
+    void resync(long nowMicros) {
+        // if nextFreeTicket is in the past, resync to now
+        if (nowMicros > nextFreeTicketMicros) {
+            double newPermits = (nowMicros - nextFreeTicketMicros) / coolDownIntervalMicros();
+            storedPermits = min(maxPermits, storedPermits + newPermits);
+            nextFreeTicketMicros = nowMicros;
+        }
+    }
+}

--- a/src/test/java/com/aws/greengrass/util/RateLimiterTest.java
+++ b/src/test/java/com/aws/greengrass/util/RateLimiterTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import org.junit.jupiter.api.Test;
+import vendored.com.google.common.util.concurrent.RateLimiter;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.CombinableMatcher.both;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
+
+class RateLimiterTest {
+    @Test
+    void GIVEN_ratelimiter_WHEN_queryForTimeToPermit_THEN_timeIsAccurate() throws InterruptedException {
+        RateLimiter rl = RateLimiter.create(100);
+        // Wait 1 second for the token bucket to be filled completely
+        TimeUnit.SECONDS.sleep(1);
+
+        for (int i=0; i < 200; i++) {
+            long estimatedTimeMicros = rl.microTimeToNextPermit();
+            long realTimeMicros = (long) (rl.acquire() * 1000.0 * 1000.0);
+
+            // Check that the durationToNextPermit is within 500 microseconds of the real wait time
+            assertThat(realTimeMicros,
+                    is(both(greaterThan(estimatedTimeMicros - 500)).and(lessThanOrEqualTo(estimatedTimeMicros))));
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Manually including `RateLimiter` from Guava instead of taking a dependency on all of Guava. Implementing rate limiting at 100TPS to avoid IoT Core throttling at 100TPS. Also rate limiting based on bandwidth used since IoT Core limits us to 512 KBPS. Tested that publishing at 100TPS did not trigger IoT Core's throttling at all.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
