### PR TITLE
Hibernate component IPC interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.0.0-HIB-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.ipc.AuthenticationHandler;
 import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceException;
 import com.aws.greengrass.logging.api.LogEventBuilder;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.util.Coerce;
@@ -342,6 +343,29 @@ public class GenericExternalService extends GreengrassService {
                 && State.STARTING.equals(getState())) {
             handleRunScript();
         }
+    }
+
+    /**
+     * Paused a running component.
+     *
+     * @throws ServiceException Error processing pause request.
+     */
+    public void pause() throws ServiceException {
+        // TODO impl
+    }
+
+    /**
+     * Resume a paused component.
+     *
+     * @throws ServiceException Error processing resume request.
+     */
+    public void resume() throws ServiceException {
+        // TODO impl
+    }
+
+    public boolean isPaused() {
+        // TODO impl
+        return false;
     }
 
     @SuppressWarnings("PMD.CloseResource")

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractDeleteThingShadowOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractDeleteThingShadowOperationHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractDeleteThingShadowOperationHandler extends OperationContinuationHandler<DeleteThingShadowRequest, DeleteThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractDeleteThingShadowOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<DeleteThingShadowRequest, DeleteThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getDeleteThingShadowModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetThingShadowOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetThingShadowOperationHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import software.amazon.awssdk.aws.greengrass.model.GetThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.GetThingShadowResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractGetThingShadowOperationHandler extends OperationContinuationHandler<GetThingShadowRequest, GetThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractGetThingShadowOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<GetThingShadowRequest, GetThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getGetThingShadowModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListNamedShadowsForThingOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListNamedShadowsForThingOperationHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import software.amazon.awssdk.aws.greengrass.model.ListNamedShadowsForThingRequest;
+import software.amazon.awssdk.aws.greengrass.model.ListNamedShadowsForThingResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractListNamedShadowsForThingOperationHandler extends OperationContinuationHandler<ListNamedShadowsForThingRequest, ListNamedShadowsForThingResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractListNamedShadowsForThingOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<ListNamedShadowsForThingRequest, ListNamedShadowsForThingResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getListNamedShadowsForThingModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPauseComponentOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPauseComponentOperationHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import software.amazon.awssdk.aws.greengrass.model.PauseComponentRequest;
+import software.amazon.awssdk.aws.greengrass.model.PauseComponentResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractPauseComponentOperationHandler extends OperationContinuationHandler<PauseComponentRequest, PauseComponentResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractPauseComponentOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<PauseComponentRequest, PauseComponentResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getPauseComponentModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractResumeComponentOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractResumeComponentOperationHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import software.amazon.awssdk.aws.greengrass.model.ResumeComponentRequest;
+import software.amazon.awssdk.aws.greengrass.model.ResumeComponentResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractResumeComponentOperationHandler extends OperationContinuationHandler<ResumeComponentRequest, ResumeComponentResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractResumeComponentOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<ResumeComponentRequest, ResumeComponentResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getResumeComponentModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateThingShadowOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateThingShadowOperationHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractUpdateThingShadowOperationHandler extends OperationContinuationHandler<UpdateThingShadowRequest, UpdateThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractUpdateThingShadowOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<UpdateThingShadowRequest, UpdateThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getUpdateThingShadowModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -5,17 +5,16 @@
 
 package software.amazon.awssdk.aws.greengrass;
 
-import java.lang.Override;
-import java.lang.String;
+import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceHandler;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceModel;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
-import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceHandler;
-import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceModel;
-import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
 public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler {
   public static final String SERVICE_NAMESPACE = "aws.greengrass";
@@ -74,6 +73,9 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String LIST_NAMED_SHADOWS_FOR_THING = SERVICE_NAMESPACE + "#ListNamedShadowsForThing";
 
+  public static final String PAUSE_COMPONENT = SERVICE_NAMESPACE + "#PauseComponent";
+
+  public static final String RESUME_COMPONENT = SERVICE_NAMESPACE + "#ResumeComponent";
   static {
     SERVICE_OPERATION_SET = new HashSet();
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_IOT_CORE);
@@ -102,6 +104,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(UPDATE_THING_SHADOW);
     SERVICE_OPERATION_SET.add(GET_THING_SHADOW);
     SERVICE_OPERATION_SET.add(LIST_NAMED_SHADOWS_FOR_THING);
+    SERVICE_OPERATION_SET.add(PAUSE_COMPONENT);
+    SERVICE_OPERATION_SET.add(RESUME_COMPONENT);
   }
 
   private final Map<String, Function<OperationContinuationHandlerContext, ? extends ServerConnectionContinuationHandler>> operationSupplierMap;
