### PR TITLE
Switched com.sun.org.apache.xerces.internal.impl.dv.util.Base64 to java.util.Base64

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/docker/DockerImageArtifactDownloadTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/docker/DockerImageArtifactDownloadTest.java
@@ -20,7 +20,6 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.NucleusPaths;
-import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -66,7 +66,7 @@ public class DockerImageArtifactDownloadTest extends BaseITCase {
     void before() throws Exception {
         Instant credentialsExpiry = Instant.now().plusSeconds(10);
         AuthorizationData authorizationData = AuthorizationData.builder()
-                .authorizationToken(Base64.encode("username:password".getBytes(StandardCharsets.UTF_8)))
+                .authorizationToken(Base64.getEncoder().encodeToString("username:password".getBytes(StandardCharsets.UTF_8)))
                 .expiresAt(credentialsExpiry).build();
         GetAuthorizationTokenResponse response =
                 GetAuthorizationTokenResponse.builder().authorizationData(authorizationData).build();

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.componentmanager.plugins.docker;
 
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.RegistryAuthException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +20,7 @@ import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenResponse;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -48,7 +48,7 @@ public class EcrAccessorTest {
     void GIVEN_ecr_accessor_WHEN_get_credentials_success_THEN_return_registry_credentials() throws Exception {
         Instant credentialsExpiry = Instant.now().plusSeconds(10);
         AuthorizationData authorizationData = AuthorizationData.builder()
-                .authorizationToken(Base64.encode("username:password".getBytes(StandardCharsets.UTF_8)))
+                .authorizationToken(Base64.getEncoder().encodeToString("username:password".getBytes(StandardCharsets.UTF_8)))
                 .expiresAt(credentialsExpiry).build();
         GetAuthorizationTokenResponse response =
                 GetAuthorizationTokenResponse.builder().authorizationData(authorizationData).build();


### PR DESCRIPTION
This internal Base64 class was giving me trouble so I switched to the java.util.Base64 version available in Java 8+.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
