### PR TITLE
feat(lifecycle): hibernate implementation using cgroup freezer subsystem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>nucleus</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCHibernateTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCHibernateTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.ipc;
+
+import com.aws.greengrass.lifecyclemanager.GenericExternalService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.TestUtils;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.Pair;
+import com.aws.greengrass.util.platforms.unix.linux.Cgroup;
+import com.aws.greengrass.util.platforms.unix.linux.LinuxSystemResourceController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.model.PauseComponentRequest;
+import software.amazon.awssdk.aws.greengrass.model.ResumeComponentRequest;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.prepareKernelFromConfigFile;
+import static com.aws.greengrass.lifecyclemanager.GenericExternalService.LIFECYCLE_RUN_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith({GGExtension.class})
+class IPCHibernateTest {
+    private static final String TARGET_COMPONENT_NAME = "HibernateTarget";
+    private static final String CONTROLLER_COMPONENT_NAME = "HibernateController";
+
+    @TempDir
+    static Path tempRootDir;
+    private Kernel kernel;
+    private EventStreamRPCConnection clientConnection;
+    private SocketOptions socketOptions;
+    private GreengrassCoreIPCClient greengrassCoreIPCClient;
+
+    @AfterEach
+    void afterEach() {
+        if (clientConnection != null) {
+            clientConnection.disconnect();
+        }
+        if (socketOptions != null) {
+            socketOptions.close();
+        }
+        if (kernel != null) {
+            kernel.shutdown();
+        }
+    }
+
+    @BeforeEach
+    void beforeEach(ExtensionContext context) throws Exception {
+        ignoreExceptionWithMessage(context, "Connection reset by peer");
+        // Ignore if IPC can't send us more lifecycle updates because the test is already done.
+        ignoreExceptionUltimateCauseWithMessage(context, "Channel not found for given connection context");
+        ignoreExceptionOfType(context, InterruptedException.class);
+        ignoreExceptionOfType(context, FileSystemException.class);
+
+        System.setProperty("root", tempRootDir.toAbsolutePath().toString());
+
+        kernel =
+                prepareKernelFromConfigFile("hibernate_init_config.yaml", IPCHibernateTest.class, TARGET_COMPONENT_NAME,
+                        CONTROLLER_COMPONENT_NAME);
+        String authToken = IPCTestUtils.getAuthTokeForService(kernel, CONTROLLER_COMPONENT_NAME);
+        socketOptions = TestUtils.getSocketOptionsForIPC();
+        clientConnection = IPCTestUtils.connectToGGCOverEventStreamIPC(socketOptions, authToken, kernel);
+        greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
+    }
+
+    @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException"})
+    @EnabledOnOs({OS.LINUX})
+    @Test
+    void GIVEN_LifeCycleEventStreamClient_WHEN_pause_resume_component_THEN_target_service_paused_and_resumed()
+            throws Exception {
+        GenericExternalService component = (GenericExternalService) kernel.locate(TARGET_COMPONENT_NAME);
+        String runCmdStr = Coerce.toString(
+                component.getServiceConfig().find(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, LIFECYCLE_RUN_NAMESPACE_TOPIC));
+
+        PauseComponentRequest pauseRequest = new PauseComponentRequest();
+        pauseRequest.setComponentName(TARGET_COMPONENT_NAME);
+        greengrassCoreIPCClient.pauseComponent(pauseRequest, Optional.empty()).getResponse().get(5, TimeUnit.SECONDS);
+
+        assertTrue(component.isPaused());
+        assertThat(getCgroupFreezerState(component.getServiceName()),
+                anyOf(is(LinuxSystemResourceController.CgroupFreezerState.FROZEN),
+                        is(LinuxSystemResourceController.CgroupFreezerState.FREEZING)));
+
+        List<String> pids = Files.readAllLines(Cgroup.Freezer.getCgroupProcsPath(component.getServiceName()));
+        assertThat("Long running test component must have at least one process alive", pids, is(not(empty())));
+
+        for (String pid : pids) {
+            Pair<String, String> status = processStatus(pid);
+            assertThat("Paused process must belong to the correct paused component", runCmdStr.replaceAll("\\n", " "),
+                    containsString(status.getRight()));
+            assertThat("CPU utilization of paused component processes must be 0", status.getLeft(), is("0"));
+        }
+
+        ResumeComponentRequest resumeRequest = new ResumeComponentRequest();
+        resumeRequest.setComponentName(TARGET_COMPONENT_NAME);
+        greengrassCoreIPCClient.resumeComponent(resumeRequest, Optional.empty()).getResponse().get(5, TimeUnit.SECONDS);
+
+        assertFalse(component.isPaused());
+        assertThat(getCgroupFreezerState(component.getServiceName()),
+                is(LinuxSystemResourceController.CgroupFreezerState.THAWED));
+    }
+
+    // Pair of cpu usage and cmd for a given pid
+    private Pair<String, String> processStatus(String pid) throws IOException, InterruptedException {
+        StringBuilder op = new StringBuilder();
+        Process proc = new ProcessBuilder().command("ps", "-o", "c,cmd", "fp", pid).start();
+        proc.waitFor(5, TimeUnit.SECONDS);
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
+            br.lines().forEach(l -> op.append(l));
+        }
+
+        String cpuAndCmd = op.toString().replaceAll("C\\p{Zs}+CMD", "").trim();
+        int separator = cpuAndCmd.indexOf(' ');
+        return new Pair<>(cpuAndCmd.substring(0, separator).trim(),
+                cpuAndCmd.substring(separator + 1).replaceAll("sh -c", "")
+                        .replaceAll("^sudo -n -E -H -u [\\w\\d\\-\\p{Zs}#]* --", "").trim());
+    }
+
+    private LinuxSystemResourceController.CgroupFreezerState getCgroupFreezerState(String serviceName)
+            throws IOException {
+        return LinuxSystemResourceController.CgroupFreezerState.valueOf(
+                new String(Files.readAllBytes(Cgroup.Freezer.getCgroupFreezerStateFilePath(serviceName)),
+                        StandardCharsets.UTF_8).trim());
+    }
+}
+

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/hibernate_init_config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/hibernate_init_config.yaml
@@ -1,0 +1,47 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    version: 2.3.0
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+
+  HibernateTarget:
+    version: 1.0.0
+    lifecycle:
+      linux:
+        run: |-
+          echo HibernateTarget running
+          while true; do
+          factor 8683317618811886495518194401279999999
+          done
+
+  HibernateController:
+    version: 1.0.0
+    lifecycle:
+      linux:
+        run: |-
+          while true; do
+          date; echo HibernateController running; sleep 5
+          done
+    configuration:
+      accessControl:
+        aws.greengrass.ipc.lifecycle:
+          hibernatePolicy:
+            policyDescription: "Access to pause or resume component"
+            operations:
+              - aws.greengrass#PauseComponent
+              - aws.greengrass#ResumeComponent
+            resources:
+              - HibernateTarget
+
+  main:
+    dependencies:
+      - HibernateController
+      - HibernateTarget
+    lifecycle:
+      linux:
+        run: |-
+          while true; do
+          echo main running; sleep 5
+          done

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.ipc.modules.LifecycleIPCService.LIFECYCLE_SERVICE_NAME;
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
 import static com.aws.greengrass.ipc.modules.PubSubIPCService.PUB_SUB_SERVICE_NAME;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.ACCESS_CONTROL_NAMESPACE_TOPIC;
