### PR TITLE
fix: during setup only add the user to the group if we just created it

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -466,10 +466,12 @@ public class GreengrassSetup {
                 }
             }
             if (setGGCUser) {
+                boolean updateGGCGroup = false;
                 if (!platform.userExists(GGC_USER)) {
                     outStream.printf("Creating user %s %n", GGC_USER);
                     platform.createUser(GGC_USER);
                     outStream.printf("%s created %n", GGC_USER);
+                    updateGGCGroup = true;
                 }
                 if (setGGCGroup) {
                     try {
@@ -478,9 +480,12 @@ public class GreengrassSetup {
                         outStream.printf("Creating group %s %n", GGC_GROUP);
                         platform.createGroup(GGC_GROUP);
                         outStream.printf("%s created %n", GGC_GROUP);
+                        updateGGCGroup = true;
                     }
-                    platform.addUserToGroup(GGC_USER, GGC_GROUP);
-                    outStream.printf("Added %s to %s %n", GGC_USER, GGC_GROUP);
+                    if (updateGGCGroup) {
+                        platform.addUserToGroup(GGC_USER, GGC_GROUP);
+                        outStream.printf("Added %s to %s %n", GGC_USER, GGC_GROUP);
+                    }
                 }
             }
             if (noDefaultSet) {

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -160,6 +160,7 @@ class GreengrassSetupTest {
         verify(runWithDefaultPosixUserTopic, times(0)).withValue(anyString());
         verify(platform, times(0)).createUser(eq("ggc_user"));
         verify(platform, times(0)).createGroup(eq("ggc_group"));
+        verify(platform, times(0)).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -183,6 +184,7 @@ class GreengrassSetupTest {
         verify(runWithDefaultPosixUserTopic, timeout(0)).withValue(anyString());
         verify(platform, times(0)).createUser(eq("ggc_user"));
         verify(platform, times(0)).createGroup(eq("ggc_group"));
+        verify(platform, times(0)).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -205,6 +207,7 @@ class GreengrassSetupTest {
 
         verify(platform).createUser(eq("ggc_user"));
         verify(platform).createGroup(eq("ggc_group"));
+        verify(platform).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -226,6 +229,7 @@ class GreengrassSetupTest {
 
         verify(platform, times(0)).createUser(eq("ggc_user"));
         verify(platform, times(0)).createGroup(eq("ggc_group"));
+        verify(platform, times(0)).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -248,6 +252,7 @@ class GreengrassSetupTest {
 
         verify(platform, times(0)).createUser(any());
         verify(platform, times(0)).createGroup(any());
+        verify(platform, times(0)).addUserToGroup(any(), any());
     }
 
     @Test
@@ -269,6 +274,7 @@ class GreengrassSetupTest {
 
         verify(platform, times(0)).createUser(any());
         verify(platform, times(0)).createGroup(any());
+        verify(platform, times(0)).addUserToGroup(any(), any());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
If both ggc_user and ggc_group already exist assume they are set up
correctly so there is no need to add ggc_user to the ggc_group.

This is important if the system has a readonly root partition.

Copy of #919 

**Issue #, if available:**

**Description of changes:**
If both ggc_user and ggc_group already exist assume they are set up
correctly so there is no need to add ggc_user to the ggc_group.

**Why is this change necessary:**
This is important if the system has a readonly root partition or is missing usermod

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
