### PR TITLE
fix(loader): wait for child PID

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -36,7 +36,7 @@ launch_kernel() {
   echo "JVM options: "${JVM_OPTIONS}
   echo "Nucleus options: "${OPTIONS}
   child_pid=""
-  trap 'echo Received SIGTERM; sigterm_received=1; kill -TERM ${child_pid}' TERM
+  trap 'echo Received SIGTERM; sigterm_received=1; kill -TERM ${child_pid}; wait ${child_pid}; echo Killed child PID' TERM
   java -Dlog.store=FILE ${JVM_OPTIONS} -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS} &
   child_pid="$!"
   wait "${child_pid}"


### PR DESCRIPTION
**Description of changes:**
Wait for the child PID to be killed once we `trap` the SIGTERM.

**Why is this change necessary:**
This is needed for Docker because otherwise when we issue SIGTERM to a container, it does not wait for the child PID and simply kills the process without exiting gracefully.

**How was this change tested:**
`docker stop` with the changes added
Observed the following output:
```
Launched Nucleus successfully.
++ echo Received SIGTERM
++ sigterm_received=1
++ kill -TERM 12
++ wait 12
Received SIGTERM
++ echo Killed child PID
+ kernel_exit_code=143
+ echo 'Nucleus exit at code: 143'
+ case ${kernel_exit_code} in
+ echo 'Nucleus exited 143. Retrying 1 times'
+ j=2
Killed child PID
+ '[' 2 -le 3 ']'
Nucleus exit at code: 143
+ '[' 1 -eq 0 ']'
Nucleus exited 143. Retrying 1 times
+ is_directory_link /greengrass/v2/alts/old
+ '[' -L /greengrass/v2/alts/old ']'
+ exit 143
```

and observed the following in `greengrass.log`:
`Shutting down Nucleus due to external signal` .
**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
