### PR TITLE
fix(runwith): partial revert of 1e12c to keep data models consistent

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
@@ -408,7 +408,7 @@ class PluginComponentTest extends BaseITCase {
                         .timeoutInSeconds(20).build())
                 .deploymentPackageConfigurationList(
                         Arrays.asList(DeploymentPackageConfiguration.builder()
-                                .name(componentName)
+                                .packageName(componentName)
                                 .rootComponent(true)
                                 .resolvedVersion(version)
                                 .build()))

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/AddNewServiceWithSafetyCheck.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/AddNewServiceWithSafetyCheck.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "NonDisruptableService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_1.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_2.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "RootComponent": true,

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_3.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_3.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_4.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_4.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_5.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_DeployDocument_5.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_InitialDocumentWithUpdate.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/ComponentConfigTest_InitialDocumentWithUpdate.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CrossComponentConfigTest_DeployDocument.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CrossComponentConfigTest_DeployDocument.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.ComponentConfigTestMain",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CustomerAppAndYellowSignal.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/CustomerAppAndYellowSignal.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "CustomerApp",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/Failure2RollbackDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/Failure2RollbackDeployment.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "BreakingService2",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureDoNothingDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureDoNothingDeployment.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "BreakingService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureRollbackDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FailureRollbackDeployment.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "BreakingService",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "CustomerApp",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentRemovingUser.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentRemovingUser.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "CustomerAppStartupShutdown",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "CustomerAppStartupShutdown",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_2.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "CustomerAppStartupShutdown",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument_updated.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocument_updated.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "CustomerApp",
       "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc1.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "DeploymentPackageConfigurationList": [
