### PR TITLE
fix(windows): increase timeout for test failing on windows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,6 @@ jobs:
           AWS_REGION: us-west-2
         run: mvn -ntp -U verify
         shell: cmd
-        continue-on-error: true
         if: matrix.os == 'windows-latest'
       - name: Build with Maven (not Windows)
         env:

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -126,7 +126,7 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
                 GreengrassService.class.getName());
         assertNotNull(deviceConfiguration.getThingName());
         // Wait for some time for the publish request to have all the components update.
-        assertTrue(allComponentsInFssUpdate.await(30, TimeUnit.SECONDS), "component publish requests");
+        assertTrue(allComponentsInFssUpdate.await(45, TimeUnit.SECONDS), "component publish requests");
         assertNotNull(fleetStatusDetails);
         assertNotNull(fleetStatusDetails.get());
         assertEquals("ThingName", fleetStatusDetails.get().getThing());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Increase timeout value for PeriodicFleetStatusService test.
Enable enforcement of Windows github action by removing "continue-on-error" configuration.

**Why is this change necessary:**
Windows image Github uses for Github actions is not powerful enough to make this test consistently pass at 30 seconds. Hoping increase to 45 seconds will fix that issue.

**How was this change tested:**
Executed the test on Windows machine and saw a passing result.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
