### PR TITLE
feat(deployment): add required capabilities feature

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -259,9 +259,9 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
 
         submitLocalDocument(request);
 
-        assertTrue(firstDeploymentCDL.await(10, TimeUnit.SECONDS));
-        assertTrue(secondDeploymentCDL.await(10, TimeUnit.SECONDS));
-        assertTrue(thirdDeploymentCDL.await(10, TimeUnit.SECONDS));
+        assertTrue(firstDeploymentCDL.await(10, TimeUnit.SECONDS), "First deployment did not succeed");
+        assertTrue(secondDeploymentCDL.await(10, TimeUnit.SECONDS), "Second deployment did not succeed");
+        assertTrue(thirdDeploymentCDL.await(10, TimeUnit.SECONDS), "Third deployment did not succeed");
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.integrationtests.deployment;
 import com.amazon.aws.iot.greengrass.configuration.common.Configuration;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.dependency.State;
-import com.aws.greengrass.deployment.DeploymentDirectoryManager;
 import com.aws.greengrass.deployment.DeploymentQueue;
 import com.aws.greengrass.deployment.DeploymentStatusKeeper;
 import com.aws.greengrass.deployment.DeviceConfiguration;
@@ -68,8 +67,6 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static com.aws.greengrass.util.Utils.copyFolderRecursively;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(GGExtension.class)
 class DeploymentServiceIntegrationTest extends BaseITCase {
@@ -89,11 +86,6 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
         NoOpPathOwnershipHandler.register(kernel);
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
                 DeploymentServiceIntegrationTest.class.getResource("onlyMain.yaml"));
-
-        kernel.getContext().runOnPublishQueueAndWait(() -> {});
-        DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
-        doNothing().when(deploymentDirectoryManager).persistLastFailedDeployment();
-        kernel.getContext().put(DeploymentDirectoryManager.class, deploymentDirectoryManager);
 
         // ensure deployment service starts
         CountDownLatch deploymentServiceLatch = new CountDownLatch(1);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -45,7 +45,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -68,7 +67,6 @@ import static com.aws.greengrass.util.Utils.copyFolderRecursively;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(GGExtension.class)

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -66,6 +66,9 @@ import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_SERVICE_
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.util.Utils.copyFolderRecursively;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(GGExtension.class)
@@ -197,6 +200,69 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
     }
 
     @Test
