### PR TITLE
fix(resource-limit): remove the linux key in the resource limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.0.0-HIB-SNAPSHOT</version>
+            <version>1.0.0-RES-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -347,10 +347,10 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
             assertTrue(deploymentFinished.await(30, TimeUnit.SECONDS));
 
             long memory = Coerce.toLong(kernel.findServiceTopic("RedSignal")
-                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "linux", "memory"));
+                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "memory"));
             assertEquals(1024000, memory);
             double cpu = Coerce.toDouble(kernel.findServiceTopic("RedSignal")
-                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "linux", "cpu"));
+                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "cpu"));
             assertEquals(1.5, cpu);
         }
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -866,10 +866,10 @@ class DeploymentTaskIntegrationTest {
                     .find(RUN_WITH_NAMESPACE_TOPIC, POSIX_USER_KEY));
             assertEquals("nobody", user);
             long memory = Coerce.toLong(kernel.findServiceTopic("CustomerAppStartupShutdown")
-                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "linux", "memory"));
+                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "memory"));
             assertEquals(1024000, memory);
             double cpu = Coerce.toDouble(kernel.findServiceTopic("CustomerAppStartupShutdown")
-                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "linux", "cpu"));
+                    .find(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS, "cpu"));
             assertEquals(1.5, cpu);
 
             countDownLatch.await(10, TimeUnit.SECONDS);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.integrationtests.lifecyclemanager;
 
-import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Subscriber;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.WhatHappened;
@@ -547,10 +546,10 @@ class GenericExternalServiceIntegTest extends BaseITCase {
 
         // Run with component resource limit
         kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, componentName, RUN_WITH_NAMESPACE_TOPIC,
-                SYSTEM_RESOURCE_LIMITS_TOPICS, PlatformResolver.getOSInfo(), "memory").withValue(102400l);
+                SYSTEM_RESOURCE_LIMITS_TOPICS, "memory").withValue(102400l);
 
         kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, componentName, RUN_WITH_NAMESPACE_TOPIC,
-                SYSTEM_RESOURCE_LIMITS_TOPICS, PlatformResolver.getOSInfo(), "cpu").withValue(0.5);
+                SYSTEM_RESOURCE_LIMITS_TOPICS, "cpu").withValue(0.5);
         //Block until events are completed
         kernel.getContext().waitForPublishQueueToClear();
 

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithResourceLimits.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithResourceLimits.json
@@ -7,10 +7,8 @@
       "runWith":  {
         "posixUser": "nobody",
         "systemResourceLimits": {
-          "linux": {
-            "memory": 1024000,
-            "cpu": 1.5
-          }
+          "memory": 1024000,
+          "cpu": 1.5
         }
       }
     }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
@@ -8,10 +8,8 @@
       "RunWith":  {
         "PosixUser": "nobody",
         "systemResourceLimits": {
-          "linux": {
-            "memory": 1024000,
-            "cpu": 1.5
-          }
+          "memory": 1024000,
+          "cpu": 1.5
         }
       }
     }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user.yaml
@@ -6,10 +6,8 @@ services:
       runWithDefault:
         posixUser: nobody
         systemResourceLimits:
-          all:
-            linux:
-              cpu: 1.5
-              memory: 10240
+          cpu: 1.5
+          memory: 10240
 
   main:
     dependencies:

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -16,7 +16,6 @@ import com.aws.greengrass.componentmanager.models.ComponentRecipe;
 import com.aws.greengrass.config.CaseInsensitiveString;
 import com.aws.greengrass.config.ChildChanged;
 import com.aws.greengrass.config.Node;
