### PR TITLE
test(docker): Add a couple more docker image uri parsing unit tests

### DIFF
--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageArtifactParserTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageArtifactParserTest.java
@@ -141,13 +141,23 @@ public class DockerImageArtifactParserTest {
                 Registry.RegistryType.PUBLIC,
                 Registry.RegistrySource.OTHER);
 
-        assertAll(getImage("docker:image_name"),
-                "image_name",
-                "latest",
+        assertAll(getImage(
+                "docker:1234567890.dkr.ecr.us-east-1.amazonaws.com/dockerimagerepository@sha256:"
+                    + "c4ffb87b09eba99383ee89b309d6d521"),
+                "dockerimagerepository",
                 null,
-                "registry.hub.docker.com/library",
-                Registry.RegistryType.PUBLIC,
-                Registry.RegistrySource.OTHER);
+                "sha256:c4ffb87b09eba99383ee89b309d6d521",
+                "1234567890.dkr.ecr.us-east-1.amazonaws.com",
+                Registry.RegistryType.PRIVATE,
+                Registry.RegistrySource.ECR);
+
+        assertAll(getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws.com/dockerimagerepository:v2.3.4"),
+                "dockerimagerepository",
+                "v2.3.4",
+                null,
+                "1234567890.dkr.ecr.us-east-1.amazonaws.com",
+                Registry.RegistryType.PRIVATE,
+                Registry.RegistrySource.ECR);
 
     }
 
@@ -235,6 +245,23 @@ public class DockerImageArtifactParserTest {
         // domain component has invalid char $
         assertThrows(InvalidArtifactUriException.class,
                 () -> getImage("docker:www.$amazon.com:8080/image:v1.10"));
+
+        // has both tag and digest
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        + ".com/dockerimagerepository:v2.3.4@sha256:c4ffb87b09eba99383ee89b309d6d521"));
+
+        // has both tag and digest in a wrong format
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository:latest/sha256"
+                        + ":c4ffb87b09eba99383ee89b309d6d521"));
+
+        // has both tag and a longer than allowed digest in a wrong format
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository:latest/sha256"
+                        + ":4d5f703cbcf9d4db75b923e5c5cc8b72479766cd1b1da77c28f8e4a059feff38"));
     }
 
 }


### PR DESCRIPTION
**Issue #, if available:**
Adding some more tests for docker image artifact parsing to account for more scenarios

**Description of changes:**
Adding some unit tests to the docker image artifact uri parser, no functional change

**Why is this change necessary:**
Helpful in ensuring all possible scenarios work

**How was this change tested:**old and new tests pass on `mvn verify`

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
