### PR TITLE
fix(mqtt): decrease connect rate limit to adjust for IoT Core's limits

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/ShadowDeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/ShadowDeploymentE2ETest.java
@@ -173,7 +173,7 @@ public class ShadowDeploymentE2ETest extends BaseE2ETestCase {
             }
         });
         //waiting for the device to report success
-        assertTrue(reportSucceededCdl.await(30, TimeUnit.SECONDS));
+        assertTrue(reportSucceededCdl.await(60, TimeUnit.SECONDS));
 
         //Updating the shadow with deployment status IN_PROGRESS to simulate out-of-order update of shadow
         ShadowState shadowState = new ShadowState();
@@ -186,7 +186,7 @@ public class ShadowDeploymentE2ETest extends BaseE2ETestCase {
                 .get(30, TimeUnit.SECONDS);
 
         // verify that the device updates shadow state to SUCCEEDED
-        assertTrue(deviceSyncedStateToSucceededCdl.await(30, TimeUnit.SECONDS));
+        assertTrue(deviceSyncedStateToSucceededCdl.await(60, TimeUnit.SECONDS));
 
 
         //Updating the shadow with a lower version number to trigger a message to /update/rejected event
@@ -213,7 +213,7 @@ public class ShadowDeploymentE2ETest extends BaseE2ETestCase {
                 }).get(30, TimeUnit.SECONDS);
 
         // verify that the device retrieved the shadow when an update operation was rejected.
-        assertTrue(deviceRetrievedShadowCdl.await(30, TimeUnit.SECONDS));
+        assertTrue(deviceRetrievedShadowCdl.await(60, TimeUnit.SECONDS));
     }
 
 

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -80,11 +80,10 @@ class AwsIotMqttClient implements Closeable {
     // Limit bandwidth to 512 KBPS
     private final RateLimiter bandwidthLimiter = RateLimiter.create(512.0 * 1024);
 
-    // TODO: re-evaluate connect rate limit.
     // Limit TPS to 1 which is IoT Core's limit for connect requests per client-id
-    // IoT was throttling connect calls even at 1 TPS, we should have a conversation with the IoT core team.
-    // Setting the limit to .25 for now to avoid throttles.
-    private final RateLimiter connectLimiter = RateLimiter.create(.25);
+    // IoT was throttling connect calls even at 1 TPS because the limit is actually 0.1 when
+    // the same host is hit with the request.
+    private final RateLimiter connectLimiter = RateLimiter.create(0.1);
 
 
     @Getter(AccessLevel.PACKAGE)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When a connect request hits the same host in IoT Core's fleet, the throttle limit is actually 0.1 TPS and not the stated 1 TPS. This discrepancy causes us to fail to connect and then backoff for 2 minutes. This slows down some of our UATs significantly and it is a negative customer experience. To avoid the issue, limit connect calls to 0.1 TPS per client ID instead of 0.25 as before.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
