### PR TITLE
fix: fix path validation in gg client factory. reset error message in s3 client factory

### DIFF
--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -84,7 +84,7 @@ public class GreengrassServiceClientFactory {
     }
 
     private boolean validPath(Node node, String key) {
-        return validString(node, key) && Files.exists(Paths.get(key));
+        return validString(node, key) && Files.exists(Paths.get(Coerce.toString(node)));
     }
 
     public synchronized GreengrassV2DataClient getGreengrassV2DataClient() {

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -34,16 +34,18 @@ public class S3SdkClientFactory {
      * @param credentialsProvider credential provider from TES
      */
     @Inject
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.NullAssignment"})
     public S3SdkClientFactory(DeviceConfiguration deviceConfiguration, LazyCredentialProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
-        try {
-            deviceConfiguration.validate(true);
-        } catch (DeviceConfigurationException e) {
-            configValidationError = e.getMessage();
-        }
-        deviceConfiguration.getAWSRegion().subscribe((what, node) ->
-                this.s3Client = getClientForRegion(Region.of(Coerce.toString(deviceConfiguration.getAWSRegion()))));
+        deviceConfiguration.getAWSRegion().subscribe((what, node) -> {
+            try {
+                deviceConfiguration.validate();
+                configValidationError = null;
+            } catch (DeviceConfigurationException e) {
+                configValidationError = e.getMessage();
+            }
+            this.s3Client = getClientForRegion(Region.of(Coerce.toString(deviceConfiguration.getAWSRegion())));
+        });
     }
 
     /**


### PR DESCRIPTION
…oning

**Issue #, if available:**
1. Validation for paths was not correct in GreengrassV2Client factory
2. S3 client does not get initialized if device is provisioned after kernel start.

**Description of changes:**
Fixes
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
