### PR TITLE
fix(windows): fix PeriodicFleetStatusServiceTest

### DIFF
--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -62,7 +62,7 @@ public class FleetStatusService extends GreengrassService {
             "$aws/things/{thingName}/greengrassv2/health/json";
     public static final String FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC = "fssPeriodicUpdateIntervalSec";
     public static final int DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC = 86_400;
-    static final String FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC = "periodicStatusPublishIntervalSeconds";
+    public static final String FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC = "periodicStatusPublishIntervalSeconds";
     static final String FLEET_STATUS_SEQUENCE_NUMBER_TOPIC = "sequenceNumber";
     static final String FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC = "lastPeriodicUpdateTime";
     private static final int MAX_PAYLOAD_LENGTH_BYTES = 128_000;
@@ -137,7 +137,6 @@ public class FleetStatusService extends GreengrassService {
                               Kernel kernel, DeviceConfiguration deviceConfiguration,
                               PlatformResolver platformResolver, int periodicPublishIntervalSec) {
         super(topics);
-
         this.mqttClient = mqttClient;
         this.deploymentStatusKeeper = deploymentStatusKeeper;
         this.kernel = kernel;

--- a/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
@@ -44,8 +44,8 @@ public class TelemetryAgent extends GreengrassService {
             = "telemetryPeriodicPublishMetricsIntervalSec";
     public static final String TELEMETRY_LAST_PERIODIC_PUBLISH_TIME_TOPIC = "lastPeriodicPublishMetricsTime";
     public static final String TELEMETRY_LAST_PERIODIC_AGGREGATION_TIME_TOPIC = "lastPeriodicAggregationMetricsTime";
-    static final int DEFAULT_PERIODIC_AGGREGATE_INTERVAL_SEC = 3_600;
-    static final int DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC = 86_400;
+    public static final int DEFAULT_PERIODIC_AGGREGATE_INTERVAL_SEC = 3_600;
+    public static final int DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC = 86_400;
     private static final int MAX_PAYLOAD_LENGTH_BYTES = 128_000;
     private final MqttClient mqttClient;
     private final MetricsAggregator metricsAggregator;


### PR DESCRIPTION
**Issue #, if available:**

Description of changes:
Update PeriodicFleetStatusServceTest to use TestFeatureParameterInterface to set the FleetStatusService period.

Why is this change necessary:
The test is failing on Windows Github Actions when the entire test suite is ran. This is because the FleetStatusService period was being reset to the initial value of 86,400 seconds because of the way Runnables were being Dequeued from LinkedBlockingDeque in Context.java.

How was this change tested:
Observing the Github Action results.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