@@ -223,6 +227,16 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setCreateLocalDeploymentHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractCreateLocalDeploymentOperationHandler> handler) {
     operationSupplierMap.put(CREATE_LOCAL_DEPLOYMENT, handler);
+  }
+
+  public void setPauseComponentHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractPauseComponentOperationHandler> handler) {
+    operationSupplierMap.put(PAUSE_COMPONENT, handler);
+  }
+
+  public void setResumeComponentHandler(
+          Function<OperationContinuationHandlerContext, GeneratedAbstractResumeComponentOperationHandler> handler) {
+    operationSupplierMap.put(RESUME_COMPONENT, handler);
   }
 
   @Override

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.eventstreamrpc;
+
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Useful to set as a handler for an operation with no implementation yet.
+ */
+public class DebugLoggingOperationHandler extends OperationContinuationHandler
+        <EventStreamJsonMessage, EventStreamJsonMessage, EventStreamJsonMessage, EventStreamJsonMessage> {
+    private static Logger LOGGER = LoggerFactory.getLogger(DebugLoggingOperationHandler.class);
+    private final OperationModelContext operationModelContext;
+
+    public DebugLoggingOperationHandler(final OperationModelContext modelContext, final OperationContinuationHandlerContext context) {
+        super(context);
+        this.operationModelContext = modelContext;
+    }
+
+    @Override
+    public OperationModelContext<EventStreamJsonMessage, EventStreamJsonMessage, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext() {
+        return operationModelContext;
+    }
+
+    /**
+     * Called when the underlying continuation is closed. Gives operations a chance to cleanup whatever
+     * resources may be on the other end of an open stream. Also invoked when an underlying ServerConnection
+     * is closed associated with the stream/continuation
+     */
+    @Override
+    protected void onStreamClosed() {
+        LOGGER.info("{} operation onStreamClosed()", operationModelContext.getOperationName());
+    }
+
+    @Override
+    public EventStreamJsonMessage handleRequest(EventStreamJsonMessage request) {
+        LOGGER.info("{} operation handleRequest() ::  {}", operationModelContext.getOperationName(),
+                operationModelContext.getServiceModel().toJson(request));
+        return new EventStreamJsonMessage() {
+            @Override
+            public byte[] toPayload(Gson gson) {
+                return "{}".getBytes(StandardCharsets.UTF_8);
+            }
+
+            @Override
+            public String getApplicationModelType() {
+                return operationModelContext.getResponseApplicationModelType();
+            }
+        };
+    }
+
+    @Override
+    public void handleStreamEvent(EventStreamJsonMessage streamRequestEvent) {
+        LOGGER.info("{} operation handleStreamEvent() ::  {}", operationModelContext.getOperationName(),
+                operationModelContext.getServiceModel().toJson(streamRequestEvent));
+    }
+}

--- a/src/test/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgentTest.java
@@ -5,8 +5,14 @@
 
 package com.aws.greengrass.builtin.services.lifecycle;
 
+import com.aws.greengrass.authorization.AuthorizationHandler;
+import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.lifecyclemanager.GenericExternalService;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Pair;
@@ -14,16 +20,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 import software.amazon.awssdk.aws.greengrass.model.DeferComponentUpdateRequest;
 import software.amazon.awssdk.aws.greengrass.model.DeferComponentUpdateResponse;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.PauseComponentRequest;
 import software.amazon.awssdk.aws.greengrass.model.ReportedLifecycleState;
 import software.amazon.awssdk.aws.greengrass.model.ResourceNotFoundError;
+import software.amazon.awssdk.aws.greengrass.model.ResumeComponentRequest;
 import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToComponentUpdatesRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToComponentUpdatesResponse;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.aws.greengrass.model.UpdateStateRequest;
 import software.amazon.awssdk.aws.greengrass.model.UpdateStateResponse;
 import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