-import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.Validator;
@@ -535,8 +534,7 @@ public class DeviceConfiguration {
     public Topics findRunWithDefaultSystemResourceLimits() {
         return kernel.getConfig()
                 .findTopics(SERVICES_NAMESPACE_TOPIC, getNucleusComponentName(),
-                        CONFIGURATION_CONFIG_KEY, RUN_WITH_TOPIC, GreengrassService.SYSTEM_RESOURCE_LIMITS_TOPICS,
-                        PlatformResolver.getOSInfo());
+                        CONFIGURATION_CONFIG_KEY, RUN_WITH_TOPIC, GreengrassService.SYSTEM_RESOURCE_LIMITS_TOPICS);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
+++ b/src/main/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverter.java
@@ -295,21 +295,17 @@ public final class DeploymentDocumentConverter {
 
     private static SystemResourceLimits convertSystemResourceLimits(
             com.amazon.aws.iot.greengrass.configuration.common.SystemResourceLimits resourceLimits) {
-        if (resourceLimits == null || resourceLimits.getLinux() == null) {
+        if (resourceLimits == null) {
             return null;
         }
-        return new SystemResourceLimits(
-                new SystemResourceLimits.LinuxSystemResourceLimits(
-                        resourceLimits.getLinux().getMemory(), resourceLimits.getLinux().getCpu()));
+        return new SystemResourceLimits(resourceLimits.getMemory(), resourceLimits.getCpu());
     }
 
     private static SystemResourceLimits convertSystemResourceLimits(
             software.amazon.awssdk.aws.greengrass.model.SystemResourceLimits resourceLimits) {
-        if (resourceLimits == null || resourceLimits.getLinux() == null) {
+        if (resourceLimits == null) {
             return null;
         }
-        return new SystemResourceLimits(
-                new SystemResourceLimits.LinuxSystemResourceLimits(
-                        resourceLimits.getLinux().getMemory(), resourceLimits.getLinux().getCpu()));
+        return new SystemResourceLimits(resourceLimits.getMemory(), resourceLimits.getCpu());
     }
 }

--- a/src/main/java/com/aws/greengrass/deployment/model/SystemResourceLimits.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/SystemResourceLimits.java
@@ -13,14 +13,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SystemResourceLimits {
-
-    LinuxSystemResourceLimits linux;
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class LinuxSystemResourceLimits {
-        long memory;
-        double cpu;
-    }
+    long memory;
+    double cpu;
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.lifecyclemanager;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.config.CaseInsensitiveString;
 import com.aws.greengrass.config.Node;
-import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
@@ -140,8 +139,7 @@ public class GenericExternalService extends GreengrassService {
     }
 
     private void updateSystemResourceLimits() {
-        Topics systemResourceLimits = config.findTopics(RUN_WITH_NAMESPACE_TOPIC,
-                        SYSTEM_RESOURCE_LIMITS_TOPICS, PlatformResolver.getOSInfo());
+        Topics systemResourceLimits = config.findTopics(RUN_WITH_NAMESPACE_TOPIC, SYSTEM_RESOURCE_LIMITS_TOPICS);
         if (systemResourceLimits == null && deviceConfiguration != null) {
             systemResourceLimits = deviceConfiguration.findRunWithDefaultSystemResourceLimits();
         }

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -167,13 +167,10 @@ class KernelConfigResolverTest {
         ComponentRecipe dependencyComponentRecipe =
                 getPackage(TEST_INPUT_PACKAGE_B, "2.3.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_B);
 
-        SystemResourceLimits systemResourceLimits = new SystemResourceLimits(
-                new SystemResourceLimits.LinuxSystemResourceLimits(102400L, 1.5));
+        SystemResourceLimits systemResourceLimits = new SystemResourceLimits(102400L, 1.5);
         Map<String, Object> expectedSystemResourceLimits = new HashMap<>();
-        Map<String, Object> expectedLinuxMap = new HashMap<>();
-        expectedLinuxMap.put("cpu", 1.5);
-        expectedLinuxMap.put("memory", 102400L);
-        expectedSystemResourceLimits.put("linux", expectedLinuxMap);
+        expectedSystemResourceLimits.put("cpu", 1.5);
+        expectedSystemResourceLimits.put("memory", 102400L);
         DeploymentPackageConfiguration rootPackageDeploymentConfig = DeploymentPackageConfiguration.builder()
                 .packageName(TEST_INPUT_PACKAGE_A)
                 .rootComponent(true)
@@ -316,8 +313,7 @@ class KernelConfigResolverTest {
         when(alreadyRunningService.getName()).thenReturn(TEST_INPUT_PACKAGE_A);
         when(alreadyRunningService.isBuiltin()).thenReturn(true);
         when(alreadyRunningServiceConfig.findTopics(RUN_WITH_NAMESPACE_TOPIC)).thenReturn(alreadyRunningServiceRunWithConfig);
-        SystemResourceLimits systemResourceLimits = new SystemResourceLimits(
-                new SystemResourceLimits.LinuxSystemResourceLimits(102400L, 1.5));
+        SystemResourceLimits systemResourceLimits = new SystemResourceLimits(102400L, 1.5);
         when(alreadyRunningServiceRunWithConfig.toPOJO()).thenReturn(new HashMap<String, Object>() {{
             put(POSIX_USER_KEY, "foo:bar");
             put(SYSTEM_RESOURCE_LIMITS_TOPICS, systemResourceLimits);

--- a/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
@@ -19,7 +19,6 @@ import com.aws.greengrass.deployment.model.LocalOverrideRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.aws.greengrass.model.LinuxSystemResourceLimits;
 import software.amazon.awssdk.aws.greengrass.model.RunWithInfo;
 import software.amazon.awssdk.aws.greengrass.model.SystemResourceLimits;
 import software.amazon.awssdk.services.greengrassv2.model.DeploymentConfigurationValidationPolicy;
@@ -90,11 +89,9 @@ class DeploymentDocumentConverterTest {
         Map<String, RunWithInfo> componentToRunWithInfo = new HashMap<>();
         RunWithInfo runWithInfo = new RunWithInfo();
         runWithInfo.setPosixUser("foo:bar");
-        LinuxSystemResourceLimits linuxLimits = new LinuxSystemResourceLimits();
-        linuxLimits.setMemory(102400L);
-        linuxLimits.setCpu(1.5);
         SystemResourceLimits limits = new SystemResourceLimits();
-        limits.setLinux(linuxLimits);
+        limits.setMemory(102400L);
+        limits.setCpu(1.5);
         runWithInfo.setSystemResourceLimits(limits);
         componentToRunWithInfo.put(NEW_ROOT_COMPONENT, runWithInfo);
         runWithInfo = new RunWithInfo();
@@ -144,8 +141,8 @@ class DeploymentDocumentConverterTest {
         assertThat(newRootComponentConfig.getResolvedVersion(), is("2.0.0"));
         assertNull(newRootComponentConfig.getConfigurationUpdateOperation());
         assertEquals("foo:bar", newRootComponentConfig.getRunWith().getPosixUser());
-        assertEquals(1.5, newRootComponentConfig.getRunWith().getSystemResourceLimits().getLinux().getCpu());
-        assertEquals(102400L, newRootComponentConfig.getRunWith().getSystemResourceLimits().getLinux().getMemory());
+        assertEquals(1.5, newRootComponentConfig.getRunWith().getSystemResourceLimits().getCpu());
+        assertEquals(102400L, newRootComponentConfig.getRunWith().getSystemResourceLimits().getMemory());
 
         DeploymentPackageConfiguration DependencyComponentConfig =
                 deploymentPackageConfigurations.stream().filter(e -> e.getPackageName().equals(DEPENDENCY_COMPONENT))
@@ -195,9 +192,9 @@ class DeploymentDocumentConverterTest {
         assertThat(componentConfiguration.getConfigurationUpdateOperation().getValueToMerge(),
                    equalTo(ImmutableMap.of("key", "val")));
 
-        assertEquals(1.5, componentConfiguration.getRunWith().getSystemResourceLimits().getLinux().getCpu());
+        assertEquals(1.5, componentConfiguration.getRunWith().getSystemResourceLimits().getCpu());
         assertEquals(1024000L,
-                componentConfiguration.getRunWith().getSystemResourceLimits().getLinux().getMemory());
+                componentConfiguration.getRunWith().getSystemResourceLimits().getMemory());
 
         componentConfiguration =
                 deploymentDocument.getDeploymentPackageConfigurationList().get(1);

--- a/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/model/RunWithTest.java
@@ -57,7 +57,7 @@ class RunWithTest {
     static Stream<Arguments> runWithValues() {
         return Stream.of(
                 arguments("{}", false, null, false, null),
-                arguments("{ \"PosixUser\": \"foo:bar\", \"systemResourceLimits\": {\"linux\": {\"cpu\": 1.5, \"memory\": 102400}}}", true, "foo:bar", false, null),
+                arguments("{ \"PosixUser\": \"foo:bar\", \"systemResourceLimits\": {\"cpu\": 1.5, \"memory\": 102400}}", true, "foo:bar", false, null),
                 arguments("{ \"WindowsUser\": \"foo\" }", false, null, true, "foo"),
                 arguments(json("foo:bar", "foo"), true, "foo:bar", true, "foo"),
                 arguments(json(null, "foo"), true, null, true, "foo"),

--- a/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
+++ b/src/test/resources/com/aws/greengrass/deployment/converter/FcsDeploymentConfig_Full.json
@@ -10,10 +10,8 @@
       "runWith": {
         "posixUser": "foo",
         "systemResourceLimits": {
-          "linux": {
-            "memory": 1024000,
-            "cpu": 1.5
-          }
+          "memory": 1024000,
+          "cpu": 1.5
         }
       },
       "configurationUpdate": {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove the `linux` key under `systemResourceLimits` to simplify the interface
**Why is this change necessary:**
The team had a discussion and decided the `linux` key is not necessary.
**How was this change tested:**
Updated the existing tests
**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
