### PR TITLE
Add loader.cmd for Windows

### DIFF
--- a/.github/scripts/binaryCompatibility.py
+++ b/.github/scripts/binaryCompatibility.py
@@ -20,12 +20,14 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--input', type=argparse.FileType('r'), help='Input file to parse')
     parser.add_argument('--token', type=str, help='GitHub token')
+    parser.add_argument('--pr', type=str, help='GitHub PR')
+    parser.add_argument('--sha', type=str, help='GitHub SHA')
     args = parser.parse_args()
 
     file = args.input
 
     my_body_dedupe = "Produced by binaryCompatability.py"
-    body = f"Binary incompatibility detected for commit {os.getenv('GITHUB_SHA')}.\n" \
+    body = f"Binary incompatibility detected for commit {args.sha}.\n" \
            f" See the uploaded artifacts from the action for details. You must bump the version number.\n\n"
 
     incompatible = False
@@ -51,7 +53,7 @@ def main():
     body += "\n" + my_body_dedupe
 
     token = args.token
-    pr = json.load(open(os.getenv("GITHUB_EVENT_PATH"), 'r'))["pull_request"]["number"]
+    pr = args.pr
 
     gh = GitHub(token=token)
     existing_comments = gh.repos[os.getenv("GITHUB_REPOSITORY")].issues[pr].comments.get()

--- a/.github/workflows/externalPR.yml
+++ b/.github/workflows/externalPR.yml
@@ -1,0 +1,88 @@
+name: External PR
+
+on:
+  workflow_run:
+    workflows: ["Java CI"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    name: Comment
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+      - name: outputs
+        run: |-
+          echo '::set-output name=PR::$(cat NR)'
+          echo '::set-output name=SHA::$(cat SHA)'
+      - name: cobertura-report-unit-test
+        uses: 5monkeys/cobertura-action@master
+        continue-on-error: true
+        with:
+          # The GITHUB_TOKEN for this repo
+          repo_token: ${{ github.token }}
+          # Path to the cobertura file.
+          path: jacoco-report/cobertura.xml
+          # If files with 100% should be skipped from report.
+          skip_covered: false
+          # Minimum allowed coverage percentage as an integer.
+          minimum_coverage: 65
+          # Show line rate as specific column.
+          show_line: true
+          # Show branch rate as specific column.
+          show_branch: true
+          # Use class names instead of the filename
+          show_class_names: true
+          # Use a unique name for the report and comment
+          report_name: Unit Tests Coverage Report
+          pull_request_number: ${{ steps.outputs.outputs.PR }}
+      - name: cobertura-report-integration-test
+        uses: 5monkeys/cobertura-action@master
+        continue-on-error: true
+        with:
+          # The GITHUB_TOKEN for this repo
+          repo_token: ${{ github.token }}
+          # Path to the cobertura file.
+          path: jacoco-report/cobertura-it.xml
+          # If files with 100% should be skipped from report.
+          skip_covered: false
+          # Minimum allowed coverage percentage as an integer.
+          minimum_coverage: 58
+          # Show line rate as specific column.
+          show_line: true
+          # Show branch rate as specific column.
+          show_branch: true
+          # Use class names instead of the filename
+          show_class_names: true
+          # Use a unique name for the report and comment
+          report_name: Integration Tests Coverage Report
+          pull_request_number: ${{ steps.outputs.outputs.PR }}
+      - name: Check compatibility
+        run: >-
+          pip3 -q install agithub &&
+          python3 .github/scripts/binaryCompatibility.py --input japicmp/default-cli.xml --token "${{ github.token }}" --pr "${{steps.outputs.outputs.PR}}" --sha "${{steps.outputs.outputs.SHA}}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,53 +59,9 @@ jobs:
       - name: Convert Jacoco interation test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco-it/jacoco.xml src/main/java > target/jacoco-report/cobertura-it.xml
         if: matrix.os == 'ubuntu-latest'
-      - name: cobertura-report-unit-test
-        uses: shaguptashaikh/cobertura-action@master
-        if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
-        with:
-          # The GITHUB_TOKEN for this repo
-          repo_token: ${{ github.token }}
-          # Path to the cobertura file.
-          path: target/jacoco-report/cobertura.xml
-          # If files with 100% should be skipped from report.
-          skip_covered: false
-          # Minimum allowed coverage percentage as an integer.
-          minimum_coverage: 65
-          # Show line rate as specific column.
-          show_line: true
-          # Show branch rate as specific column.
-          show_branch: true
-          # Use class names instead of the filename
-          show_class_names: true
-          # Use a unique name for the report and comment
-          report_name: Unit Tests Coverage Report
-      - name: cobertura-report-integration-test
-        uses: shaguptashaikh/cobertura-action@master
-        if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
-        with:
-          # The GITHUB_TOKEN for this repo
-          repo_token: ${{ github.token }}
-          # Path to the cobertura file.
-          path: target/jacoco-report/cobertura-it.xml
-          # If files with 100% should be skipped from report.
-          skip_covered: false
-          # Minimum allowed coverage percentage as an integer.
-          minimum_coverage: 58
-          # Show line rate as specific column.
-          show_line: true
-          # Show branch rate as specific column.
-          show_branch: true
-          # Use class names instead of the filename
-          show_class_names: true
-          # Use a unique name for the report and comment
-          report_name: Integration Tests Coverage Report
       - name: Check compatibility
         run: >-
-          mvn -ntp japicmp:cmp -DskipTests &&
-          pip3 -q install agithub &&
-          python3 .github/scripts/binaryCompatibility.py --input target/japicmp/default-cli.xml --token "${{ github.token }}"
+          mvn -ntp japicmp:cmp -DskipTests
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload Compatibility Report
         uses: actions/upload-artifact@v1.0.0
@@ -119,3 +75,22 @@ jobs:
           mvn -ntp -U install -DskipTests
           mvn -ntp -U -f src/test/greengrass-nucleus-benchmark install
         if: matrix.os == 'ubuntu-latest'
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr/jacoco-report
+          mkdir -p ./pr/japicmp
+          mkdir -p target/japicmp
+          mkdir -p target/jacoco-report
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
+
+          cp -R target/japicmp/default-cli.xml ./pr/japicmp/default-cli.xml
+          cp target/jacoco-report/cobertura.xml ./pr/jacoco-report/cobertura.xml
+          cp target/jacoco-report/cobertura-it.xml ./pr/jacoco-report/cobertura-it.xml
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
+      - name: Upload files
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'

--- a/.license/style.xml
+++ b/.license/style.xml
@@ -16,4 +16,14 @@
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>
     </java_style>
+    <batch>
+        <firstLine>@REM -------------------------------</firstLine>
+        <beforeEachLine>@REM </beforeEachLine>
+        <endLine>@REM -------------------------------</endLine>
+        <firstLineDetectionPattern>@REM(\\s|\\t)*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>@REM(\\s|\\t)*.*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </batch>
 </additionalHeaders>

--- a/assembly.xml
+++ b/assembly.xml
@@ -17,6 +17,7 @@
             <directory>${basedir}/scripts</directory>
             <outputDirectory>/bin</outputDirectory>
             <includes>
+                <include>loader.cmd</include>
                 <include>loader</include>
                 <include>greengrass.service.template</include>
             </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>nucleus</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.2.18</version>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -338,6 +338,7 @@
                     </licenseSets>
                     <mapping>
                         <java>JAVA_STYLE</java>
+                        <cmd>BATCH</cmd>
                     </mapping>
                 </configuration>
                 <executions>

--- a/scripts/loader
+++ b/scripts/loader
@@ -1,7 +1,11 @@
 #!/bin/sh -x
 
+#Disable job control so that all child processes run in the same process group as the parent
+set +m
+
 PWD=$(dirname "$0")
 
+sigterm_received=0
 # Assuming loader is launched from "$GG_ROOT/alts/current/distro/bin/loader"
 GG_ROOT=$(cd $PWD/../../../..; pwd)
 
@@ -31,7 +35,11 @@ launch_kernel() {
   fi
   echo "JVM options: "${JVM_OPTIONS}
   echo "Nucleus options: "${OPTIONS}
-  java -Dlog.store=FILE ${JVM_OPTIONS} -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS}
+  child_pid=""
+  trap 'echo Received SIGTERM; sigterm_received=1; kill -TERM ${child_pid}' TERM
+  java -Dlog.store=FILE ${JVM_OPTIONS} -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS} &
+  child_pid="$!"
+  wait "${child_pid}"
   kernel_exit_code=$?
   echo "Nucleus exit at code: "${kernel_exit_code}
 }
