### PR TITLE
chore: remove jackson-jr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,23 +77,8 @@
             <version>2.11.3</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jr</groupId>
-            <artifactId>jackson-jr-objects</artifactId>
-            <version>2.11.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.jr</groupId>
-            <artifactId>jackson-jr-stree</artifactId>
-            <version>2.11.3</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.11.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-cbor</artifactId>
             <version>2.11.3</version>
         </dependency>
         <dependency>

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -39,8 +39,8 @@ import com.aws.greengrass.util.ProxyUtils;
 import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.Platform;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -94,6 +94,8 @@ public class Kernel {
     static final String DEFAULT_CONFIG_TLOG_FILE = "config.tlog";
     public static final String SERVICE_DIGEST_TOPIC_KEY = "service-digest";
     private static final String DEPLOYMENT_STAGE_LOG_KEY = "stage";
+    protected static final ObjectMapper CONFIG_YAML_WRITER =
+            YAMLMapper.builder().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET).build();
 
     @Getter
     private final Context context;
@@ -338,7 +340,7 @@ public class Kernel {
         configMap.put(DeviceConfiguration.SYSTEM_NAMESPACE_KEY,
                 config.findTopics(DeviceConfiguration.SYSTEM_NAMESPACE_KEY).toPOJO());
         try {
-            JSON.std.with(new YAMLFactory().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)).write(configMap, w);
+            CONFIG_YAML_WRITER.writeValue(w, configMap);
         } catch (IOException ex) {
             logger.atError().setEventType("write-config-error").setCause(ex).log();
         }

--- a/src/test/greengrass-nucleus-benchmark/pom.xml
+++ b/src/test/greengrass-nucleus-benchmark/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.aws.greengrass</groupId>
     <artifactId>greengrass-nucleus-benchmark</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JMH benchmark sample: Java</name>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/com/aws/greengrass/authorization/AuthorizationPolicyParserTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/AuthorizationPolicyParserTest.java
@@ -13,9 +13,7 @@ import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +61,7 @@ class AuthorizationPolicyParserTest {
         realConfig = new Configuration(new Context());
         try (InputStream inputStream = getClass().getResourceAsStream(filename)) {
             assertNotNull(inputStream);
-            realConfig.mergeMap(0, (Map) JSON.std.with(new YAMLFactory()).anyFrom(inputStream));
+            realConfig.mergeMap(0, new YAMLMapper().readValue(inputStream, Map.class));
         }
         when(kernel.getConfig()).thenReturn(realConfig);
     }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -17,8 +17,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Coerce;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import lombok.Setter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,7 +104,7 @@ class LifecycleTest {
         config = rootConfig.createInteriorChild(GreengrassService.SERVICES_NAMESPACE_TOPIC)
                 .createInteriorChild("MockService");
         try (InputStream inputStream = new ByteArrayInputStream(BLANK_CONFIG_YAML_WITH_TIMEOUT.getBytes())) {
-            config.updateFromMap((Map) JSON.std.with(new YAMLFactory()).anyFrom(inputStream),
+            config.updateFromMap(new YAMLMapper().readValue(inputStream, Map.class),
                     new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, 0));
         }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Drop jackson-jr and cbor since we use full jackson anyway and we do not use cbor at all.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
