### PR TITLE
fix: validate artifact uri from component recipe

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -353,7 +353,7 @@ public class ComponentManager implements InjectionActions {
                                 componentId));
             }
             artifactDownloaderFactory
-                    .checkDownloadPrerequisites(recipeOption.get().getArtifacts(), componentIds);
+                    .checkDownloadPrerequisites(recipeOption.get().getArtifacts(), componentId, componentIds);
         }
     }
 

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
@@ -581,7 +581,7 @@ class ComponentManagerTest {
         when(mockRecipe.getArtifacts()).thenReturn(artifacts);
         when(componentStore.findPackageRecipe(any())).thenReturn(recipeResult);
         doThrow(new MissingRequiredComponentsException("Missing required component for download")).when
-         (artifactDownloaderFactory).checkDownloadPrerequisites(any(), any());
+         (artifactDownloaderFactory).checkDownloadPrerequisites(any(), any(), any());
 
         List<ComponentIdentifier> dependencyClosure =
                 Arrays.asList(

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
@@ -118,7 +118,7 @@ class ArtifactDownloaderFactoryTest {
                 Arrays.asList(new ComponentIdentifier(DOCKER_MANAGER_PLUGIN_SERVICE_NAME, new Semver("2.0.0")),
                         new ComponentIdentifier("aws.greengrass.TokenExchangeService", new Semver("2.0.0")),
                         testComponent);
-        artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, dependencyClosure);
+        artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, testComponent, dependencyClosure);
     }
 
     @Test
@@ -133,7 +133,7 @@ class ArtifactDownloaderFactoryTest {
         List<ComponentIdentifier> dependencyClosure =
                 Arrays.asList(new ComponentIdentifier(DOCKER_MANAGER_PLUGIN_SERVICE_NAME, new Semver("2.0.0")),
                         testComponent);
-        artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, dependencyClosure);
+        artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, testComponent, dependencyClosure);
     }
 
     @Test
@@ -147,7 +147,7 @@ class ArtifactDownloaderFactoryTest {
         List<ComponentIdentifier> dependencyClosure =
                 Arrays.asList(new ComponentIdentifier(DOCKER_MANAGER_PLUGIN_SERVICE_NAME, new Semver("2.0.0")),
                         testComponent);
-        artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, dependencyClosure);
+        artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, testComponent, dependencyClosure);
     }
 
     @Test
@@ -160,7 +160,8 @@ class ArtifactDownloaderFactoryTest {
 
         List<ComponentIdentifier> dependencyClosure = Arrays.asList(testComponent);
         Throwable err = assertThrows(MissingRequiredComponentsException.class,
-                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, dependencyClosure));
+                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, testComponent,
+                        dependencyClosure));
         assertThat(err.getMessage(), containsString(DOCKER_PLUGIN_REQUIRED_ERROR_MSG));
     }
 
@@ -176,7 +177,8 @@ class ArtifactDownloaderFactoryTest {
                 Arrays.asList(new ComponentIdentifier(DOCKER_MANAGER_PLUGIN_SERVICE_NAME, new Semver("2.0.0")),
                         testComponent);
         Throwable err = assertThrows(MissingRequiredComponentsException.class,
-                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, dependencyClosure));
+                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, testComponent,
+                        dependencyClosure));
         assertThat(err.getMessage(), containsString(TOKEN_EXCHANGE_SERVICE_REQUIRED_ERROR_MSG));
     }
 
@@ -191,7 +193,8 @@ class ArtifactDownloaderFactoryTest {
 
         List<ComponentIdentifier> dependencyClosure = Arrays.asList(testComponent);
         Throwable err = assertThrows(MissingRequiredComponentsException.class,
-                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, dependencyClosure));
+                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, testComponent,
+                        dependencyClosure));
         assertThat(err.getMessage(), containsString(DOCKER_PLUGIN_REQUIRED_ERROR_MSG));
     }
 
@@ -205,7 +208,8 @@ class ArtifactDownloaderFactoryTest {
 
         List<ComponentIdentifier> dependencyClosure = Arrays.asList(testComponent);
         Throwable err = assertThrows(MissingRequiredComponentsException.class,
-                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, dependencyClosure));
+                () -> artifactDownloaderFactory.checkDownloadPrerequisites(artifacts, testComponent,
+                        dependencyClosure));
         assertThat(err.getMessage(), containsString(DOCKER_PLUGIN_REQUIRED_ERROR_MSG));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Artifact Uri in component recipe was not being validated leading to NPE if the URI did not have a scheme.
**Description of changes:**
Adding the validation
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
