### PR TITLE
fix(windows): disable unit tests that requires user/group on Windows

### DIFF
--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -14,6 +14,8 @@ import com.aws.greengrass.util.platforms.Platform;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -101,6 +103,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_no_default_user_WHEN_script_is_used_THEN_default_user_created_and_added_to_config() throws Exception {
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
@@ -121,6 +124,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_ggc_user_as_arg_WHEN_script_is_used_THEN_default_user_created_and_added_to_config() throws Exception {
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
@@ -144,6 +148,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_no_default_user_arg_but_user_present_in_config_WHEN_script_is_used_THEN_user_from_config_used()
             throws Exception {
         greengrassSetup =
@@ -164,6 +169,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_default_user_arg_and_user_present_in_config_WHEN_script_is_used_THEN_default_user_arg_used()
             throws Exception {
         greengrassSetup =
@@ -188,6 +194,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_default_user_WHEN_script_is_used_THEN_default_user_created() throws Exception {
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
@@ -211,6 +218,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_existing_default_user_WHEN_script_is_used_THEN_default_user_not_created() throws Exception {
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
@@ -233,6 +241,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_existing_non_default_user_WHEN_script_is_used_THEN_user_not_created_and_passed_to_kernel()
             throws Exception {
         greengrassSetup =
@@ -256,6 +265,7 @@ class GreengrassSetupTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_existing_non_default_user_no_group_WHEN_script_is_used_THEN_user_passed_to_kernel() throws Exception {
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
@@ -279,6 +289,7 @@ class GreengrassSetupTest {
 
     @ParameterizedTest
     @MethodSource("invalidUsers")
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_invalid_user_WHEN_script_is_used_THEN_error(String user, ExtensionContext context) throws Exception {
         ignoreExceptionUltimateCauseOfType(context, IOException.class);
         Kernel realKernel = new Kernel();

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
@@ -13,6 +13,8 @@ import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.platforms.Platform;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.mockito.Mock;
 
 import java.util.Collections;
@@ -179,6 +181,7 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_runwith_info_WHEN_exec_add_group_THEN_use_runwith() throws Exception {
         ges.runWith = RunWith.builder().user("foo").group("bar").build();
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently Github Action is running on Linux as well as on Windows. However we are not enforcing unit tests and integration tests to pass on Windows yet.

One functionality not implemented on Windows yet is RunWith. Tests that use RunWith as well as creating user/group for RunWith is expected to fail. I want to disable these tests for now so that we can check the result of the tests. There are tickets to followup with these tests.

The tests that need to be disabled are all unit tests. We are fixing failing integration tests in separate PRs and there is no plan to disable any integration tests.

**Why is this change necessary:**
To enable checking Github action result on Windows.

**How was this change tested:**
All unit tests should pass after this PR.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
