### PR TITLE
fix(windows): add windows os to recipe.yaml

### DIFF
--- a/conf/recipe.yaml
+++ b/conf/recipe.yaml
@@ -53,3 +53,5 @@ Manifests:
           echo "{configuration:/jvmOptions}" > "$KERNEL_ROOT/alts/current/launch.params"
           ln -sf "$UNPACK_DIR" "$KERNEL_ROOT/alts/current/distro"
           exit 100
+  - Platform:
+      os: windows


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding Windows OS to recipe.yaml as a platform. No Bootstrap definition yet until we have a separate feature for it.

**Why is this change necessary:**
If Windows isn't in the recipe, then the recipe will exist but a definition for Windows will be missing.

Specifically, the error is [here](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/d047ceeeb6c468bde7a545c7d6733f7fe28800c7/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java#L372)

**How was this change tested:**
Tested via `verify`

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
