### PR TITLE
feat(windows): add loader.cmd batch script

### DIFF
--- a/.license/style.xml
+++ b/.license/style.xml
@@ -16,4 +16,14 @@
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>
     </java_style>
+    <batch>
+        <firstLine>@REM -------------------------------</firstLine>
+        <beforeEachLine>@REM </beforeEachLine>
+        <endLine>@REM -------------------------------</endLine>
+        <firstLineDetectionPattern>@REM(\\s|\\t)*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>@REM(\\s|\\t)*.*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </batch>
 </additionalHeaders>

--- a/assembly.xml
+++ b/assembly.xml
@@ -17,6 +17,7 @@
             <directory>${basedir}/scripts</directory>
             <outputDirectory>/bin</outputDirectory>
             <includes>
+                <include>loader.cmd</include>
                 <include>loader</include>
                 <include>greengrass.service.template</include>
             </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,7 @@
                     </licenseSets>
                     <mapping>
                         <java>JAVA_STYLE</java>
+                        <cmd>BATCH</cmd>
                     </mapping>
                 </configuration>
                 <executions>

--- a/scripts/loader.cmd
+++ b/scripts/loader.cmd
@@ -1,0 +1,138 @@
+@REM -------------------------------
+@REM Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+@REM SPDX-License-Identifier: Apache-2.0
+@REM -------------------------------
+@echo off
+SETLOCAL EnableDelayedExpansion
+SET DIR=%~dp0
+
+@REM Get the root GG directory (generally /greengrass/v2)
+FOR %%I IN ("%DIR%\..\..\..\..") DO SET "GG_ROOT=%%~fI"
+SET LAUNCH_DIR=%GG_ROOT%\alts\current
+@REM SET CONFIG_FILE=""
+
+SET IS_SYMLINK=0
+CALL :directory_is_symlink "%GG_ROOT%\alts\new" IS_SYMLINK
+IF %IS_SYMLINK% EQU 1 (
+    CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 0 (
+        CALL :directory_is_symlink "%LAUNCH_DIR%" IS_SYMLINK
+        IF !IS_SYMLINK! EQU 1 (
+            CALL :flip_links "%LAUNCH_DIR%" "%GG_ROOT%\alts\old"
+        )
+    )
+    CALL :flip_links "%GG_ROOT%\alts\new" "%LAUNCH_DIR%"
+)
+
+CALL :directory_is_symlink "%GG_ROOT%\alts\broken" IS_SYMLINK
+IF !IS_SYMLINK! EQU 1 (
+    CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 1 (
+        CALL :flip_links "%GG_ROOT%\alts\old" "%LAUNCH_DIR%"
+    )
+)
+
+CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+IF !IS_SYMLINK! EQU 1 (
+    CALL :directory_is_symlink "%LAUNCH_DIR%" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 0 (
+        CALL :flip_links "%GG_ROOT%\alts\old" "%LAUNCH_DIR%"
+    )
+)
+
+@REM EXIST works for files, directories, and symlink dirs
+IF NOT EXIST %LAUNCH_DIR% (
+    ECHO FATAL: No Nucelus found!
+    EXIT /B 1
+)
+
+@REM Get JVM_OPTIONS from launch.params if it exists
+IF EXIST %LAUNCH_DIR%\launch.params (
+    FOR /F "delims=" %%A IN (%LAUNCH_DIR%\launch.params) DO SET JVM_OPTIONS=%%A
+)
+
+SET JVM_OPTIONS=%JVM_OPTIONS% -Droot="%GG_ROOT%"
+SET OPTIONS=--setup-system-service false
+
+ECHO JVM options: %JVM_OPTIONS%
+ECHO Nucleus options: %OPTIONS%
+SET /A MAX_RETRIES=3
+@REM Attempt to start the nucleus 3 times
+FOR /L %%i IN (1,1,%MAX_RETRIES%) DO (
+    java -Dlog.store=FILE %JVM_OPTIONS% -jar "%LAUNCH_DIR%\distro\lib\Greengrass.jar" %OPTIONS%
+    SET KERNEL_EXIT_CODE=%ERRORLEVEL%
+
+    IF KERNEL_EXIT_CODE EQU 0 (
+        ECHO Restarting Nucleus
+        %LAUNCH_DIR%\distroy\bin\loader.cmd
+    ) ELSE (
+    IF KERNEL_EXIT_CODE EQU 100 (
+        ECHO Restarting Nucleus
+        %LAUNCH_DIR%\distroy\bin\loader.cmd
+    ) ELSE (
+    IF KERNEL_EXIT_CODE EQU 101 (
+        ECHO Rebooting host
+        SHUTDOWN /R
+    ) ELSE (
+        ECHO Nucleus exited %KERNEL_EXIT_CODE%. Attempt %%i out of %MAX_RETRIES%
+    )))
+)
+
+CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK
+IF !IS_SYMLINK! EQU 1 (
+    CALL :directory_is_symlink "%LAUNCH_DIR%" IS_SYMLINK
+    IF !IS_SYMLINK! EQU 1 (
+        CALL :flip_links "%LAUNCH_DIR%" "%GG_ROOT%\alts\broken"
+        CALL :flip_links "%GG_ROOT%\alts\old" "%LAUNCH_DIR%"
+    )
+)
+
+EXIT /B %KERNEL_EXIT_CODE%
+
+@REM ==========================================================
+@REM ================== FUNCTION DEFINITIONS ==================
+@REM ==========================================================
+
+@REM Checks if directory is a symlink by checking its attributes
+@REM @param1 directory to test
+@REM @param2 out varialbe (pass by reference)
+@REM    1 = @param1 is a symlinked directory
+@REM    0 = @param1 is NOT a symlink
+:directory_is_symlink
+SET RETURN_VALUE=0
+if EXIST %1 (
+    FOR %%I IN (%1) DO SET attribs=%%~aI
+    @REM The 8th element of directory attributes indicate if it is a reparse point (symlink)
+    if "!attribs:~8,1!" EQU "l" (
+        if "!attribs:~0,1!" EQU "d" (
+            SET RETURN_VALUE=1
+        )
+    ) ELSE (
+        SET RETURN_VALUE=0
+    )
+)
+SET %~2=%RETURN_VALUE%
+EXIT /B 0
+
+@REM Gets the source of symlink @param1 and points symlink @param2 to that source
+@REM Removes @param1 symlink
+:flip_links
+@REM Delete symlink @param2 because it will be overwritten with the source of @param1
+RMDIR %2 2>NUL || :
+
+@REM Split the parent directory from fully qualified path and file name
+FOR %%I IN (%1) DO SET PARENT_DIR=%%~dpI && SET DIR_NAME=%%~nxI
+
+@REM Get linked dir information using some regex
+@REM Example output:
+@REM    04/08/2021  05:19 PM    <SYMLINKD>     current [C:\greengrass\v2\alts\init]
+FOR /F "delims=" %%I IN ('DIR /A:L %PARENT_DIR% ^| FINDSTR /R /C:"\<SYMLINKD\>[ ]*%DIR_NAME%[ ]*\[.*\]$"') DO SET DIR_OUT=%%I
+@REM Get second token (B starting from A) when considering [] as delimiters
+FOR /F "tokens=1,2 delims=[]" %%A IN ("%DIR_OUT%") DO SET SOURCE_FILE=%%B
+
+@REM Create new symlink with @param2's name and point towards @param1's source
+MKLINK /D %2 "%SOURCE_FILE%" >NUL
+
+@REM Remove @param1
+RMDIR %1 2>NUL || : 
+EXIT /B 0


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
New File: **loader.cmd**
Excluded **loader.cmd** from maven license plugin (it wasn't recognizing comment style of _@REM_)
Included **loader.cmd** in zip package

**Known issue:**
If the symlink **target** contains brackets in the name, then the function to flip the symlinks will not correctly set the symlink target.

**Why is this change necessary:**
The existing **loader** shell script does NOT work on Windows platforms. This new **loader.cmd** replicates the behavior in the existing **loader** shell script but for Windows platforms.

**How was this change tested:**
1 .Created a zip via the following command:
`mvn -DskipTests clean package`
I had to skip tests because there are existing tests that do not pass on Windows.

2. Deployed Greengrass without starting the Nucleus by running the **<GreengrassCoreRootDirectory>/lib/Greengrass.jar** with *--start false* flag. 

3. Ran **loader.cmd** from Greengrass directory (**\greengrass\v2\alts\current\distory\bin**)

4. Observed output and observed Greengrass logs in **\greengrass\v2\logs\** for proof Greengrass Nucleus running and logging.

5. Stopped Nucleus via Ctrl+C

6. Observed Greengrass logs for termination confirmation:
> com.aws.greengrass.lifecyclemanager.Kernel: Shutting down Nucleus due to external signal. {}

Note: Error seen in greengrass.log
> com.aws.greengrass.deployment.DeviceConfiguration: Unable to set up Nucleus from build recipe file. {}
com.aws.greengrass.componentmanager.exceptions.PackageLoadingException: Failed to load Nucleus recipe
	at com.aws.greengrass.deployment.DeviceConfiguration.initializeNucleusFromRecipe(DeviceConfiguration.java:371)
	at com.aws.greengrass.lifecyclemanager.Kernel.parseArgs(Kernel.java:637)
	at com.aws.greengrass.easysetup.GreengrassSetup.performSetup(GreengrassSetup.java:269)
	at com.aws.greengrass.easysetup.GreengrassSetup.main(GreengrassSetup.java:242)

Is this an existing Windows bug?

7. Observed existing java.exe process end and a new process spin up (the loader script retries 3 times)

Broken deployment testing:
started with _alts/new_ symlinked to a folder without a JAR and _alts/current_ symlinked to a functioning release.
End result:
because JAR couldn't be accessed (because it doesn't exist) the it looped 3 times to start, failed and created a symlink _alts/broken_ pointing towards the broken deployment and _alts/current_ continued to point at the working directory.

New deployment testing:
started with _alts/new_ symlinked to a new deployment and _alts/current_ symlinked to a previous deployment
End result:
_alts/current_ got moved to _alts/old_ and _alts/new_ got moved to _alts/current_

New deployment with an existing _alts/broken_ symlink:
started with _alts/broken, alts/current,_ and _alts/new_.
_alts/current_ symlink was renamed to _alts/old_
_alts/new_ symlink was renamed to _alts/current_
_alts/old_ symlink was renamed to _alts/current_

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
