### PR TITLE
fix(device provisioning): fix duplicate subscriptions to iot jobs and…

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -87,6 +87,13 @@ public class ShadowDeploymentListener implements InjectionActions {
     public static final String DEVICE_OFFLINE_MESSAGE = "Device not configured to talk to AWS Iot cloud. "
             + "Single device deployment is offline";
     public static final String SUBSCRIBING_TO_SHADOW_TOPICS_MESSAGE = "Subscribing to Iot Shadow topics";
+
+    private static final String SHADOW_UPDATE_ACCEPTED_TOPIC = "$aws/things/{thingName}/shadow/name/{shadowName}"
+            + "/update/accepted";
+    private static final String SHADOW_UPDATE_REJECTED_TOPIC = "$aws/things/{thingName}/shadow/name/{shadowName}"
+            + "/update/rejected";
+    private static final String SHADOW_GET_TOPIC = "$aws/things/{thingName}/shadow/name/{shadowName}/get/accepted";
+
     @Inject
     private Kernel kernel;
     @Inject
@@ -101,7 +108,7 @@ public class ShadowDeploymentListener implements InjectionActions {
     private DeviceConfiguration deviceConfiguration;
     @Setter
     private IotShadowClient iotShadowClient;
-    private String thingName;
+    private volatile String thingName;
     private AtomicBoolean isSubscribedToShadowTopics = new AtomicBoolean(false);
     private Future<?> subscriptionFuture;
 
@@ -133,20 +140,28 @@ public class ShadowDeploymentListener implements InjectionActions {
      * @param executorService {@link ExecutorService}
      * @param deviceConfiguration {@link DeviceConfiguration}
      * @param iotShadowClient {@link IotShadowClient}
+     * @param kernel {@link Kernel}
      */
     public ShadowDeploymentListener(DeploymentQueue deploymentQueue, DeploymentStatusKeeper deploymentStatusKeeper,
                                     MqttClient mqttClient, ExecutorService executorService,
-                                    DeviceConfiguration deviceConfiguration, IotShadowClient iotShadowClient) {
+                                    DeviceConfiguration deviceConfiguration, IotShadowClient iotShadowClient,
+                                    Kernel kernel) {
         this.deploymentQueue = deploymentQueue;
         this.deploymentStatusKeeper = deploymentStatusKeeper;
         this.mqttClient = mqttClient;
         this.executorService = executorService;
         this.deviceConfiguration = deviceConfiguration;
         this.iotShadowClient = iotShadowClient;
+        this.kernel = kernel;
     }
 
     @Override
     public void postInject() {
+        if (iotShadowClient == null) {
+            this.iotShadowClient = new IotShadowClient(getMqttClientConnection());
+        }
+        mqttClient.addToCallbackEvents(callbacks);
+
         deviceConfiguration.onAnyChange((what, node) -> {
             if (WhatHappened.childChanged.equals(what) && node != null && relevantNodeChanged(node)) {
                 try {
@@ -185,18 +200,25 @@ public class ShadowDeploymentListener implements InjectionActions {
     }
 
     private void setupShadowCommunications() {
-        this.thingName = Coerce.toString(deviceConfiguration.getThingName());
-        if (iotShadowClient == null) {
-            this.iotShadowClient = new IotShadowClient(getMqttClientConnection());
-        }
-        mqttClient.addToCallbackEvents(callbacks);
-        deploymentStatusKeeper.registerDeploymentStatusConsumer(DeploymentType.SHADOW,
-                this::deploymentStatusChanged, ShadowDeploymentListener.class.getName());
+
         if (subscriptionFuture != null && !subscriptionFuture.isDone()) {
             subscriptionFuture.cancel(true);
         }
+        if (isSubscribedToShadowTopics.get()) {
+            unsubscribeToShadowTopics();
+        }
+        deploymentStatusKeeper.registerDeploymentStatusConsumer(DeploymentType.SHADOW,
+                this::deploymentStatusChanged, ShadowDeploymentListener.class.getName());
+        this.thingName = Coerce.toString(deviceConfiguration.getThingName());
         if (subscriptionFuture == null || subscriptionFuture.isDone()) {
             subscriptionFuture = executorService.submit(() -> {
+                // Wait for all node updates to come through before we subscribe to the topics
+                Throwable ex = kernel.getContext().runOnPublishQueueAndWait(() -> {});
+                if (ex instanceof InterruptedException) {
+                    logger.atDebug().log("Got interrupted while waiting for publish queue to clear, during Iot "
+                            + "Shadow subscriptions");
+                    return;
+                }
                 subscribeToShadowTopics();
                 this.isSubscribedToShadowTopics.set(true);
                 // Get the shadow state when kernel starts up by publishing to get topic
@@ -271,6 +293,23 @@ public class ShadowDeploymentListener implements InjectionActions {
                 return;
             }
         }
+    }
+
+    /*
+      UnSubscribe to "$aws/things/{thingName}/shadow/update/accepted" topic to get notified when shadow is updated
+      UnSubscribe to "$aws/things/{thingName}/shadow/update/rejected" topic to get notified when an update is rejected
+      UnSubscribe to "$aws/things/{thingName}/shadow/get/accepted" topic to retrieve shadow by publishing to get topic
+   */
+    @SuppressWarnings("PMD.CloseResource")
+    private void unsubscribeToShadowTopics() {
+        MqttClientConnection connection = getMqttClientConnection();
+        // This is best effort. Do not want to block on it.
+        connection.unsubscribe(SHADOW_UPDATE_ACCEPTED_TOPIC.replace("{thingName}", thingName)
+                .replace("{shadowName}", DEPLOYMENT_SHADOW_NAME));
+        connection.unsubscribe(SHADOW_UPDATE_REJECTED_TOPIC.replace("{thingName}", thingName)
+                .replace("{shadowName}", DEPLOYMENT_SHADOW_NAME));
+        connection.unsubscribe(SHADOW_GET_TOPIC.replace("{thingName}", thingName)
+                .replace("{shadowName}", DEPLOYMENT_SHADOW_NAME));
     }
 
     private void handleNamedShadowRejectedEvent() {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -200,7 +200,6 @@ public class KernelLifecycle {
                     .getSystemConfiguration(), UpdateBehaviorTree.UpdateBehavior.MERGE);
             provisioningConfigUpdateHelper.updateNucleusConfiguration(provisionConfiguration
                     .getNucleusConfiguration(), UpdateBehaviorTree.UpdateBehavior.MERGE);
-            kernel.writeEffectiveConfig();
             logger.atDebug().kv("PluginName", pluginName)
                     .log(UPDATED_PROVISIONING_MESSAGE);
         });


### PR DESCRIPTION
… shadow

**Issue #, if available:**
Mqtt topics for jobs and shadow are subscribed multiple times when provisioning plugin runs since it updates a number of nodes in config.

**Description of changes:**
This PR ensures that the subscriptions are done only once and any previous subscriptions are removed.

**Why is this change necessary:**
It is required for device provisioning to work cleanly.

**How was this change tested:**
Tested manually by running Fleet provisioning plugin.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
