### PR TITLE
perf: use interned strings for MQTT topics for lower memory usage

### DIFF
--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -92,7 +92,8 @@ public class MqttProxyIPCAgent {
         @Override
         public PublishToIoTCoreResponse handleRequest(PublishToIoTCoreRequest request) {
             return translateExceptions(() -> {
-                String topic = validateTopic(request.getTopicName(), serviceName);
+                // Intern the string to deduplicate topic strings in memory
+                String topic = validateTopic(request.getTopicName(), serviceName).intern();
 
                 try {
                     doAuthorization(this.getOperationModelContext().getOperationName(), serviceName, topic);

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 import java.io.Closeable;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -571,7 +570,7 @@ public class MqttClient implements Closeable {
         }
 
         // Check the topic size
-        if (topic.getBytes(StandardCharsets.UTF_8).length > MAX_LENGTH_OF_TOPIC) {
+        if (topic.length() > MAX_LENGTH_OF_TOPIC) {
             String errMsg = String.format("The topic size of request must be no "
                             + "larger than %d bytes of UTF-8 encoded characters. This excludes the first "
                             + "3 mandatory segments for Basic Ingest topics ($AWS/rules/rule-name/).",

--- a/src/main/java/com/aws/greengrass/mqttclient/PublishRequest.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/PublishRequest.java
@@ -10,16 +10,27 @@ import lombok.NonNull;
 import lombok.Value;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
-@Builder
+@SuppressWarnings("PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal")
 @Value
 public class PublishRequest {
     @NonNull String topic;
-    @Builder.Default
-    @NonNull QualityOfService qos = QualityOfService.AT_LEAST_ONCE;
+    @NonNull QualityOfService qos;
     /**
      * Retain the message in the cloud MQTT broker (only last message with retain is actually kept).
      * Subscribers will immediately receive the last retained message when they first subscribe.
      */
     boolean retain;
-    @NonNull byte[] payload;
+    byte[] payload;
+
+    @Builder
+    protected PublishRequest(String topic, QualityOfService qos, boolean retain, byte[] payload) {
+        // Intern the string to deduplicate topic strings in memory
+        this.topic = topic.intern();
+        if (qos == null) {
+            qos = QualityOfService.AT_LEAST_ONCE;
+        }
+        this.qos = qos;
+        this.retain = retain;
+        this.payload = payload;
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use [String.intern()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#intern()) in order to save strings into Java's string pool to avoid string duplication in memory. For MQTT messages with the same topic, which is a fairly common use case, we'd normally end up using quite a bit more memory than just the payload size due to duplicating the topic names.

Additionally, using `String.length()` instead of getting the bytes since getting the bytes requires actually re-encoding the value which is expensive and unnecessary.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
