### PR TITLE
fix(logging): config not applied to component logger. support reset

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -821,31 +821,31 @@ public class DeviceConfiguration {
      * @throws IllegalArgumentException if the POJO map has an invalid argument.
      */
     private LogConfigUpdate fromPojo(Map<String, Object> pojoMap) {
-        LogConfigUpdate configuration = LogConfigUpdate.builder().build();
+        LogConfigUpdate.LogConfigUpdateBuilder configUpdate = LogConfigUpdate.builder();
         pojoMap.forEach((s, o) -> {
             switch (s) {
                 case "level":
-                    configuration.setLevel(Level.valueOf(Coerce.toString(o)));
+                    configUpdate.level(Level.valueOf(Coerce.toString(o)));
                     break;
                 case "fileSizeKB":
-                    configuration.setFileSizeKB(Coerce.toLong(o));
+                    configUpdate.fileSizeKB(Coerce.toLong(o));
                     break;
                 case "totalLogsSizeKB":
-                    configuration.setTotalLogsSizeKB(Coerce.toLong(o));
+                    configUpdate.totalLogsSizeKB(Coerce.toLong(o));
                     break;
                 case "format":
-                    configuration.setFormat(LogFormat.valueOf(Coerce.toString(o)));
+                    configUpdate.format(LogFormat.valueOf(Coerce.toString(o)));
                     break;
                 case "outputDirectory":
-                    configuration.setOutputDirectory(Coerce.toString(o));
+                    configUpdate.outputDirectory(Coerce.toString(o));
                     break;
                 case "outputType":
-                    configuration.setOutputType(LogStore.valueOf(Coerce.toString(o)));
+                    configUpdate.outputType(LogStore.valueOf(Coerce.toString(o)));
                     break;
                 default:
                     throw new IllegalArgumentException("Unexpected value: " + s);
             }
         });
-        return configuration;
+        return configUpdate.build();
     }
 }

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -453,6 +453,9 @@ public class DeviceConfiguration {
             case removed:
                 LogManager.resetAllLoggers(null);
                 break;
+            default:
+                // do nothing
+                break;
         }
     }
 

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -390,7 +390,7 @@ public class KernelLifecycle {
             logger.atError("system-shutdown-error", ex).log();
         }
         // Stop all the contexts for the loggers.
-        LogConfig.getInstance().closeContext();
+        LogConfig.getRootLogConfig().closeContext();
         for (LogConfig logConfig : LogManager.getLogConfigurations().values()) {
             logConfig.closeContext();
         }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.lifecyclemanager;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
 
 /**
@@ -28,7 +27,6 @@ public final class LogManagerHelper {
      * @return a logger with configuration to log to a log file with the same name.
      */
     public static Logger getComponentLogger(GreengrassService service) {
-        // TODO: [P41214167]: Dynamically reconfigure service loggers
         return getComponentLogger(service.getServiceName(), service.getServiceName() + LOG_FILE_EXTENSION);
     }
 
