### PR TITLE
fix(docker): simplify image specification parsing

### DIFF
--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageArtifactParserTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageArtifactParserTest.java
@@ -149,6 +149,32 @@ public class DockerImageArtifactParserTest {
                 Registry.RegistryType.PUBLIC,
                 Registry.RegistrySource.OTHER);
 
+        assertAll(getImage(
+                "docker:1234567890.dkr.ecr.us-east-1.amazonaws.com/dockerimagerepository@sha256:"
+                        + "c4ffb87b09eba99383ee89b309d6d521"),
+                "dockerimagerepository",
+                null,
+                "sha256:c4ffb87b09eba99383ee89b309d6d521",
+                "1234567890.dkr.ecr.us-east-1.amazonaws.com",
+                Registry.RegistryType.PRIVATE,
+                Registry.RegistrySource.ECR);
+
+        assertAll(getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws.com/dockerimagerepository:v2.3.4"),
+                "dockerimagerepository",
+                "v2.3.4",
+                null,
+                "1234567890.dkr.ecr.us-east-1.amazonaws.com",
+                Registry.RegistryType.PRIVATE,
+                Registry.RegistrySource.ECR);
+
+        assertAll(getImage("docker:public.ecr.aws/some-repo/some-img:latest"),
+                "some-repo/some-img",
+                "latest",
+                null,
+                "public.ecr.aws",
+                Registry.RegistryType.PUBLIC,
+                Registry.RegistrySource.ECR);
+
     }
 
     private Image getImage(String uriString) throws InvalidArtifactUriException {
@@ -235,6 +261,43 @@ public class DockerImageArtifactParserTest {
         // domain component has invalid char $
         assertThrows(InvalidArtifactUriException.class,
                 () -> getImage("docker:www.$amazon.com:8080/image:v1.10"));
+
+        // has both tag and digest
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        + ".com/dockerimagerepository:v2.3.4@sha256:c4ffb87b09eba99383ee89b309d6d521"));
+
+        // has both tag and digest in a wrong format
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository:latest/sha256"
+                        + ":c4ffb87b09eba99383ee89b309d6d521"));
+
+        // has both tag and a longer than allowed digest in a wrong format
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository:latest/sha256"
+                        + ":4d5f703cbcf9d4db75b923e5c5cc8b72479766cd1b1da77c28f8e4a059feff38"));
+
+        // digest identifier @ present but not followed by digest value
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository@"));
+
+        // digest identifier @ followed by tag identifier : but no value for either
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository@:"));
+
+        // tag identifier : followed by digest identifier @ but no value for either
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository:@"));
+
+        // tag identifier : present but not followed by tag value
+        assertThrows(InvalidArtifactUriException.class,
+                () -> getImage("docker:1234567890.dkr.ecr.us-east-1.amazonaws"
+                        +".com/dockerimagerepository:"));
     }
 
 }


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
Simplifying image parsing code by moving away from an overly large regex which in certain environment cannot handle an edge case when both tag and digest or their starting identifiers (i.e. `:` or `@`) are present. 

**Why is this change necessary:**
Above mentioned case needs to be handled correctly.

**How was this change tested:**
Existing unit tests pass so there is no regression, newly added tests for previously unhandled case pass as well

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