+    "Packages": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "1.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc2.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "DeploymentPackageConfigurationList": [
+    "Packages": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "2.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc3.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc3.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "DeploymentPackageConfigurationList": [
+    "Packages": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "3.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc4.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SimpleAppJobDoc4.json
@@ -1,6 +1,6 @@
 {
     "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-    "DeploymentPackageConfigurationList": [
+    "Packages": [
       {
         "Name": "SimpleApp",
         "ResolvedVersion": "4.0.0",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SkipPolicyCheck.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SkipPolicyCheck.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "NonDisruptableService",
       "ResolvedVersion": "1.0.1",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SystemConfigTest_DeployDocument.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SystemConfigTest_DeployDocument.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "arn:aws:us-east-1:greengrass:configuration:thinggroup/group1:1",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "aws.iot.gg.test.integ.SystemConfigTest",
       "ResolvedVersion": "0.0.1",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/UpdateServiceWithSafetyCheck.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/UpdateServiceWithSafetyCheck.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "NonDisruptableService",
       "ResolvedVersion": "1.0.1",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/YellowAndRedSignal.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/YellowAndRedSignal.json
@@ -1,6 +1,6 @@
 {
   "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
-  "DeploymentPackageConfigurationList": [
+  "Packages": [
     {
       "Name": "RedSignal",
       "ResolvedVersion": "1.0.0",

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -108,12 +108,12 @@ public class DependencyResolver {
         List<String> targetComponentsToResolve = new ArrayList<>();
         document.getDeploymentPackageConfigurationList().stream()
                 .filter(DeploymentPackageConfiguration::isRootComponent).forEach(e -> {
-            logger.atDebug().kv(COMPONENT_NAME_KEY, e.getName()).kv(VERSION_KEY, e.getResolvedVersion())
+            logger.atDebug().kv(COMPONENT_NAME_KEY, e.getPackageName()).kv(VERSION_KEY, e.getResolvedVersion())
                     .log("Found component configuration");
-            componentNameToVersionConstraints.putIfAbsent(e.getName(), new HashMap<>());
-            componentNameToVersionConstraints.get(e.getName())
+            componentNameToVersionConstraints.putIfAbsent(e.getPackageName(), new HashMap<>());
+            componentNameToVersionConstraints.get(e.getPackageName())
                     .put(document.getGroupName(), Requirement.buildNPM(e.getResolvedVersion()));
-            targetComponentsToResolve.add(e.getName());
+            targetComponentsToResolve.add(e.getPackageName());
         });
 
         logger.atInfo().setEventType("resolve-group-dependencies-start")

--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -203,7 +203,7 @@ public class KernelConfigResolver {
 
         Optional<DeploymentPackageConfiguration> optionalDeploymentPackageConfig =
                 document.getDeploymentPackageConfigurationList().stream()
-                        .filter(e -> e.getName().equals(componentRecipe.getComponentName()))
+                        .filter(e -> e.getPackageName().equals(componentRecipe.getComponentName()))
 
                         // only allow update config for root
                         // no need to check version because root's version will be pinned
@@ -212,7 +212,7 @@ public class KernelConfigResolver {
         Optional<ConfigurationUpdateOperation> optionalConfigUpdate = Optional.empty();
         if (optionalDeploymentPackageConfig.isPresent()) {
             DeploymentPackageConfiguration packageConfiguration = optionalDeploymentPackageConfig.get();
-            optionalConfigUpdate = Optional.ofNullable(packageConfiguration.getConfigurationUpdate());
+            optionalConfigUpdate = Optional.ofNullable(packageConfiguration.getConfigurationUpdateOperation());
 
             updateRunWith(packageConfiguration.getRunWith(), resolvedServiceConfig, componentIdentifier.getName());
         } else {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -366,7 +366,7 @@ public class DeploymentService extends GreengrassService {
                 pkgDetails.put(GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN,
                         deploymentDocument.getDeploymentId());
                 pkgDetails.put(GROUP_TO_ROOT_COMPONENTS_GROUP_NAME, deploymentDocument.getGroupName());
-                deploymentGroupToRootPackages.put(pkgConfig.getName(), pkgDetails);
+                deploymentGroupToRootPackages.put(pkgConfig.getPackageName(), pkgDetails);
             }
         });
         Topics deploymentGroupTopics = config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS);

--- a/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
+++ b/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
@@ -107,7 +107,7 @@ public final class DeploymentDocumentConverter {
         if (localOverrideRequest.getConfigurationUpdate() != null) {
             localOverrideRequest.getConfigurationUpdate().forEach((componentName, configUpdate) -> {
                 packageConfigurations.computeIfAbsent(componentName, DeploymentPackageConfiguration::new);
-                packageConfigurations.get(componentName).setConfigurationUpdate(configUpdate);
+                packageConfigurations.get(componentName).setConfigurationUpdateOperation(configUpdate);
                 packageConfigurations.get(componentName).setResolvedVersion(ANY_VERSION);
             });
         }
@@ -209,10 +209,10 @@ public final class DeploymentDocumentConverter {
             ComponentUpdate componentUpdate) {
 
         DeploymentPackageConfiguration.DeploymentPackageConfigurationBuilder builder =
-                DeploymentPackageConfiguration.builder().name(componentName)
+                DeploymentPackageConfiguration.builder().packageName(componentName)
                 .resolvedVersion(componentUpdate.getVersion().getValue())
                 .rootComponent(true) // As of now, CreateDeployment API only gives root component
-                .configurationUpdate(
+                .configurationUpdateOperation(
                         convertComponentUpdateOperation(componentUpdate.getConfigurationUpdate()));
         builder = builder.runWith(RunWith.builder()
                 .posixUser(componentUpdate.getRunWith() == null ? null : componentUpdate.getRunWith().getPosixUser())

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.deployment.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -47,23 +48,31 @@ import java.util.stream.Collectors;
 @EqualsAndHashCode
 public class DeploymentDocument {
 
+    @JsonProperty("DeploymentId")
     private String deploymentId;
 
+    @JsonProperty("Packages")
     private List<DeploymentPackageConfiguration> deploymentPackageConfigurationList;
 
+    @JsonProperty("RequiredCapabilities")
     private List<String> requiredCapabilities;
 
+    @JsonProperty("GroupName")
     private String groupName;
 
     @Setter
+    @JsonProperty("Timestamp")
     private Long timestamp;
 
+    @JsonProperty("FailureHandlingPolicy")
     @Builder.Default
     private FailureHandlingPolicy failureHandlingPolicy = FailureHandlingPolicy.ROLLBACK;
 
+    @JsonProperty("ComponentUpdatePolicy")
     @Builder.Default
     private ComponentUpdatePolicy componentUpdatePolicy = new ComponentUpdatePolicy();
 
+    @JsonProperty("ConfigurationValidationPolicy")
     @Builder.Default
     @JsonSerialize(using = SDKSerializer.class)
     @JsonDeserialize(converter = SDKDeserializer.class)
@@ -81,7 +90,7 @@ public class DeploymentDocument {
             return Collections.emptyList();
         }
         return deploymentPackageConfigurationList.stream().filter(DeploymentPackageConfiguration::isRootComponent)
-                .map(DeploymentPackageConfiguration::getName).collect(Collectors.toList());
+                .map(DeploymentPackageConfiguration::getPackageName).collect(Collectors.toList());
     }
 
     // Custom serializer for AWS SDK model since Jackson can't figure it out itself

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentPackageConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentPackageConfiguration.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.deployment.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -26,23 +27,31 @@ import lombok.ToString;
 @ToString
 public class DeploymentPackageConfiguration {
 
-    private String name;
+    @JsonProperty("Name")
+    private String packageName;
+
+    @JsonProperty("RootComponent")
     private boolean rootComponent;
 
     // TODO: [P41179644] change to versionRequirements which can be a pinned version or a version range
+    @JsonProperty("ResolvedVersion")
     private String resolvedVersion;
-    private ConfigurationUpdateOperation configurationUpdate;
+
+    @JsonProperty("ConfigurationUpdate")
+    private ConfigurationUpdateOperation configurationUpdateOperation;
+
+    @JsonProperty("RunWith")
     private RunWith runWith;
 
     /**
      * Constructor for no update configuration update. Used for testing
      *
-     * @param name     name of package
+     * @param packageName     name of package
      * @param rootComponent   if it is root
      * @param resolvedVersion resolved version
      */
-    public DeploymentPackageConfiguration(String name, boolean rootComponent, String resolvedVersion) {
-        this.name = name;
+    public DeploymentPackageConfiguration(String packageName, boolean rootComponent, String resolvedVersion) {
+        this.packageName = packageName;
         this.rootComponent = rootComponent;
         this.resolvedVersion = resolvedVersion;
     }
@@ -50,25 +59,25 @@ public class DeploymentPackageConfiguration {
     /**
      * Constructor for no legacy configuration.
      *
-     * @param name     name of package
+     * @param packageName     name of package
      * @param rootComponent   if it is root
      * @param resolvedVersion resolved version
-     * @param configurationUpdate   configuration update
+     * @param configurationUpdateOperation   configuration update
      */
-    public DeploymentPackageConfiguration(String name, boolean rootComponent, String resolvedVersion,
-                                          ConfigurationUpdateOperation configurationUpdate) {
-        this.name = name;
+    public DeploymentPackageConfiguration(String packageName, boolean rootComponent, String resolvedVersion,
+            ConfigurationUpdateOperation configurationUpdateOperation) {
+        this.packageName = packageName;
         this.rootComponent = rootComponent;
         this.resolvedVersion = resolvedVersion;
-        this.configurationUpdate = configurationUpdate;
+        this.configurationUpdateOperation = configurationUpdateOperation;
     }
 
 
     /**
      * Constructor. Non provided fields are null.
-     * @param name packageName
+     * @param packageName packageName
      */
-    public DeploymentPackageConfiguration(String name) {
-        this.name = name;
+    public DeploymentPackageConfiguration(String packageName) {
+        this.packageName = packageName;
     }
 }

--- a/src/main/java/com/aws/greengrass/deployment/model/RunWith.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/RunWith.java
@@ -5,6 +5,8 @@
 
 package com.aws.greengrass.deployment.model;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -47,6 +49,7 @@ public class RunWith {
      *
      * @param value the posix user
      */
+    @JsonSetter("PosixUser")
     public void setPosixUser(String value) {
         posixUser = value;
         callPosixUser = true;
@@ -57,6 +60,7 @@ public class RunWith {
      *
      * @return the posix user
      */
+    @JsonGetter("PosixUser")
     public String getPosixUser() {
         if (hasPosixUserValue()) {
             return posixUser;
@@ -69,6 +73,7 @@ public class RunWith {
      *
      * @param value the windows user
      */
+    @JsonSetter("WindowsUser")
     public void setWindowsUser(String value) {
         windowsUser = value;
         callWindowsUser = true;
@@ -79,6 +84,7 @@ public class RunWith {
      *
      * @return the windows user
      */
+    @JsonGetter("WindowsUser")
     public String getWindowsUser() {
         if (hasWindowsUserValue()) {
             return windowsUser;

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -159,14 +159,14 @@ class KernelConfigResolverTest {
         SystemResourceLimits systemResourceLimits = new SystemResourceLimits(
                 new SystemResourceLimits.LinuxSystemResourceLimits(102400L, 1.5));
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .runWith(RunWith.builder().posixUser("foo:bar").systemResourceLimits(systemResourceLimits).build())
                 .build();
 
         DeploymentPackageConfiguration dependencyPackageDeploymentConfig =  DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_B)
+                .packageName(TEST_INPUT_PACKAGE_B)
                 .rootComponent(false)
                 .resolvedVersion("=2.3")
                 .build();
@@ -278,7 +278,7 @@ class KernelConfigResolverTest {
                 TEST_INPUT_PACKAGE_A);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig =
-                DeploymentPackageConfiguration.builder().name(TEST_INPUT_PACKAGE_A)
+                DeploymentPackageConfiguration.builder().packageName(TEST_INPUT_PACKAGE_A)
                         .rootComponent(true)
                         .resolvedVersion("=1.2")
                         .runWith(RunWith.builder().posixUser(null).build())
@@ -428,13 +428,13 @@ class KernelConfigResolverTest {
                 null);
 
         DeploymentPackageConfiguration componentDeploymentConfigA = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
 
         DeploymentPackageConfiguration componentDeploymentConfigB = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_B)
+                .packageName(TEST_INPUT_PACKAGE_B)
                 .rootComponent(true)
                 .resolvedVersion("=2.3")
                 .build();
@@ -486,18 +486,18 @@ class KernelConfigResolverTest {
                 null);
 
         DeploymentPackageConfiguration componentDeploymentConfigA = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
 
         DeploymentPackageConfiguration componentDeploymentConfigB = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_B)
+                .packageName(TEST_INPUT_PACKAGE_B)
                 .rootComponent(false)
                 .resolvedVersion("=2.3")
                 .build();
         DeploymentPackageConfiguration componentDeploymentConfigC = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_C)
+                .packageName(TEST_INPUT_PACKAGE_C)
                 .rootComponent(false)
                 .resolvedVersion("=3.4")
                 .build();
@@ -538,7 +538,7 @@ class KernelConfigResolverTest {
                 node, "/startup/paramA", null, null);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
                 .build();
@@ -576,7 +576,7 @@ class KernelConfigResolverTest {
                 node, "/startup/paramA", null, null);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
                 .build();
@@ -640,11 +640,11 @@ class KernelConfigResolverTest {
         updateOperation.setValueToMerge(Collections.singletonMap("startup", Collections.singletonMap("paramA",
                 "valueC")));
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
                 // For a timestamp of -1, we want to not update anything so that the default gets used instead
-                .configurationUpdate(previousDeploymentTimestamp == -1 ? null : updateOperation)
+                .configurationUpdateOperation(previousDeploymentTimestamp == -1 ? null : updateOperation)
                 .build();
         DeploymentDocument document = DeploymentDocument.builder()
                 .deploymentPackageConfigurationList(Collections.singletonList(rootPackageDeploymentConfig))
@@ -691,10 +691,10 @@ class KernelConfigResolverTest {
         ConfigurationUpdateOperation updateOperation = new ConfigurationUpdateOperation();
         updateOperation.setPathsToReset(Arrays.asList("/startup/paramA", "/startup/paramB"));
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion(">=1.2")
-                .configurationUpdate(updateOperation)
+                .configurationUpdateOperation(updateOperation)
                 .build();
         DeploymentDocument document = DeploymentDocument.builder()
                 .deploymentPackageConfigurationList(Collections.singletonList(rootPackageDeploymentConfig))
@@ -757,7 +757,7 @@ class KernelConfigResolverTest {
                         null, "/startup/paramA", TEST_INPUT_PACKAGE_B, "/startup/paramB");
 
         DeploymentPackageConfiguration componentDeploymentConfigA = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
@@ -765,13 +765,13 @@ class KernelConfigResolverTest {
         updateOperation.setValueToMerge(Collections.singletonMap("startup", Collections.singletonMap("paramB",
                 "valueB1")));
         DeploymentPackageConfiguration componentDeploymentConfigB = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_B)
+                .packageName(TEST_INPUT_PACKAGE_B)
                 .rootComponent(true)
                 .resolvedVersion("=2.3")
-                .configurationUpdate(updateOperation)
+                .configurationUpdateOperation(updateOperation)
                 .build();
         DeploymentPackageConfiguration componentDeploymentConfigC = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_C)
+                .packageName(TEST_INPUT_PACKAGE_C)
                 .rootComponent(true)
                 .resolvedVersion("=3.4")
                 .build();
@@ -883,13 +883,13 @@ class KernelConfigResolverTest {
                 getPackage(TEST_INPUT_PACKAGE_B, "2.3.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_B);
 
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_A)
+                .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
                 .resolvedVersion("=1.2")
                 .build();
 
         DeploymentPackageConfiguration dependencyPackageDeploymentConfig =  DeploymentPackageConfiguration.builder()
-                .name(TEST_INPUT_PACKAGE_B)
+                .packageName(TEST_INPUT_PACKAGE_B)
                 .rootComponent(false)
                 .resolvedVersion("=2.3")
                 .build();
@@ -965,7 +965,7 @@ class KernelConfigResolverTest {
                 kernelConfigResolver.resolve(new ArrayList<>(componentsToResolve.keySet()), deploymentDocument,
                         deploymentDocument.getDeploymentPackageConfigurationList().stream().filter(
                                 DeploymentPackageConfiguration::isRootComponent).map(
-                                DeploymentPackageConfiguration::getName).collect(
+                                DeploymentPackageConfiguration::getPackageName).collect(
                                 Collectors.toList()));
 
         // THEN

--- a/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
@@ -130,28 +130,28 @@ class DeploymentDocumentConverterTest {
 
         // verify deploymentConfigs
         DeploymentPackageConfiguration existingRootComponentConfig =
-                deploymentPackageConfigurations.stream().filter(e -> e.getName().equals(EXISTING_ROOT_COMPONENT))
+                deploymentPackageConfigurations.stream().filter(e -> e.getPackageName().equals(EXISTING_ROOT_COMPONENT))
                         .findAny().get();
 
         assertThat(existingRootComponentConfig.getResolvedVersion(), is("2.0.0"));
-        assertThat(existingRootComponentConfig.getConfigurationUpdate(),
+        assertThat(existingRootComponentConfig.getConfigurationUpdateOperation(),
                 is(mapper.readValue(existingUpdateConfigString, ConfigurationUpdateOperation.class)));
 
         DeploymentPackageConfiguration newRootComponentConfig =
-                deploymentPackageConfigurations.stream().filter(e -> e.getName().equals(NEW_ROOT_COMPONENT))
+                deploymentPackageConfigurations.stream().filter(e -> e.getPackageName().equals(NEW_ROOT_COMPONENT))
                         .findAny().get();
 
         assertThat(newRootComponentConfig.getResolvedVersion(), is("2.0.0"));
-        assertNull(newRootComponentConfig.getConfigurationUpdate());
+        assertNull(newRootComponentConfig.getConfigurationUpdateOperation());
         assertEquals("foo:bar", newRootComponentConfig.getRunWith().getPosixUser());
         assertEquals(1.5, newRootComponentConfig.getRunWith().getSystemResourceLimits().getLinux().getCpu());
         assertEquals(102400L, newRootComponentConfig.getRunWith().getSystemResourceLimits().getLinux().getMemory());
 
         DeploymentPackageConfiguration DependencyComponentConfig =
-                deploymentPackageConfigurations.stream().filter(e -> e.getName().equals(DEPENDENCY_COMPONENT))
+                deploymentPackageConfigurations.stream().filter(e -> e.getPackageName().equals(DEPENDENCY_COMPONENT))
                         .findAny().get();
 
-        assertEquals(DependencyComponentConfig.getConfigurationUpdate(),
+        assertEquals(DependencyComponentConfig.getConfigurationUpdateOperation(),
                 mapper.readValue(dependencyUpdateConfigString, ConfigurationUpdateOperation.class));
         assertThat(DependencyComponentConfig.getResolvedVersion(), is("*"));
     }
@@ -186,19 +186,19 @@ class DeploymentDocumentConverterTest {
         DeploymentPackageConfiguration componentConfiguration =
                 deploymentDocument.getDeploymentPackageConfigurationList().get(0);
 
-        assertThat(componentConfiguration.getName(), equalTo("CustomerApp"));
+        assertThat(componentConfiguration.getPackageName(), equalTo("CustomerApp"));
         assertThat(componentConfiguration.getResolvedVersion(), equalTo("1.0.0"));
         assertThat(componentConfiguration.getRunWith(), is(notNullValue()));
         assertThat(componentConfiguration.getRunWith().getPosixUser(), equalTo("foo"));
-        assertThat(componentConfiguration.getConfigurationUpdate().getPathsToReset(),
+        assertThat(componentConfiguration.getConfigurationUpdateOperation().getPathsToReset(),
                    equalTo(Arrays.asList("/sampleText", "/path")));
-        assertThat(componentConfiguration.getConfigurationUpdate().getValueToMerge(),
+        assertThat(componentConfiguration.getConfigurationUpdateOperation().getValueToMerge(),
                    equalTo(ImmutableMap.of("key", "val")));
 
         componentConfiguration =
                 deploymentDocument.getDeploymentPackageConfigurationList().get(1);
 
-        assertThat(componentConfiguration.getName(), equalTo("CustomerApp2"));
+        assertThat(componentConfiguration.getPackageName(), equalTo("CustomerApp2"));
         assertThat(componentConfiguration.getRunWith(), is(notNullValue()));
         assertThat(componentConfiguration.getRunWith().getPosixUser(), is(nullValue()));
         assertThat(componentConfiguration.getRunWith().hasPosixUserValue(), is(true));
@@ -231,9 +231,9 @@ class DeploymentDocumentConverterTest {
         DeploymentPackageConfiguration componentConfiguration =
                 deploymentDocument.getDeploymentPackageConfigurationList().get(0);
 
-        assertThat(componentConfiguration.getName(), equalTo("CustomerApp"));
+        assertThat(componentConfiguration.getPackageName(), equalTo("CustomerApp"));
         assertThat(componentConfiguration.getResolvedVersion(), equalTo("1.0.0"));
-        assertNull(componentConfiguration.getConfigurationUpdate());
+        assertNull(componentConfiguration.getConfigurationUpdateOperation());
 
         // The following fields are not provided in the json so default values should be used.
         // Default for FailureHandlingPolicy should be ROLLBACK

--- a/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.deployment.model;
 
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @ExtendWith(GGExtension.class)
 class RunWithTest {
-    static final ObjectMapper MAPPER = new ObjectMapper().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
+    static final ObjectMapper MAPPER = new ObjectMapper();
 
     @ParameterizedTest
     @MethodSource("runWithValues")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Reverting all the deployment model changes in 1e12c because prior nucleus versions are not case insensitive unfortunately. This means that an old nucleus won't be able to read the deployment files written by a newer nucleus. This will happen if a user attempts to downgrade their nucleus version.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