@@ -33,19 +44,28 @@ import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.aws.greengrass.ipc.modules.LifecycleIPCService.LIFECYCLE_SERVICE_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class LifecycleIPCEventStreamAgentTest {
 
     private static final String TEST_SERVICE = "TestService";
+    private static final String TEST_TARGET_COMPONENT = "TestTargetComponent";
 
     LifecycleIPCEventStreamAgent lifecycleIPCEventStreamAgent;
 
@@ -58,6 +78,12 @@ class LifecycleIPCEventStreamAgentTest {
     @Mock
     AuthenticationData mockAuthenticationData;
 
+    @Mock
+    AuthorizationHandler authorizationHandler;
+
+    @Mock
+    GenericExternalService targetComponent;
+
     @BeforeEach
     void setup() {
         when(mockContext.getContinuation()).thenReturn(mock(ServerConnectionContinuation.class));
@@ -65,6 +91,7 @@ class LifecycleIPCEventStreamAgentTest {
         when(mockAuthenticationData.getIdentityLabel()).thenReturn(TEST_SERVICE);
         lifecycleIPCEventStreamAgent = new LifecycleIPCEventStreamAgent();
         lifecycleIPCEventStreamAgent.setKernel(kernel);
+        lifecycleIPCEventStreamAgent.setAuthorizationHandler(authorizationHandler);
     }
 
     @Test
@@ -184,5 +211,315 @@ class LifecycleIPCEventStreamAgentTest {
         deferComponentUpdateRequest.setRecheckAfterMs(1000L);
         assertThrows(InvalidArgumentsError.class, () -> lifecycleIPCEventStreamAgent.getDeferComponentHandler(mockContext)
                 .handleRequest(deferComponentUpdateRequest));
+    }
+
+    // Pause component tests
+    @Test
+    void GIVEN_pause_component_request_WHEN_successful_THEN_return_response()
+            throws ServiceException, AuthorizationException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(targetComponent);
+        when(targetComponent.getState()).thenReturn(State.RUNNING);
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        PauseComponentRequest request = new PauseComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertNotNull(lifecycleIPCEventStreamAgent.getPauseComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.PAUSE_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent).getState();
+        verify(targetComponent).pause();
+    }
+
+    @Test
+    void GIVEN_pause_component_request_WHEN_failure_THEN_return_service_error()
+            throws AuthorizationException, ServiceException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(targetComponent);
+        when(targetComponent.getState()).thenReturn(State.RUNNING);
+        doThrow(new ServiceException("Failed to pause")).when(targetComponent).pause();
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        PauseComponentRequest request = new PauseComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(ServiceError.class, () ->
+                lifecycleIPCEventStreamAgent.getPauseComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.PAUSE_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent).getState();
+        verify(targetComponent).pause();
+    }
+
+    @Test
+    void GIVEN_pause_component_request_WHEN_component_name_input_not_present_THEN_return_invalid_error()
+            throws AuthorizationException, ServiceException {
+        assertThrows(InvalidArgumentsError.class, () ->
+                lifecycleIPCEventStreamAgent.getPauseComponentHandler(mockContext)
+                        .handleRequest(new PauseComponentRequest()));
+
+        verify(authorizationHandler, never()).isAuthorized(any(), any());
+        verify(kernel, never()).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).getState();
+        verify(targetComponent, never()).pause();
+    }
+
+    @Test
+    void GIVEN_pause_component_request_WHEN_unauthorized_THEN_return_auth_error()
+            throws AuthorizationException, ServiceException {
+        when(authorizationHandler.isAuthorized(any(), any())).thenThrow(new AuthorizationException("Unauthorized"));
+
+        PauseComponentRequest request = new PauseComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(UnauthorizedError.class, () ->
+                lifecycleIPCEventStreamAgent.getPauseComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.PAUSE_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel, never()).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).getState();
+        verify(targetComponent, never()).pause();
+    }
+
+    @Test
+    void GIVEN_pause_component_request_WHEN_component_not_present_THEN_return_resource_not_found_error()
+            throws ServiceException, AuthorizationException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenThrow(new ServiceLoadException("Failed to load"));
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        PauseComponentRequest request = new PauseComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(ResourceNotFoundError.class, () ->
+                lifecycleIPCEventStreamAgent.getPauseComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.PAUSE_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).getState();
+        verify(targetComponent, never()).pause();
+    }
+
+    @Test
+    void GIVEN_pause_component_request_WHEN_component_not_running_THEN_return_invalid_error()
+            throws ServiceException, AuthorizationException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(targetComponent);
+        when(targetComponent.getState()).thenReturn(State.FINISHED);
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        PauseComponentRequest request = new PauseComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(InvalidArgumentsError.class, () ->
+                lifecycleIPCEventStreamAgent.getPauseComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.PAUSE_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent).getState();
+        verify(targetComponent, never()).pause();
+    }
+
+    @Test
+    void GIVEN_pause_component_request_WHEN_component_not_external_THEN_return_invalid_error()
+            throws ServiceException, AuthorizationException {
+        GreengrassService mockInternalComponent = mock(GreengrassService.class);
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(mockInternalComponent);
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        PauseComponentRequest request = new PauseComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(InvalidArgumentsError.class, () ->
+                lifecycleIPCEventStreamAgent.getPauseComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.PAUSE_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).getState();
+        verify(targetComponent, never()).pause();
+    }
+
+    // Resume component tests
+    @Test
+    void GIVEN_resume_component_request_WHEN_successful_THEN_return_response()
+            throws AuthorizationException, ServiceException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(targetComponent);
+        when(targetComponent.isPaused()).thenReturn(true);
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        ResumeComponentRequest request = new ResumeComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertNotNull(lifecycleIPCEventStreamAgent.getResumeComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.RESUME_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent).isPaused();
+        verify(targetComponent).resume();
+    }
+
+    @Test
+    void GIVEN_resume_component_request_WHEN_failure_THEN_return_service_error()
+            throws AuthorizationException, ServiceException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(targetComponent);
+        when(targetComponent.isPaused()).thenReturn(true);
+        doThrow(new ServiceException("Failed to resume")).when(targetComponent).resume();
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        ResumeComponentRequest request = new ResumeComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(ServiceError.class, () ->
+                lifecycleIPCEventStreamAgent.getResumeComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.RESUME_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent).isPaused();
+        verify(targetComponent).resume();
+    }
+
+    @Test
+    void GIVEN_resume_component_request_WHEN_component_name_input_not_present_THEN_return_invalid_error()
+            throws ServiceException, AuthorizationException {
+        ResumeComponentRequest request = new ResumeComponentRequest();
+        assertThrows(InvalidArgumentsError.class, () ->
+                lifecycleIPCEventStreamAgent.getResumeComponentHandler(mockContext).handleRequest(request));
+
+        verify(authorizationHandler, never()).isAuthorized(any(), any());
+        verify(kernel, never()).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).isPaused();
+        verify(targetComponent, never()).resume();
+    }
+
+    @Test
+    void GIVEN_resume_component_request_WHEN_unauthorized_THEN_return_auth_error()
+            throws AuthorizationException, ServiceException {
+        when(authorizationHandler.isAuthorized(any(), any())).thenThrow(new AuthorizationException("Unauthorized"));
+
+        ResumeComponentRequest request = new ResumeComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(UnauthorizedError.class, () ->
+                lifecycleIPCEventStreamAgent.getResumeComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.RESUME_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel, never()).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).isPaused();
+        verify(targetComponent, never()).resume();
+    }
+
+    @Test
+    void GIVEN_resume_component_request_WHEN_component_not_present_THEN_return_resource_not_found_error()
+            throws ServiceException, AuthorizationException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenThrow(new ServiceLoadException("Failed to load"));
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        ResumeComponentRequest request = new ResumeComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(ResourceNotFoundError.class, () ->
+                lifecycleIPCEventStreamAgent.getResumeComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.RESUME_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).isPaused();
+        verify(targetComponent, never()).resume();
+    }
+
+    @Test
+    void GIVEN_resume_component_request_WHEN_component_not_paused_THEN_return_invalid_error()
+            throws ServiceException, AuthorizationException {
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(targetComponent);
+        when(targetComponent.isPaused()).thenReturn(false);
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        ResumeComponentRequest request = new ResumeComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(InvalidArgumentsError.class, () ->
+                lifecycleIPCEventStreamAgent.getResumeComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.RESUME_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent).isPaused();
+        verify(targetComponent, never()).resume();
+    }
+
+    @Test
+    void GIVEN_resume_component_request_WHEN_component_not_external_THEN_return_invalid_error()
+            throws ServiceException, AuthorizationException {
+        GreengrassService mockInternalComponent = mock(GreengrassService.class);
+        when(kernel.locate(TEST_TARGET_COMPONENT)).thenReturn(mockInternalComponent);
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        ResumeComponentRequest request = new ResumeComponentRequest();
+        request.setComponentName(TEST_TARGET_COMPONENT);
+        assertThrows(InvalidArgumentsError.class, () ->
+                lifecycleIPCEventStreamAgent.getResumeComponentHandler(mockContext).handleRequest(request));
+
+        ArgumentCaptor<Permission> permissionArg = ArgumentCaptor.forClass(Permission.class);
+        verify(authorizationHandler).isAuthorized(eq(LIFECYCLE_SERVICE_NAME), permissionArg.capture());
+        Permission permission = permissionArg.getValue();
+        assertThat(permission.getOperation(), is(GreengrassCoreIPCService.RESUME_COMPONENT));
+        assertThat(permission.getPrincipal(), is(TEST_SERVICE));
+        assertThat(permission.getResource(), is(TEST_TARGET_COMPONENT));
+
+        verify(kernel).locate(TEST_TARGET_COMPONENT);
+        verify(targetComponent, never()).isPaused();
+        verify(targetComponent, never()).resume();
     }
 }

