### PR TITLE
fix(tlog): close tlog writer to prevent fd leak

### DIFF
--- a/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
+++ b/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
@@ -210,6 +210,7 @@ public class ConfigurationWriter implements Closeable, ChildChanged {
         logger.atDebug(TRUNCATE_TLOG_EVENT).log("existing tlog writer closed");
         // move old tlog
         try {
+            out.close();
             Files.move(tlogOutputPath, oldTlogPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             logger.atError(TRUNCATE_TLOG_EVENT, e).log("failed to rename existing tlog");

--- a/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
+++ b/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
@@ -207,10 +207,11 @@ public class ConfigurationWriter implements Closeable, ChildChanged {
         if (out instanceof Commitable) {
             ((Commitable) out).commit();
         }
-        logger.atDebug(TRUNCATE_TLOG_EVENT).log("existing tlog writer closed");
+
         // move old tlog
         try {
             out.close();
+            logger.atDebug(TRUNCATE_TLOG_EVENT).log("existing tlog writer closed");
             Files.move(tlogOutputPath, oldTlogPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             logger.atError(TRUNCATE_TLOG_EVENT, e).log("failed to rename existing tlog");


### PR DESCRIPTION
**Issue #, if available:**
File descriptor leak when rotating tlog file.  

**How was this change tested:**

Tested on dev box. Tested by reducing the frequency at which tlogs are rotated. Without the fix, the kernel FD count goes up by 1 after each rotation. 

 The fix can also be verified by checking the metrics in deployment performance tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
