### PR TITLE
fix(loader): catch SIGTERM to shutdown nicely in docker

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -1,7 +1,11 @@
 #!/bin/sh -x
 
+#Disable job control so that all child processes run in the same process group as the parent
+set +m
+
 PWD=$(dirname "$0")
 
+sigterm_received=0
 # Assuming loader is launched from "$GG_ROOT/alts/current/distro/bin/loader"
 GG_ROOT=$(cd $PWD/../../../..; pwd)
 
@@ -31,6 +35,7 @@ launch_kernel() {
   fi
   echo "JVM options: "${JVM_OPTIONS}
   echo "Nucleus options: "${OPTIONS}
+  trap "echo Received SIGTERM; sigterm_received=1" TERM
   java -Dlog.store=FILE ${JVM_OPTIONS} -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS}
   kernel_exit_code=$?
   echo "Nucleus exit at code: "${kernel_exit_code}
@@ -60,7 +65,7 @@ fi
 
 # Launch Nucleus with max 3 retries
 j=1
-while [ $j -le 3 ]; do
+while [ $j -le 3 ] && [ $sigterm_received -eq 0 ];  do
   launch_kernel
   case ${kernel_exit_code} in
   100|0)


### PR DESCRIPTION
**Description of changes:**
When Greengrass is running in Docker or elsewhere, it will attempt to restart when receiving a SIGTERM. 
Added a new variable `sigterm_received` to track this via a `trap` and stop restart attempts.
Also added `set +m` to the loader script.
**Why is this change necessary:**

**How was this change tested:**
`docker run --init -d -e "TINI_KILL_PROCESS_GROUP=1" -e "TINI_VERBOSITY=3" --entrypoint /greengrass-entrypoint.sh <image ID>`
`docker stop` (to send SIGTERM)
`docker logs <container ID>` to verify output :
```
Launched Nucleus successfully.
++ echo Received SIGTERM
++ sigterm_received=1
+ kernel_exit_code=143
+ echo 'Nucleus exit at code: 143'
+ case ${kernel_exit_code} in
Received SIGTERM
Nucleus exit at code: 143
+ echo 'Nucleus exited 143. Retrying 1 times'
+ j=2
Nucleus exited 143. Retrying 1 times
+ '[' 2 -le 3 ']'
+ '[' 1 -eq 0 ']'
+ is_directory_link /greengrass/v2/alts/old
+ '[' -L /greengrass/v2/alts/old ']'
+ exit 143
[INFO  tini (1)] Spawned child process '/greengrass-entrypoint.sh' with pid '9'
[DEBUG tini (1)] Passing signal: 'Terminated'
[DEBUG tini (1)] Received SIGCHLD
[DEBUG tini (1)] Reaped child with pid: '9'
[INFO  tini (1)] Main child exited normally (with status '143')
```

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
