### PR TITLE
fix(sdk-clients): close AWS SDK clients when creating new copies

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.tes.LazyCredentialProvider;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.ProxyUtils;
-import lombok.AllArgsConstructor;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ecr.EcrClient;
@@ -26,28 +25,43 @@ import javax.inject.Inject;
 
 /**
  * AWS ECR SDK client wrapper.
- *
  */
-@AllArgsConstructor
 public class EcrAccessor {
-    private EcrClient ecrClient;
+    private final EcrClient injectedClient;
+    private final DeviceConfiguration deviceConfiguration;
+    private final LazyCredentialProvider lazyCredentialProvider;
 
     /**
      * Constructor.
      *
-     * @param deviceConfiguration Device config
+     * @param deviceConfiguration    Device config
      * @param lazyCredentialProvider AWS credentials provider
      */
     @Inject
+    @SuppressWarnings("PMD.NullAssignment")
     public EcrAccessor(DeviceConfiguration deviceConfiguration, LazyCredentialProvider lazyCredentialProvider) {
-        configureClient(deviceConfiguration, lazyCredentialProvider);
-        deviceConfiguration.getAWSRegion()
-                .subscribe((what, node) -> configureClient(deviceConfiguration, lazyCredentialProvider));
+        this.deviceConfiguration = deviceConfiguration;
+        this.lazyCredentialProvider = lazyCredentialProvider;
+        this.injectedClient = null;
     }
 
-    private void configureClient(DeviceConfiguration deviceConfiguration,
-                                 LazyCredentialProvider lazyCredentialProvider) {
-        this.ecrClient = EcrClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
+    /**
+     * Constructor for testing with a mocked client.
+     *
+     * @param client EcrClient
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    public EcrAccessor(EcrClient client) {
+        this.injectedClient = client;
+        this.deviceConfiguration = null;
+        this.lazyCredentialProvider = null;
+    }
+
+    private EcrClient getClient() {
+        if (injectedClient != null) {
+            return injectedClient;
+        }
+        return EcrClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
                 .region(Region.of(Coerce.toString(deviceConfiguration.getAWSRegion())))
                 .credentialsProvider(lazyCredentialProvider).build();
     }
@@ -61,22 +75,20 @@ public class EcrAccessor {
      */
     @SuppressWarnings("PMD.AvoidRethrowingException")
     public Registry.Credentials getCredentials(String registryId) throws RegistryAuthException {
-        try {
-            AuthorizationData authorizationData = ecrClient.getAuthorizationToken(
+        try (EcrClient client = getClient()) {
+            AuthorizationData authorizationData = client.getAuthorizationToken(
                     GetAuthorizationTokenRequest.builder().registryIds(Collections.singletonList(registryId)).build())
                     .authorizationData().get(0);
             // Decoded auth token is of the format <username>:<password>
-            String[] authTokenParts =
-                    new String(Base64.getDecoder().decode(authorizationData.authorizationToken()),
-                            StandardCharsets.UTF_8).split(":");
-            return new Registry.Credentials(authTokenParts[0], authTokenParts[1],
-                    authorizationData.expiresAt());
+            String[] authTokenParts = new String(Base64.getDecoder().decode(authorizationData.authorizationToken()),
+                    StandardCharsets.UTF_8).split(":");
+            return new Registry.Credentials(authTokenParts[0], authTokenParts[1], authorizationData.expiresAt());
         } catch (ServerException | SdkClientException e) {
             // Errors we can retry on
             throw e;
         } catch (EcrException e) {
-            throw new RegistryAuthException(String.format("Failed to get credentials for ECR registry - %s",
-                    registryId), e);
+            throw new RegistryAuthException(
+                    String.format("Failed to get credentials for ECR registry - %s", registryId), e);
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.util;
 
 import com.aws.greengrass.componentmanager.ClientConfigurationUtils;
 import com.aws.greengrass.config.Node;
+import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.api.Logger;
@@ -48,6 +49,9 @@ public class GreengrassServiceClientFactory {
     @Inject
     public GreengrassServiceClientFactory(DeviceConfiguration deviceConfiguration) {
         deviceConfiguration.onAnyChange((what, node) -> {
+            if (WhatHappened.interiorAdded.equals(what) || WhatHappened.timestampUpdated.equals(what)) {
+                return;
+            }
             if (validString(node, DEVICE_PARAM_AWS_REGION) || validPath(node, DEVICE_PARAM_ROOT_CA_PATH) || validPath(
                     node, DEVICE_PARAM_CERTIFICATE_FILE_PATH) || validPath(node, DEVICE_PARAM_PRIVATE_KEY_PATH)
                     || validString(node, DEVICE_PARAM_GG_DATA_PLANE_PORT)) {
@@ -83,6 +87,10 @@ public class GreengrassServiceClientFactory {
         return validString(node, key) && Files.exists(Paths.get(key));
     }
 
+    public synchronized GreengrassV2DataClient getGreengrassV2DataClient() {
+        return greengrassV2DataClient;
+    }
+
     private void configureClient(DeviceConfiguration deviceConfiguration) {
         logger.atDebug().log(CONFIGURING_GGV2_INFO_MESSAGE);
         ApacheHttpClient.Builder httpClient = ClientConfigurationUtils.getConfiguredClientBuilder(deviceConfiguration);
@@ -111,6 +119,11 @@ public class GreengrassServiceClientFactory {
                 clientBuilder.region(Region.of(region));
             }
         }
-        this.greengrassV2DataClient = clientBuilder.build();
+        synchronized (this) {
+            if (this.greengrassV2DataClient != null) {
+                this.greengrassV2DataClient.close();
+            }
+            this.greengrassV2DataClient = clientBuilder.build();
+        }
     }
 }


### PR DESCRIPTION
ignore some config change events to prevent us from creating new clients when not needed

**Issue #, if available:**
Cherrypick #991 into main

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [x] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
