### PR TITLE
fix(build): only upload PR info when the event is a pull request

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -87,10 +87,10 @@ jobs:
           cp -R target/japicmp/default-cli.xml ./pr/japicmp/default-cli.xml
           cp target/jacoco-report/cobertura.xml ./pr/jacoco-report/cobertura.xml
           cp target/jacoco-report/cobertura-it.xml ./pr/jacoco-report/cobertura-it.xml
-        if: matrix.os == 'ubuntu-latest'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload files
         uses: actions/upload-artifact@v2
         with:
           name: pr
           path: pr/
-        if: matrix.os == 'ubuntu-latest'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix for issue: https://github.com/aws-greengrass/aws-greengrass-nucleus/runs/2326996814

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
