### PR TITLE
fix: auth policy parser duplicate policy error message

### DIFF
--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -359,12 +359,16 @@ public class AuthorizationHandler  {
 
     private void validatePolicyId(List<AuthorizationPolicy> policies) throws AuthorizationException {
         if (policies.stream().anyMatch(p -> Utils.isEmpty(p.getPolicyId()))) {
-            throw new AuthorizationException("Malformed policy with empty/null policy Id's");
+            throw new AuthorizationException("Malformed policy with empty/null policy IDs");
         }
         // check for duplicates
         Set<String> duplicates = new HashSet<>();
-        if (policies.stream().anyMatch(p -> !duplicates.add(p.getPolicyId()))) {
-            throw new AuthorizationException("Malformed policy with duplicate policy Id's ");
+        for (AuthorizationPolicy policy : policies) {
+            if (!duplicates.add(policy.getPolicyId())) {
+                throw new AuthorizationException(
+                        String.format("Duplicate policy ID \"%s\" for principal \"%s\"",
+                                policy.getPolicyId(), policy.getPrincipals()));
+            }
         }
     }
 

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -353,8 +353,6 @@ class AwsIotMqttClient implements Closeable {
                 connection = null;
             }
         }
-        // Use code 0 which means this is intentional and we won't log any error
-        connectionEventCallback.onConnectionInterrupted(0);
     }
 
     @Override


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
New error: `Duplicate policy ID "Id1" for principal "[compB, compA]"`
Old error: `Malformed policy with duplicate policy Id's`

Also removing call to `onConnectionInterrupt` in the MQTT connection cleanup as it isn't needed and is called by the IoT SDK anyway.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
