### PR TITLE
chore: use new pre-released data plane SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>greengrassv2</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>greengrassv2-data</artifactId>
+            <version>2.15.x-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.10</version>

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -42,7 +42,7 @@ import com.vdurmont.semver4j.SemverException;
 import lombok.AccessLevel;
 import lombok.Setter;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.services.greengrassv2.model.ResolvedComponentVersion;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolvedComponentVersion;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
@@ -9,15 +9,16 @@ import com.aws.greengrass.componentmanager.exceptions.NoAvailableComponentVersio
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
 import org.apache.commons.lang3.Validate;
-import software.amazon.awssdk.services.greengrassv2.model.ComponentCandidate;
-import software.amazon.awssdk.services.greengrassv2.model.ComponentPlatform;
-import software.amazon.awssdk.services.greengrassv2.model.ResolveComponentCandidatesRequest;
-import software.amazon.awssdk.services.greengrassv2.model.ResolveComponentCandidatesResponse;
-import software.amazon.awssdk.services.greengrassv2.model.ResolvedComponentVersion;
-import software.amazon.awssdk.services.greengrassv2.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.greengrassv2data.model.ComponentCandidate;
+import software.amazon.awssdk.services.greengrassv2data.model.ComponentPlatform;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolveComponentCandidatesRequest;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolveComponentCandidatesResponse;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolvedComponentVersion;
+import software.amazon.awssdk.services.greengrassv2data.model.ResourceNotFoundException;
 
 import java.util.Collections;
 import java.util.Map;
