### PR TITLE
[WIP/DNM] fix(exec): execute subprocesses through setsid to create new process groups

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -400,6 +400,7 @@ public final class Exec implements Closeable {
         if (userDecorator != null) {
             decorated = userDecorator.decorate(decorated);
         }
+        decorated = Platform.getInstance().finalDecorateCommand(decorated);
         return decorated;
     }
 

--- a/src/main/java/com/aws/greengrass/util/platforms/Platform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/Platform.java
@@ -74,6 +74,12 @@ public abstract class Platform implements UserPlatform {
 
     public abstract ShellDecorator getShellDecorator();
 
+    @SuppressWarnings("PMD.UseVarargs")
+    public String[] finalDecorateCommand(String[] command) {
+        // Default is no-op.
+        return command;
+    }
+
     public abstract int exitCodeWhenCommandDoesNotExist();
 
     public abstract UserDecorator getUserDecorator();

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/QNXPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/QNXPlatform.java
@@ -35,6 +35,12 @@ public class QNXPlatform extends UnixPlatform {
         return childPids;
     }
 
+    @Override
+    protected boolean canUseSetsid() {
+        // QNX does not have setsid command
+        return false;
+    }
+
     private void killUsingSlay(int pid, boolean force, UserDecorator userDecorator)
             throws IOException, InterruptedException {
         logger.atInfo().log("Slaying pid {} with signal {}", pid, force ? SIGKILL : SIGTERM);


### PR DESCRIPTION
**Issue #, if available:**

Another potential resolution for #910 by using `setsid` to force the subprocesses to run with their own process groups which then enables us to kill them using `kill <signal> -<pid>` so that it kills the entire process group. This means that Greengrass does not need to find all children and then kill them all which is slow and can be error prone.

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