@@ -60,7 +68,7 @@ fi
 
 # Launch Nucleus with max 3 retries
 j=1
-while [ $j -le 3 ]; do
+while [ $j -le 3 ] && [ $sigterm_received -eq 0 ];  do
   launch_kernel
   case ${kernel_exit_code} in
   100|0)

--- a/scripts/loader.cmd
+++ b/scripts/loader.cmd
@@ -1,0 +1,138 @@
+@REM -------------------------------
+@REM Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+@REM SPDX-License-Identifier: Apache-2.0
+@REM -------------------------------
+@echo off
+SETLOCAL EnableDelayedExpansion
+SET DIR=%~dp0
+
+@REM Get the root GG directory (generally /greengrass/v2)
+FOR %%I IN ("%DIR%\..\..\..\..") DO SET "GG_ROOT=%%~fI"
+SET LAUNCH_DIR=%GG_ROOT%\alts\current
+@REM SET CONFIG_FILE=""
+
+SET IS_SYMLINK=0
+CALL :directory_is_symlink "%GG_ROOT%\alts\new" IS_SYMLINK
+IF %IS_SYMLINK% EQU 1 (
+    CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 0 (
+        CALL :directory_is_symlink "%LAUNCH_DIR%" IS_SYMLINK
+        IF !IS_SYMLINK! EQU 1 (
+            CALL :flip_links "%LAUNCH_DIR%" "%GG_ROOT%\alts\old"
+        )
+    )
+    CALL :flip_links "%GG_ROOT%\alts\new" "%LAUNCH_DIR%"
+)
+
+CALL :directory_is_symlink "%GG_ROOT%\alts\broken" IS_SYMLINK
+IF !IS_SYMLINK! EQU 1 (
+    CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 1 (
+        CALL :flip_links "%GG_ROOT%\alts\old" "%LAUNCH_DIR%"
+    )
+)
+
+CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+IF !IS_SYMLINK! EQU 1 (
+    CALL :directory_is_symlink "%LAUNCH_DIR%" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 0 (
+        CALL :flip_links "%GG_ROOT%\alts\old" "%LAUNCH_DIR%"
+    )
+)
+
+@REM EXIST works for files, directories, and symlink dirs
+IF NOT EXIST %LAUNCH_DIR% (
+    ECHO FATAL: No Nucelus found!
+    EXIT /B 1
+)
+
+@REM Get JVM_OPTIONS from launch.params if it exists
+IF EXIST %LAUNCH_DIR%\launch.params (
+    FOR /F "delims=" %%A IN (%LAUNCH_DIR%\launch.params) DO SET JVM_OPTIONS=%%A
+)
+
+SET JVM_OPTIONS=%JVM_OPTIONS% -Droot="%GG_ROOT%"
+SET OPTIONS=--setup-system-service false
+
+ECHO JVM options: %JVM_OPTIONS%
+ECHO Nucleus options: %OPTIONS%
+SET /A MAX_RETRIES=3
+@REM Attempt to start the nucleus 3 times
+FOR /L %%i IN (1,1,%MAX_RETRIES%) DO (
+    java -Dlog.store=FILE %JVM_OPTIONS% -jar "%LAUNCH_DIR%\distro\lib\Greengrass.jar" %OPTIONS%
+    SET KERNEL_EXIT_CODE=%ERRORLEVEL%
+
+    IF KERNEL_EXIT_CODE EQU 0 (
+        ECHO Restarting Nucleus
+        %LAUNCH_DIR%\distroy\bin\loader.cmd
+    ) ELSE (
+    IF KERNEL_EXIT_CODE EQU 100 (
+        ECHO Restarting Nucleus
+        %LAUNCH_DIR%\distroy\bin\loader.cmd
+    ) ELSE (
+    IF KERNEL_EXIT_CODE EQU 101 (
+        ECHO Rebooting host
+        SHUTDOWN /R
+    ) ELSE (
+        ECHO Nucleus exited %KERNEL_EXIT_CODE%. Attempt %%i out of %MAX_RETRIES%
+    )))
+)
+
+CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+IF !IS_SYMLINK! EQU 1 (
+    CALL :directory_is_symlink "%LAUNCH_DIR%" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 1 (
+        CALL :flip_links "%LAUNCH_DIR%" "%GG_ROOT%\alts\broken"
+        CALL :flip_links "%GG_ROOT%\alts\old" "%LAUNCH_DIR%"
+    )
+)
+
+EXIT /B %KERNEL_EXIT_CODE%
+
+@REM ==========================================================
+@REM ================== FUNCTION DEFINITIONS ==================
+@REM ==========================================================
+
+@REM Checks if directory is a symlink by checking its attributes
+@REM @param1 directory to test
+@REM @param2 out varialbe (pass by reference)
+@REM    1 = @param1 is a symlinked directory
+@REM    0 = @param1 is NOT a symlink
+:directory_is_symlink
+SET RETURN_VALUE=0
+if EXIST %1 (
+    FOR %%I IN (%1) DO SET attribs=%%~aI
+    @REM The 8th element of directory attributes indicate if it is a reparse point (symlink)
+    if "!attribs:~8,1!" EQU "l" (
+        if "!attribs:~0,1!" EQU "d" (
+            SET RETURN_VALUE=1
+        )
+    ) ELSE (
+        SET RETURN_VALUE=0
+    )
+)
+SET %~2=%RETURN_VALUE%
+EXIT /B 0
+
+@REM Gets the source of symlink @param1 and points symlink @param2 to that source
+@REM Removes @param1 symlink
+:flip_links
+@REM Delete symlink @param2 because it will be overwritten with the source of @param1
+RMDIR %2 2>NUL || :
+
+@REM Split the parent directory from fully qualified path and file name
+FOR %%I IN (%1) DO SET PARENT_DIR=%%~dpI && SET DIR_NAME=%%~nxI
+
+@REM Get linked dir information using some regex
+@REM Example output:
+@REM    04/08/2021  05:19 PM    <SYMLINKD>     current [C:\greengrass\v2\alts\init]
+FOR /F "delims=" %%I IN ('DIR /A:L %PARENT_DIR% ^| FINDSTR /R /C:"\<SYMLINKD\>[ ]*%DIR_NAME%[ ]*\[.*\]$"') DO SET DIR_OUT=%%I
+@REM Get second token (B starting from A) when considering [] as delimiters
+FOR /F "tokens=1,2 delims=[]" %%A IN ("%DIR_OUT%") DO SET SOURCE_FILE=%%B
+
+@REM Create new symlink with @param2's name and point towards @param1's source
+MKLINK /D %2 "%SOURCE_FILE%" >NUL
+
+@REM Remove @param1
+RMDIR %1 2>NUL || : 
+EXIT /B 0

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithRequiredCapability.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithRequiredCapability.json
@@ -1,0 +1,18 @@
+{
+  "configurationArn": "Test",
+  "requiredCapabilities": ["LARGE_CONFIGURATION", "ANOTHER_CAPABILITY"],
+  "components": {
+    "RedSignal": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -36,11 +36,15 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.ACCESS_CONTR
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.tes.TokenExchangeService.AUTHZ_TES_OPERATION;
 import static com.aws.greengrass.tes.TokenExchangeService.TOKEN_EXCHANGE_SERVICE_TOPICS;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DELETE_THING_SHADOW;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_SECRET_VALUE;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_THING_SHADOW;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.LIST_NAMED_SHADOWS_FOR_THING;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_TOPIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_TOPIC;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_THING_SHADOW;
 
 /**
  * Main module which is responsible for handling AuthZ for Greengrass. This only manages
@@ -56,6 +60,7 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUB
 public class AuthorizationHandler  {
     public static final String ANY_REGEX = "*";
     public static final String SECRETS_MANAGER_SERVICE_NAME = "aws.greengrass.SecretManager";
+    public static final String SHADOW_MANAGER_SERVICE_NAME = "aws.greengrass.ShadowManager";
     private static final Logger logger = LogManager.getLogger(AuthorizationHandler.class);
     private final ConcurrentHashMap<String, Set<String>> componentToOperationsMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, List<AuthorizationPolicy>>
@@ -85,6 +90,8 @@ public class AuthorizationHandler  {
                 SUBSCRIBE_TO_IOT_CORE, ANY_REGEX)));
         componentToOperationsMap.put(SECRETS_MANAGER_SERVICE_NAME, new HashSet<>(Arrays.asList(GET_SECRET_VALUE,
                 ANY_REGEX)));
+        componentToOperationsMap.put(SHADOW_MANAGER_SERVICE_NAME, new HashSet<>(Arrays.asList(GET_THING_SHADOW,
+                UPDATE_THING_SHADOW, DELETE_THING_SHADOW, LIST_NAMED_SHADOWS_FOR_THING, ANY_REGEX)));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(
                 kernel);

--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -92,7 +92,8 @@ public class MqttProxyIPCAgent {
         @Override
         public PublishToIoTCoreResponse handleRequest(PublishToIoTCoreRequest request) {
             return translateExceptions(() -> {
-                String topic = validateTopic(request.getTopicName(), serviceName);
+                // Intern the string to deduplicate topic strings in memory
+                String topic = validateTopic(request.getTopicName(), serviceName).intern();
 
                 try {
                     doAuthorization(this.getOperationModelContext().getOperationName(), serviceName, topic);

--- a/src/main/java/com/aws/greengrass/config/ConfigurationReader.java
+++ b/src/main/java/com/aws/greengrass/config/ConfigurationReader.java
@@ -21,6 +21,8 @@ import java.util.function.Predicate;
 
 public final class ConfigurationReader {
     private static final Logger logger = LogManager.getLogger(ConfigurationReader.class);
+    private static final TypeReference<Tlogline> TLOG_LINE_REF = new TypeReference<Tlogline>() {
+    };
 
     private ConfigurationReader() {
     }
@@ -42,7 +44,7 @@ public final class ConfigurationReader {
 
             for (l = in.readLine(); l != null; l = in.readLine()) {
                 try {
-                    Tlogline tlogline = Coerce.toObject(l, new TypeReference<Tlogline>() {});
+                    Tlogline tlogline = Coerce.toObject(l, TLOG_LINE_REF);
                     if (WhatHappened.changed.equals(tlogline.action)) {
 
                         Topic targetTopic = config.lookup(tlogline.timestamp, tlogline.topicPath);
@@ -89,11 +91,45 @@ public final class ConfigurationReader {
      */
     public static void mergeTLogInto(Configuration config, Path tlogPath, boolean forceTimestamp,
                                      Predicate<Node> mergeCondition) throws IOException {
-        mergeTLogInto(config, Files.newBufferedReader(tlogPath), forceTimestamp, mergeCondition);
+        try (BufferedReader bufferedReader = Files.newBufferedReader(tlogPath)) {
+            mergeTLogInto(config, bufferedReader, forceTimestamp, mergeCondition);
+        }
     }
 
     private static void mergeTLogInto(Configuration c, Path p) throws IOException {
-        mergeTLogInto(c, Files.newBufferedReader(p), false, null);
+        try (BufferedReader bufferedReader = Files.newBufferedReader(p)) {
+            mergeTLogInto(c, bufferedReader, false, null);
+        }
+    }
+
+    /**
+     * Validate the tlog contents at the given path. Throws an IOException if any entry is invalid.
+     *
+     * @param tlogPath path to the file to validate.
+     * @throws IOException if any entry is invalid.
+     */
+    public static void validateTlog(Path tlogPath) throws IOException {
+        try (BufferedReader in = Files.newBufferedReader(tlogPath)) {
+            // We have been seeing that very rarely the transaction log gets corrupted when a device (specifically
+            // raspberry pi using an SD card) has a power outage.
+            // The corruption is happening at the hardware level and there really isn't anything that we can do
+            // about it right now.
+            // The corruption that we see is that the tlog file is filled with kilobytes of null
+            // bytes, depending on how large the configuration was before dumping the entire config to disk.
+
+            // When parsing the tlog using a buffered reader, the corrupt section won't be parsable and so we will
+            // throw an exception here. This validate method is specifically targeting this type of corruption where
+            // the first line is corrupted.
+            // The other opportunity for corruption is when we write to the end of the
+            // file and we do not want to throw on that corruption because our reader is already setup to skip over that
+            // type of problem.
+
+            String l = in.readLine();
+            // null if EOF
+            if (l != null) {
+                Coerce.toObject(l, TLOG_LINE_REF);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
+++ b/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
@@ -85,6 +85,7 @@ public final class DeploymentDocumentConverter {
         return DeploymentDocument.builder().timestamp(localOverrideRequest.getRequestTimestamp())
                 .deploymentId(localOverrideRequest.getRequestId())
                 .deploymentPackageConfigurationList(packageConfigurations)
+                .requiredCapabilities(localOverrideRequest.getRequiredCapabilities())
                 .failureHandlingPolicy(FailureHandlingPolicy.DO_NOTHING)    // Can't rollback for local deployment
                 // Currently we skip update policy check for local deployment to not slow down testing for customers
                 // If we make this configurable in local development then we can plug that input in here
@@ -142,6 +143,7 @@ public final class DeploymentDocumentConverter {
 
         DeploymentDocument.DeploymentDocumentBuilder builder =
                 DeploymentDocument.builder().deploymentId(config.getConfigurationArn())
+                        .requiredCapabilities(config.getRequiredCapabilities())
                         .deploymentPackageConfigurationList(convertComponents(config.getComponents()))
                         .groupName(parseGroupNameFromConfigurationArn(config)).timestamp(config.getCreationTimestamp());
         if (config.getFailureHandlingPolicy() == null) {
@@ -172,6 +174,7 @@ public final class DeploymentDocumentConverter {
                     config.getConfigurationValidationPolicy())
             );
         }
+
         return builder.build();
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/MissingRequiredCapabilitiesException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/MissingRequiredCapabilitiesException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.exceptions;
+
+public class MissingRequiredCapabilitiesException extends DeploymentException {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public MissingRequiredCapabilitiesException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
@@ -56,6 +56,9 @@ public class DeploymentDocument {
     @JsonProperty("Packages")
     private List<DeploymentPackageConfiguration> deploymentPackageConfigurationList;
 
+    @JsonProperty("RequiredCapabilities")
+    private List<String> requiredCapabilities;
+
     @JsonProperty("GroupName")
     private String groupName;
 

--- a/src/main/java/com/aws/greengrass/deployment/model/LocalOverrideRequest.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/LocalOverrideRequest.java
@@ -30,6 +30,7 @@ public class LocalOverrideRequest {
     Map<String, String> componentsToMerge;  // name to version
     List<String> componentsToRemove; // remove just need name
     String groupName;
+    List<String> requiredCapabilities;
 
     @Deprecated
     Map<String, Map<String, Object>> componentNameToConfig;

--- a/src/main/java/com/aws/greengrass/iot/IotCloudHelper.java
+++ b/src/main/java/com/aws/greengrass/iot/IotCloudHelper.java
@@ -7,45 +7,32 @@ package com.aws.greengrass.iot;
 
 import com.aws.greengrass.deployment.exceptions.AWSIotException;
 import com.aws.greengrass.iot.model.IotCloudResponse;
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.BaseRetryableAccessor;
 import com.aws.greengrass.util.CrashableSupplier;
 import com.aws.greengrass.util.Utils;
 import lombok.NoArgsConstructor;
-import software.amazon.awssdk.crt.http.HttpClientConnection;
-import software.amazon.awssdk.crt.http.HttpHeader;
-import software.amazon.awssdk.crt.http.HttpRequest;
-import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
-import software.amazon.awssdk.crt.http.HttpStream;
-import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.utils.IoUtils;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Singleton;
 
 
 @Singleton
 @NoArgsConstructor
 public class IotCloudHelper {
-    private static final Logger LOGGER = LogManager.getLogger(IotCloudHelper.class);
-    private static final String HTTP_HEADER_REQUEST_ID = "x-amzn-RequestId";
-    private static final String HTTP_HEADER_ERROR_TYPE = "x-amzn-ErrorType";
     private static final String HTTP_HEADER_THING_NAME = "x-amzn-iot-thingname";
     // TODO: [P41179510]: User configurable network timeout settings
     // Max wait time for device to receive HTTP response from IOT CLOUD
-    private static final long TIMEOUT_FOR_RESPONSE_FROM_IOT_CLOUD_SECONDS = Duration.ofSeconds(30).getSeconds();
     private static final int RETRY_COUNT = 3;
     private static final int BACKOFF_MILLIS = 200;
 
@@ -60,87 +47,45 @@ public class IotCloudHelper {
      * @return Http response corresponding to http request for path
      * @throws AWSIotException when unable to send the request successfully
      */
-    public IotCloudResponse sendHttpRequest(final IotConnectionManager connManager, String thingName,
-                                            final String path, final String verb, final byte[] body)
-            throws AWSIotException {
-        List<HttpHeader> headers = new ArrayList<>();
-        headers.add(new HttpHeader("host", connManager.getHost()));
+    public IotCloudResponse sendHttpRequest(final IotConnectionManager connManager, String thingName, final String path,
+                                            final String verb, final byte[] body) throws AWSIotException {
+        SdkHttpRequest.Builder innerRequestBuilder = SdkHttpRequest.builder().method(SdkHttpMethod.fromValue(verb));
+
+        URI uri = connManager.getURI();
+        // If the path is actually a full URI, then treat it as such
+        if (path.startsWith("https://")) {
+            uri = URI.create(path);
+            innerRequestBuilder.uri(uri);
+        } else {
+            innerRequestBuilder.uri(uri).encodedPath(path);
+        }
+
         if (Utils.isNotEmpty(thingName)) {
-            headers.add(new HttpHeader(HTTP_HEADER_THING_NAME, thingName));
+            innerRequestBuilder.appendHeader(HTTP_HEADER_THING_NAME, thingName);
         }
 
-        final HttpRequestBodyStream httpRequestBodyStream = body == null ? null : createHttpRequestBodyStream(body);
-        final HttpRequest request = new HttpRequest(verb, path, headers.toArray(new HttpHeader[0]),
-                httpRequestBodyStream);
+        ExecutableHttpRequest request = connManager.getClient().prepareRequest(HttpExecuteRequest.builder()
+                .contentStreamProvider(body == null ? null : () -> new ByteArrayInputStream(body))
+                .request(innerRequestBuilder.build()).build());
 
-        try (HttpClientConnection conn = connManager.getConnection()) {
-            BaseRetryableAccessor accessor = new BaseRetryableAccessor();
-            CrashableSupplier<IotCloudResponse, AWSIotException> getHttpResponse = () -> getHttpResponse(conn, request);
-            return accessor.retry(RETRY_COUNT, BACKOFF_MILLIS, getHttpResponse,
-                    new HashSet<>(Arrays.asList(AWSIotException.class)));
-        }
+        BaseRetryableAccessor accessor = new BaseRetryableAccessor();
+        CrashableSupplier<IotCloudResponse, AWSIotException> getHttpResponse = () -> getHttpResponse(request);
+        return accessor.retry(RETRY_COUNT, BACKOFF_MILLIS, getHttpResponse,
+                new HashSet<>(Collections.singletonList(AWSIotException.class)));
     }
 
-    private HttpRequestBodyStream createHttpRequestBodyStream(byte[] bytes) {
-        return new HttpRequestBodyStream() {
-            @Override
-            public boolean sendRequestBody(ByteBuffer bodyBytesOut) {
-                bodyBytesOut.put(bytes);
-                return true;
-            }
-
-            @Override
-            public boolean resetPosition() {
-                return true;
-            }
-        };
-    }
-
-    private HttpStreamResponseHandler createResponseHandler(CompletableFuture<Integer> reqCompleted,
-                                                            Map<String, String> responseHeaders,
-                                                            IotCloudResponse response) {
-        return new HttpStreamResponseHandler() {
-            @Override
-            public void onResponseHeaders(HttpStream httpStream, int i, int i1, HttpHeader[] httpHeaders) {
-                Arrays.stream(httpHeaders).forEach(header -> responseHeaders.put(header.getName(), header.getValue()));
-            }
-
-            @Override
-            public int onResponseBody(HttpStream stream, byte[] bodyBytes) {
-                ByteArrayOutputStream responseByteArray = new ByteArrayOutputStream();
-                if (response.getResponseBody() != null) {
-                    responseByteArray.write(response.getResponseBody(), 0, response.getResponseBody().length);
-                }
-                responseByteArray.write(bodyBytes, 0, bodyBytes.length);
-                response.setResponseBody(responseByteArray.toByteArray());
-                return bodyBytes.length;
-            }
-
-            @Override
-            public void onResponseComplete(HttpStream httpStream, int errorCode) {
-                response.setStatusCode(httpStream.getResponseStatusCode());
-                httpStream.close();
-                reqCompleted.complete(errorCode);
-            }
-        };
-    }
-
-    private IotCloudResponse getHttpResponse(HttpClientConnection conn, HttpRequest request) throws AWSIotException {
-        final CompletableFuture<Integer> reqCompleted = new CompletableFuture<>();
-        final Map<String, String> responseHeaders = new HashMap<>();
+    private IotCloudResponse getHttpResponse(ExecutableHttpRequest request) throws AWSIotException {
         final IotCloudResponse response = new IotCloudResponse();
-        // Give the request up to N seconds to complete, otherwise throw a TimeoutException
         try {
-            conn.makeRequest(request, createResponseHandler(reqCompleted, responseHeaders, response)).activate();
-            int error = reqCompleted.get(TIMEOUT_FOR_RESPONSE_FROM_IOT_CLOUD_SECONDS, TimeUnit.SECONDS);
-            if (error != 0) {
-                throw new AWSIotException(String.format("Error %s(%d); RequestId: %s", HTTP_HEADER_ERROR_TYPE, error,
-                        HTTP_HEADER_REQUEST_ID));
+            HttpExecuteResponse httpResponse = request.call();
+            response.setStatusCode(httpResponse.httpResponse().statusCode());
+            try (AbortableInputStream bodyStream = httpResponse.responseBody()
+                    .orElseThrow(() -> new AWSIotException("No response body"))) {
+                response.setResponseBody(IoUtils.toByteArray(bodyStream));
             }
-            return response;
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.error("Http request failed with error", e);
-            throw new AWSIotException(e);
+        } catch (IOException e) {
+            throw new AWSIotException("Unable to get response", e);
         }
+        return response;
     }
 }

--- a/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
+++ b/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
@@ -7,30 +7,14 @@ package com.aws.greengrass.iot;
 
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.deployment.DeviceConfiguration;
-import com.aws.greengrass.deployment.exceptions.AWSIotException;
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.ProxyUtils;
-import software.amazon.awssdk.crt.http.HttpClientConnection;
-import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
-import software.amazon.awssdk.crt.http.HttpClientConnectionManagerOptions;
-import software.amazon.awssdk.crt.http.HttpException;
-import software.amazon.awssdk.crt.io.ClientBootstrap;
-import software.amazon.awssdk.crt.io.EventLoopGroup;
-import software.amazon.awssdk.crt.io.HostResolver;
-import software.amazon.awssdk.crt.io.SocketOptions;
-import software.amazon.awssdk.crt.io.TlsContext;
-import software.amazon.awssdk.crt.io.TlsContextOptions;
+import software.amazon.awssdk.http.SdkHttpClient;
 
 import java.io.Closeable;
 import java.net.URI;
-import java.time.Duration;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.componentmanager.ClientConfigurationUtils.getConfiguredClientBuilder;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_MQTT_NAMESPACE;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_CERTIFICATE_FILE_PATH;
@@ -38,17 +22,10 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PRIVATE_KEY_PATH;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROOT_CA_PATH;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
-import static com.aws.greengrass.mqttclient.MqttClient.EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS;
 
 public class IotConnectionManager implements Closeable {
-    private static final Logger LOGGER = LogManager.getLogger(IotConnectionManager.class);
-    // Max wait time for device to establish mTLS connection with IOT core
-    private static final long TIMEOUT_FOR_CONNECTION_SETUP_SECONDS = Duration.ofMinutes(1).getSeconds();
-    private HttpClientConnectionManager connManager;
-
-    private final EventLoopGroup eventLoopGroup;
-    private final HostResolver resolver;
-    private final ClientBootstrap clientBootstrap;
+    private final DeviceConfiguration deviceConfiguration;
+    private SdkHttpClient client;
 
     /**
      * Constructor.
@@ -58,89 +35,45 @@ public class IotConnectionManager implements Closeable {
     @Inject
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public IotConnectionManager(final DeviceConfiguration deviceConfiguration) {
-        eventLoopGroup = new EventLoopGroup(1);
-        resolver = new HostResolver(eventLoopGroup);
-        clientBootstrap = new ClientBootstrap(eventLoopGroup, resolver);
-        try {
-            this.connManager = initConnectionManager(deviceConfiguration);
-            reconfigureOnConfigChange(deviceConfiguration);
-        } catch (RuntimeException e) {
-            // If we couldn't initialize the connection manager, then make sure to shutdown
-            // everything which was started up
-            clientBootstrap.close();
-            resolver.close();
-            eventLoopGroup.close();
-            throw e;
-        }
+        this.deviceConfiguration = deviceConfiguration;
+        this.client = initConnectionManager();
+        reconfigureOnConfigChange();
     }
 
-    private void reconfigureOnConfigChange(DeviceConfiguration deviceConfiguration) {
+    public URI getURI() {
+        return URI.create("https://" + Coerce.toString(deviceConfiguration.getIotCredentialEndpoint()));
+    }
+
+    public synchronized SdkHttpClient getClient() {
+        return this.client;
+    }
+
+    private void reconfigureOnConfigChange() {
         deviceConfiguration.onAnyChange((what, node) -> {
             if (WhatHappened.childChanged.equals(what) && node != null && (node.childOf(DEVICE_MQTT_NAMESPACE) || node
                     .childOf(DEVICE_PARAM_THING_NAME) || node.childOf(DEVICE_PARAM_IOT_DATA_ENDPOINT) || node
                     .childOf(DEVICE_PARAM_PRIVATE_KEY_PATH) || node.childOf(DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node
                     .childOf(DEVICE_PARAM_ROOT_CA_PATH) || node.childOf(DEVICE_PARAM_AWS_REGION))) {
-                this.connManager = initConnectionManager(deviceConfiguration);
+                synchronized (this) {
+                    this.client.close();
+                    this.client = initConnectionManager();
+                }
             }
         });
     }
 
-    private HttpClientConnectionManager initConnectionManager(DeviceConfiguration deviceConfiguration) {
-        final String certPath = Coerce.toString(deviceConfiguration.getCertificateFilePath());
-        final String keyPath = Coerce.toString(deviceConfiguration.getPrivateKeyFilePath());
-        final String caPath = Coerce.toString(deviceConfiguration.getRootCAFilePath());
-        try (TlsContextOptions tlsCtxOptions = TlsContextOptions.createWithMtlsFromPath(certPath, keyPath)) {
-            tlsCtxOptions.overrideDefaultTrustStoreFromPath(null, caPath);
-            return HttpClientConnectionManager
-                    .create(new HttpClientConnectionManagerOptions().withClientBootstrap(clientBootstrap)
-                            .withProxyOptions(ProxyUtils.getHttpProxyOptions(deviceConfiguration))
-                            .withSocketOptions(new SocketOptions()).withTlsContext(new TlsContext(tlsCtxOptions))
-                            .withUri(URI.create(
-                                    "https://" + Coerce.toString(deviceConfiguration.getIotCredentialEndpoint()))));
-        }
+    private SdkHttpClient initConnectionManager() {
+        return getConfiguredClientBuilder(deviceConfiguration).build();
     }
 
-    /**
-     * Get a connection object for sending requests.
-     *
-     * @return {@link HttpClientConnection}
-     * @throws AWSIotException when getting a connection from underlying manager fails.
-     */
-    public HttpClientConnection getConnection() throws AWSIotException {
-        try {
-            return connManager.acquireConnection().get(TIMEOUT_FOR_CONNECTION_SETUP_SECONDS, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException | HttpException e) {
-            LOGGER.error("Getting connection failed for endpoint {} with error {} ", connManager.getUri(), e);
-            throw new AWSIotException(e);
-        }
-    }
-
-    /**
-     * Get the host string underlying connection manager.
-     *
-     * @return Host string to be used in HTTP Host headers
-     */
-    public String getHost() {
-        return connManager.getUri().getHost();
-    }
 
     /**
      * Clean up underlying connections and close gracefully.
      */
     @Override
-    public void close() {
-        connManager.close();
-        clientBootstrap.close();
-        resolver.close();
-        eventLoopGroup.close();
-        try {
-            eventLoopGroup.getShutdownCompleteFuture().get(EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (ExecutionException e) {
-            LOGGER.atError().log("Error shutting down event loop", e);
-        } catch (TimeoutException e) {
-            LOGGER.atError().log("Timed out shutting down event loop");
+    public synchronized void close() {
+        if (this.client != null) {
+            this.client.close();
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCEventStreamService.java
@@ -16,7 +16,6 @@ import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.Platform;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.NoArgsConstructor;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCServiceModel;
 import software.amazon.awssdk.crt.eventstream.Header;
@@ -35,7 +34,6 @@ import javax.inject.Inject;
 
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 
-@NoArgsConstructor
 public class IPCEventStreamService implements Startable, Closeable {
     public static final long DEFAULT_STREAM_MESSAGE_TIMEOUT_SECONDS = 5;
     public static final int DEFAULT_PORT_NUMBER = 8033;
@@ -51,27 +49,26 @@ public class IPCEventStreamService implements Startable, Closeable {
 
     private RpcServer rpcServer;
 
-    @Inject
-    private Kernel kernel;
+    private final Kernel kernel;
 
-    @Inject
-    private GreengrassCoreIPCService greengrassCoreIPCService;
+    private final GreengrassCoreIPCService greengrassCoreIPCService;
 
-    @Inject
-    private AuthenticationHandler authenticationHandler;
+    private final AuthenticationHandler authenticationHandler;
 
-    @Inject
-    private Configuration config;
+    private final Configuration config;
 
     private SocketOptions socketOptions;
     private EventLoopGroup eventLoopGroup;
 
+    @Inject
     IPCEventStreamService(Kernel kernel,
-                                 GreengrassCoreIPCService greengrassCoreIPCService,
-                                 Configuration config) {
+                          GreengrassCoreIPCService greengrassCoreIPCService,
+                          Configuration config,
+                          AuthenticationHandler authenticationHandler) {
         this.kernel = kernel;
         this.greengrassCoreIPCService = greengrassCoreIPCService;
         this.config = config;
+        this.authenticationHandler = authenticationHandler;
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.ExceptionAsFlowControl"})

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -56,6 +56,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -92,10 +93,12 @@ public class Kernel {
     static final String DEFAULT_CONFIG_YAML_FILE_READ = "config.yaml";
     static final String DEFAULT_CONFIG_YAML_FILE_WRITE = "effectiveConfig.yaml";
     static final String DEFAULT_CONFIG_TLOG_FILE = "config.tlog";
+    public static final String DEFAULT_BOOTSTRAP_CONFIG_TLOG_FILE = "bootstrap.tlog";
     public static final String SERVICE_DIGEST_TOPIC_KEY = "service-digest";
     private static final String DEPLOYMENT_STAGE_LOG_KEY = "stage";
     protected static final ObjectMapper CONFIG_YAML_WRITER =
             YAMLMapper.builder().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET).build();
+    private static final List<String> SUPPORTED_CAPABILITIES = Collections.emptyList();
 
     @Getter
     private final Context context;
@@ -660,5 +663,9 @@ public class Kernel {
      */
     public String deTilde(String filename) {
         return kernelCommandLine.deTilde(filename);
+    }
+
+    public List<String> getSupportedCapabilities() {
+        return SUPPORTED_CAPABILITIES;
     }
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
@@ -63,10 +63,6 @@ public class KernelCommandLine {
     private static final String cliIpcInfoPathName = "~root/cli_ipc_info";
     private static final String binPathName = "~root/bin";
 
-    public static void main(String[] args) {
-        new Kernel().parseArgs(args).launch();
-    }
-
     public KernelCommandLine(Kernel kernel) {
         this(kernel, kernel.getNucleusPaths());
     }

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 import java.io.Closeable;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -571,7 +570,7 @@ public class MqttClient implements Closeable {
         }
 
         // Check the topic size
-        if (topic.getBytes(StandardCharsets.UTF_8).length > MAX_LENGTH_OF_TOPIC) {
+        if (topic.length() > MAX_LENGTH_OF_TOPIC) {
             String errMsg = String.format("The topic size of request must be no "
                             + "larger than %d bytes of UTF-8 encoded characters. This excludes the first "
                             + "3 mandatory segments for Basic Ingest topics ($AWS/rules/rule-name/).",

--- a/src/main/java/com/aws/greengrass/mqttclient/PublishRequest.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/PublishRequest.java
@@ -10,16 +10,27 @@ import lombok.NonNull;
 import lombok.Value;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
-@Builder
+@SuppressWarnings("PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal")
 @Value
 public class PublishRequest {
     @NonNull String topic;
-    @Builder.Default
-    @NonNull QualityOfService qos = QualityOfService.AT_LEAST_ONCE;
+    @NonNull QualityOfService qos;
     /**
      * Retain the message in the cloud MQTT broker (only last message with retain is actually kept).
      * Subscribers will immediately receive the last retained message when they first subscribe.
      */
     boolean retain;
-    @NonNull byte[] payload;
+    byte[] payload;
+
+    @Builder
+    protected PublishRequest(String topic, QualityOfService qos, boolean retain, byte[] payload) {
+        // Intern the string to deduplicate topic strings in memory
+        this.topic = topic.intern();
+        if (qos == null) {
+            qos = QualityOfService.AT_LEAST_ONCE;
+        }
+        this.qos = qos;
+        this.retain = retain;
+        this.payload = payload;
+    }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
@@ -47,7 +47,9 @@ import java.util.Set;
 import java.util.UUID;
 
 public class WindowsPlatform extends Platform {
-    private static final String NAMED_PIPE = "\\\\.\\pipe\\NucleusNamedPipe-" + UUID.randomUUID().toString();
+    private static final String NAMED_PIPE_PREFIX = "\\\\.\\pipe\\NucleusNamedPipe-";
+    private static final String NAMED_PIPE_UUID_SUFFIX = UUID.randomUUID().toString();
+    private static final int MAX_NAMED_PIPE_LEN = 256;
 
     static final Set<AclEntryPermission> READ_PERMS = new HashSet<>(Arrays.asList(
             AclEntryPermission.READ_DATA,
@@ -366,17 +368,22 @@ public class WindowsPlatform extends Platform {
 
     @Override
     public String prepareIpcFilepath(Path rootPath) {
-        return NAMED_PIPE;
+        String absolutePath = rootPath.toAbsolutePath().toString();
+        if (NAMED_PIPE_PREFIX.length() + absolutePath.length() <= MAX_NAMED_PIPE_LEN) {
+            return NAMED_PIPE_PREFIX + absolutePath;
+        }
+
+        return NAMED_PIPE_PREFIX + NAMED_PIPE_UUID_SUFFIX;
     }
 
     @Override
     public String prepareIpcFilepathForComponent(Path rootPath) {
-        return NAMED_PIPE;
+        return prepareIpcFilepath(rootPath);
     }
 
     @Override
     public String prepareIpcFilepathForRpcServer(Path rootPath) {
-        return NAMED_PIPE;
+        return prepareIpcFilepath(rootPath);
     }
 
     @Override

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -66,6 +66,14 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String CREATE_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CreateLocalDeployment";
 
+  public static final String DELETE_THING_SHADOW = SERVICE_NAMESPACE + "#DeleteThingShadow";
+
+  public static final String UPDATE_THING_SHADOW = SERVICE_NAMESPACE + "#UpdateThingShadow";
+
+  public static final String GET_THING_SHADOW = SERVICE_NAMESPACE + "#GetThingShadow";
+
+  public static final String LIST_NAMED_SHADOWS_FOR_THING = SERVICE_NAMESPACE + "#ListNamedShadowsForThing";
+
   static {
     SERVICE_OPERATION_SET = new HashSet();
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_IOT_CORE);
@@ -90,6 +98,10 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(LIST_LOCAL_DEPLOYMENTS);
     SERVICE_OPERATION_SET.add(STOP_COMPONENT);
     SERVICE_OPERATION_SET.add(CREATE_LOCAL_DEPLOYMENT);
+    SERVICE_OPERATION_SET.add(DELETE_THING_SHADOW);
+    SERVICE_OPERATION_SET.add(UPDATE_THING_SHADOW);
+    SERVICE_OPERATION_SET.add(GET_THING_SHADOW);
+    SERVICE_OPERATION_SET.add(LIST_NAMED_SHADOWS_FOR_THING);
   }
 
   private final Map<String, Function<OperationContinuationHandlerContext, ? extends ServerConnectionContinuationHandler>> operationSupplierMap;

--- a/src/test/greengrass-nucleus-benchmark/pom.xml
+++ b/src/test/greengrass-nucleus-benchmark/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.aws.greengrass</groupId>
     <artifactId>greengrass-nucleus-benchmark</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JMH benchmark sample: Java</name>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.aws.greengrass.jmh.PreloadComponentStoreHelper.preloadRecipesFromTestResourceDir;
@@ -47,8 +48,8 @@ public class DependencyResolverBenchmark {
     public abstract static class DRIntegration {
         private final DeploymentDocument jobDoc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration("boto3", true, "1.9.128"),
-                        new DeploymentPackageConfiguration("awscli", true, "1.16.144")), "mockGroup1",
-                1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS),
+                        new DeploymentPackageConfiguration("awscli", true, "1.16.144")), Collections.emptyList(),
+                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS),
                 DeploymentConfigurationValidationPolicy.builder().timeoutInSeconds(20).build());
 
         private DependencyResolver resolver;

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -141,7 +141,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -208,7 +208,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -306,7 +306,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -366,7 +366,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -445,7 +445,7 @@ class DependencyResolverTest {
 
         DeploymentDocument doc = new DeploymentDocument("mockJob1", Collections
                 .singletonList(
-                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())),
+                        new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -515,7 +515,7 @@ class DependencyResolverTest {
         // top-level package order: A, B2
         DeploymentDocument doc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
-                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())),
+                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -600,7 +600,7 @@ class DependencyResolverTest {
         // top-level package order: A, B2
         DeploymentDocument doc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
-                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())),
+                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
@@ -674,7 +674,7 @@ class DependencyResolverTest {
         // top-level package order: A, B2
         DeploymentDocument doc = new DeploymentDocument("mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
-                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())),
+                        new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)

--- a/src/test/java/com/aws/greengrass/config/ConfigurationWriterTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationWriterTest.java
@@ -72,12 +72,12 @@ class ConfigurationWriterTest {
             // Assert that we can get back to the current in-memory state by reading the tlog
             Configuration readConfig = ConfigurationReader.createFromTLog(context, tlog);
             assertThat(readConfig.toPOJO(), is(config.toPOJO()));
-
-            Files.deleteIfExists(tlog);
-            ConfigurationWriter.dump(config, tlog);
-            readConfig = ConfigurationReader.createFromTLog(context, tlog);
-            assertThat(readConfig.toPOJO(), is(config.toPOJO()));
         }
+
+        Files.deleteIfExists(tlog);
+        ConfigurationWriter.dump(config, tlog);
+        Configuration readConfig = ConfigurationReader.createFromTLog(context, tlog);
+        assertThat(readConfig.toPOJO(), is(config.toPOJO()));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
@@ -168,6 +168,8 @@ class DeploymentDocumentConverterTest {
         assertThat(deploymentDocument.getDeploymentId(),
                    is("arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/SampleGroup:2"));
         assertThat(deploymentDocument.getGroupName(), is("thinggroup/SampleGroup"));
+        assertThat(deploymentDocument.getRequiredCapabilities(), equalTo(Arrays.asList("LARGE_CONFIGURATION",
+                "ANOTHER_CAPABILITY")));
 
         assertThat(deploymentDocument.getDeploymentPackageConfigurationList(), hasSize(1));
 
@@ -205,6 +207,7 @@ class DeploymentDocumentConverterTest {
         assertThat(deploymentDocument.getDeploymentId(),
                    is("arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/SampleGroup:2"));
         assertThat(deploymentDocument.getGroupName(), is("thinggroup/SampleGroup"));
+        assertNull(deploymentDocument.getRequiredCapabilities());
 
         assertThat(deploymentDocument.getDeploymentPackageConfigurationList(), hasSize(1));
 
@@ -248,6 +251,7 @@ class DeploymentDocumentConverterTest {
         assertThat(deploymentDocument.getDeploymentId(),
                    is("arn:aws:greengrass:us-east-1:698947471564:configuration:thinggroup/SampleGroup:2"));
         assertThat(deploymentDocument.getGroupName(), is("thinggroup/SampleGroup"));
+        assertNull(deploymentDocument.getRequiredCapabilities());
 
         // The following fields are not provided in the json so default values should be used.
         // Default for FailureHandlingPolicy should be ROLLBACK

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 class GreengrassSetupTest {
     @Mock
     private DeviceProvisioningHelper deviceProvisioningHelper;
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Kernel kernel;
     @Mock
     private Context context;
@@ -160,6 +160,7 @@ class GreengrassSetupTest {
         verify(runWithDefaultPosixUserTopic, times(0)).withValue(anyString());
         verify(platform, times(0)).createUser(eq("ggc_user"));
         verify(platform, times(0)).createGroup(eq("ggc_group"));
+        verify(platform, times(0)).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -183,6 +184,7 @@ class GreengrassSetupTest {
         verify(runWithDefaultPosixUserTopic, timeout(0)).withValue(anyString());
         verify(platform, times(0)).createUser(eq("ggc_user"));
         verify(platform, times(0)).createGroup(eq("ggc_group"));
+        verify(platform, times(0)).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -205,6 +207,7 @@ class GreengrassSetupTest {
 
         verify(platform).createUser(eq("ggc_user"));
         verify(platform).createGroup(eq("ggc_group"));
+        verify(platform).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -226,6 +229,7 @@ class GreengrassSetupTest {
 
         verify(platform, times(0)).createUser(eq("ggc_user"));
         verify(platform, times(0)).createGroup(eq("ggc_group"));
+        verify(platform, times(0)).addUserToGroup(eq("ggc_user"), eq("ggc_group"));
     }
 
     @Test
@@ -248,6 +252,7 @@ class GreengrassSetupTest {
 
         verify(platform, times(0)).createUser(any());
         verify(platform, times(0)).createGroup(any());
+        verify(platform, times(0)).addUserToGroup(any(), any());
     }
 
     @Test
@@ -269,6 +274,7 @@ class GreengrassSetupTest {
 
         verify(platform, times(0)).createUser(any());
         verify(platform, times(0)).createGroup(any());
+        verify(platform, times(0)).addUserToGroup(any(), any());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -205,7 +206,9 @@ class KernelLifecycleTest {
 
         kernelLifecycle.initConfigAndTlog();
         verify(mockKernel.getConfig()).read(eq(configTlog.toPath()));
-        verify(mockKernel).writeEffectiveConfigAsTransactionLog(tempRootDir.resolve("config").resolve("config.tlog"));
+        // Since we read from the tlog, we don't need to re-write the same info
+        verify(mockKernel, never()).writeEffectiveConfigAsTransactionLog(
+                tempRootDir.resolve("config").resolve("config.tlog"));
         verify(mockKernel).writeEffectiveConfig();
     }
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -67,6 +67,8 @@ import static org.mockito.Mockito.when;
 class LogManagerHelperTest {
     @TempDir
     protected Path tempRootDir;
+    @TempDir
+    protected Path tempRootDir2;
     @Mock
     private GreengrassService mockGreengrassService;
     @Mock
@@ -140,7 +142,7 @@ class LogManagerHelperTest {
         loggingConfig.createLeafChild("totalLogsSizeKB").withValue("1026");
         loggingConfig.createLeafChild("format").withValue("TEXT");
         loggingConfig.createLeafChild("outputType").withValue("FILE");
-        loggingConfig.createLeafChild("outputDirectory").withValue("/tmp/test");
+        loggingConfig.createLeafChild("outputDirectory").withValue(tempRootDir2.toAbsolutePath().toString());
         Topics topics = Topics.of(mock(Context.class), SERVICES_NAMESPACE_TOPIC, mock(Topics.class));
         when(configuration.lookupTopics(anyString(), anyString(), anyString(), anyString())).thenReturn(loggingConfig);
         when(configuration.lookupTopics(anyString())).thenReturn(topics);
@@ -154,7 +156,8 @@ class LogManagerHelperTest {
         assertEquals(LogFormat.TEXT, LogManager.getRootLogConfiguration().getFormat());
         assertEquals(10, LogManager.getRootLogConfiguration().getFileSizeKB());
         assertEquals(1026, LogManager.getRootLogConfiguration().getTotalLogStoreSizeKB());
-        assertEquals("/tmp/test", LogManager.getRootLogConfiguration().getStoreDirectory().toAbsolutePath().toString());
+        assertEquals(tempRootDir2.toAbsolutePath(),
+                LogManager.getRootLogConfiguration().getStoreDirectory().toAbsolutePath());
 
         assertEquals(Level.TRACE, LogManager.getTelemetryConfig().getLevel());
         assertEquals(LogStore.FILE, LogManager.getTelemetryConfig().getStore());

--- a/src/test/java/com/aws/greengrass/tes/IotCloudHelperTest.java
+++ b/src/test/java/com/aws/greengrass/tes/IotCloudHelperTest.java
@@ -13,50 +13,51 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.crt.http.HttpClientConnection;
-import software.amazon.awssdk.crt.http.HttpRequest;
-import software.amazon.awssdk.crt.http.HttpStream;
-import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpResponse;
 
-import java.nio.ByteBuffer;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class IotCloudHelperTest {
     private static final byte[] CLOUD_RESPONSE = "HELLO WORLD".getBytes(StandardCharsets.UTF_8);
     private static final int STATUS_CODE = 200;
-    private static final String HOST = "localhost";
+    private static final URI HOST = URI.create("http://localhost");
     private static final String IOT_CREDENTIALS_PATH = "MOCK_PATH/get.json";
 
     @Mock
     IotConnectionManager mockConnectionManager;
 
     @Mock
-    HttpClientConnection mockConnection;
-
-    @Mock
-    HttpStream mockHttpStream;
+    SdkHttpClient mockClient;
 
     @Test
     void GIVEN_valid_creds_WHEN_send_request_called_THEN_success() throws Exception {
-        when(mockConnectionManager.getConnection()).thenReturn(mockConnection);
-        when(mockConnectionManager.getHost()).thenReturn(HOST);
-        when(mockHttpStream.getResponseStatusCode()).thenReturn(STATUS_CODE);
-        doAnswer(invocationArgs -> {
-            HttpStreamResponseHandler handler = (HttpStreamResponseHandler)invocationArgs.getArguments()[1];
-            handler.onResponseBody(mockHttpStream, CLOUD_RESPONSE);
-            handler.onResponseComplete(mockHttpStream, 0);
-            return mockHttpStream;
-        }).when(mockConnection).makeRequest(any(), any());
+        when(mockConnectionManager.getClient()).thenReturn(mockClient);
+        when(mockConnectionManager.getURI()).thenReturn(HOST);
+
+        ExecutableHttpRequest requestMock = mock(ExecutableHttpRequest.class);
+        when(requestMock.call()).thenReturn(
+                HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(STATUS_CODE).build())
+                        .responseBody(AbortableInputStream.create(new ByteArrayInputStream(CLOUD_RESPONSE))).build());
+
+        doReturn(requestMock).when(mockClient).prepareRequest(any());
         IotCloudHelper cloudHelper = new IotCloudHelper();
-        final IotCloudResponse response = cloudHelper.sendHttpRequest(mockConnectionManager, null,
-                IOT_CREDENTIALS_PATH, CredentialRequestHandler.IOT_CREDENTIALS_HTTP_VERB, null);
+        final IotCloudResponse response = cloudHelper.sendHttpRequest(mockConnectionManager, null, IOT_CREDENTIALS_PATH,
+                CredentialRequestHandler.IOT_CREDENTIALS_HTTP_VERB, null);
         assertArrayEquals(CLOUD_RESPONSE, response.getResponseBody());
         assertEquals(STATUS_CODE, response.getStatusCode());
     }
@@ -64,41 +65,30 @@ class IotCloudHelperTest {
     @Test
     void GIVEN_valid_creds_WHEN_send_request_called_with_body_THEN_success() throws Exception {
         byte[] body = "hello".getBytes(StandardCharsets.UTF_8);
-        when(mockConnectionManager.getConnection()).thenReturn(mockConnection);
-        when(mockConnectionManager.getHost()).thenReturn(HOST);
-        doAnswer(invocationArgs -> {
-            HttpRequest request = invocationArgs.getArgument(0);
-            ByteBuffer byteBuffer = ByteBuffer.allocate(body.length);
-            request.getBodyStream().sendRequestBody(byteBuffer);
-            assertArrayEquals(body, byteBuffer.array());
-            HttpStreamResponseHandler handler = invocationArgs.getArgument(1);
-            handler.onResponseBody(mockHttpStream, CLOUD_RESPONSE);
-            handler.onResponseComplete(mockHttpStream, 0);
-            return mockHttpStream;
-        }).when(mockConnection).makeRequest(any(), any());
+        when(mockConnectionManager.getClient()).thenReturn(mockClient);
+        when(mockConnectionManager.getURI()).thenReturn(HOST);
+        ExecutableHttpRequest requestMock = mock(ExecutableHttpRequest.class);
+        when(requestMock.call()).thenReturn(
+                HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(STATUS_CODE).build())
+                        .responseBody(AbortableInputStream.create(new ByteArrayInputStream(CLOUD_RESPONSE))).build());
+
+        doReturn(requestMock).when(mockClient).prepareRequest(any());
         IotCloudHelper cloudHelper = new IotCloudHelper();
-        final byte[] creds = cloudHelper.sendHttpRequest(mockConnectionManager, null,
-                IOT_CREDENTIALS_PATH, CredentialRequestHandler.IOT_CREDENTIALS_HTTP_VERB, body).getResponseBody();
+        final byte[] creds = cloudHelper.sendHttpRequest(mockConnectionManager, null, IOT_CREDENTIALS_PATH,
+                CredentialRequestHandler.IOT_CREDENTIALS_HTTP_VERB, body).getResponseBody();
         assertArrayEquals(CLOUD_RESPONSE, creds);
     }
 
     @Test
     void GIVEN_error_code_once_WHEN_send_request_called_THEN_retry_and_success() throws Exception {
-        when(mockConnectionManager.getConnection()).thenReturn(mockConnection);
-        when(mockConnectionManager.getHost()).thenReturn(HOST);
-        when(mockHttpStream.getResponseStatusCode()).thenReturn(STATUS_CODE);
-        doAnswer(invocationArgs -> {
-            HttpStreamResponseHandler handler = (HttpStreamResponseHandler) invocationArgs.getArguments()[1];
-            handler.onResponseBody(mockHttpStream, CLOUD_RESPONSE);
-            // error code not 0, fail to complete
-            handler.onResponseComplete(mockHttpStream, 1);
-            return mockHttpStream;
-        }).doAnswer(invocationArgs -> {
-            HttpStreamResponseHandler handler = (HttpStreamResponseHandler) invocationArgs.getArguments()[1];
-            handler.onResponseBody(mockHttpStream, CLOUD_RESPONSE);
-            handler.onResponseComplete(mockHttpStream, 0);
-            return mockHttpStream;
-        }).when(mockConnection).makeRequest(any(), any());
+        when(mockConnectionManager.getClient()).thenReturn(mockClient);
+        when(mockConnectionManager.getURI()).thenReturn(HOST);
+        ExecutableHttpRequest requestMock = mock(ExecutableHttpRequest.class);
+        when(requestMock.call()).thenThrow(IOException.class).thenReturn(
+                HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(STATUS_CODE).build())
+                        .responseBody(AbortableInputStream.create(new ByteArrayInputStream(CLOUD_RESPONSE))).build());
+
+        doReturn(requestMock).when(mockClient).prepareRequest(any());
         IotCloudHelper cloudHelper = new IotCloudHelper();
         final IotCloudResponse response = cloudHelper.sendHttpRequest(mockConnectionManager, null, IOT_CREDENTIALS_PATH,
                 CredentialRequestHandler.IOT_CREDENTIALS_HTTP_VERB, null);

--- a/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
+++ b/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
@@ -1,5 +1,6 @@
 {
   "deploymentId": "3b86691d-4f81-408a-852e-edc14cd351a7",
+  "requiredCapabilities": ["LARGE_CONFIGURATION", "ANOTHER_CAPABILITY"],
   "configurationValidationPolicy": {
     "timeout": 120.0
   },


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
New File: **loader.cmd**
Excluded **loader.cmd** from maven license plugin (it wasn't recognizing comment style of _@REM_)
Included **loader.cmd** in zip package

**Known issue:**
If the symlink **target** contains brackets in the name, then the function to flip the symlinks will not correctly set the symlink target.

**Why is this change necessary:**
The existing **loader** shell script does NOT work on Windows platforms. This new **loader.cmd** replicates the behavior in the existing **loader** shell script but for Windows platforms.

**How was this change tested:**
1 .Created a zip via the following command:
`mvn -DskipTests clean package`
I had to skip tests because there are existing tests that do not pass on Windows.

2. Deployed Greengrass without starting the Nucleus by running the **<GreengrassCoreRootDirectory>/lib/Greengrass.jar** with *--start false* flag. 

3. Ran **loader.cmd** from Greengrass directory (**\greengrass\v2\alts\current\distory\bin**)

4. Observed output and observed Greengrass logs in **\greengrass\v2\logs\** for proof Greengrass Nucleus running and logging.

5. Stopped Nucleus via Ctrl+C

6. Observed Greengrass logs for termination confirmation:
> com.aws.greengrass.lifecyclemanager.Kernel: Shutting down Nucleus due to external signal. {}

Note: Error seen in greengrass.log
> com.aws.greengrass.deployment.DeviceConfiguration: Unable to set up Nucleus from build recipe file. {}
com.aws.greengrass.componentmanager.exceptions.PackageLoadingException: Failed to load Nucleus recipe
	at com.aws.greengrass.deployment.DeviceConfiguration.initializeNucleusFromRecipe(DeviceConfiguration.java:371)
	at com.aws.greengrass.lifecyclemanager.Kernel.parseArgs(Kernel.java:637)
	at com.aws.greengrass.easysetup.GreengrassSetup.performSetup(GreengrassSetup.java:269)
	at com.aws.greengrass.easysetup.GreengrassSetup.main(GreengrassSetup.java:242)

Is this an existing Windows bug?

7. Observed existing java.exe process end and a new process spin up (the loader script retries 3 times)

Broken deployment testing:
started with _alts/new_ symlinked to a folder without a JAR and _alts/current_ symlinked to a functioning release.
End result:
because JAR couldn't be accessed (because it doesn't exist) the it looped 3 times to start, failed and created a symlink _alts/broken_ pointing towards the broken deployment and _alts/current_ continued to point at the working directory.

New deployment testing:
started with _alts/new_ symlinked to a new deployment and _alts/current_ symlinked to a previous deployment
End result:
_alts/current_ got moved to _alts/old_ and _alts/new_ got moved to _alts/current_

New deployment with an existing _alts/broken_ symlink:
started with _alts/broken, alts/current,_ and _alts/new_.
_alts/current_ symlink was renamed to _alts/old_
_alts/new_ symlink was renamed to _alts/current_
_alts/old_ symlink was renamed to _alts/current_

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
