### PR TITLE
fix: timestamp of initial jvmOptions; bootstrap config comparison

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -275,7 +275,7 @@ public class DeviceConfiguration {
             String jvmOptions = ManagementFactory.getRuntimeMXBean().getInputArguments().stream().sorted()
                     .filter(s -> !s.startsWith(JVM_OPTION_ROOT_PATH)).collect(Collectors.joining(" "));
             kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, getNucleusComponentName(), CONFIGURATION_CONFIG_KEY,
-                    DEVICE_PARAM_JVM_OPTIONS).dflt(jvmOptions);
+                    DEVICE_PARAM_JVM_OPTIONS).withNewerValue(DEFAULT_VALUE_TIMESTAMP + 1, jvmOptions);
 
             kernelAlts.writeLaunchParamsToFile(jvmOptions);
             logger.atInfo().log("Successfully setup Nucleus launch parameters");

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
@@ -127,6 +127,58 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     }
 
     @Test
+    void GIVEN_bootstrap_definition_WHEN_isBootstrapRequired_THEN_key_case_insensitive_value_type_insensitive() {
+        Topics bootstrap = Topics.of(context, Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC, null);
+        bootstrap.createLeafChild("script").withValue("\necho complete\n");
+        bootstrap.createLeafChild("RequiresPrivilege").withValue("true");
+        bootstrap.createLeafChild("Timeout").withValue("120");
+        doReturn(bootstrap).when(config)
+                .findNode(eq(SERVICE_LIFECYCLE_NAMESPACE_TOPIC), eq(Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC));
+
+        assertFalse(ges.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "1.0.0");
+            put(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                put(Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                    put("script", "\necho complete\n");
+                    put("requiresPrivilege", true);
+                    put("Timeout", 120);
+                }});
+            }});
+        }}));
+        assertFalse(ges.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "1.0.0");
+            put(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                put("Bootstrap", new HashMap<String, Object>() {{
+                    put("script", "\necho complete\n");
+                    put("RequiresPrivilege", true);
+                    put("timeout", 120);
+                }});
+            }});
+        }}));
+        assertTrue(ges.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "1.0.0");
+            put(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                put("Bootstrap", new HashMap<String, Object>() {{
+                    put("script", "\necho complete\n");
+                    put("RequiresPrivilege", true);
+                    put("timeout", 100);
+                }});
+            }});
+        }}));
+        assertTrue(ges.isBootstrapRequired(new HashMap<String, Object>() {{
+            put(VERSION_CONFIG_KEY, "1.0.0");
+            put(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                put("Bootstrap", new HashMap<String, Object>() {{
+                    put("script", "\necho complete\n");
+                    put("RequiresPrivilege", true);
+                    put("timeout", 120);
+                    put("Setenv", "");
+                }});
+            }});
+        }}));
+    }
+
+    @Test
     void GIVEN_runwith_info_WHEN_exec_add_group_THEN_use_runwith() throws Exception {
         ges.runWith = RunWith.builder().user("foo").group("bar").build();
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Update timestamp of initial `jvmOptions` config.
During deployments, default config values from recipes are loaded with timestamp `1` [here](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/003f19ee79627f5a0e281beee285c26aaa311ef6/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java#L310-L315), and during the config merge, config values with the same timestamp will override current value in [withNewerValue](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/8a9bd022c7a1da82012eec4a006839d7b7e36f70/src/main/java/com/aws/greengrass/config/Topic.java#L210-L213).
As a result, `jvmOptions` will be reset to default value from recipe, i.e. `""`, incorrectly during deployments.
The timestamp of initial `jvmOptions` should not be set to 1, because it's not the default in recipe. 
Bumping timestamp in this PR.
2. Fix bootstrap step comparison logic to handle config keys in a case-insensitive manner and handle config values as strings. e.g.
```
before. {RequiresPrivilege=true, script=...} # true is of type string
after. {requiresPrivilege=true, script=...}  # true is of type boolean
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
