### PR TITLE
fix(windows): fix GenericExternalServiceTest

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/service_error_recovery_step_fixes_service.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/service_error_recovery_step_fixes_service.yaml
@@ -24,6 +24,19 @@ services:
           script: |-
             echo Fixing ServiceA
             rm ErrorIndicator
+      windows:
+        install:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& echo $null > ErrorIndicator"
+        startup:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& { if (Test-Path ErrorIndicator) { echo "Startup Failed"; exit 1; } }"
+        recover:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& echo Fixing ServiceA; del ErrorIndicator"
 
   main:
     dependencies:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix `GenericExternalServiceTest.GIVEN_service_has_recovery_step_WHEN_recovery_logic_fixes_issue_THEN_service_recovers`
on Windows.

**Why is this change necessary:**

**How was this change tested:**
Tested locally with Intellij

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