@@ -40,8 +41,10 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DEL
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_SECRET_VALUE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_THING_SHADOW;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.LIST_NAMED_SHADOWS_FOR_THING;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PAUSE_COMPONENT;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_TOPIC;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.RESUME_COMPONENT;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_TOPIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_THING_SHADOW;
@@ -92,6 +95,8 @@ public class AuthorizationHandler  {
                 ANY_REGEX)));
         componentToOperationsMap.put(SHADOW_MANAGER_SERVICE_NAME, new HashSet<>(Arrays.asList(GET_THING_SHADOW,
                 UPDATE_THING_SHADOW, DELETE_THING_SHADOW, LIST_NAMED_SHADOWS_FOR_THING, ANY_REGEX)));
+        componentToOperationsMap.put(LIFECYCLE_SERVICE_NAME, new HashSet<>(Arrays.asList(PAUSE_COMPONENT,
+                RESUME_COMPONENT, ANY_REGEX)));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(
                 kernel);

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -382,7 +382,7 @@ public class GenericExternalService extends GreengrassService {
             paused.set(true);
             logger.atDebug().log("Paused component");
         } catch (IOException e) {
-            logger.atDebug().log("Error pausing component");
+            logger.atError().setCause(e).log("Error pausing component");
             throw new ServiceException(String.format("Error pausing component %s", getServiceName()), e);
         }
     }
