### PR TITLE
feat(windows): enable github action to run on Windows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,11 +21,13 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v2
+        if: matrix.os == 'ubuntu-latest'
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
       - run: rm -rf /tmp/*
+        if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
       - name: Build with Maven
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [Linux]
+        os: [Linux, Windows]
     name: Build on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -28,6 +28,8 @@ jobs:
       - run: rm -rf /tmp/*
         continue-on-error: true
       - name: Build with Maven
+        env:
+          AWS_REGION: us-west-2
         run: mvn -ntp -U verify
         shell: cmd
         if: matrix.os == 'Windows'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [Linux, Windows]
+        os: [ubuntu-latest, windows-latest]
     name: Build on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -32,12 +32,12 @@ jobs:
           AWS_REGION: us-west-2
         run: mvn -ntp -U verify
         shell: cmd
-        if: matrix.os == 'Windows'
+        if: matrix.os == 'windows-latest'
       - name: Build with Maven
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U verify
-        if: matrix.os != 'Windows'
+        if: matrix.os != 'windows-latest'
       - name: Upload Failed Test Report
         uses: actions/upload-artifact@v1.0.0
         if: failure()
@@ -52,10 +52,10 @@ jobs:
           path: target/jacoco-report
       - name: Convert Jacoco unit test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco.xml src/main/java > target/jacoco-report/cobertura.xml
-        if: matrix.os == 'Linux'
+        if: matrix.os == 'ubuntu-latest'
       - name: Convert Jacoco interation test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco-it/jacoco.xml src/main/java > target/jacoco-report/cobertura-it.xml
-        if: matrix.os == 'Linux'
+        if: matrix.os == 'ubuntu-latest'
       - name: cobertura-report-unit-test
         uses: shaguptashaikh/cobertura-action@master
         continue-on-error: true
@@ -101,16 +101,16 @@ jobs:
           mvn -ntp japicmp:cmp -DskipTests &&
           pip3 -q install agithub &&
           python3 .github/scripts/binaryCompatibility.py --input target/japicmp/default-cli.xml --token "${{ github.token }}"
-        if: github.event_name == 'pull_request' && matrix.os == 'Linux'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload Compatibility Report
         uses: actions/upload-artifact@v1.0.0
         with:
           name: Binary Compatibility Report
           path: target/japicmp/default-cli.html
-        if: github.event_name == 'pull_request' && matrix.os == 'Linux'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Build benchmark with Maven
         # Changes can break the benchmark, so compile it now to make sure it is buildable
         run: |
           mvn -ntp -U install -DskipTests
           mvn -ntp -U -f src/test/greengrass-nucleus-benchmark install
-        if: matrix.os == 'Linux'
+        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,13 +29,14 @@ jobs:
       - run: rm -rf /tmp/*
         if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
-      - name: Build with Maven
+      - name: Build with Maven ${{ matrix.os }}
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U verify
         shell: cmd
+        continue-on-error: true
         if: matrix.os == 'windows-latest'
-      - name: Build with Maven
+      - name: Build with Maven ${{ matrix.os }}
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,14 +29,14 @@ jobs:
       - run: rm -rf /tmp/*
         if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
-      - name: Build with Maven ${{ matrix.os }}
+      - name: Build with Maven (Windows)
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U verify
         shell: cmd
         continue-on-error: true
         if: matrix.os == 'windows-latest'
-      - name: Build with Maven ${{ matrix.os }}
+      - name: Build with Maven (not Windows)
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U verify
@@ -49,7 +49,7 @@ jobs:
           path: target/surefire-reports
       - name: Upload Coverage
         uses: actions/upload-artifact@v1.0.0
-        if: always()
+        if: matrix.os == 'ubuntu-latest'
         with:
           name: Coverage Report ${{ matrix.os }}
           path: target/jacoco-report
@@ -61,6 +61,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - name: cobertura-report-unit-test
         uses: shaguptashaikh/cobertura-action@master
+        if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
         with:
           # The GITHUB_TOKEN for this repo
@@ -81,6 +82,7 @@ jobs:
           report_name: Unit Tests Coverage Report
       - name: cobertura-report-integration-test
         uses: shaguptashaikh/cobertura-action@master
+        if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
         with:
           # The GITHUB_TOKEN for this repo


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Enable Github Action to run on Windows.

**Why is this change necessary:**
Github Action is not being run on Windows. As we ports to Windows, having it run on Windows can help us to write tests specific for Windows as well as to make sure new developments do not break the Windows build.

**How was this change tested:**
Github Action itself. 

**Any additional information or context required to review the change:**
Note that the tests are not passing 100% on Windows yet. Once the Action runs on Windows, the next step is to investigate the failing tests.

We also need to update branch protection to check on `Build on ubuntu-latest` before we merge this PR. Since tests running on Windows do not pass 100% yet, so do not check `Build on windows-latest` for now.

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
