### PR TITLE
fix(runwith): enable runwith resetting to default when runwith is not set

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -39,6 +39,7 @@ import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vdurmont.semver4j.Semver;
 import org.hamcrest.Matchers;
@@ -134,7 +135,8 @@ class DeploymentTaskIntegrationTest {
     private static final String TEST_MOSQUITTO_STRING = "Hello this is mosquitto getting started";
     private static final String TEST_TICK_TOCK_STRING = "Go ahead with 2 approvals";
     private static final ObjectMapper OBJECT_MAPPER =
-            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+            new ObjectMapper().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+                    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     @TempDir
     static Path rootDir;
     private static Logger logger;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
@@ -408,7 +408,7 @@ class PluginComponentTest extends BaseITCase {
                         .timeoutInSeconds(20).build())
                 .deploymentPackageConfigurationList(
                         Arrays.asList(DeploymentPackageConfiguration.builder()
-                                .packageName(componentName)
+                                .name(componentName)
                                 .rootComponent(true)
                                 .resolvedVersion(version)
                                 .build()))

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/AddNewServiceWithSafetyCheck.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/AddNewServiceWithSafetyCheck.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "NonDisruptableService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_1.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_2.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "RootComponent": true,

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_3.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_3.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_4.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_4.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_5.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_5.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_InitialDocumentWithUpdate.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_InitialDocumentWithUpdate.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CrossComponentConfigTest_DeployDocument.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CrossComponentConfigTest_DeployDocument.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestMain",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CustomerAppAndYellowSignal.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CustomerAppAndYellowSignal.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "CustomerApp",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/Failure2RollbackDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/Failure2RollbackDeployment.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "BreakingService2",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureDoNothingDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureDoNothingDeployment.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "BreakingService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureRollbackDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureRollbackDeployment.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "BreakingService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "CustomerApp",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentRemovingUser.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentRemovingUser.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "CustomerAppStartupShutdown",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "CustomerAppStartupShutdown",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_2.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "CustomerAppStartupShutdown",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument_updated.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument_updated.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "CustomerApp",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc1.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "Packages": [
+    "DeploymentPackageConfigurationList": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc2.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "Packages": [
+    "DeploymentPackageConfigurationList": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "2.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc3.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc3.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "Packages": [
+    "DeploymentPackageConfigurationList": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "3.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc4.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc4.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "Packages": [
+    "DeploymentPackageConfigurationList": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "4.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SkipPolicyCheck.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SkipPolicyCheck.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "NonDisruptableService",
       "ResolvedVersion": "1.0.1",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SystemConfigTest_DeployDocument.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SystemConfigTest_DeployDocument.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "aws.iot.gg.test.integ.SystemConfigTest",
       "ResolvedVersion": "0.0.1",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/UpdateServiceWithSafetyCheck.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/UpdateServiceWithSafetyCheck.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "NonDisruptableService",
       "ResolvedVersion": "1.0.1",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/YellowAndRedSignal.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/YellowAndRedSignal.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "Packages": [
+  "DeploymentPackageConfigurationList": [
     {
       "Name": "RedSignal",
       "ResolvedVersion": "1.0.0",

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -108,12 +108,12 @@ public class DependencyResolver {
         List<String> targetComponentsToResolve = new ArrayList<>();
         document.getDeploymentPackageConfigurationList().stream()
                 .filter(DeploymentPackageConfiguration::isRootComponent).forEach(e -> {
-            logger.atDebug().kv(COMPONENT_NAME_KEY, e.getPackageName()).kv(VERSION_KEY, e.getResolvedVersion())
+            logger.atDebug().kv(COMPONENT_NAME_KEY, e.getName()).kv(VERSION_KEY, e.getResolvedVersion())
                     .log("Found component configuration");
-            componentNameToVersionConstraints.putIfAbsent(e.getPackageName(), new HashMap<>());
-            componentNameToVersionConstraints.get(e.getPackageName())
+            componentNameToVersionConstraints.putIfAbsent(e.getName(), new HashMap<>());
+            componentNameToVersionConstraints.get(e.getName())
                     .put(document.getGroupName(), Requirement.buildNPM(e.getResolvedVersion()));
-            targetComponentsToResolve.add(e.getPackageName());
+            targetComponentsToResolve.add(e.getName());
         });
 
         logger.atInfo().setEventType("resolve-group-dependencies-start")

--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -202,7 +202,7 @@ public class KernelConfigResolver {
 
         Optional<DeploymentPackageConfiguration> optionalDeploymentPackageConfig =
                 document.getDeploymentPackageConfigurationList().stream()
-                        .filter(e -> e.getPackageName().equals(componentRecipe.getComponentName()))
+                        .filter(e -> e.getName().equals(componentRecipe.getComponentName()))
 
                         // only allow update config for root
                         // no need to check version because root's version will be pinned
@@ -211,7 +211,7 @@ public class KernelConfigResolver {
         Optional<ConfigurationUpdateOperation> optionalConfigUpdate = Optional.empty();
         if (optionalDeploymentPackageConfig.isPresent()) {
             DeploymentPackageConfiguration packageConfiguration = optionalDeploymentPackageConfig.get();
-            optionalConfigUpdate = Optional.ofNullable(packageConfiguration.getConfigurationUpdateOperation());
+            optionalConfigUpdate = Optional.ofNullable(packageConfiguration.getConfigurationUpdate());
 
             updateRunWith(packageConfiguration.getRunWith(), resolvedServiceConfig, componentIdentifier.getName());
         } else {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -366,7 +366,7 @@ public class DeploymentService extends GreengrassService {
                 pkgDetails.put(GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN,
                         deploymentDocument.getDeploymentId());
                 pkgDetails.put(GROUP_TO_ROOT_COMPONENTS_GROUP_NAME, deploymentDocument.getGroupName());
-                deploymentGroupToRootPackages.put(pkgConfig.getPackageName(), pkgDetails);
+                deploymentGroupToRootPackages.put(pkgConfig.getName(), pkgDetails);
             }
         });
         Topics deploymentGroupTopics = config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS);

--- a/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
+++ b/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
@@ -106,7 +106,7 @@ public final class DeploymentDocumentConverter {
         if (localOverrideRequest.getConfigurationUpdate() != null) {
             localOverrideRequest.getConfigurationUpdate().forEach((componentName, configUpdate) -> {
                 packageConfigurations.computeIfAbsent(componentName, DeploymentPackageConfiguration::new);
-                packageConfigurations.get(componentName).setConfigurationUpdateOperation(configUpdate);
+                packageConfigurations.get(componentName).setConfigurationUpdate(configUpdate);
                 packageConfigurations.get(componentName).setResolvedVersion(ANY_VERSION);
             });
         }
@@ -206,14 +206,14 @@ public final class DeploymentDocumentConverter {
             ComponentUpdate componentUpdate) {
 
         DeploymentPackageConfiguration.DeploymentPackageConfigurationBuilder builder =
-                DeploymentPackageConfiguration.builder().packageName(componentName)
+                DeploymentPackageConfiguration.builder().name(componentName)
                 .resolvedVersion(componentUpdate.getVersion().getValue())
                 .rootComponent(true) // As of now, CreateDeployment API only gives root component
-                .configurationUpdateOperation(
+                .configurationUpdate(
                         convertComponentUpdateOperation(componentUpdate.getConfigurationUpdate()));
-        if (componentUpdate.getRunWith() != null && componentUpdate.getRunWith().getPosixUser() != null) {
-            builder = builder.runWith(RunWith.builder().posixUser(componentUpdate.getRunWith().getPosixUser()).build());
-        }
+        builder = builder.runWith(RunWith.builder()
+                .posixUser(componentUpdate.getRunWith() == null ? null : componentUpdate.getRunWith().getPosixUser())
+                .build());
         return builder.build();
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
@@ -6,8 +6,6 @@
 package com.aws.greengrass.deployment.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -40,7 +38,6 @@ import java.util.stream.Collectors;
  * <p>JSON Annotations are only in tests to easily generate this model from a JSON file. They are not part of business
  * logic.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
 @Builder
@@ -50,31 +47,23 @@ import java.util.stream.Collectors;
 @EqualsAndHashCode
 public class DeploymentDocument {
 
-    @JsonProperty("DeploymentId")
     private String deploymentId;
 
-    @JsonProperty("Packages")
     private List<DeploymentPackageConfiguration> deploymentPackageConfigurationList;
 
-    @JsonProperty("RequiredCapabilities")
     private List<String> requiredCapabilities;
 
-    @JsonProperty("GroupName")
     private String groupName;
 
     @Setter
-    @JsonProperty("Timestamp")
     private Long timestamp;
 
-    @JsonProperty("FailureHandlingPolicy")
     @Builder.Default
     private FailureHandlingPolicy failureHandlingPolicy = FailureHandlingPolicy.ROLLBACK;
 
-    @JsonProperty("ComponentUpdatePolicy")
     @Builder.Default
     private ComponentUpdatePolicy componentUpdatePolicy = new ComponentUpdatePolicy();
 
-    @JsonProperty("ConfigurationValidationPolicy")
     @Builder.Default
     @JsonSerialize(using = SDKSerializer.class)
     @JsonDeserialize(converter = SDKDeserializer.class)
@@ -92,7 +81,7 @@ public class DeploymentDocument {
             return Collections.emptyList();
         }
         return deploymentPackageConfigurationList.stream().filter(DeploymentPackageConfiguration::isRootComponent)
-                .map(DeploymentPackageConfiguration::getPackageName).collect(Collectors.toList());
+                .map(DeploymentPackageConfiguration::getName).collect(Collectors.toList());
     }
 
     // Custom serializer for AWS SDK model since Jackson can't figure it out itself

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentPackageConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentPackageConfiguration.java
@@ -5,8 +5,6 @@
 
 package com.aws.greengrass.deployment.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,7 +17,6 @@ import lombok.ToString;
 /**
  * Class to represent a single package along with its dependencies that comes in the deployment configuration.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
 @Builder
@@ -29,31 +26,23 @@ import lombok.ToString;
 @ToString
 public class DeploymentPackageConfiguration {
 
-    @JsonProperty("Name")
-    private String packageName;
-
-    @JsonProperty("RootComponent")
+    private String name;
     private boolean rootComponent;
 
     // TODO: [P41179644] change to versionRequirements which can be a pinned version or a version range
-    @JsonProperty("ResolvedVersion")
     private String resolvedVersion;
-
-    @JsonProperty("ConfigurationUpdate")
-    private ConfigurationUpdateOperation configurationUpdateOperation;
-
-    @JsonProperty("RunWith")
+    private ConfigurationUpdateOperation configurationUpdate;
     private RunWith runWith;
 
     /**
      * Constructor for no update configuration update. Used for testing
      *
-     * @param packageName     name of package
+     * @param name     name of package
      * @param rootComponent   if it is root
      * @param resolvedVersion resolved version
      */
-    public DeploymentPackageConfiguration(String packageName, boolean rootComponent, String resolvedVersion) {
-        this.packageName = packageName;
+    public DeploymentPackageConfiguration(String name, boolean rootComponent, String resolvedVersion) {
+        this.name = name;
         this.rootComponent = rootComponent;
         this.resolvedVersion = resolvedVersion;
     }
@@ -61,25 +50,25 @@ public class DeploymentPackageConfiguration {
     /**
      * Constructor for no legacy configuration.
      *
-     * @param packageName     name of package
+     * @param name     name of package
      * @param rootComponent   if it is root
      * @param resolvedVersion resolved version
-     * @param configurationUpdateOperation   configuration update
+     * @param configurationUpdate   configuration update
      */
-    public DeploymentPackageConfiguration(String packageName, boolean rootComponent, String resolvedVersion,
-            ConfigurationUpdateOperation configurationUpdateOperation) {
-        this.packageName = packageName;
+    public DeploymentPackageConfiguration(String name, boolean rootComponent, String resolvedVersion,
+                                          ConfigurationUpdateOperation configurationUpdate) {
+        this.name = name;
         this.rootComponent = rootComponent;
         this.resolvedVersion = resolvedVersion;
-        this.configurationUpdateOperation = configurationUpdateOperation;
+        this.configurationUpdate = configurationUpdate;
     }
 
 
     /**
      * Constructor. Non provided fields are null.
-     * @param packageName packageName
+     * @param name packageName
      */
-    public DeploymentPackageConfiguration(String packageName) {
-        this.packageName = packageName;
+    public DeploymentPackageConfiguration(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/aws/greengrass/deployment/model/RunWith.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/RunWith.java
@@ -5,8 +5,6 @@
 
 package com.aws.greengrass.deployment.model;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -45,7 +43,6 @@ public class RunWith {
      *
      * @param value the posix user
      */
-    @JsonSetter("PosixUser")
     public void setPosixUser(String value) {
         posixUser = value;
         callPosixUser = true;
@@ -56,7 +53,6 @@ public class RunWith {
      *
      * @return the posix user
      */
-    @JsonGetter("PosixUser")
     public String getPosixUser() {
         if (hasPosixUserValue()) {
             return posixUser;
@@ -69,7 +65,6 @@ public class RunWith {
      *
      * @param value the windows user
      */
-    @JsonSetter("WindowsUser")
     public void setWindowsUser(String value) {
         windowsUser = value;
         callWindowsUser = true;
@@ -80,7 +75,6 @@ public class RunWith {
      *
      * @return the windows user
      */
-    @JsonGetter("WindowsUser")
     public String getWindowsUser() {
         if (hasWindowsUserValue()) {
             return windowsUser;

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -155,14 +155,14 @@ class KernelConfigResolverTest {
                 getPackage(TEST_INPUT_PACKAGE_B, "2.3.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_B);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .runWith(RunWith.builder().posixUser("foo:bar").build())
                 .build();
 
         DeploymentPackageConfiguration dependencyPackageDeploymentConfig =  DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_B)
+                .name(TEST_INPUT_PACKAGE_B)
                 .rootComponent(false)
                 .resolvedVersion("=2.3")
                 .build();
@@ -272,7 +272,7 @@ class KernelConfigResolverTest {
                 TEST_INPUT_PACKAGE_A);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig =
-                DeploymentPackageConfiguration.builder().packageName(TEST_INPUT_PACKAGE_A)
+                DeploymentPackageConfiguration.builder().name(TEST_INPUT_PACKAGE_A)
                         .rootComponent(true)
                         .resolvedVersion("=1.2")
                         .runWith(RunWith.builder().posixUser(null).build())
@@ -417,13 +417,13 @@ class KernelConfigResolverTest {
                 null);
 
         DeploymentPackageConfiguration componentDeploymentConfigA = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
 
         DeploymentPackageConfiguration componentDeploymentConfigB = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_B)
+                .name(TEST_INPUT_PACKAGE_B)
                 .rootComponent(true)
                 .resolvedVersion("=2.3")
                 .build();
@@ -475,18 +475,18 @@ class KernelConfigResolverTest {
                 null);
 
         DeploymentPackageConfiguration componentDeploymentConfigA = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
 
         DeploymentPackageConfiguration componentDeploymentConfigB = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_B)
+                .name(TEST_INPUT_PACKAGE_B)
                 .rootComponent(false)
                 .resolvedVersion("=2.3")
                 .build();
         DeploymentPackageConfiguration componentDeploymentConfigC = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_C)
+                .name(TEST_INPUT_PACKAGE_C)
                 .rootComponent(false)
                 .resolvedVersion("=3.4")
                 .build();
@@ -527,7 +527,7 @@ class KernelConfigResolverTest {
                 node, "/startup/paramA", null, null);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
                 .build();
@@ -565,7 +565,7 @@ class KernelConfigResolverTest {
                 node, "/startup/paramA", null, null);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
                 .build();
@@ -629,11 +629,11 @@ class KernelConfigResolverTest {
         updateOperation.setValueToMerge(Collections.singletonMap("startup", Collections.singletonMap("paramA",
                 "valueC")));
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
                 // For a timestamp of -1, we want to not update anything so that the default gets used instead
-                .configurationUpdateOperation(previousDeploymentTimestamp == -1 ? null : updateOperation)
+                .configurationUpdate(previousDeploymentTimestamp == -1 ? null : updateOperation)
                 .build();
         DeploymentDocument document = DeploymentDocument.builder()
                 .deploymentPackageConfigurationList(Collections.singletonList(rootPackageDeploymentConfig))
@@ -680,10 +680,10 @@ class KernelConfigResolverTest {
         ConfigurationUpdateOperation updateOperation = new ConfigurationUpdateOperation();
         updateOperation.setPathsToReset(Arrays.asList("/startup/paramA", "/startup/paramB"));
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
-                .configurationUpdateOperation(updateOperation)
+                .configurationUpdate(updateOperation)
                 .build();
         DeploymentDocument document = DeploymentDocument.builder()
                 .deploymentPackageConfigurationList(Collections.singletonList(rootPackageDeploymentConfig))
@@ -746,7 +746,7 @@ class KernelConfigResolverTest {
                         null, "/startup/paramA", TEST_INPUT_PACKAGE_B, "/startup/paramB");
 
         DeploymentPackageConfiguration componentDeploymentConfigA = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
@@ -754,13 +754,13 @@ class KernelConfigResolverTest {
         updateOperation.setValueToMerge(Collections.singletonMap("startup", Collections.singletonMap("paramB",
                 "valueB1")));
         DeploymentPackageConfiguration componentDeploymentConfigB = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_B)
+                .name(TEST_INPUT_PACKAGE_B)
                 .rootComponent(true)
                 .resolvedVersion("=2.3")
-                .configurationUpdateOperation(updateOperation)
+                .configurationUpdate(updateOperation)
                 .build();
         DeploymentPackageConfiguration componentDeploymentConfigC = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_C)
+                .name(TEST_INPUT_PACKAGE_C)
                 .rootComponent(true)
                 .resolvedVersion("=3.4")
                 .build();
@@ -872,13 +872,13 @@ class KernelConfigResolverTest {
                 getPackage(TEST_INPUT_PACKAGE_B, "2.3.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_B);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_A)
+                .name(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
 
         DeploymentPackageConfiguration dependencyPackageDeploymentConfig =  DeploymentPackageConfiguration.builder()
-                .packageName(TEST_INPUT_PACKAGE_B)
+                .name(TEST_INPUT_PACKAGE_B)
                 .rootComponent(false)
                 .resolvedVersion("=2.3")
                 .build();
@@ -954,7 +954,7 @@ class KernelConfigResolverTest {
                 kernelConfigResolver.resolve(new ArrayList<>(componentsToResolve.keySet()), deploymentDocument,
                         deploymentDocument.getDeploymentPackageConfigurationList().stream().filter(
                                 DeploymentPackageConfiguration::isRootComponent).map(
-                                DeploymentPackageConfiguration::getPackageName).collect(
+                                DeploymentPackageConfiguration::getName).collect(
                                 Collectors.toList()));
 
         // THEN

--- a/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.deployment.model;
 
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,7 +24,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @ExtendWith(GGExtension.class)
 class RunWithTest {
-    static final ObjectMapper MAPPER = new ObjectMapper();
+    static final ObjectMapper MAPPER = new ObjectMapper().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
 
     @ParameterizedTest
     @MethodSource("runWithValues")

--- a/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
+++ b/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
@@ -19,6 +19,13 @@
           "/path"
         ]
       }
+    },
+    "CustomerApp2": {
+      "version": "1.0.0",
+      "runWith": {
+      },
+      "configurationUpdate": {
+      }
     }
   },
   "componentUpdatePolicy": {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removes null check when converting cloud deployment into internal deployment type. This means that the `posixUser` field will have been set (even if it was set to null), thus when the deployment happens the runWith user will be reset to the default.

**Why is this change necessary:**

**How was this change tested:**
Added new test to verify the functionality. Verified that based on the cloud-serialized data, this check removal now works as expected.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
