### PR TITLE
fix(sdk-clients): close AWS SDK clients when creating new copies

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.tes.LazyCredentialProvider;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.ProxyUtils;
-import lombok.AllArgsConstructor;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ecr.EcrClient;
@@ -26,28 +25,43 @@ import javax.inject.Inject;
 
 /**
  * AWS ECR SDK client wrapper.
- *
  */
-@AllArgsConstructor
 public class EcrAccessor {
-    private EcrClient ecrClient;
+    private final EcrClient injectedClient;
+    private final DeviceConfiguration deviceConfiguration;
+    private final LazyCredentialProvider lazyCredentialProvider;
 
     /**
      * Constructor.
      *
-     * @param deviceConfiguration Device config
+     * @param deviceConfiguration    Device config
      * @param lazyCredentialProvider AWS credentials provider
      */
     @Inject
+    @SuppressWarnings("PMD.NullAssignment")
     public EcrAccessor(DeviceConfiguration deviceConfiguration, LazyCredentialProvider lazyCredentialProvider) {
-        configureClient(deviceConfiguration, lazyCredentialProvider);
-        deviceConfiguration.getAWSRegion()
-                .subscribe((what, node) -> configureClient(deviceConfiguration, lazyCredentialProvider));
+        this.deviceConfiguration = deviceConfiguration;
+        this.lazyCredentialProvider = lazyCredentialProvider;
+        this.injectedClient = null;
     }
 
-    private void configureClient(DeviceConfiguration deviceConfiguration,
-                                 LazyCredentialProvider lazyCredentialProvider) {
-        this.ecrClient = EcrClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
+    /**
+     * Constructor for testing with a mocked client.
+     *
+     * @param client EcrClient
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    public EcrAccessor(EcrClient client) {
+        this.injectedClient = client;
+        this.deviceConfiguration = null;
+        this.lazyCredentialProvider = null;
+    }
+
+    private EcrClient getClient() {
+        if (injectedClient != null) {
+            return injectedClient;
+        }
+        return EcrClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
                 .region(Region.of(Coerce.toString(deviceConfiguration.getAWSRegion())))
                 .credentialsProvider(lazyCredentialProvider).build();
     }
@@ -61,22 +75,20 @@ public class EcrAccessor {
      */
     @SuppressWarnings("PMD.AvoidRethrowingException")
     public Registry.Credentials getCredentials(String registryId) throws RegistryAuthException {
-        try {
-            AuthorizationData authorizationData = ecrClient.getAuthorizationToken(
+        try (EcrClient client = getClient()) {
+            AuthorizationData authorizationData = client.getAuthorizationToken(
                     GetAuthorizationTokenRequest.builder().registryIds(Collections.singletonList(registryId)).build())
                     .authorizationData().get(0);
             // Decoded auth token is of the format <username>:<password>
-            String[] authTokenParts =
-                    new String(Base64.getDecoder().decode(authorizationData.authorizationToken()),
-                            StandardCharsets.UTF_8).split(":");
-            return new Registry.Credentials(authTokenParts[0], authTokenParts[1],
-                    authorizationData.expiresAt());
+            String[] authTokenParts = new String(Base64.getDecoder().decode(authorizationData.authorizationToken()),
+                    StandardCharsets.UTF_8).split(":");
+            return new Registry.Credentials(authTokenParts[0], authTokenParts[1], authorizationData.expiresAt());
         } catch (ServerException | SdkClientException e) {
             // Errors we can retry on
             throw e;
         } catch (EcrException e) {
-            throw new RegistryAuthException(String.format("Failed to get credentials for ECR registry - %s",
-                    registryId), e);
+            throw new RegistryAuthException(
+                    String.format("Failed to get credentials for ECR registry - %s", registryId), e);
         }
     }
 }


### PR DESCRIPTION
ignore some config change events to prevent us from creating new clients when not needed

**Issue #, if available:**

**Description of changes:**
Greengrass has been creating new SDK clients whenever a configuration changes, however we were not closing the client due to worries about closing a client that someone might be using. This causes an issue because the SDK http clients must be closed in order to remove them from the idle connection reaper thread's mapping. If they are not closed, then they will be referenced by the idle connection reaper forever and leak ~1MB/hr when doing continuous deployments.

An alternative solution would be to disable the idle connection reaper in our SDK clients.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