+    void GIVEN_a_cloud_deployment_WHEN_receives_deployment_THEN_service_runs_and_deployment_succeeds() throws Exception {
+        CountDownLatch cdlDeployRedSignal = new CountDownLatch(1);
+        Consumer<GreengrassLogMessage> listener = m -> {
+
+            if (m.getMessage() != null) {
+                if (m.getMessage().contains("Current deployment finished") && m.getContexts().get("DeploymentId").equals("deployRedSignal")) {
+                    cdlDeployRedSignal.countDown();
+                }
+            }
+        };
+
+        try (AutoCloseable l = TestUtils.createCloseableLogListener(listener)) {
+
+
+            CountDownLatch redSignalServiceLatch = new CountDownLatch(1);
+            kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+                if (service.getName().equals("RedSignal") && newState.equals(State.RUNNING)) {
+                    redSignalServiceLatch.countDown();
+
+                }
+            });
+
+            submitSampleJobDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRedSignalService.json")
+                    .toURI(), "deployRedSignal", DeploymentType.SHADOW); // DeploymentType.SHADOW is used here and it
+            // is same for DeploymentType.IOT_JOBS
+            assertTrue(redSignalServiceLatch.await(30, TimeUnit.SECONDS));
+            assertTrue(cdlDeployRedSignal.await(30, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void GIVEN_cloud_deployment_has_required_capabilities_WHEN_receives_deployment_THEN_fail_with_proper_detailed_status() throws Exception {
+        CountDownLatch cdlDeployRedSignal = new CountDownLatch(1);
+        Consumer<GreengrassLogMessage> listener = m -> {
+            if (m.getMessage() != null) {
+                if (m.getMessage().contains("Current deployment finished") && m.getContexts().get("DeploymentId").equals("deployRedSignal")) {
+                    cdlDeployRedSignal.countDown();
+                }
+            }
+        };
+
+        CountDownLatch deploymentCDL = new CountDownLatch(1);
+        DeploymentStatusKeeper deploymentStatusKeeper = kernel.getContext().get(DeploymentStatusKeeper.class);
+        deploymentStatusKeeper.registerDeploymentStatusConsumer(DeploymentType.SHADOW, (status) -> {
+            if (status.get(DEPLOYMENT_ID_KEY_NAME).equals("deployRedSignal") &&
+                    status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("FAILED")) {
+                deploymentCDL.countDown();
+                assertThat(((Map) status.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)).get(DEPLOYMENT_FAILURE_CAUSE_KEY),
+                        equalTo("The current nucleus version doesn't support one or more capabilities that are required by "
+                    + "this deployment: LARGE_CONFIGURATION, ANOTHER_CAPABILITY"));
+            }
+            return true;
+        },"dummy");
+
+        try (AutoCloseable l = TestUtils.createCloseableLogListener(listener)) {
+            submitSampleJobDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRequiredCapability.json")
+                    .toURI(), "deployRedSignal", DeploymentType.SHADOW);
+            assertTrue(cdlDeployRedSignal.await(30, TimeUnit.SECONDS));
+            assertTrue(deploymentCDL.await(10,TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
     void WHEN_multiple_local_deployment_scheduled_THEN_all_deployments_succeed() throws Exception {
 
         CountDownLatch firstDeploymentCDL = new CountDownLatch(1);
@@ -300,7 +366,8 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
             if(status.get(DEPLOYMENT_ID_KEY_NAME).equals("requiredCapabilityNotPresent") &&
                     status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("FAILED") &&
                     ((Map)status.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)).get(DEPLOYMENT_FAILURE_CAUSE_KEY)
-                            .equals("Missing required capabilities: NOT_SUPPORTED_1, NOT_SUPPORTED_2")){
+                            .equals("The current nucleus version doesn't support one or more capabilities that are "
+                                    + "required by this deployment: NOT_SUPPORTED_1, NOT_SUPPORTED_2, LARGE_CONFIGURATION")){
                 deploymentCDL.countDown();
             }
             return true;
@@ -316,50 +383,6 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
 
         submitLocalDocument(request);
         assertTrue(deploymentCDL.await(10, TimeUnit.SECONDS));
-    }
-
-    @Test
-    void GIVEN_local_deployment_WHEN_required_capabilities_present_THEN_deployments_succeeds() throws Exception {
-
-        String recipeDir = localStoreContentPath.resolve("recipes").toAbsolutePath().toString();
-        String artifactsDir = localStoreContentPath.resolve("artifacts").toAbsolutePath().toString();
-
-        CountDownLatch requiredCapabilityPresentCDL = new CountDownLatch(1);
-        CountDownLatch requiredCapabilityEmptyCDL = new CountDownLatch(1);
-        DeploymentStatusKeeper deploymentStatusKeeper = kernel.getContext().get(DeploymentStatusKeeper.class);
-        deploymentStatusKeeper.registerDeploymentStatusConsumer(DeploymentType.LOCAL, (status) -> {
-
-            if(status.get(DEPLOYMENT_ID_KEY_NAME).equals("requiredCapabilityPresent") &&
-                    status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("SUCCEEDED")){
-                requiredCapabilityPresentCDL.countDown();
-            }
-            if(status.get(DEPLOYMENT_ID_KEY_NAME).equals("requiredCapabilityEmpty") &&
-                    status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("SUCCEEDED")){
-                requiredCapabilityEmptyCDL.countDown();
-            }
-            return true;
-        },"DeploymentServiceIntegrationTest4" );
-
-        Map<String, String> componentsToMerge = new HashMap<>();
-        componentsToMerge.put("YellowSignal", "1.0.0");
-        LocalOverrideRequest request = LocalOverrideRequest.builder().requestId("requiredCapabilityPresent")
-                .componentsToMerge(componentsToMerge)
-                .requestTimestamp(System.currentTimeMillis())
-                .requiredCapabilities(Arrays.asList("LARGE_CONFIGURATION"))
-                .recipeDirectoryPath(recipeDir).artifactsDirectoryPath(artifactsDir).build();
-
-        submitLocalDocument(request);
-        assertTrue(requiredCapabilityPresentCDL.await(10, TimeUnit.SECONDS));
-
-        componentsToMerge = new HashMap<>();
-        componentsToMerge.put("SimpleApp", "1.0.0");
-        request = LocalOverrideRequest.builder().requestId("requiredCapabilityEmpty")
-                .componentsToMerge(componentsToMerge)
-                .requestTimestamp(System.currentTimeMillis())
-                .requiredCapabilities(Collections.emptyList())
-                .recipeDirectoryPath(recipeDir).artifactsDirectoryPath(artifactsDir).build();
-        submitLocalDocument(request);
-        assertTrue(requiredCapabilityEmptyCDL.await(10, TimeUnit.SECONDS));
     }
 
     private void submitSampleJobDocument(URI uri, String arn, DeploymentType type) throws Exception {

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -90,6 +90,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
                 DeploymentServiceIntegrationTest.class.getResource("onlyMain.yaml"));
 
+        kernel.getContext().runOnPublishQueueAndWait(() -> {});
         DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
         doNothing().when(deploymentDirectoryManager).persistLastFailedDeployment();
         kernel.getContext().put(DeploymentDirectoryManager.class, deploymentDirectoryManager);

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithRequiredCapability.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithRequiredCapability.json
@@ -1,0 +1,18 @@
+{
+  "configurationArn": "Test",
+  "requiredCapabilities": ["LARGE_CONFIGURATION", "ANOTHER_CAPABILITY"],
+  "components": {
+    "RedSignal": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -461,7 +461,7 @@ public class DeploymentService extends GreengrassService {
                         .collect(Collectors.toList());
                 if (!missingCapabilities.isEmpty()) {
                     updateDeploymentResultAsFailed(deployment, deploymentTask, false,
-                            new MissingRequiredCapabilitiesException("Missing required capabilities: "
+                            new MissingRequiredCapabilitiesException("The current nucleus version doesn't support one or more capabilities that are required by this deployment: "
                                     + String.join(", ", missingCapabilities)));
                     return;
                 }

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -23,9 +23,11 @@ import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
 import com.aws.greengrass.deployment.exceptions.DeploymentTaskFailureException;
 import com.aws.greengrass.deployment.exceptions.InvalidRequestException;
+import com.aws.greengrass.deployment.exceptions.MissingRequiredCapabilitiesException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus;
 import com.aws.greengrass.deployment.model.DeploymentTask;
 import com.aws.greengrass.deployment.model.DeploymentTaskMetadata;
 import com.aws.greengrass.deployment.model.LocalOverrideRequest;
@@ -51,6 +53,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -280,11 +283,11 @@ public class DeploymentService extends GreengrassService {
             // if something is going wrong
             DeploymentResult result = currentDeploymentTaskMetadata.getDeploymentResultFuture().get();
             if (result != null) {
-                DeploymentResult.DeploymentStatus deploymentStatus = result.getDeploymentStatus();
+                DeploymentStatus deploymentStatus = result.getDeploymentStatus();
 
                 Map<String, String> statusDetails = new HashMap<>();
                 statusDetails.put(DEPLOYMENT_DETAILED_STATUS_KEY, deploymentStatus.name());
-                if (DeploymentResult.DeploymentStatus.SUCCESSFUL.equals(deploymentStatus)) {
+                if (DeploymentStatus.SUCCESSFUL.equals(deploymentStatus)) {
                     //Add the root packages of successful deployment to the configuration
                     persistGroupToRootComponents(currentDeploymentTaskMetadata.getDeploymentDocument());
 
@@ -437,35 +440,55 @@ public class DeploymentService extends GreengrassService {
         deploymentStatusKeeper.persistAndPublishDeploymentStatus(deployment.getId(), deployment.getDeploymentType(),
                                                                  JobStatus.IN_PROGRESS.toString(), new HashMap<>());
 
-        if (DEFAULT.equals(deployment.getDeploymentStage())
-                && DeploymentType.LOCAL.equals(deployment.getDeploymentType())) {
-            try {
-                copyRecipesAndArtifacts(deployment);
-            } catch (InvalidRequestException | IOException e) {
-                logger.atError().log("Error copying recipes and artifacts", e);
-                HashMap<String, String> statusDetails = new HashMap<>();
-                statusDetails.put("error", e.getMessage());
-                deploymentStatusKeeper.persistAndPublishDeploymentStatus(deployment.getId(),
-                        deployment.getDeploymentType(), JobStatus.FAILED.toString(), statusDetails);
-                return;
-            }
-        }
+        if (DEFAULT.equals(deployment.getDeploymentStage())) {
 
-        try {
-            if (DEFAULT.equals(deployment.getDeploymentStage())) {
+            List<String> requiredCapabilities = deployment.getDeploymentDocumentObj().getRequiredCapabilities();
+            if (requiredCapabilities != null && !requiredCapabilities.isEmpty()) {
+                List<String> missingCapabilities = requiredCapabilities.stream()
+                        .filter(reqCapabilities -> !kernel.getSupportedCapabilities().contains(reqCapabilities))
+                        .collect(Collectors.toList());
+                if (!missingCapabilities.isEmpty()) {
+                    DeploymentResult result = new DeploymentResult(DeploymentStatus.FAILED_NO_STATE_CHANGE,
+                            new MissingRequiredCapabilitiesException("Missing required capabilities: "
+                                    + String.join(", ", missingCapabilities)));
+                    CompletableFuture<DeploymentResult> process = CompletableFuture.completedFuture(result);
+                    currentDeploymentTaskMetadata = new DeploymentTaskMetadata(deploymentTask, process,
+                            deployment.getId(), deployment.getDeploymentType(), new AtomicInteger(1),
+                            deployment.getDeploymentDocumentObj(), false);
+                    return;
+                }
+            }
+
+            if (DeploymentType.LOCAL.equals(deployment.getDeploymentType())) {
+                try {
+                    copyRecipesAndArtifacts(deployment);
+                } catch (InvalidRequestException | IOException e) {
+                    logger.atError().log("Error copying recipes and artifacts", e);
+                    HashMap<String, String> statusDetails = new HashMap<>();
+                    statusDetails.put("error", e.getMessage());
+                    deploymentStatusKeeper.persistAndPublishDeploymentStatus(deployment.getId(),
+                            deployment.getDeploymentType(), JobStatus.FAILED.toString(), statusDetails);
+                    return;
+                }
+            }
+
+            try {
                 context.get(KernelAlternatives.class).cleanupLaunchDirectoryLinks();
                 deploymentDirectoryManager.createNewDeploymentDirectory(deployment.getDeploymentDocumentObj()
                         .getDeploymentId());
                 deploymentDirectoryManager.writeDeploymentMetadata(deployment);
+            } catch (IOException ioException) {
+                logger.atError().log("Unable to create deployment directory", ioException);
+                CompletableFuture<DeploymentResult> process = new CompletableFuture<>();
+                process.completeExceptionally(new DeploymentTaskFailureException(ioException));
+                currentDeploymentTaskMetadata = new DeploymentTaskMetadata(deploymentTask, process, deployment.getId(),
+                        deployment.getDeploymentType(), new AtomicInteger(1),
+                        deployment.getDeploymentDocumentObj(), false);
+                return;
             }
-        } catch (IOException ioException) {
-            logger.atError().log("Unable to create deployment directory", ioException);
-            CompletableFuture<DeploymentResult> process = new CompletableFuture<>();
-            process.completeExceptionally(new DeploymentTaskFailureException(ioException));
-            currentDeploymentTaskMetadata = new DeploymentTaskMetadata(deploymentTask, process, deployment.getId(),
-                    deployment.getDeploymentType(), new AtomicInteger(1), deployment.getDeploymentDocumentObj(), false);
-            return;
         }
+
+
         Future<DeploymentResult> process = executorService.submit(deploymentTask);
         logger.atInfo().kv("deployment", deployment.getId()).log("Started deployment execution");
 

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -461,7 +461,8 @@ public class DeploymentService extends GreengrassService {
                         .collect(Collectors.toList());
                 if (!missingCapabilities.isEmpty()) {
                     updateDeploymentResultAsFailed(deployment, deploymentTask, false,
-                            new MissingRequiredCapabilitiesException("The current nucleus version doesn't support one or more capabilities that are required by this deployment: "
+                            new MissingRequiredCapabilitiesException("The current nucleus version doesn't support one "
+                                    + "or more capabilities that are required by this deployment: "
                                     + String.join(", ", missingCapabilities)));
                     return;
                 }

--- a/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
+++ b/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
@@ -85,6 +85,7 @@ public final class DeploymentDocumentConverter {
         return DeploymentDocument.builder().timestamp(localOverrideRequest.getRequestTimestamp())
                 .deploymentId(localOverrideRequest.getRequestId())
                 .deploymentPackageConfigurationList(packageConfigurations)
+                .requiredCapabilities(localOverrideRequest.getRequiredCapabilities())
                 .failureHandlingPolicy(FailureHandlingPolicy.DO_NOTHING)    // Can't rollback for local deployment
                 // Currently we skip update policy check for local deployment to not slow down testing for customers
                 // If we make this configurable in local development then we can plug that input in here

--- a/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
+++ b/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
@@ -143,6 +143,7 @@ public final class DeploymentDocumentConverter {
 
         DeploymentDocument.DeploymentDocumentBuilder builder =
                 DeploymentDocument.builder().deploymentId(config.getConfigurationArn())
+                        .requiredCapabilities(config.getRequiredCapabilities())
                         .deploymentPackageConfigurationList(convertComponents(config.getComponents()))
                         .groupName(parseGroupNameFromConfigurationArn(config)).timestamp(config.getCreationTimestamp());
         if (config.getFailureHandlingPolicy() == null) {
@@ -173,6 +174,7 @@ public final class DeploymentDocumentConverter {
                     config.getConfigurationValidationPolicy())
             );
         }
+
         return builder.build();
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/MissingRequiredCapabilitiesException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/MissingRequiredCapabilitiesException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.exceptions;
+
+public class MissingRequiredCapabilitiesException extends DeploymentException {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public MissingRequiredCapabilitiesException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
@@ -56,6 +56,9 @@ public class DeploymentDocument {
     @JsonProperty("Packages")
     private List<DeploymentPackageConfiguration> deploymentPackageConfigurationList;
 
+    @JsonProperty("RequiredCapabilities")
+    private List<String> requiredCapabilities;
+
     @JsonProperty("GroupName")
     private String groupName;
 

--- a/src/main/java/com/aws/greengrass/deployment/model/LocalOverrideRequest.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/LocalOverrideRequest.java
@@ -30,6 +30,7 @@ public class LocalOverrideRequest {
     Map<String, String> componentsToMerge;  // name to version
     List<String> componentsToRemove; // remove just need name
     String groupName;
+    List<String> requiredCapabilities;
 
     @Deprecated
     Map<String, Map<String, Object>> componentNameToConfig;

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -51,7 +51,6 @@ import java.lang.reflect.Constructor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -98,7 +97,7 @@ public class Kernel {
     private static final String DEPLOYMENT_STAGE_LOG_KEY = "stage";
     protected static final ObjectMapper CONFIG_YAML_WRITER =
             YAMLMapper.builder().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET).build();
-    private static final List<String> supportedCapabilities = Arrays.asList("LARGE_CONFIGURATION");
+    private static final List<String> SUPPORTED_CAPABILITIES = Collections.emptyList();
 
     @Getter
     private final Context context;
@@ -666,6 +665,6 @@ public class Kernel {
     }
 
     public List<String> getSupportedCapabilities() {
-        return supportedCapabilities;
+        return SUPPORTED_CAPABILITIES;
     }
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -51,11 +51,13 @@ import java.lang.reflect.Constructor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -96,6 +98,7 @@ public class Kernel {
     private static final String DEPLOYMENT_STAGE_LOG_KEY = "stage";
     protected static final ObjectMapper CONFIG_YAML_WRITER =
             YAMLMapper.builder().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET).build();
+    private static final List<String> supportedCapabilities = Arrays.asList("LARGE_CONFIGURATION");
 
     @Getter
     private final Context context;
@@ -660,5 +663,9 @@ public class Kernel {
      */
     public String deTilde(String filename) {
         return kernelCommandLine.deTilde(filename);
+    }
+
+    public List<String> getSupportedCapabilities() {
+        return supportedCapabilities;
     }
 }

--- a/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.aws.greengrass.jmh.PreloadComponentStoreHelper.preloadRecipesFromTestResourceDir;
@@ -47,8 +48,8 @@ public class DependencyResolverBenchmark {
     public abstract static class DRIntegration {
         private final DeploymentDocument jobDoc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration("boto3", true, "1.9.128"),
-                        new DeploymentPackageConfiguration("awscli", true, "1.16.144")), "mockGroup1",
-                1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS),
+                        new DeploymentPackageConfiguration("awscli", true, "1.16.144")), Collections.emptyList(),
+                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS),
                 DeploymentConfigurationValidationPolicy.builder().timeoutInSeconds(20).build());
 
         private DependencyResolver resolver;

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -141,7 +141,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -208,7 +208,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -306,7 +306,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -366,7 +366,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -445,7 +445,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -515,7 +515,7 @@ class DependencyResolverTest {
         // top-level package order: A, B2
         DeploymentDocument doc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
-                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())),
+                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -600,7 +600,7 @@ class DependencyResolverTest {
         // top-level package order: A, B2
         DeploymentDocument doc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
-                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())),
+                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -674,7 +674,7 @@ class DependencyResolverTest {
         // top-level package order: A, B2
         DeploymentDocument doc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
-                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())),
+                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -469,7 +469,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
                 eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), statusDetails.capture());
-        assertEquals("java.io.IOException: mock error", statusDetails.getValue().get("error"));
+        assertEquals("mock error", statusDetails.getValue().get("deployment-failure-cause"));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -469,7 +469,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
                 eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), statusDetails.capture());
-        assertEquals("mock error", statusDetails.getValue().get("deployment-failure-cause"));
+        assertEquals("java.io.IOException: mock error", statusDetails.getValue().get("error"));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
@@ -168,6 +168,8 @@ class DeploymentDocumentConverterTest {
         assertThat(deploymentDocument.getDeploymentId(),
                    is("arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/SampleGroup:2"));
         assertThat(deploymentDocument.getGroupName(), is("thinggroup/SampleGroup"));
+        assertThat(deploymentDocument.getRequiredCapabilities(), equalTo(Arrays.asList("LARGE_CONFIGURATION",
+                "ANOTHER_CAPABILITY")));
 
         assertThat(deploymentDocument.getDeploymentPackageConfigurationList(), hasSize(1));
 
@@ -205,6 +207,7 @@ class DeploymentDocumentConverterTest {
         assertThat(deploymentDocument.getDeploymentId(),
                    is("arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/SampleGroup:2"));
         assertThat(deploymentDocument.getGroupName(), is("thinggroup/SampleGroup"));
+        assertNull(deploymentDocument.getRequiredCapabilities());
 
         assertThat(deploymentDocument.getDeploymentPackageConfigurationList(), hasSize(1));
 
@@ -248,6 +251,7 @@ class DeploymentDocumentConverterTest {
         assertThat(deploymentDocument.getDeploymentId(),
                    is("arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/SampleGroup:2"));
         assertThat(deploymentDocument.getGroupName(), is("thinggroup/SampleGroup"));
+        assertNull(deploymentDocument.getRequiredCapabilities());
 
         // The following fields are not provided in the json so default values should be used.
         // Default for FailureHandlingPolicy should be ROLLBACK

--- a/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
+++ b/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
@@ -1,5 +1,6 @@
 {
   "deploymentId": "3b86691d-4f81-408a-852e-edc14cd351a7",
+  "requiredCapabilities": ["LARGE_CONFIGURATION", "ANOTHER_CAPABILITY"],
   "configurationValidationPolicy": {
     "timeout": 120.0
   },


### PR DESCRIPTION
**Description of changes:**
In order to support controllable errors, the GGC will support a requiredCapabilities element in the deployment document that describes capabilities needed to execute the deployment. If the required capability is not found, Nucleus will fail the deployment.

**How was this change tested:**
Test Plan:
1.  When required capabilities field in deployment document is not present/empty THEN deployment succeeds
2. When one of the required capabilities in deployment document is not supported by GGC THEN deployment fails. Deployment failure cause contains the missing required capability.
3. When all required capabilities in deployment document is supported by GGC THEN deployment succeeds. 

Tested using integration tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