@@ -409,9 +409,10 @@ public class GenericExternalService extends GreengrassService {
                     return;
                 } catch (IOException e) {
                     if (retryOnFail && retryAttempts > 0) {
-                        logger.atDebug().log("Error resuming component, retrying");
+                        logger.atInfo().setCause(e).log("Error resuming component, retrying");
                     } else {
-                        logger.atDebug().log("Error resuming component and all retried exhausted, restarting");
+                        logger.atError().setCause(e).log("Error resuming component and all retried exhausted, "
+                                + "restarting");
                         if (restartOnFail) {
                             // Reset tracking flag
                             paused.set(false);

--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -404,6 +404,15 @@ public final class Exec implements Closeable {
     }
 
     /**
+     * Get associated process instance representing underlying OS process.
+     *
+     * @return process object.
+     */
+    public Process getProcess() {
+        return process;
+    }
+
+    /**
      * Execute a command.
      *
      * @returns the process exit code if it is not a background process.

--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -404,15 +404,6 @@ public final class Exec implements Closeable {
     }
 
     /**
-     * Get associated process instance representing underlying OS process.
-     *
-     * @return process object.
-     */
-    public Process getProcess() {
-        return process;
-    }
-
-    /**
      * Execute a command.
      *
      * @returns the process exit code if it is not a background process.
@@ -494,6 +485,11 @@ public final class Exec implements Closeable {
         return process == null ? !isClosed.get() : process.isAlive();
     }
 
+    /**
+     * Get associated process instance representing underlying OS process.
+     *
+     * @return process object.
+     */
     public Process getProcess() {
         return process;
     }

--- a/src/main/java/com/aws/greengrass/util/platforms/StubResourceController.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/StubResourceController.java
@@ -7,6 +7,8 @@ package com.aws.greengrass.util.platforms;
 
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public class StubResourceController implements SystemResourceController {
@@ -28,6 +30,16 @@ public class StubResourceController implements SystemResourceController {
 
     @Override
     public void addComponentProcess(GreengrassService component, Process process) {
+        // no op
+    }
+
+    @Override
+    public void pauseComponentProcesses(GreengrassService component, List<Process> processes) throws IOException {
+        // no op
+    }
+
+    @Override
+    public void resumeComponentProcesses(GreengrassService component) throws IOException {
         // no op
     }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/SystemResourceController.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/SystemResourceController.java
@@ -7,21 +7,24 @@ package com.aws.greengrass.util.platforms;
 
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public interface SystemResourceController {
+
     /**
      * Remove the resource controller. This method should be called when an existing generic external service is
      * removed.
      *
-     * @param component a generic external service
+     * @param component a greengrass service instance
      */
     void removeResourceController(GreengrassService component);
 
     /**
      * Update the resource limits for a generic external service.
      *
-     * @param component     a generic external service
+     * @param component     a greengrass service instance
      * @param resourceLimit resource limits
      */
     void updateResourceLimits(GreengrassService component, Map<String, Object> resourceLimit);
@@ -29,15 +32,31 @@ public interface SystemResourceController {
     /**
      * Reset the resource limits of a generic external service to system default.
      *
-     * @param component a generic external service
+     * @param component a greengrass service instance
      */
     void resetResourceLimits(GreengrassService component);
 
     /**
      * Add the processes of a generic external service to the resource controller.
-     *
-     * @param component a generic external service
+     *  @param component a greengrass service instance
      * @param process   the first process of the external service
      */
     void addComponentProcess(GreengrassService component, Process process);
+
+    /**
+     * Add the processes of a generic external service to the resource controller.
+     *
+     * @param component a greengrass service instance
+     * @param processes currently alive processes for the component
+     * @throws IOException on failure to pause
+     */
+    void pauseComponentProcesses(GreengrassService component, List<Process> processes) throws IOException;
+
+    /**
+     * Add the processes of a generic external service to the resource controller.
+     *
+     * @param component a greengrass service instance
+     * @throws IOException on failure to resume
+     */
+    void resumeComponentProcesses(GreengrassService component) throws IOException;
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/linux/Cgroup.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/linux/Cgroup.java
@@ -13,9 +13,10 @@ import java.nio.file.Paths;
 /**
  * Represents Linux cgroup v1 subsystems.
  */
-@SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
+@SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME", justification = "Cgroup virtual filesystem path "
+        + "cannot be relative")
 public enum Cgroup {
-    Memory("memory"), CPU("cpu,cpuacct");
+    Memory("memory"), CPU("cpu,cpuacct"), Freezer("freezer", "freezer");
 
     private static final String CGROUP_ROOT = "/sys/fs/cgroup";
     private static final String GG_NAMESPACE = "greengrass";
@@ -23,11 +24,19 @@ public enum Cgroup {
     private static final String CPU_CFS_PERIOD_US = "cpu.cfs_period_us";
     private static final String CPU_CFS_QUOTA_US = "cpu.cfs_quota_us";
     private static final String CGROUP_PROCS = "cgroup.procs";
+    private static final String FREEZER_STATE_FILE = "freezer.state";
 
     private final String osString;
+    private final String mountSrc;
 
     Cgroup(String str) {
         osString = str;
+        mountSrc = "cgroup";
+    }
+
+    Cgroup(String str, String mountSrc) {
+        this.osString = str;
+        this.mountSrc = mountSrc;
     }
 
     public static Path getRootPath() {
@@ -39,7 +48,7 @@ public enum Cgroup {
     }
 
     public String subsystemMountCmd() {
-        return String.format("mount -t cgroup -o %s cgroup %s", osString, getSubsystemRootPath());
+        return String.format("mount -t cgroup -o %s %s %s", osString, mountSrc, getSubsystemRootPath());
     }
 
     public Path getSubsystemRootPath() {
@@ -68,5 +77,9 @@ public enum Cgroup {
 
     public Path getCgroupProcsPath(String componentName) {
         return getSubsystemComponentPath(componentName).resolve(CGROUP_PROCS);
+    }
+
+    public Path getCgroupFreezerStateFilePath(String componentName) {
+        return getSubsystemComponentPath(componentName).resolve(FREEZER_STATE_FILE);
     }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/linux/LinuxSystemResourceController.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/linux/LinuxSystemResourceController.java
@@ -9,19 +9,21 @@ import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.SystemResourceController;
-import org.zeroturnaround.process.PidUtil;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class LinuxSystemResourceController implements SystemResourceController {
     private static final Logger logger = LogManager.getLogger(LinuxSystemResourceController.class);
@@ -29,7 +31,9 @@ public class LinuxSystemResourceController implements SystemResourceController {
     private static final String MEMORY_KEY = "memory";
     private static final String CPU_KEY = "cpu";
     private static final String UNICODE_SPACE = "\\040";
-    private static final List<Cgroup> ENABLED_CGROUPS = Arrays.asList(Cgroup.Memory, Cgroup.CPU);
+    private static final List<Cgroup> RESOURCE_LIMIT_CGROUPS = Arrays.asList(Cgroup.Memory, Cgroup.CPU);
+
+    private final CopyOnWriteArrayList<Cgroup> usedCgroups = new CopyOnWriteArrayList<>();
 
     protected final LinuxPlatform platform;
 
@@ -39,14 +43,15 @@ public class LinuxSystemResourceController implements SystemResourceController {
 
     @Override
     public void removeResourceController(GreengrassService component) {
-        for (Cgroup cg : ENABLED_CGROUPS) {
+        usedCgroups.forEach(cg -> {
             try {
+                // Assumes processes belonging to cgroups would already be terminated/killed.
                 Files.deleteIfExists(cg.getSubsystemComponentPath(component.getServiceName()));
             } catch (IOException e) {
                 logger.atError().setCause(e).kv(COMPONENT_NAME, component.getServiceName())
                         .log("Failed to remove the resource controller");
             }
-        }
+        });
     }
 
     @Override
@@ -89,7 +94,7 @@ public class LinuxSystemResourceController implements SystemResourceController {
 
     @Override
     public void resetResourceLimits(GreengrassService component) {
-        for (Cgroup cg : ENABLED_CGROUPS) {
+        for (Cgroup cg : RESOURCE_LIMIT_CGROUPS) {
             try {
                 Files.deleteIfExists(cg.getSubsystemComponentPath(component.getServiceName()));
                 Files.createDirectory(cg.getSubsystemComponentPath(component.getServiceName()));
@@ -102,34 +107,67 @@ public class LinuxSystemResourceController implements SystemResourceController {
 
     @Override
     public void addComponentProcess(GreengrassService component, Process process) {
+        RESOURCE_LIMIT_CGROUPS.forEach(cg -> {
+            try {
+                addComponentProcessToCgroup(component.getServiceName(), process, cg);
+            } catch (IOException e) {
+                logger.atError().setCause(e).kv(COMPONENT_NAME, component).log("Failed to add pid to the cgroup");
+            }
+        });
+    }
 
-        if (!Files.exists(Cgroup.CPU.getSubsystemComponentPath(component.getServiceName()))
-                || !Files.exists(Cgroup.Memory.getSubsystemComponentPath(component.getServiceName()))) {
-            logger.atInfo().kv(COMPONENT_NAME, component.getServiceName()).log("Resource controller is not enabled");
+    @Override
+    public void pauseComponentProcesses(GreengrassService component, List<Process> processes) throws IOException {
+        initializeCgroup(component, Cgroup.Freezer);
+
+        for (Process process: processes) {
+            addComponentProcessToCgroup(component.getServiceName(), process, Cgroup.Freezer);
+        }
+
+        if (CgroupFreezerState.FROZEN.equals(currentFreezerCgroupState(component.getServiceName()))) {
+            return;
+        }
+        Files.write(freezerCgroupStateFile(component.getServiceName()),
+                CgroupFreezerState.FROZEN.toString().getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    @Override
+    public void resumeComponentProcesses(GreengrassService component) throws IOException {
+        if (CgroupFreezerState.THAWED.equals(currentFreezerCgroupState(component.getServiceName()))) {
+            return;
+        }
+        Files.write(freezerCgroupStateFile(component.getServiceName()),
+                CgroupFreezerState.THAWED.toString().getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    void addComponentProcessToCgroup(String component, Process process, Cgroup cg)
+            throws IOException {
+
+        if (!Files.exists(cg.getSubsystemComponentPath(component))) {
+            logger.atInfo().kv(COMPONENT_NAME, component).kv("resource-controller", cg.toString())
+                    .log("Resource controller is not enabled");
             return;
         }
 
         try {
             if (process != null) {
                 Set<Integer> childProcesses = platform.getChildPids(process);
-                childProcesses.add(PidUtil.getPid(process));
+
+                // Writing pid to cgroup.procs file should auto add the pid to tasks file
+                // Once a process is added to a cgroup, its forked child processes inherit its (parent's) cgroup settings
                 for (Integer pid : childProcesses) {
                     if (pid == null) {
                         logger.atError().log("The process doesn't exist and is skipped");
                         continue;
                     }
 
-                    Files.write(Cgroup.Memory.getCgroupProcsPath(component.getServiceName()),
-                            Integer.toString(pid).getBytes(StandardCharsets.UTF_8));
-                    Files.write(Cgroup.CPU.getCgroupProcsPath(component.getServiceName()),
-                            Integer.toString(pid).getBytes(StandardCharsets.UTF_8));
+                    Files.write(cg.getCgroupProcsPath(component), Integer.toString(pid).getBytes(StandardCharsets.UTF_8));
                 }
             }
-        } catch (IOException e) {
-            logger.atError().kv(COMPONENT_NAME, component.getServiceName())
-                    .log("Failed to add pid to the cgroup", e.getMessage());
         } catch (InterruptedException e) {
-            logger.atWarn().setCause(e).log("Thread interrupted when adding process to system limit controller");
+            logger.atWarn().setCause(e).log("Interrupted while getting processes to add to system limit controller");
             Thread.currentThread().interrupt();
         }
     }
@@ -175,5 +213,23 @@ public class LinuxSystemResourceController implements SystemResourceController {
         if (!Files.exists(cgroup.getSubsystemComponentPath(component.getServiceName()))) {
             Files.createDirectory(cgroup.getSubsystemComponentPath(component.getServiceName()));
         }
+        usedCgroups.add(cgroup);
+    }
+
+    private Path freezerCgroupStateFile(String component) {
+        return Cgroup.Freezer.getCgroupFreezerStateFilePath(component);
+    }
+
+    private CgroupFreezerState currentFreezerCgroupState(String component) throws IOException {
+        List<String> stateFileContent =
+                Files.readAllLines(freezerCgroupStateFile(component));
+        if (Utils.isEmpty(stateFileContent) || stateFileContent.size() != 1) {
+            throw new IOException("Unexpected error reading freezer cgroup state");
+        }
+        return CgroupFreezerState.valueOf(stateFileContent.get(0).trim());
+    }
+
+    public enum CgroupFreezerState {
+        THAWED, FREEZING, FROZEN
     }
 }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
@@ -28,6 +28,7 @@ import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_C
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.LogManagerHelper.SERVICE_CONFIG_LOGGING_TOPICS;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -222,7 +223,9 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_service_paused_WHEN_pause_fails_THEN_service_exception_thrown() throws Exception {
+    void GIVEN_service_paused_WHEN_pause_fails_THEN_service_exception_thrown(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionWithMessage(context, "Could not pause");
         doThrow(new IOException("Could not pause")).when(resourceController).pauseComponentProcesses(any(), any());
         ges.install();
         ges.startup();
@@ -258,7 +261,8 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_service_paused_WHEN_resume_fails_THEN_retry_and_succeed() throws Exception {
+    void GIVEN_service_paused_WHEN_resume_fails_THEN_retry_and_succeed(ExtensionContext context) throws Exception {
+        ignoreExceptionWithMessage(context, "Could not resume");
         doThrow(new IOException("Could not resume")).doThrow(new IOException("Could not resume")).doNothing()
                 .when(resourceController).resumeComponentProcesses(ges);
         ges.install();
@@ -280,8 +284,9 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_service_paused_WHEN_resume_fails_all_attempts_THEN_service_exception_thrown_service_restarted()
-            throws Exception {
+    void GIVEN_service_paused_WHEN_resume_fails_all_attempts_THEN_service_exception_thrown_service_restarted(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionWithMessage(context, "Could not resume");
         doThrow(new IOException("Could not resume")).doThrow(new IOException("Could not resume"))
                 .doThrow(new IOException("Could not resume")).when(resourceController).resumeComponentProcesses(ges);
         ges.install();
@@ -299,9 +304,10 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_service_paused_WHEN_shutdown_requested_and_resume_fails_THEN_service_force_stopped(ExtensionContext context)
-            throws Exception {
+    void GIVEN_service_paused_WHEN_shutdown_requested_and_resume_fails_THEN_service_force_stopped(
+            ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, ServiceException.class);
+        ignoreExceptionWithMessage(context, "Could not resume");
         doThrow(new IOException("Could not resume")).when(resourceController).resumeComponentProcesses(ges);
 
         ges.install();

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/GenericExternalServiceTest.java
@@ -8,29 +8,41 @@ package com.aws.greengrass.lifecyclemanager;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceException;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.platforms.Platform;
+import com.aws.greengrass.util.platforms.StubResourceController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.LogManagerHelper.SERVICE_CONFIG_LOGGING_TOPICS;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class GenericExternalServiceTest extends GGServiceTestUtil {
     private GenericExternalService ges;
@@ -38,12 +50,16 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
     @Mock
     private Platform platform;
 
+    @Mock
+    private StubResourceController resourceController;
+
     @BeforeEach
     void beforeEach() {
         lenient().doReturn(Topics.of(context, SERVICE_CONFIG_LOGGING_TOPICS, null))
                 .when(config).lookupTopics(eq(SERVICE_CONFIG_LOGGING_TOPICS));
         lenient().doReturn(Topic.of(context, VERSION_CONFIG_KEY, "1.0.0")).when(config).find(eq(VERSION_CONFIG_KEY));
-        ges = new GenericExternalService(initializeMockedConfig(), platform);
+        lenient().when(platform.getSystemResourceController()).thenReturn(resourceController);
+        ges = spy(new GenericExternalService(initializeMockedConfig(), platform));
         ges.deviceConfiguration = mock(DeviceConfiguration.class);
     }
 
@@ -189,5 +205,116 @@ class GenericExternalServiceTest extends GGServiceTestUtil {
             assertThat(exec.getCommand(), arrayContaining("sudo", "-n", "-E", "-H", "-u", "foo", "-g", "bar",
                     "--", "echo", "hello"));
         }
+    }
+
+    @Test
+    void GIVEN_service_running_WHEN_pause_requested_THEN_pause() throws Exception {
+        ges.install();
+        ges.startup();
+        ges.pause();
+        verify(resourceController).pauseComponentProcesses(any(), any());
+        assertTrue(ges.isPaused());
+
+        ges.shutdown();
+        // On shutdown, expect resume and remove to be invoked.
+        verify(resourceController).resumeComponentProcesses(ges);
+        verify(resourceController).removeResourceController(ges);
+    }
+
+    @Test
+    void GIVEN_service_paused_WHEN_pause_fails_THEN_service_exception_thrown() throws Exception {
+        doThrow(new IOException("Could not pause")).when(resourceController).pauseComponentProcesses(any(), any());
+        ges.install();
+        ges.startup();
+
+        assertThrows(ServiceException.class, () -> ges.pause());
+        verify(resourceController).pauseComponentProcesses(any(), any());
+        assertFalse(ges.isPaused());
+
+        ges.shutdown();
+
+        // On shutdown, expect remove to be invoked. As the component could not be paused, resume should not be invoked
+        verify(resourceController, never()).resumeComponentProcesses(ges);
+        verify(resourceController).removeResourceController(ges);
+    }
+
+    @Test
+    void GIVEN_service_paused_WHEN_resume_requested_THEN_resume() throws Exception {
+        ges.install();
+        ges.startup();
+        ges.pause();
+        verify(resourceController).pauseComponentProcesses(any(), any());
+        assertTrue(ges.isPaused());
+
+        ges.resume();
+        verify(resourceController).resumeComponentProcesses(ges);
+        assertFalse(ges.isPaused());
+
+        ges.shutdown();
+        // On shutdown, expect remove to be invoked. As the component was already resumed, resume should
+        // not be invoked again
+        verify(resourceController).resumeComponentProcesses(ges);
+        verify(resourceController).removeResourceController(ges);
+    }
+
+    @Test
+    void GIVEN_service_paused_WHEN_resume_fails_THEN_retry_and_succeed() throws Exception {
+        doThrow(new IOException("Could not resume")).doThrow(new IOException("Could not resume")).doNothing()
+                .when(resourceController).resumeComponentProcesses(ges);
+        ges.install();
+        ges.startup();
+        ges.pause();
+        verify(resourceController).pauseComponentProcesses(any(), any());
+        assertTrue(ges.isPaused());
+
+        ges.resume();
+        // Should be retried 3 times
+        verify(resourceController, times(3)).resumeComponentProcesses(ges);
+        assertFalse(ges.isPaused());
+
+        ges.shutdown();
+        // On shutdown, expect remove to be invoked. As the component was already resumed paused, resume should
+        // not be invoked again
+        verify(resourceController, times(3)).resumeComponentProcesses(ges);
+        verify(resourceController).removeResourceController(ges);
+    }
+
+    @Test
+    void GIVEN_service_paused_WHEN_resume_fails_all_attempts_THEN_service_exception_thrown_service_restarted()
+            throws Exception {
+        doThrow(new IOException("Could not resume")).doThrow(new IOException("Could not resume"))
+                .doThrow(new IOException("Could not resume")).when(resourceController).resumeComponentProcesses(ges);
+        ges.install();
+        ges.startup();
+        ges.pause();
+        verify(resourceController).pauseComponentProcesses(any(), any());
+        assertTrue(ges.isPaused());
+
+        assertThrows(ServiceException.class, () -> ges.resume());
+        // Should be retried 3 times
+        verify(resourceController, times(3)).resumeComponentProcesses(ges);
+        verify(ges).requestRestart();
+        // Tracking flag should still be reset
+        assertFalse(ges.isPaused());
+    }
+
+    @Test
+    void GIVEN_service_paused_WHEN_shutdown_requested_and_resume_fails_THEN_service_force_stopped(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, ServiceException.class);
+        doThrow(new IOException("Could not resume")).when(resourceController).resumeComponentProcesses(ges);
+
+        ges.install();
+        ges.startup();
+        ges.pause();
+        verify(resourceController).pauseComponentProcesses(any(), any());
+        assertTrue(ges.isPaused());
+
+        ges.shutdown();
+        // On shutdown, expect resume (without retry) and remove to be invoked.
+        verify(resourceController).resumeComponentProcesses(ges);
+        verify(resourceController).removeResourceController(ges);
+        // Tracking flag should still be reset
+        assertFalse(ges.isPaused());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Component lifecycle implementation of component hibernation using linux cgroup freezer subsystem. IPC interface changes in separate earlier PR. 
Adding a change to run the linux maven github workflow as root since some of the tests for resource management require that

**Why is this change necessary:**
New feature for hibernate(pause/resume) components to save consumed resources

**How was this change tested:**
New unit and integ tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
