### PR TITLE
fix(fss): make fss local agent more robust

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
@@ -216,7 +216,7 @@ class IotJobsFleetStatusServiceTest extends BaseITCase {
         ((Map) kernel.getContext().getvIfExists(Kernel.SERVICE_TYPE_TO_CLASS_MAP_KEY).get()).put("plugin",
                 GreengrassService.class.getName());
         assertNotNull(deviceConfiguration.getThingName());
-        CountDownLatch fssPublishLatch = new CountDownLatch(2);
+        CountDownLatch fssPublishLatch = new CountDownLatch(1);
         logListener = eslm -> {
             if (eslm.getEventType() != null && eslm.getEventType().equals("fss-status-update-published")
                     && eslm.getMessage().equals("Status update published to FSS")) {

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
@@ -30,7 +30,6 @@ import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.status.OverallStatus;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
-import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.exceptions.TLSAuthException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/FleetConfigSimpleApp.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/FleetConfigSimpleApp.json
@@ -1,0 +1,17 @@
+{
+  "configurationArn": "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1",
+  "components": {
+    "SimpleApp": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 100,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 120,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 120
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/FleetConfigSimpleApp2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/FleetConfigSimpleApp2.json
@@ -1,0 +1,17 @@
+{
+  "configurationArn": "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1",
+  "components": {
+    "SimpleApp": {
+      "version": "2.0.0"
+    }
+  },
+  "creationTimestamp": 200,
+  "failureHandlingPolicy": "DO_NOTHING",
+  "componentUpdatePolicy": {
+    "timeout": 120,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 120
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/local_store_content/recipes/SimpleApp-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/local_store_content/recipes/SimpleApp-1.0.0.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: SimpleApp
+ComponentDescription: A simple test app
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentConfiguration:
+  DefaultConfiguration:
+    sampleText: This is a test
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:
+        echo "Hello From Simple App v1. {configuration:/sampleText}"

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/local_store_content/recipes/SimpleApp-2.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/local_store_content/recipes/SimpleApp-2.0.0.yaml
@@ -1,0 +1,16 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: SimpleApp
+ComponentDescription: A simple test app
+ComponentPublisher: Me
+ComponentVersion: '2.0.0'
+ComponentConfiguration:
+  DefaultConfiguration:
+    sampleText: This is a test
+
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:
+        echo "Hello From Simple App v2. {configuration:/sampleText}"

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -29,7 +29,6 @@ import org.apache.commons.lang3.RandomUtils;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
 import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
 
-import javax.inject.Inject;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +42,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
 
 import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.RandomUtils;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
 import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
 
+import javax.inject.Inject;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,7 +43,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.inject.Inject;
 
 import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;
@@ -82,7 +82,7 @@ public class FleetStatusService extends GreengrassService {
     private final AtomicBoolean isEventTriggeredUpdateInProgress = new AtomicBoolean(false);
     private final Set<GreengrassService> updatedGreengrassServiceSet =
             Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private final ConcurrentHashMap<GreengrassService, Instant> allServiceNamesMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<GreengrassService, Instant> serviceFssTracksMap = new ConcurrentHashMap<>();
     private final AtomicBoolean isDeploymentInProgress = new AtomicBoolean(false);
     private final Object periodicUpdateInProgressLock = new Object();
     @Setter // Needed for integration tests.
@@ -189,6 +189,12 @@ public class FleetStatusService extends GreengrassService {
         this.deploymentStatusKeeper.registerDeploymentStatusConsumer(SHADOW,
                 this::deploymentStatusChanged, FLEET_STATUS_SERVICE_TOPICS);
         schedulePeriodicFleetStatusDataUpdate(false);
+
+        //populating services when kernel starts up
+        Instant now = Instant.now();
+        this.kernel.orderedDependencies().forEach(greengrassService -> {
+            serviceFssTracksMap.put(greengrassService, now);
+        });
     }
 
     @SuppressWarnings("PMD.UnusedFormalParameter")
@@ -326,19 +332,19 @@ public class FleetStatusService extends GreengrassService {
         // Check if the removed dependency is still running (Probably as a dependant service to another service).
         // If so, then remove it from the removedDependencies collection.
         this.kernel.orderedDependencies().forEach(greengrassService -> {
-            allServiceNamesMap.put(greengrassService, now);
+            serviceFssTracksMap.put(greengrassService, now);
             overAllStatus.set(getOverallStatusBasedOnServiceState(overAllStatus.get(), greengrassService));
         });
         Set<GreengrassService> removedDependenciesSet = new HashSet<>();
 
         // Add all the removed dependencies to the collection of services to update.
-        allServiceNamesMap.forEach((greengrassService, instant) -> {
+        serviceFssTracksMap.forEach((greengrassService, instant) -> {
             if (!instant.equals(now)) {
                 updatedGreengrassServiceSet.add(greengrassService);
                 removedDependenciesSet.add(greengrassService);
             }
         });
-        removedDependenciesSet.forEach(allServiceNamesMap::remove);
+        removedDependenciesSet.forEach(serviceFssTracksMap::remove);
         removedDependenciesSet.clear();
         uploadFleetStatusServiceData(updatedGreengrassServiceSet, overAllStatus.get(), deploymentInformation);
         isEventTriggeredUpdateInProgress.set(false);
@@ -353,11 +359,26 @@ public class FleetStatusService extends GreengrassService {
         }
         List<ComponentStatusDetails> components = new ArrayList<>();
         long sequenceNumber;
+
         synchronized (greengrassServiceSet) {
+
             // If there are no Greengrass services to be updated, do not send an update.
             if (greengrassServiceSet.isEmpty()) {
                 return;
             }
+
+            //When a component version is bumped up, FSS may have pointers to both GreengrassService
+            //Filtering out the service instance of the old version and only sending the update for the new version
+            Set<GreengrassService> filteredServices = new HashSet<>();
+            greengrassServiceSet.forEach(service -> {
+                try {
+                    GreengrassService runningService = kernel.locate(service.getName());
+                    filteredServices.add(runningService);
+                } catch (ServiceLoadException e) {
+                    //not able to find service, service might be removed.
+                    filteredServices.add(service);
+                }
+            });
 
             Topics componentsToGroupsTopics = null;
             HashSet<String> allGroups = new HashSet<>();
@@ -377,7 +398,7 @@ public class FleetStatusService extends GreengrassService {
             Topics finalComponentsToGroupsTopics = componentsToGroupsTopics;
 
             DeploymentService finalDeploymentService = deploymentService;
-            greengrassServiceSet.forEach(service -> {
+            filteredServices.forEach(service -> {
                 if (isSystemLevelService(service)) {
                     return;
                 }
@@ -402,7 +423,7 @@ public class FleetStatusService extends GreengrassService {
                 components.add(componentStatusDetails);
             });
 
-            greengrassServiceSet.forEach(service -> {
+            filteredServices.forEach(service -> {
                 if (!isSystemLevelService(service)) {
                     return;
                 }
@@ -494,7 +515,7 @@ public class FleetStatusService extends GreengrassService {
      */
     void addServicesToPreviouslyKnownServicesList(List<GreengrassService> greengrassServices,
                                                            Instant instant) {
-        greengrassServices.forEach(greengrassService -> allServiceNamesMap.put(greengrassService, instant));
+        greengrassServices.forEach(greengrassService -> serviceFssTracksMap.put(greengrassService, instant));
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -367,8 +367,8 @@ public class FleetStatusService extends GreengrassService {
                 return;
             }
 
-            //When a component version is bumped up, FSS may have pointers to both GreengrassService
-            //Filtering out the service instance of the old version and only sending the update for the new version
+            //When a component version is bumped up, FSS may have pointers to both old and new service instances
+            //Filtering out the old version and only sending the update for the new version
             Set<GreengrassService> filteredServices = new HashSet<>();
             greengrassServiceSet.forEach(service -> {
                 try {

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -170,6 +170,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockGreengrassService2.getState()).thenReturn(State.RUNNING);
         when(mockGreengrassService2.isBuiltin()).thenReturn(true);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
+        when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
+        when(mockKernel.locate("MockService2")).thenReturn(mockGreengrassService2);
         when(mockKernel.orderedDependencies()).thenReturn(Arrays.asList(mockGreengrassService1, mockGreengrassService2));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         when(mockDeploymentService.isComponentRoot("MockService")).thenReturn(true);
@@ -257,6 +259,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService1.getState()).thenReturn(State.BROKEN);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
+        when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
 
         when(mockDeploymentService.getConfig()).thenReturn(config);
@@ -400,6 +403,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
+        when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
@@ -504,7 +508,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
-        when(mockKernel.locate(anyString())).thenReturn(mockDeploymentService);
+        when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
+        when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singletonList(mockDeploymentService));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
@@ -578,9 +583,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
 
         // Set up all the mocks
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
+        when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService1.getState()).thenReturn(State.BROKEN);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
+        when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
 
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
@@ -667,7 +674,10 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockGreengrassService2.getName()).thenReturn("MockService2");
         when(mockGreengrassService2.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService2.getState()).thenReturn(State.RUNNING);
+        when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
+        when(mockKernel.locate("MockService2")).thenReturn(mockGreengrassService2);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
+
         when(mockKernel.orderedDependencies()).thenReturn(Arrays.asList(mockGreengrassService1, mockGreengrassService2));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
@@ -749,9 +759,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
 
         // Set up all the mocks
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
+        when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
+        when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
         when(mockDeploymentService.getConfig()).thenReturn(config);
         doNothing().when(context).addGlobalStateChangeListener(addGlobalStateChangeListenerArgumentCaptor.capture());
@@ -810,9 +822,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             when(greengrassService.getName()).thenReturn(serviceName);
             when(greengrassService.getState()).thenReturn(State.RUNNING);
             when(greengrassService.getServiceConfig()).thenReturn(config);
-
             greengrassServices.add(greengrassService);
             serviceNamesToCheck.add(serviceName);
+            when(mockKernel.locate(serviceName)).thenReturn(greengrassService);
         }
         lenient().when(config.lookupTopics(COMPONENTS_TO_GROUPS_TOPICS)).thenReturn(allComponentToGroupsTopics);
 


### PR DESCRIPTION
**Issue #, if available:**

**1: list Installed components returns components that got removed from the device**

The contract between the device and cloud is that when a component is removed from the device, the FSS local agent will update cloud of the removal by reporting status for the components with the fleetConfigArns field as empty. There is a bug in FSS local agent which causes it not send this update. The bug is hit when three events happen in the following order:

i. Kernel restarts
ii. Any Component moves to BROKEN state
iii. A deployment removes a component in BROKEN or FINISHED state.


Root cause:
FSS local agent keeps tracks of components running on the device in two ways.

i. FSS agent keeps track of all components added by a deployment. [STATE 1]
ii. FSS agent keeps track of all components which changed state after the previous FSS update. [STATE 2]

Both the states are not persisted to disk so when the device restarts both states are reset. When the kernel starts up STATE 1 and STATE 2 are empty. When the kernel starts the components STATE 2 starts filling up as all the components will move through the different life-cycle stages to reach RUNNING. But when a component reached BROKEN state, FSS agent will send an update to the cloud and include all the information in STATE 2, then it wipes STATE 2 as its already sent to the cloud. Now the device receives a deployment to remove a component X which is in the BROKEN or FINISHED state. Since X is in BROKEN/FINISHED state it does not makes any state changes before its removed from the mains dependency tree and therefore FSS local agent looses track of the component and is not included in any FSS update afterwards. The data set that list Installed components API looks at is FSS data and hence the component will show up in list Installed components API even after it is removed from the device.

Fix:
Updated FSS local agent to keep state across kernel restarts.

**2: list Installed components returns wrong components version, when a component version is upgraded by a deployment**

Root cause:
FSS local agent will send 2 updates for the component when a version is bumped up (one for old version and one new version). Cloud stores the version based on the order in which the updates is processed. 

Fix:
FSS local agent will only send one update for the component.

**How was this change tested:**
Integ tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
