### PR TITLE
feat(recipe-interp): add {iot:thingName} variable for recipes

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -62,6 +62,8 @@ public class KernelConfigResolver {
     public static final String VERSION_CONFIG_KEY = "version";
     public static final String PREV_VERSION_CONFIG_KEY = "previousVersion";
     public static final String CONFIGURATION_CONFIG_KEY = "configuration";
+    static final String IOT_NAMESPACE = "iot";
+    static final String THING_NAME_PATH = "thingName";
     static final String ARTIFACTS_NAMESPACE = "artifacts";
     static final String WORK_NAMESPACE = "work";
     static final String KERNEL_NAMESPACE = "kernel";
@@ -112,20 +114,23 @@ public class KernelConfigResolver {
         this.deviceConfiguration = deviceConfiguration;
 
         // More system parameters can be added over time by extending this map with new namespaces/keys
-        HashMap<String, CrashableFunction<ComponentIdentifier, String, IOException>> artifactNamespace =
-                new HashMap<>();
+        Map<String, CrashableFunction<ComponentIdentifier, String, IOException>> artifactNamespace = new HashMap<>();
         artifactNamespace.put(PATH_KEY, (id) -> nucleusPaths.artifactPath(id).toAbsolutePath().toString());
         artifactNamespace
                 .put(DECOMPRESSED_PATH_KEY, (id) -> nucleusPaths.unarchiveArtifactPath(id).toAbsolutePath().toString());
         systemParameters.put(ARTIFACTS_NAMESPACE, artifactNamespace);
 
-        HashMap<String, CrashableFunction<ComponentIdentifier, String, IOException>> workNamespace = new HashMap<>();
+        Map<String, CrashableFunction<ComponentIdentifier, String, IOException>> workNamespace = new HashMap<>();
         workNamespace.put(PATH_KEY, (id) -> nucleusPaths.workPath(id.getName()).toAbsolutePath().toString());
         systemParameters.put(WORK_NAMESPACE, workNamespace);
 
-        HashMap<String, CrashableFunction<ComponentIdentifier, String, IOException>> kernelNamespace = new HashMap<>();
+        Map<String, CrashableFunction<ComponentIdentifier, String, IOException>> kernelNamespace = new HashMap<>();
         kernelNamespace.put(KERNEL_ROOT_PATH, (id) -> nucleusPaths.rootPath().toAbsolutePath().toString());
         systemParameters.put(KERNEL_NAMESPACE, kernelNamespace);
+
+        Map<String, CrashableFunction<ComponentIdentifier, String, IOException>> iotNamespace = new HashMap<>();
+        iotNamespace.put(THING_NAME_PATH, (id) -> Coerce.toString(deviceConfiguration.getThingName()));
+        systemParameters.put(IOT_NAMESPACE, iotNamespace);
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -77,11 +77,17 @@ class KernelConfigResolverTest {
     private static final String LIFECYCLE_RUN_KEY = "run";
     private static final String LIFECYCLE_SCRIPT_KEY = "script";
     private static final String LIFECYCLE_MOCK_INSTALL_COMMAND_FORMAT =
-            "echo installing service in Package %s with param , kernel rootPath as {" + KernelConfigResolver.KERNEL_NAMESPACE + ":" + KernelConfigResolver.KERNEL_ROOT_PATH + "} and "
-                    + "unpack dir as {{" + KernelConfigResolver.ARTIFACTS_NAMESPACE + ":" + KernelConfigResolver.DECOMPRESSED_PATH_KEY + "}}";
+            "echo installing service in Package %s with param , kernel rootPath as {"
+                    + KernelConfigResolver.KERNEL_NAMESPACE + ":" + KernelConfigResolver.KERNEL_ROOT_PATH + "} and "
+                    + "unpack dir as {{" + KernelConfigResolver.ARTIFACTS_NAMESPACE + ":"
+                    + KernelConfigResolver.DECOMPRESSED_PATH_KEY + "}}";
     private static final String LIFECYCLE_INSTALL_COMMAND_FORMAT =
-            "echo installing service in Component %s with param {" + KernelConfigResolver.CONFIGURATION_NAMESPACE + ":%s}, kernel rootPath as {" + KernelConfigResolver.KERNEL_NAMESPACE + ":" + KernelConfigResolver.KERNEL_ROOT_PATH + "} and "
-                    + "unpack dir as {" + KernelConfigResolver.ARTIFACTS_NAMESPACE + ":" + KernelConfigResolver.DECOMPRESSED_PATH_KEY + "}";
+            "echo installing service in Component %s with param {" + KernelConfigResolver.CONFIGURATION_NAMESPACE
+                    + ":%s}, kernel rootPath as {" + KernelConfigResolver.KERNEL_NAMESPACE + ":"
+                    + KernelConfigResolver.KERNEL_ROOT_PATH + "} and " + "unpack dir as {"
+                    + KernelConfigResolver.ARTIFACTS_NAMESPACE + ":" + KernelConfigResolver.DECOMPRESSED_PATH_KEY
+                    + "}, thing name is {" + KernelConfigResolver.IOT_NAMESPACE + ":"
+                    + KernelConfigResolver.THING_NAME_PATH + "}";
 
     private static final String LIFECYCLE_MOCK_RUN_COMMAND_FORMAT =
             "echo running service in Package %s ";
@@ -89,7 +95,8 @@ class KernelConfigResolverTest {
             "echo running service in Component %s with param {" + KernelConfigResolver.CONFIGURATION_NAMESPACE + ":%s}";
 
     private static final String LIFECYCLE_MOCK_CROSS_COMPONENT_FORMAT =
-            "Package %s with param {{%s:params:%s_Param_1.value}} {{%s:" + KernelConfigResolver.ARTIFACTS_NAMESPACE + ":" + KernelConfigResolver.PATH_KEY + "}}";
+            "Package %s with param {{%s:params:%s_Param_1.value}} {{%s:" + KernelConfigResolver.ARTIFACTS_NAMESPACE
+                    + ":" + KernelConfigResolver.PATH_KEY + "}}";
     private static final String LIFECYCLE_CROSS_COMPONENT_FORMAT =
             "Component %s with param {%s:" + KernelConfigResolver.CONFIGURATION_NAMESPACE + ":%s}"
                     + " cross component %s artifact dir {%s:" + KernelConfigResolver.ARTIFACTS_NAMESPACE + ":"
@@ -104,6 +111,7 @@ class KernelConfigResolverTest {
     private static final Path DUMMY_ARTIFACT_PATH = Paths.get("/dummyArtifactDir");
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    protected static final String THE_THINGNAME = "ThisIsMyThingName";
 
     @Mock
     private Kernel kernel;
@@ -133,6 +141,8 @@ class KernelConfigResolverTest {
         config = new Configuration(new Context());
         lenient().when(kernel.getConfig()).thenReturn(config);
         lenient().when(deviceConfiguration.getNucleusComponentName()).thenReturn(DEFAULT_NUCLEUS_COMPONENT_NAME);
+        lenient().when(deviceConfiguration.getThingName())
+                .thenReturn(config.lookup("thingname").withValue(THE_THINGNAME));
     }
 
     @AfterEach
@@ -563,7 +573,7 @@ class KernelConfigResolverTest {
                 serviceInstallCommand.get(LIFECYCLE_SCRIPT_KEY),
                 equalTo("echo installing service in Component PackageA with param valueA,"
                         + " kernel rootPath as " + DUMMY_ROOT_PATH.toAbsolutePath().toString() + " and unpack dir as "
-                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath().toString()));
+                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath().toString() + ", thing name is " + THE_THINGNAME));
 
         assertThat("no running and no update configuration, the default value should be used",
                 getServiceRunCommand(TEST_INPUT_PACKAGE_A, servicesConfig),
@@ -607,8 +617,8 @@ class KernelConfigResolverTest {
         assertThat("has running and no update configuration, the running value should be used",
                 serviceInstallCommand.get(LIFECYCLE_SCRIPT_KEY),
                 equalTo("echo installing service in Component PackageA with param valueB,"
-                        + " kernel rootPath as " + DUMMY_ROOT_PATH.toAbsolutePath().toString() + " and unpack dir as "
-                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath().toString()));
+                        + " kernel rootPath as " + DUMMY_ROOT_PATH.toAbsolutePath() + " and unpack dir as "
+                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath() + ", thing name is " + THE_THINGNAME));
 
         assertThat("has running and no update configuration, the running value should be used",
                 getServiceRunCommand(TEST_INPUT_PACKAGE_A, servicesConfig),
@@ -676,7 +686,7 @@ class KernelConfigResolverTest {
                 serviceInstallCommand.get(LIFECYCLE_SCRIPT_KEY),
                 equalTo("echo installing service in Component PackageA with param "+expectedValue+","
                         + " kernel rootPath as " + DUMMY_ROOT_PATH.toAbsolutePath().toString() + " and unpack dir as "
-                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath().toString()));
+                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath().toString() + ", thing name is " + THE_THINGNAME));
 
         assertThat("has running and has update configuration, the updated value should be used",
                 getServiceRunCommand(TEST_INPUT_PACKAGE_A, servicesConfig),
@@ -725,8 +735,8 @@ class KernelConfigResolverTest {
         assertThat("reset configuration, the default value should be used",
                 serviceInstallCommand.get(LIFECYCLE_SCRIPT_KEY),
                 equalTo("echo installing service in Component PackageA with param valueA,"
-                        + " kernel rootPath as " + DUMMY_ROOT_PATH.toAbsolutePath().toString() + " and unpack dir as "
-                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath().toString()));
+                        + " kernel rootPath as " + DUMMY_ROOT_PATH.toAbsolutePath() + " and unpack dir as "
+                        + DUMMY_DECOMPRESSED_PATH_KEY.toAbsolutePath() + ", thing name is " + THE_THINGNAME));
 
         assertThat("reset configuration, the default value should be used",
                 getServiceRunCommand(TEST_INPUT_PACKAGE_A, servicesConfig),


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change adds `{iot:thingName}` variable into recipe resolution. To be clear, this does not get interpolated into default configuration, only the lifecycle section of the recipe (as with all other recipe variables that we support). The purpose is to allow easy access to the thing name.

We should consider following up and allowing a similar variable replacement in our access control policies, especially for MQTT topic pub/sub where thing name is in the topic.

**Why is this change necessary:**

**How was this change tested:**
Updated existing config resolver test to use the new variable.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
