### PR TITLE
fix: correct the system resource limit merge

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -104,6 +104,7 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.POSIX_USER_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUN_WITH_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SYSTEM_RESOURCE_LIMITS_TOPICS;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
 import static com.aws.greengrass.testcommons.testutilities.SudoUtil.assumeCanSudoShell;
@@ -864,12 +865,18 @@ class DeploymentTaskIntegrationTest {
             String user = Coerce.toString(kernel.findServiceTopic("CustomerAppStartupShutdown")
                     .find(RUN_WITH_NAMESPACE_TOPIC, POSIX_USER_KEY));
             assertEquals("nobody", user);
+            long memory = Coerce.toLong(kernel.findServiceTopic("CustomerAppStartupShutdown")
+                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "linux", "memory"));
+            assertEquals(1024000, memory);
+            double cpu = Coerce.toDouble(kernel.findServiceTopic("CustomerAppStartupShutdown")
+                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "linux", "cpu"));
+            assertEquals(1.5, cpu);
+
             countDownLatch.await(10, TimeUnit.SECONDS);
             assertThat(stdouts, hasItem(containsString("installing app with user root")));
             assertThat(stdouts, hasItem(containsString("starting app with user nobody")));
             stdouts.clear();
         }
-
 
         /*
          * 2nd deployment. Change user

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
@@ -6,7 +6,13 @@
       "ResolvedVersion": "1.0.0",
       "RootComponent": true,
       "RunWith":  {
-        "PosixUser": "nobody"
+        "PosixUser": "nobody",
+        "systemResourceLimits": {
+          "linux": {
+            "memory": 1024000,
+            "cpu": 1.5
+          }
+        }
       }
     }
   ],

--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -266,7 +266,8 @@ public class KernelConfigResolver {
             if (runWith.getSystemResourceLimits() == null) {
                 runWithConfig.remove(SYSTEM_RESOURCE_LIMITS_TOPICS);
             } else {
-                runWithConfig.put(SYSTEM_RESOURCE_LIMITS_TOPICS, runWith.getSystemResourceLimits());
+                runWithConfig.put(SYSTEM_RESOURCE_LIMITS_TOPICS,
+                        MAPPER.convertValue(runWith.getSystemResourceLimits(), Map.class));
             }
         }
 

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
+@SuppressWarnings("PMD.ExcessiveClassLength")
 class KernelConfigResolverTest {
     private static final String LIFECYCLE_INSTALL_KEY = "install";
     private static final String LIFECYCLE_RUN_KEY = "run";
@@ -158,6 +159,11 @@ class KernelConfigResolverTest {
 
         SystemResourceLimits systemResourceLimits = new SystemResourceLimits(
                 new SystemResourceLimits.LinuxSystemResourceLimits(102400L, 1.5));
+        Map<String, Object> expectedSystemResourceLimits = new HashMap<>();
+        Map<String, Object> expectedLinuxMap = new HashMap<>();
+        expectedLinuxMap.put("cpu", 1.5);
+        expectedLinuxMap.put("memory", 102400L);
+        expectedSystemResourceLimits.put("linux", expectedLinuxMap);
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
                 .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
@@ -207,7 +213,7 @@ class KernelConfigResolverTest {
         Map<String, Object> runWith = (Map<String, Object>)serviceA.get(RUN_WITH_NAMESPACE_TOPIC);
         assertThat("Service A must set posix user", runWith, hasEntry(POSIX_USER_KEY, "foo:bar"));
         assertThat("Service A must have system resource limits",runWith,
-                hasEntry(SYSTEM_RESOURCE_LIMITS_TOPICS, systemResourceLimits) );
+                hasEntry(SYSTEM_RESOURCE_LIMITS_TOPICS, expectedSystemResourceLimits) );
 
         Map<String, Object> serviceB = (Map<String, Object>)servicesConfig.get(TEST_INPUT_PACKAGE_B);
         assertThat("Service B must not have runWith", serviceB, not(hasKey(RUN_WITH_NAMESPACE_TOPIC)));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Need to convert `SystemResourceLimits` object to map before merging it to the config.

**Why is this change necessary:**

**How was this change tested:**
Update an existing test case to cover this

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