--- a/src/test/java/com/aws/greengrass/ipc/modules/LifecycleIPCServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/modules/LifecycleIPCServiceTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.ipc.modules;
 
+import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.builtin.services.lifecycle.LifecycleIPCEventStreamAgent;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractDeferComponentUpdateOperationHandler;
+import software.amazon.awssdk.aws.greengrass.GeneratedAbstractPauseComponentOperationHandler;
+import software.amazon.awssdk.aws.greengrass.GeneratedAbstractResumeComponentOperationHandler;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractSubscribeToComponentUpdatesOperationHandler;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractUpdateStateOperationHandler;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
@@ -38,11 +41,15 @@ class LifecycleIPCServiceTest {
     @Mock
     OperationContinuationHandlerContext mockContext;
 
+    @Mock
+    private AuthorizationHandler authorizationHandler;
+
     @BeforeEach
     public void setup() {
         lifecycleIPCService = new LifecycleIPCService();
         lifecycleIPCService.setEventStreamAgent(eventStreamAgent);
         lifecycleIPCService.setGreengrassCoreIPCService(greengrassCoreIPCService);
+        lifecycleIPCService.setAuthorizationHandler(authorizationHandler);
     }
 
     @Test
@@ -70,5 +77,19 @@ class LifecycleIPCServiceTest {
                         GeneratedAbstractDeferComponentUpdateOperationHandler>)argumentCaptor.getValue();
         deferHandler.apply(mockContext);
         verify(eventStreamAgent).getDeferComponentHandler(mockContext);
+
+        verify(greengrassCoreIPCService).setPauseComponentHandler(argumentCaptor.capture());
+        Function<OperationContinuationHandlerContext, GeneratedAbstractPauseComponentOperationHandler> pauseHandler =
+                (Function<OperationContinuationHandlerContext,
+                        GeneratedAbstractPauseComponentOperationHandler>)argumentCaptor.getValue();
+        pauseHandler.apply(mockContext);
+        verify(eventStreamAgent).getPauseComponentHandler(mockContext);
+
+        verify(greengrassCoreIPCService).setResumeComponentHandler(argumentCaptor.capture());
+        Function<OperationContinuationHandlerContext, GeneratedAbstractResumeComponentOperationHandler> resumeHandler =
+                (Function<OperationContinuationHandlerContext,
+                        GeneratedAbstractResumeComponentOperationHandler>)argumentCaptor.getValue();
+        resumeHandler.apply(mockContext);
+        verify(eventStreamAgent).getResumeComponentHandler(mockContext);
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
Adding IPC APIs for pause/resume component operations

**Why is this change necessary:**
We are working on adding pause/resume(hibernate on demand) component capability to let customers better manage which components can consume resources dynamically

**How was this change tested:**
Unit tests added, pass locally, currently build will fail due to sdk client not having been updated yet, working on that atm

**Any additional information or context required to review the change:**
Note - ignore the shadow APIs related generated code, that's coming up due to another set of APIs being developed in parallel

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
