### PR TITLE
fix: local deployment use thing group name

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Future;
 
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_ID_LOG_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY;
+import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 
 /**
  * A task of deploying a configuration specified by a deployment document to a Greengrass device.
@@ -188,6 +189,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
             // skip root packages if device does not belong to that group anymore
             if (!groupTopics.getName().equals(deploymentDocument.getGroupName())
                     && (groupTopics.getName().startsWith(DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX)
+                    || groupTopics.getName().equals(LOCAL_DEPLOYMENT_GROUP_NAME)
                     || groupsDeviceBelongsToOptional.isPresent() && groupsDeviceBelongsToOptional.get()
                     .contains(groupTopics.getName()))) {
                 groupTopics.forEach(pkgNode -> {

--- a/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
+++ b/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
@@ -45,6 +45,7 @@ public final class DeploymentDocumentConverter {
     private static final Logger logger = LogManager.getLogger(DeploymentDocumentConverter.class);
 
     public static final String LOCAL_DEPLOYMENT_GROUP_NAME = "LOCAL_DEPLOYMENT";
+    public static final String THING_GROUP_RESOURCE_NAME_PREFIX = "thinggroup/";
     public static final Integer NO_OP_TIMEOUT = 0;
 
     public static final String ANY_VERSION = "*";
@@ -94,9 +95,9 @@ public final class DeploymentDocumentConverter {
                 .configurationValidationPolicy(
                         DeploymentConfigurationValidationPolicy.builder().timeoutInSeconds(DEFAULT_TIMEOUT_SECOND)
                                 .build())
-                .componentUpdatePolicy(new ComponentUpdatePolicy(NO_OP_TIMEOUT, SKIP_NOTIFY_COMPONENTS)).groupName(
-                        StringUtils.isEmpty(localOverrideRequest.getGroupName()) ? LOCAL_DEPLOYMENT_GROUP_NAME
-                                : localOverrideRequest.getGroupName()).build();
+                .componentUpdatePolicy(new ComponentUpdatePolicy(NO_OP_TIMEOUT, SKIP_NOTIFY_COMPONENTS))
+                .groupName(StringUtils.isEmpty(localOverrideRequest.getGroupName()) ? LOCAL_DEPLOYMENT_GROUP_NAME
+                        : THING_GROUP_RESOURCE_NAME_PREFIX + localOverrideRequest.getGroupName()).build();
     }
 
 


### PR DESCRIPTION
**Description of changes:**
1. For local deployments, the input from the CLI is thing group name (ex FirstGroup) while kernel uses  thing group resource name (ex thinggroup/FirstGroup) to track packages to thing group.
2. Components deployed via local deployments without a group name are excluded from the thing group removal check. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