@@ -41,11 +39,8 @@ public final class LogManagerHelper {
      * @return a logger with configuration to log to a log file with the same name.
      */
     private static Logger getComponentLogger(String name, String fileName) {
-        LoggerConfiguration config = LoggerConfiguration.builder()
-                // Explicitly inherit the format, otherwise the default from the builder would be used
-                .format(LogConfig.getInstance().getFormat())
-                .fileName(fileName)
-                .build();
+        // Explicitly set the output file. Other configs will inherit the root logger
+        LoggerConfiguration config = LoggerConfiguration.builder().fileName(fileName).build();
         return LogManager.getLogger(name, config);
     }
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.lifecyclemanager;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 
 /**
  * Helper function to get a logger with configurations separate from the root logger.
@@ -40,7 +40,7 @@ public final class LogManagerHelper {
      */
     private static Logger getComponentLogger(String name, String fileName) {
         // Explicitly set the output file. Other configs will inherit the root logger
-        LoggerConfiguration config = LoggerConfiguration.builder().fileName(fileName).build();
+        LogConfigUpdate config = LogConfigUpdate.builder().fileName(fileName).build();
         return LogManager.getLogger(name, config);
     }
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/LogManagerHelper.java
@@ -27,6 +27,7 @@ public final class LogManagerHelper {
      * @return a logger with configuration to log to a log file with the same name.
      */
     public static Logger getComponentLogger(GreengrassService service) {
+        // TODO: [P41214167]: Dynamically reconfigure service loggers individually
         return getComponentLogger(service.getServiceName(), service.getServiceName() + LOG_FILE_EXTENSION);
     }
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -174,7 +174,7 @@ class LogManagerHelperTest {
 
     @Test
     void GIVEN_mock_service_logger_WHEN_reconfigure_multiple_configs_THEN_change_applied_correctly()
-            throws IOException {
+            throws IOException, InterruptedException {
         Path tempRootDir2 = tempRootDir.resolve("test_logs_" + Utils.generateRandomString(8));
         Path tempRootDir3 = tempRootDir.resolve("test_logs_" + Utils.generateRandomString(8));
         String mockServiceName = "MockService002";
@@ -214,11 +214,9 @@ class LogManagerHelperTest {
         LogManager.reconfigureAllLoggers(newConfig);
         logRandomMessages(componentLogger, 4000, LogFormat.TEXT);
         componentLogger.atInfo().log();
-        long numLogFilesBefore = getLogFileCount(testLogConfig, mockServiceName);
-        logRandomMessages(componentLogger, 4000, LogFormat.TEXT);
-        componentLogger.atInfo().log();
         // older rotated file should be deleted. Log file count should not change
-        assertEquals(numLogFilesBefore, getLogFileCount(testLogConfig, mockServiceName));
+        Thread.sleep(850);
+        assertEquals(1, getLogFileCount(testLogConfig, mockServiceName));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -84,6 +84,8 @@ class LogManagerHelperTest {
     @Captor
     ArgumentCaptor<ChildChanged> childChangedArgumentCaptor;
 
+    private static final Base64.Encoder base64Encoder = Base64.getEncoder();
+
     @BeforeEach
     void setup() {
         LogManager.setRoot(tempRootDir);
@@ -133,8 +135,8 @@ class LogManagerHelperTest {
 
     @Test
     void GIVEN_mock_service_logger_WHEN_reconfigure_THEN_change_applied_correctly() throws IOException {
-        Path tempRootDir2 = tempRootDir.resolve("2");
-        Path tempRootDir3 = tempRootDir.resolve("3");
+        Path tempRootDir2 = tempRootDir.resolve("test_logs_" + Utils.generateRandomString(8));
+        Path tempRootDir3 = tempRootDir.resolve("test_logs_" + Utils.generateRandomString(8));
         String mockServiceName = "MockService001";
         when(mockGreengrassService.getServiceName()).thenReturn(mockServiceName);
         LogConfig.getInstance().setStore(LogStore.FILE);
@@ -198,8 +200,8 @@ class LogManagerHelperTest {
     }
 
     @Test
-    void GIVEN_mock_service_logger_WHEN_reset_THEN_reset_applied_correctly() throws IOException {
-        Path tempRootDir2 = tempRootDir.resolve("2");
+    void GIVEN_mock_service_logger_WHEN_reset_THEN_reset_applied_correctly() {
+        Path tempRootDir2 = tempRootDir.resolve("test_logs" + Utils.generateRandomString(8));
         String mockServiceName = "MockService001";
         when(mockGreengrassService.getServiceName()).thenReturn(mockServiceName);
 
@@ -372,7 +374,6 @@ class LogManagerHelperTest {
     private static void logRandomMessages(Logger logger, int messageSize, int messageCount) {
         Random random = new Random();
         byte[] message = new byte[messageSize];
-        Base64.Encoder base64Encoder = Base64.getEncoder();
         for (int i = 0; i < messageCount; i++) {
             random.nextBytes(message);
             logger.info(base64Encoder.encodeToString(message));

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -71,6 +71,10 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class LogManagerHelperTest {
+    private static final int TEXT_LOG_MIN_LEN = 46;
+    private static final int JSON_LOG_MIN_LEN = 132;
+    private static final int DEFAULT_TEST_MSG_LEN = 60;
+
     @TempDir
     protected Path tempRootDir;
     @Mock
@@ -79,10 +83,6 @@ class LogManagerHelperTest {
     private Kernel kernel;
     @Captor
     ArgumentCaptor<ChildChanged> childChangedArgumentCaptor;
-
-    private static final int TEXT_LOG_MIN_LEN = 46;
-    private static final int JSON_LOG_MIN_LEN = 132;
-    private static final int DEFAULT_TEST_MSG_LEN = 60;
 
     @BeforeEach
     void setup() {

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -82,6 +82,13 @@ class LogManagerHelperTest {
     private GreengrassService mockGreengrassService;
     @Mock
     private Kernel kernel;
+    @Mock
+    private Context context;
+    @Mock
+    private Configuration configuration;
+    @Mock
+    private NucleusPaths nucleusPaths;
+
     @Captor
     ArgumentCaptor<ChildChanged> childChangedArgumentCaptor;
 
@@ -219,9 +226,6 @@ class LogManagerHelperTest {
         Path tempRootDir2 = tempRootDir.resolve("test_logs" + Utils.generateRandomString(8));
         String mockServiceName = "MockService001";
         when(mockGreengrassService.getServiceName()).thenReturn(mockServiceName);
-        Context context = mock(Context.class);
-        Configuration configuration = mock(Configuration.class);
-        NucleusPaths nucleusPaths = mock(NucleusPaths.class);
         Topics rootConfigTopics = mock(Topics.class);
         when(rootConfigTopics.findOrDefault(any(), anyString(), anyString(), anyString())).thenReturn(new ArrayList<>());
         when(configuration.lookup(anyString(), anyString(), anyString())).thenReturn(mock(Topic.class));
@@ -294,9 +298,6 @@ class LogManagerHelperTest {
     @Test
     void GIVEN_all_fields_logger_config_WHEN_subscribe_THEN_correctly_reconfigures_all_loggers() throws IOException {
         Path tempRootDir2 = tempRootDir.resolve("2");
-        Context context = mock(Context.class);
-        Configuration configuration = mock(Configuration.class);
-        NucleusPaths nucleusPaths = mock(NucleusPaths.class);
         Topics rootConfigTopics = mock(Topics.class);
         when(rootConfigTopics.findOrDefault(any(), anyString(), anyString(), anyString())).thenReturn(new ArrayList<>());
         when(configuration.lookup(anyString(), anyString(), anyString())).thenReturn(mock(Topic.class));
@@ -337,8 +338,6 @@ class LogManagerHelperTest {
 
     @Test
     void GIVEN_null_logger_config_WHEN_subscribe_THEN_correctly_reconfigures_all_loggers() throws IOException {
-        Configuration configuration = mock(Configuration.class);
-        NucleusPaths nucleusPaths = mock(NucleusPaths.class);
         Topics rootConfigTopics = mock(Topics.class);
         when(rootConfigTopics.findOrDefault(any(), anyString(), anyString(), anyString())).thenReturn(new ArrayList<>());
         when(configuration.lookup(anyString(), anyString(), anyString())).thenReturn(mock(Topic.class));

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -93,8 +93,8 @@ class LogManagerHelperTest {
 
     @AfterEach
     void cleanup() {
-        LogConfig.getInstance().reset();
-        LogConfig.getInstance().closeContext();
+        LogConfig.getRootLogConfig().reset();
+        LogConfig.getRootLogConfig().closeContext();
         for (LogConfig logConfig : LogManager.getLogConfigurations().values()) {
             logConfig.reset();
             logConfig.closeContext();
@@ -117,7 +117,7 @@ class LogManagerHelperTest {
     void GIVEN_mock_service_WHEN_getComponentLogger_THEN_logs_to_correct_log_file() throws IOException {
         when(mockGreengrassService.getServiceName()).thenReturn("MockService");
 
-        LogConfig.getInstance().setStore(LogStore.FILE);
+        LogConfig.getRootLogConfig().setStore(LogStore.FILE);
         Logger componentLogger = LogManagerHelper.getComponentLogger(mockGreengrassService);
 
         componentLogger.atInfo().log("Something");
@@ -139,7 +139,7 @@ class LogManagerHelperTest {
         Path tempRootDir3 = tempRootDir.resolve("test_logs_" + Utils.generateRandomString(8));
         String mockServiceName = "MockService001";
         when(mockGreengrassService.getServiceName()).thenReturn(mockServiceName);
-        LogConfig.getInstance().setStore(LogStore.FILE);
+        LogConfig.getRootLogConfig().setStore(LogStore.FILE);
         Logger componentLogger = LogManagerHelper.getComponentLogger(mockGreengrassService);
 
         // change log file size

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -209,13 +209,13 @@ class LogManagerHelperTest {
         });
 
         // change file size, total size, also change to another directory so it's clean
-        newConfig = LogConfigUpdate.builder().fileSizeKB(1L).totalLogsSizeKB(2L).format(LogFormat.TEXT)
+        newConfig = LogConfigUpdate.builder().fileSizeKB(1L).totalLogsSizeKB(1L).format(LogFormat.TEXT)
                 .outputDirectory(tempRootDir3.toAbsolutePath().toString()).build();
         LogManager.reconfigureAllLoggers(newConfig);
-        logRandomMessages(componentLogger, 8000, LogFormat.TEXT);
+        logRandomMessages(componentLogger, 4000, LogFormat.TEXT);
         componentLogger.atInfo().log();
         long numLogFilesBefore = getLogFileCount(testLogConfig, mockServiceName);
-        logRandomMessages(componentLogger, 8000, LogFormat.TEXT);
+        logRandomMessages(componentLogger, 4000, LogFormat.TEXT);
         componentLogger.atInfo().log();
         // older rotated file should be deleted. Log file count should not change
         assertEquals(numLogFilesBefore, getLogFileCount(testLogConfig, mockServiceName));

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -380,7 +380,8 @@ class LogManagerHelperTest {
     }
 
     /**
-     * Write log messages of approximate size.
+     * Write log messages of given size.
+     * Minimum size of one log message estimated as follows:
      *
      * TEXT logs follow this format:
      * 2021-05-07T15:56:54.912Z [INFO] (main)  :. {}
@@ -391,10 +392,8 @@ class LogManagerHelperTest {
      * "timestamp":1620403177433,"cause":null}
      * ~132 bytes without service name and message body
      *
-     * 2021-05-07T16:47:06.193Z [INFO] (main) MockService001: hIto1cCs54zPc55TatPa44kJwdwuKMYvwzI1H7RfeAFBQVC4iv3QNaKvKmiK. {}
-     * 2021-05-07T16:47:06.249Z [INFO] (main) MockService001: {}
      * @param logger logger to use
-     * @param size approximate size of logs to write, this will be a lower bound
+     * @param size bytes of logs to write
      */
     private static void logRandomMessages(Logger logger, int size, LogFormat format) {
         int minLogLength =

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -19,7 +19,7 @@ import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.LogFormat;
 import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.PersistenceConfig;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.Utils;
@@ -141,7 +141,7 @@ class LogManagerHelperTest {
         Logger componentLogger = LogManagerHelper.getComponentLogger(mockGreengrassService);
 
         // change log file size
-        LoggerConfiguration newConfig = LoggerConfiguration.builder().fileSizeKB(1L).build();
+        LogConfigUpdate newConfig = LogConfigUpdate.builder().fileSizeKB(1L).build();
         LogManager.reconfigureAllLoggers(newConfig);
 
         // should apply change to all loggers
@@ -160,7 +160,7 @@ class LogManagerHelperTest {
         assertTrue(getLogFileCount(testLogConfig, mockServiceName) > 1);
 
         // change format and log directory
-        newConfig = LoggerConfiguration.builder().format(LogFormat.JSON)
+        newConfig = LogConfigUpdate.builder().format(LogFormat.JSON)
                 .outputDirectory(tempRootDir2.toAbsolutePath().toString()).build();
         LogManager.reconfigureAllLoggers(newConfig);
         logRandomMessages(componentLogger, 50, 20);
@@ -184,7 +184,7 @@ class LogManagerHelperTest {
         });
 
         // change totalLogsSizeKB, also change to another directory so it's cleaner
-        newConfig = LoggerConfiguration.builder().totalLogsSizeKB(2L).format(LogFormat.TEXT)
+        newConfig = LogConfigUpdate.builder().totalLogsSizeKB(2L).format(LogFormat.TEXT)
                 .outputDirectory(tempRootDir3.toAbsolutePath().toString()).build();
         LogManager.reconfigureAllLoggers(newConfig);
         // Get over the total limit. Must be separate calls. If log all at once, log may not rotate in time
@@ -208,7 +208,7 @@ class LogManagerHelperTest {
         PersistenceConfig defaultConfig = new PersistenceConfig(LOG_FILE_EXTENSION, LOGS_DIRECTORY);
 
         // first set a few non-default configs
-        LoggerConfiguration newConfig = LoggerConfiguration.builder().format(LogFormat.JSON)
+        LogConfigUpdate newConfig = LogConfigUpdate.builder().format(LogFormat.JSON)
                 .outputDirectory(tempRootDir2.toAbsolutePath().toString()).outputType(LogStore.CONSOLE).fileSizeKB(10L)
                 .build();
         LogManager.reconfigureAllLoggers(newConfig);
@@ -329,7 +329,7 @@ class LogManagerHelperTest {
     @Test
     void GIVEN_nondefault_options_on_root_logger_WHEN_create_component_logger_THEN_inherits_options() {
         LogManager
-                .reconfigureAllLoggers(LoggerConfiguration.builder().level(Level.TRACE).format(LogFormat.JSON).build());
+                .reconfigureAllLoggers(LogConfigUpdate.builder().level(Level.TRACE).format(LogFormat.JSON).build());
         when(mockGreengrassService.getServiceName()).thenReturn("MockService2");
 
         Logger logger = LogManagerHelper.getComponentLogger(mockGreengrassService);


### PR DESCRIPTION
**Issue #, if available:**

Requires the following logging package change. Expecting workflow to fail for now.
https://github.com/aws-greengrass/aws-greengrass-logging-java/pull/103

**Description of changes:**
- Fix bug: config not applying to component log.
- Support RESET logging topics to revert to default.

**Why is this change necessary:**
- This allows customers to configure greengrass logging as desired

**How was this change tested:**
- Added unit tests
- Added UATs

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