@@ -28,11 +29,11 @@ public class ComponentServiceHelper {
 
     protected static final Logger logger = LogManager.getLogger(ComponentServiceHelper.class);
 
-    private final GreengrassComponentServiceClientFactory clientFactory;
+    private final GreengrassServiceClientFactory clientFactory;
     private final PlatformResolver platformResolver;
 
     @Inject
-    public ComponentServiceHelper(GreengrassComponentServiceClientFactory clientFactory,
+    public ComponentServiceHelper(GreengrassServiceClientFactory clientFactory,
                                   PlatformResolver platformResolver) {
         this.clientFactory = clientFactory;
         this.platformResolver = platformResolver;
@@ -64,7 +65,7 @@ public class ComponentServiceHelper {
 
         ResolveComponentCandidatesResponse result;
         try {
-            result = clientFactory.getCmsClient().resolveComponentCandidates(request);
+            result = clientFactory.getGreengrassV2DataClient().resolveComponentCandidates(request);
         } catch (ResourceNotFoundException e) {
             logger.atDebug().kv("componentName", componentName).kv("versionRequirements", versionRequirements)
                     .log("No applicable version found in cloud registry");

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
-import com.aws.greengrass.componentmanager.GreengrassComponentServiceClientFactory;
 import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriException;
 import com.aws.greengrass.componentmanager.exceptions.MissingRequiredComponentsException;
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
@@ -15,6 +14,7 @@ import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.plugins.docker.DockerImageDownloader;
 import com.aws.greengrass.componentmanager.plugins.docker.Image;
 import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.S3SdkClientFactory;
 
 import java.net.URI;
@@ -40,7 +40,7 @@ public class ArtifactDownloaderFactory {
 
     private final S3SdkClientFactory s3ClientFactory;
 
-    private final GreengrassComponentServiceClientFactory greengrassComponentServiceClientFactory;
+    private final GreengrassServiceClientFactory clientFactory;
 
     private final ComponentStore componentStore;
 
@@ -50,17 +50,17 @@ public class ArtifactDownloaderFactory {
      * ArtifactDownloaderFactory constructor.
      *
      * @param s3SdkClientFactory                      s3SdkClientFactory
-     * @param greengrassComponentServiceClientFactory greengrassComponentServiceClientFactory
+     * @param greengrassServiceClientFactory greengrassComponentServiceClientFactory
      * @param componentStore                          componentStore
      * @param context                                 context
      */
     @Inject
     public ArtifactDownloaderFactory(S3SdkClientFactory s3SdkClientFactory,
-                                     GreengrassComponentServiceClientFactory greengrassComponentServiceClientFactory,
+                                     GreengrassServiceClientFactory greengrassServiceClientFactory,
                                      ComponentStore componentStore,
                                      Context context) {
         this.s3ClientFactory = s3SdkClientFactory;
-        this.greengrassComponentServiceClientFactory = greengrassComponentServiceClientFactory;
+        this.clientFactory = greengrassServiceClientFactory;
         this.componentStore = componentStore;
         this.context = context;
     }
@@ -80,8 +80,7 @@ public class ArtifactDownloaderFactory {
         URI artifactUri = artifact.getArtifactUri();
         String scheme = artifactUri.getScheme() == null ? null : artifactUri.getScheme().toUpperCase();
         if (GREENGRASS_SCHEME.equals(scheme)) {
-            return new GreengrassRepositoryDownloader(
-                    greengrassComponentServiceClientFactory, identifier, artifact, artifactDir, componentStore);
+            return new GreengrassRepositoryDownloader(clientFactory, identifier, artifact, artifactDir, componentStore);
         }
         if (S3_SCHEME.equals(scheme)) {
             return new S3Downloader(s3ClientFactory, identifier, artifact, artifactDir);

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
@@ -49,7 +49,7 @@ import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.services.greengrassv2.model.ResolvedComponentVersion;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolvedComponentVersion;
 
 import java.io.File;
 import java.net.URI;

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.componentmanager;
 import com.aws.greengrass.componentmanager.exceptions.NoAvailableComponentVersionException;
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
 import org.apache.commons.codec.Charsets;
@@ -19,12 +20,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
-import software.amazon.awssdk.services.greengrassv2.model.ComponentCandidate;
-import software.amazon.awssdk.services.greengrassv2.model.ResolveComponentCandidatesRequest;
-import software.amazon.awssdk.services.greengrassv2.model.ResolveComponentCandidatesResponse;
-import software.amazon.awssdk.services.greengrassv2.model.ResolvedComponentVersion;
-import software.amazon.awssdk.services.greengrassv2.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+import software.amazon.awssdk.services.greengrassv2data.model.ComponentCandidate;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolveComponentCandidatesRequest;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolveComponentCandidatesResponse;
+import software.amazon.awssdk.services.greengrassv2data.model.ResolvedComponentVersion;
+import software.amazon.awssdk.services.greengrassv2data.model.ResourceNotFoundException;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,17 +50,17 @@ class ComponentServiceHelperTest {
     private static final String COMPONENT_A = "A";
 
     @Mock
-    private GreengrassV2Client client;
+    private GreengrassV2DataClient client;
 
     @Mock
-    private GreengrassComponentServiceClientFactory clientFactory;
+    private GreengrassServiceClientFactory clientFactory;
 
     private ComponentServiceHelper helper;
 
     @BeforeEach
     void beforeEach() {
         PlatformResolver platformResolver = new PlatformResolver(null);
-        lenient().when(clientFactory.getCmsClient()).thenReturn(client);
+        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
         this.helper = spy(new ComponentServiceHelper(clientFactory, platformResolver));
     }
 

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
@@ -6,13 +6,13 @@
 package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
-import com.aws.greengrass.componentmanager.GreengrassComponentServiceClientFactory;
 import com.aws.greengrass.componentmanager.exceptions.MissingRequiredComponentsException;
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.S3SdkClientFactory;
 import com.vdurmont.semver4j.Semver;
 import org.hamcrest.core.IsInstanceOf;
@@ -46,7 +46,7 @@ class ArtifactDownloaderFactoryTest {
     S3SdkClientFactory s3SdkClientFactory;
 
     @Mock
-    GreengrassComponentServiceClientFactory greengrassComponentServiceClientFactory;
+    GreengrassServiceClientFactory greengrassServiceClientFactory;
 
     @Mock
     ComponentStore componentStore;
@@ -59,7 +59,7 @@ class ArtifactDownloaderFactoryTest {
     @BeforeEach
     public void setup() {
         artifactDownloaderFactory =
-                new ArtifactDownloaderFactory(s3SdkClientFactory, greengrassComponentServiceClientFactory,
+                new ArtifactDownloaderFactory(s3SdkClientFactory, greengrassServiceClientFactory,
                         componentStore, context);
     }
 

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
@@ -7,12 +7,12 @@ package com.aws.greengrass.componentmanager.builtins;
 
 import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.ComponentTestResourceHelper;
-import com.aws.greengrass.componentmanager.GreengrassComponentServiceClientFactory;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.RecipeMetadata;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.RetryUtils;
 import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,9 +29,9 @@ import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpResponse;
-import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
-import software.amazon.awssdk.services.greengrassv2.model.GetComponentVersionArtifactRequest;
-import software.amazon.awssdk.services.greengrassv2.model.GetComponentVersionArtifactResponse;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+import software.amazon.awssdk.services.greengrassv2data.model.GetComponentVersionArtifactRequest;
+import software.amazon.awssdk.services.greengrassv2data.model.GetComponentVersionArtifactResponse;
 
 import java.io.IOException;
 import java.net.URI;
@@ -70,15 +70,15 @@ class GreengrassRepositoryDownloaderTest {
     @Mock
     private SdkHttpClient httpClient;
     @Mock
-    private GreengrassV2Client client;
+    private GreengrassV2DataClient client;
     @Mock
-    private GreengrassComponentServiceClientFactory clientFactory;
+    private GreengrassServiceClientFactory clientFactory;
     @Mock
     private ComponentStore componentStore;
 
     @BeforeEach
     void beforeEach() {
-        lenient().when(clientFactory.getCmsClient()).thenReturn(client);
+        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use new pre-release data plane SDK which contains two existing component service APIs and three new client device APIs

**Why is this change necessary:**
client device management components need to integrate with greengrass cloud

**How was this change tested:**
existing tests pass

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
