### PR TITLE
build(ci): separate commenting steps to allow forks to run

### DIFF
--- a/.github/scripts/binaryCompatibility.py
+++ b/.github/scripts/binaryCompatibility.py
@@ -20,12 +20,14 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--input', type=argparse.FileType('r'), help='Input file to parse')
     parser.add_argument('--token', type=str, help='GitHub token')
+    parser.add_argument('--pr', type=str, help='GitHub PR')
+    parser.add_argument('--sha', type=str, help='GitHub SHA')
     args = parser.parse_args()
 
     file = args.input
 
     my_body_dedupe = "Produced by binaryCompatability.py"
-    body = f"Binary incompatibility detected for commit {os.getenv('GITHUB_SHA')}.\n" \
+    body = f"Binary incompatibility detected for commit {args.sha}.\n" \
            f" See the uploaded artifacts from the action for details. You must bump the version number.\n\n"
 
     incompatible = False
@@ -51,7 +53,7 @@ def main():
     body += "\n" + my_body_dedupe
 
     token = args.token
-    pr = json.load(open(os.getenv("GITHUB_EVENT_PATH"), 'r'))["pull_request"]["number"]
+    pr = args.pr
 
     gh = GitHub(token=token)
     existing_comments = gh.repos[os.getenv("GITHUB_REPOSITORY")].issues[pr].comments.get()

--- a/.github/workflows/externalPR.yml
+++ b/.github/workflows/externalPR.yml
@@ -1,0 +1,88 @@
+name: External PR
+
+on:
+  workflow_run:
+    workflows: ["Java CI"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    name: Comment
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+      - name: outputs
+        run: |-
+          echo '::set-output name=PR::$(cat NR)'
+          echo '::set-output name=SHA::$(cat SHA)'
+      - name: cobertura-report-unit-test
+        uses: 5monkeys/cobertura-action@master
+        continue-on-error: true
+        with:
+          # The GITHUB_TOKEN for this repo
+          repo_token: ${{ github.token }}
+          # Path to the cobertura file.
+          path: jacoco-report/cobertura.xml
+          # If files with 100% should be skipped from report.
+          skip_covered: false
+          # Minimum allowed coverage percentage as an integer.
+          minimum_coverage: 65
+          # Show line rate as specific column.
+          show_line: true
+          # Show branch rate as specific column.
+          show_branch: true
+          # Use class names instead of the filename
+          show_class_names: true
+          # Use a unique name for the report and comment
+          report_name: Unit Tests Coverage Report
+          pull_request_number: ${{ steps.outputs.outputs.PR }}
+      - name: cobertura-report-integration-test
+        uses: 5monkeys/cobertura-action@master
+        continue-on-error: true
+        with:
+          # The GITHUB_TOKEN for this repo
+          repo_token: ${{ github.token }}
+          # Path to the cobertura file.
+          path: jacoco-report/cobertura-it.xml
+          # If files with 100% should be skipped from report.
+          skip_covered: false
+          # Minimum allowed coverage percentage as an integer.
+          minimum_coverage: 58
+          # Show line rate as specific column.
+          show_line: true
+          # Show branch rate as specific column.
+          show_branch: true
+          # Use class names instead of the filename
+          show_class_names: true
+          # Use a unique name for the report and comment
+          report_name: Integration Tests Coverage Report
+          pull_request_number: ${{ steps.outputs.outputs.PR }}
+      - name: Check compatibility
+        run: >-
+          pip3 -q install agithub &&
+          python3 .github/scripts/binaryCompatibility.py --input japicmp/default-cli.xml --token "${{ github.token }}" --pr "${{steps.outputs.outputs.PR}}" --sha "${{steps.outputs.outputs.SHA}}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,53 +59,9 @@ jobs:
       - name: Convert Jacoco interation test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco-it/jacoco.xml src/main/java > target/jacoco-report/cobertura-it.xml
         if: matrix.os == 'ubuntu-latest'
-      - name: cobertura-report-unit-test
-        uses: shaguptashaikh/cobertura-action@master
-        if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
-        with:
-          # The GITHUB_TOKEN for this repo
-          repo_token: ${{ github.token }}
-          # Path to the cobertura file.
-          path: target/jacoco-report/cobertura.xml
-          # If files with 100% should be skipped from report.
-          skip_covered: false
-          # Minimum allowed coverage percentage as an integer.
-          minimum_coverage: 65
-          # Show line rate as specific column.
-          show_line: true
-          # Show branch rate as specific column.
-          show_branch: true
-          # Use class names instead of the filename
-          show_class_names: true
-          # Use a unique name for the report and comment
-          report_name: Unit Tests Coverage Report
-      - name: cobertura-report-integration-test
-        uses: shaguptashaikh/cobertura-action@master
-        if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
-        with:
-          # The GITHUB_TOKEN for this repo
-          repo_token: ${{ github.token }}
-          # Path to the cobertura file.
-          path: target/jacoco-report/cobertura-it.xml
-          # If files with 100% should be skipped from report.
-          skip_covered: false
-          # Minimum allowed coverage percentage as an integer.
-          minimum_coverage: 58
-          # Show line rate as specific column.
-          show_line: true
-          # Show branch rate as specific column.
-          show_branch: true
-          # Use class names instead of the filename
-          show_class_names: true
-          # Use a unique name for the report and comment
-          report_name: Integration Tests Coverage Report
       - name: Check compatibility
         run: >-
-          mvn -ntp japicmp:cmp -DskipTests &&
-          pip3 -q install agithub &&
-          python3 .github/scripts/binaryCompatibility.py --input target/japicmp/default-cli.xml --token "${{ github.token }}"
+          mvn -ntp japicmp:cmp -DskipTests
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload Compatibility Report
         uses: actions/upload-artifact@v1.0.0
@@ -118,4 +74,23 @@ jobs:
         run: |
           mvn -ntp -U install -DskipTests
           mvn -ntp -U -f src/test/greengrass-nucleus-benchmark install
+        if: matrix.os == 'ubuntu-latest'
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr/jacoco-report
+          mkdir -p ./pr/japicmp
+          mkdir -p target/japicmp
+          mkdir -p target/jacoco-report
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
+
+          cp -R target/japicmp/default-cli.xml ./pr/japicmp/default-cli.xml
+          cp target/jacoco-report/cobertura.xml ./pr/jacoco-report/cobertura.xml
+          cp target/jacoco-report/cobertura-it.xml ./pr/jacoco-report/cobertura-it.xml
+        if: matrix.os == 'ubuntu-latest'
+      - name: Upload files
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move steps which require the github secret for commenting into a separate workflow which is triggered by the pull request workflow completing.
This will enable us to test code from forks.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
