### PR TITLE
fix: read procfs (via oshi) instead of ps to find process tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
              <groupId>com.github.oshi</groupId>
              <artifactId>oshi-core</artifactId>
-             <version>5.8.2</version>
+             <version>6.3.2</version>
         </dependency>
 
         <!-- zeroturnaround brings in an older version jna which tries to load msvcr100.dll. msvcr100.dll is not shipped
@@ -206,13 +206,13 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.9.0</version>
+            <version>5.12.1</version>
         </dependency>
         <!-- jna-platform adds support for calling Windows system DLLs -->
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
-            <version>5.9.0</version>
+            <version>5.12.1</version>
         </dependency>
 
         <dependency>
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.10.3</version>
+            <version>1.10.6</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
@@ -410,6 +410,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
 
         GreengrassService main = kernel.locate("main");
         deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig).get(60, TimeUnit.SECONDS);
+        kernel.getContext().waitForPublishQueueToClear();
 
         // Verify that first merge succeeded.
         assertTrue(newService2Started.get());
@@ -417,7 +418,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         assertTrue(mainRestarted.await(10, TimeUnit.SECONDS));
         assertThat(kernel.orderedDependencies().stream().map(GreengrassService::getName).collect(Collectors.toList()),
                 containsInRelativeOrder("new_service2", "new_service", "main"));
-        // Wait for main to finish before continuing, otherwise the state change listner may cause a failure
+        // Wait for main to finish before continuing, otherwise the state change listener may cause a failure
         assertThat(main::getState, eventuallyEval(is(State.FINISHED)));
 
         // WHEN
@@ -435,6 +436,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         // merge in the same config the second time
         // merge shouldn't block
         deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig).get(60, TimeUnit.SECONDS);
+        kernel.getContext().waitForPublishQueueToClear();
 
         // main should be finished
         assertEquals(State.FINISHED, main.getState());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change updates the `UnixPlatform` implementation for finding child processes so that it does not find processes using `ps`, instead we will use the oshi library that we already depend on to list all child processes.

**Why is this change necessary:**
Resolves #910.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
