### PR TITLE
fix(deployment): duplicated shadow deployment if restart required

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -323,7 +323,7 @@ public class ShadowDeploymentListener implements InjectionActions {
                     if (deploymentServiceLocateResult instanceof DeploymentService) {
                         DeploymentTaskMetadata currentDeployment =
                                 ((DeploymentService) deploymentServiceLocateResult).getCurrentDeploymentTaskMetadata();
-                        if (currentDeployment != null && currentDeployment.getDeploymentId().equals(configurationArn)) {
+                        if (currentDeployment != null && configurationArn.equals(currentDeployment.getDeploymentId())) {
                             logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, configurationArn)
                                     .log("Ongoing deployment. Ignoring shadow update at startup");
                             return;

--- a/src/test/greengrass-nucleus-benchmark/pom.xml
+++ b/src/test/greengrass-nucleus-benchmark/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.aws.greengrass</groupId>
     <artifactId>greengrass-nucleus-benchmark</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JMH benchmark sample: Java</name>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.3.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added one more check when processing shadow update.

**Why is this change necessary:**
Currently, if a shadow deployment requires restart (aka kernel update workflow), ShadowDeploymentListener will create the same deployment again after restart.

Before the restart, the deployment will have been reported as IN_PROGRESS, which is a non-terminal state. Because it could be due to power off or other unexpected failure, we decided to allow it to create the deployment if the reported status was non-terminal (IN_PROGRESS). But if we're restarting normally, we're still adding the deployment which is duplicated.

If we persist the lastConfigurationArn through restart, then this will be caught by existing logic and won't create duplicated deployment. However, it will also bypass the existing logic to catch unexpected restart. Therefore, we're adding new logic to handle the above scenario.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
