### PR TITLE
build: remove netty client from dependency closure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,15 +97,6 @@
             <version>2.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>greengrassv2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>greengrassv2-data</artifactId>
-            <version>2.15.x-SNAPSHOT</version>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.10</version>
@@ -127,24 +118,75 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>greengrassv2</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>greengrassv2-data</artifactId>
+            <version>2.15.x-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>iot</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>iam</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Temporary, need to remove when docker image downloading moves out of the Nucleus -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecr</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.zeroturnaround</groupId>
@@ -621,6 +663,12 @@
                                     <artifact>software.amazon.awssdk:apache-client:jar:*</artifact>
                                     <excludes>
                                         <exclude>software.amazon.awssdk.http.apache.internal.conn.SdkTlsSocketFactory.class</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:jar:*</artifact>
+                                    <excludes>
+                                        <exclude>*.a</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.tes.LazyCredentialProvider;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.ProxyUtils;
 import lombok.AllArgsConstructor;
-import org.apache.commons.codec.binary.Base64;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ecr.EcrClient;
@@ -21,6 +20,7 @@ import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest;
 import software.amazon.awssdk.services.ecr.model.ServerException;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import javax.inject.Inject;
 
@@ -67,8 +67,8 @@ public class EcrAccessor {
                     .authorizationData().get(0);
             // Decoded auth token is of the format <username>:<password>
             String[] authTokenParts =
-                    new String(Base64.decodeBase64(authorizationData.authorizationToken()), StandardCharsets.UTF_8)
-                            .split(":");
+                    new String(Base64.getDecoder().decode(authorizationData.authorizationToken()),
+                            StandardCharsets.UTF_8).split(":");
             return new Registry.Credentials(authTokenParts[0], authTokenParts[1],
                     authorizationData.expiresAt());
         } catch (ServerException | SdkClientException e) {

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -212,9 +212,9 @@ public class DeviceProvisioningHelper {
         // Find or create IoT policy
         try {
             client.getPolicy(GetPolicyRequest.builder().policyName(policyName).build());
-            outStream.println(String.format("Found IoT policy \"%s\", reusing it", policyName));
+            outStream.printf("Found IoT policy \"%s\", reusing it%n", policyName);
         } catch (ResourceNotFoundException e) {
-            outStream.println(String.format("Creating new IoT policy \"%s\"", policyName));
+            outStream.printf("Creating new IoT policy \"%s\"%n", policyName);
             client.createPolicy(CreatePolicyRequest.builder().policyName(policyName).policyDocument(
                     "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n"
                             + "      \"Effect\": \"Allow\",\n      \"Action\": [\n"
@@ -236,7 +236,7 @@ public class DeviceProvisioningHelper {
                 AttachPolicyRequest.builder().policyName(policyName).target(keyResponse.certificateArn()).build());
 
         // Create the thing and attach the cert to it
-        outStream.println(String.format("Creating IoT Thing \"%s\"...", thingName));
+        outStream.printf("Creating IoT Thing \"%s\"...%n", thingName);
         String thingArn = client.createThing(CreateThingRequest.builder().thingName(thingName).build()).thingArn();
         outStream.println("Attaching certificate to IoT thing...");
         client.attachThingPrincipal(
@@ -282,10 +282,10 @@ public class DeviceProvisioningHelper {
      */
     private void downloadRootCAToFile(File f) throws IOException {
         if (f.exists()) {
-            outStream.println(String.format("Root CA found at \"%s\". Skipping download.", f.toString()));
+            outStream.printf("Root CA found at \"%s\". Skipping download.%n", f);
             return;
         }
-        outStream.println(String.format("Downloading Root CA from \"%s\"", ROOT_CA_URL));
+        outStream.printf("Downloading Root CA from \"%s\"%n", ROOT_CA_URL);
         downloadFileFromURL(ROOT_CA_URL, f);
     }
 
@@ -366,8 +366,7 @@ public class DeviceProvisioningHelper {
                     DescribeRoleAliasRequest.builder().roleAlias(roleAliasName).build();
             roleAliasArn = iotClient.describeRoleAlias(describeRoleAliasRequest).roleAliasDescription().roleAliasArn();
         } catch (ResourceNotFoundException ranfe) {
-            outStream.println(
-                    String.format("TES role alias \"%s\" does not exist, creating new alias...", roleAliasName));
+            outStream.printf("TES role alias \"%s\" does not exist, creating new alias...%n", roleAliasName);
 
             // Get IAM role arn in order to attach an alias to it
             String roleArn;
@@ -375,7 +374,7 @@ public class DeviceProvisioningHelper {
                 GetRoleRequest getRoleRequest = GetRoleRequest.builder().roleName(roleName).build();
                 roleArn = iamClient.getRole(getRoleRequest).role().arn();
             } catch (NoSuchEntityException | ResourceNotFoundException rnfe) {
-                outStream.println(String.format("TES role \"%s\" does not exist, creating role...", roleName));
+                outStream.printf("TES role \"%s\" does not exist, creating role...%n", roleName);
                 CreateRoleRequest createRoleRequest = CreateRoleRequest.builder().roleName(roleName).description(
                         "Role for Greengrass IoT things to interact with AWS services using token exchange service")
                         .assumeRolePolicyDocument("{\n  \"Version\": \"2012-10-17\",\n"
@@ -395,8 +394,8 @@ public class DeviceProvisioningHelper {
         try {
             iotClient.getPolicy(GetPolicyRequest.builder().policyName(iotRolePolicyName).build());
         } catch (ResourceNotFoundException e) {
-            outStream.println(String.format("IoT role policy \"%s\" for TES Role alias not exist, creating policy...",
-                    iotRolePolicyName));
+            outStream.printf("IoT role policy \"%s\" for TES Role alias not exist, creating policy...%n",
+                    iotRolePolicyName);
             CreatePolicyRequest createPolicyRequest = CreatePolicyRequest.builder().policyName(iotRolePolicyName)
                     .policyDocument("{\n\t\"Version\": \"2012-10-17\",\n\t\"Statement\": {\n"
                             + "\t\t\"Effect\": \"Allow\",\n\t\t\"Action\": \"iot:AssumeRoleWithCertificate\",\n"
@@ -465,11 +464,11 @@ public class DeviceProvisioningHelper {
             outStream.println("No managed IAM policy found, looking for user defined policy...");
         } catch (IamException e) {
             if (e.getMessage().contains("not authorized to perform")) {
-                outStream.println(String.format("Encountered error - %s; No permissions to lookup managed policy, "
-                        + "looking for a user defined policy...", e.getMessage()));
+                outStream.printf("Encountered error - %s; No permissions to lookup managed policy, "
+                        + "looking for a user defined policy...%n", e.getMessage());
             }
-            outStream.println(String.format("Exiting due to unexpected error while looking up managed policy - %s ",
-                    e.getMessage()));
+            outStream.printf("Exiting due to unexpected error while looking up managed policy - %s %n",
+                    e.getMessage());
             throw e;
         }
         // Check if a customer policy exists with the name
@@ -481,14 +480,14 @@ public class DeviceProvisioningHelper {
             outStream.println("No IAM policy found, will attempt creating one...");
         } catch (IamException e) {
             if (e.getMessage().contains("not authorized to perform")) {
-                outStream.println(String.format(
+                outStream.printf(
                         "Encountered error - %s; No permissions to lookup IAM policy, will attempt creating one. If you"
                                 + " wish to use an existing policy instead, please make sure the credentials used for "
-                                + "setup have iam::getPolicy permissions for the policy resource and retry...",
-                        e.getMessage()));
+                                + "setup have iam::getPolicy permissions for the policy resource and retry...%n",
+                        e.getMessage());
             }
-            outStream.println(String.format("Exiting due to unexpected error while looking up user defined policy - %s",
-                    e.getMessage()));
+            outStream.printf("Exiting due to unexpected error while looking up user defined policy - %s%n",
+                    e.getMessage());
             throw e;
         }
         return Optional.empty();

--- a/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
+++ b/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
@@ -5,8 +5,6 @@
 
 package com.aws.greengrass.util;
 
-import org.apache.commons.codec.binary.Base64;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +18,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 
@@ -65,13 +64,13 @@ public final class EncryptionUtils {
         if (keyString.contains(PKCS_1_PEM_HEADER)) {
             keyString = keyString.replace(PKCS_1_PEM_HEADER, "");
             keyString = keyString.replace(PKCS_1_PEM_FOOTER, "");
-            return readPkcs1PrivateKey(Base64.decodeBase64(keyString));
+            return readPkcs1PrivateKey(Base64.getMimeDecoder().decode(keyString));
         }
 
         if (keyString.contains(PKCS_8_PEM_HEADER)) {
             keyString = keyString.replace(PKCS_8_PEM_HEADER, "");
             keyString = keyString.replace(PKCS_8_PEM_FOOTER, "");
-            return readPkcs8PrivateKey(Base64.decodeBase64(keyString));
+            return readPkcs8PrivateKey(Base64.getMimeDecoder().decode(keyString));
         }
 
         return readPkcs8PrivateKey(keyBytes);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removing netty client and the `.a` files from the IoT Device SDK which aren't needed.
Saves ~7MB in our jar.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
