### PR TITLE
chore: remove unused main method

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
@@ -63,10 +63,6 @@ public class KernelCommandLine {
     private static final String cliIpcInfoPathName = "~root/cli_ipc_info";
     private static final String binPathName = "~root/bin";
 
-    public static void main(String[] args) {
-        new Kernel().parseArgs(args).launch();
-    }
-
     public KernelCommandLine(Kernel kernel) {
         this(kernel, kernel.getNucleusPaths());
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The `main` method in `KernelCommandLine` is not used. The `main` method being used is in `GreengrassSetup`. This PR removes the one in `KernelCommandLine` to reduce confusion.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
