### PR TITLE
perf: only initialize DeviceProvisioningHelper if we are provisioning

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -173,7 +173,7 @@ public class GreengrassSetup {
     private final String[] setupArgs;
     private final List<String> kernelArgs = new ArrayList<>();
     @Setter
-    DeviceProvisioningHelper deviceProvisioningHelper;
+    private DeviceProvisioningHelper deviceProvisioningHelper;
     private final PrintStream outStream;
     private final PrintStream errStream;
     private int argpos = 0;
@@ -287,10 +287,9 @@ public class GreengrassSetup {
             throw new RuntimeException(e);
         }
 
-        //initialize the device provisioning helper
-        this.deviceProvisioningHelper = new DeviceProvisioningHelper(awsRegion, environmentStage, this.outStream);
-
         if (needProvisioning) {
+            // initialize the device provisioning helper only if we're doing provisioning
+            this.deviceProvisioningHelper = new DeviceProvisioningHelper(awsRegion, environmentStage, this.outStream);
             provision(kernel);
         }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Be more lazy about initializing the DeviceProvisioningHelper which creates many AWS SDK clients leading to increased memory usage. This change saves approximately 10MB at runtime.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
