### PR TITLE
fix(resource-limit): fix the race condition in test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.config.Subscriber;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.State;
-import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.GenericExternalService;
@@ -563,23 +562,6 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         kernel.getContext().waitForPublishQueueToClear();
 
         assertResourceLimits(componentName, 10240l * 1024, 1.5);
-        // remove default resource limit
-        DeviceConfiguration deviceConfiguration = new DeviceConfiguration(kernel);
-        deviceConfiguration.findRunWithDefaultSystemResourceLimits().remove();
-        kernel.getContext().waitForPublishQueueToClear();
-
-        assertSystemDefaultLimits(componentName);
-    }
-
-    private void assertSystemDefaultLimits(String componentName) throws Exception {
-        long defaultCgroupMemoryLimit = 9223372036854771712l;
-        int defaultCpuQuota = -1;
-
-        byte[] buf1 = Files.readAllBytes(Cgroup.Memory.getComponentMemoryLimitPath(componentName));
-        assertThat(String.valueOf(defaultCgroupMemoryLimit), equalTo(new String(buf1, StandardCharsets.UTF_8).trim()));
-
-        byte[] buf2 = Files.readAllBytes(Cgroup.CPU.getComponentCpuQuotaPath(componentName));
-        assertThat(String.valueOf(defaultCpuQuota), equalTo(new String(buf2, StandardCharsets.UTF_8).trim()));
     }
 
     private void assertResourceLimits(String componentName, long memory, double cpu) throws Exception {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
There appears to be a race condition in the integration test that two different threads are trying to remove the cgroup folder simutaneously and causes inconsistent test result. 
**Why is this change necessary:**
Improve test stability
**How was this change tested:**
ran the test locally
**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
