### PR TITLE
build: remove .a files from jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -671,6 +671,12 @@
                                         <exclude>*.a</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>software.amazon.awssdk.crt:aws-crt:jar:*</artifact>
+                                    <excludes>
+                                        <exclude>*.a</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                         </configuration>
                     </execution>

--- a/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
@@ -65,7 +65,6 @@ public final class ClientConfigurationUtils {
      */
     public static ApacheHttpClient.Builder getConfiguredClientBuilder(DeviceConfiguration deviceConfiguration) {
         ApacheHttpClient.Builder httpClient = ProxyUtils.getSdkHttpClientBuilder();
-        httpClient = httpClient == null ? ApacheHttpClient.builder() : httpClient;
 
         try {
             configureClientMutualTLS(httpClient, deviceConfiguration);

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -22,7 +22,6 @@ import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpResponse;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.greengrassv2data.model.GetComponentVersionArtifactRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.GetComponentVersionArtifactResponse;
 
@@ -211,8 +210,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     }
 
     SdkHttpClient getSdkHttpClient() {
-        SdkHttpClient proxyClient = ProxyUtils.getSdkHttpClient();
-        return proxyClient == null ? ApacheHttpClient.builder().build() : proxyClient;
+        return ProxyUtils.getSdkHttpClient();
     }
 
     private long getContentLengthLong(SdkHttpResponse sdkHttpResponse) {

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
 import software.amazon.awssdk.services.greengrassv2.model.ComponentDeploymentSpecification;
@@ -314,8 +313,7 @@ public class DeviceProvisioningHelper {
     }
 
     private SdkHttpClient getSdkHttpClient() {
-        SdkHttpClient proxyClient = ProxyUtils.getSdkHttpClient();
-        return proxyClient == null ? ApacheHttpClient.builder().build() : proxyClient;
+        return ProxyUtils.getSdkHttpClient();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -201,10 +201,8 @@ public final class ProxyUtils {
      * @return httpClient built with a ProxyConfiguration or null if no proxy is configured (null is ignored in AWS
      *     SDK clients)
      */
-    @Nullable
     public static SdkHttpClient getSdkHttpClient() {
-        ApacheHttpClient.Builder builder = getSdkHttpClientBuilder();
-        return builder == null ? null : builder.build();
+        return getSdkHttpClientBuilder().build();
     }
 
     /**
@@ -216,7 +214,6 @@ public final class ProxyUtils {
      * @return httpClient built with a ProxyConfiguration or null if no proxy is configured (null is ignored in AWS
      *     SDK clients)
      */
-    @Nullable
     public static ApacheHttpClient.Builder getSdkHttpClientBuilder() {
         ProxyConfiguration proxyConfiguration = getProxyConfiguration();
 
@@ -224,7 +221,7 @@ public final class ProxyUtils {
             return ApacheHttpClient.builder().proxyConfiguration(proxyConfiguration);
         }
 
-        return null;
+        return ApacheHttpClient.builder();
     }
 
     private static String removeAuthFromProxyUrl(String proxyUrl) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove .a files again, also updates proxy http client provider so that it always provides a client so that we can remove all the nullchecks all over the place.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
