### PR TITLE
fix: remove default environment variable for HOME which is non-writable

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
@@ -174,8 +174,6 @@ public class KernelCommandLine {
                     Paths.get(deTilde(cliIpcInfoPathName)).toAbsolutePath(),
                     Paths.get(deTilde(binPathName)).toAbsolutePath());
 
-            Exec.setDefaultEnv("HOME", nucleusPaths.workPath().toString());
-
             // Initialize file and directory managers after kernel root directory is set up
             deploymentDirectoryManager = new DeploymentDirectoryManager(kernel, nucleusPaths);
             kernel.getContext().put(DeploymentDirectoryManager.class, deploymentDirectoryManager);

--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -67,7 +67,7 @@ public final class Exec implements Closeable {
 
     private static final ConcurrentLinkedDeque<Path> paths = new ConcurrentLinkedDeque<>();
     private static String[] defaultEnvironment = {"PATH=" + System.getenv("PATH"), "JAVA_HOME=" + System.getProperty(
-            "java.home")};
+            "java.home"), "HOME=" + System.getProperty("user.home")};
 
     static {
         addPathEntries(System.getenv("PATH"));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The root work path is not writable, so instead of setting HOME to a non-writable path we just won't set it at all. The shell will be setting HOME for us to the user's home directory.

**Why is this change necessary:**

**How was this change tested:**
```
unset HOME
sudo -H -u $(whoami) -- sh -c "echo \$HOME"
```

This shows that when launched without $HOME set, sudo and the child shell will still set the HOME correctly.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
