### PR TITLE
feat(easysetup): added an optional thing-policy-name flag for device provisioning

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -89,7 +89,6 @@ import java.util.UUID;
  */
 @Getter
 public class DeviceProvisioningHelper {
-    private static final String GG_THING_POLICY_NAME = "GreengrassV2IoTThingPolicy";
     private static final String GG_TOKEN_EXCHANGE_ROLE_ACCESS_POLICY_SUFFIX = "Access";
     private static final String GG_TOKEN_EXCHANGE_ROLE_ACCESS_POLICY_DOCUMENT =
             "{\n" + "    \"Version\": \"2012-10-17\",\n"
@@ -182,17 +181,6 @@ public class DeviceProvisioningHelper {
     public ThingInfo createThingForE2ETests() {
         return createThing(iotClient, E2E_TESTS_POLICY_NAME_PREFIX,
                 E2E_TESTS_THING_NAME_PREFIX + UUID.randomUUID().toString());
-    }
-
-    /**
-     * Create a thing with provided configuration.
-     *
-     * @param client    iotClient to use
-     * @param thingName thingName
-     * @return created thing info
-     */
-    public ThingInfo createThing(IotClient client, String thingName) {
-        return createThing(client, GG_THING_POLICY_NAME, thingName);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/easysetup/README.md
+++ b/src/main/java/com/aws/greengrass/easysetup/README.md
@@ -1,9 +1,9 @@
 # Easy setup script
 The setup script is intended to give a brand new user of Greengrass to get started with Greengrass device quickly.
 As part of that experience the user can get a fat jar for the Greengrass Nucleus, the script can launch the Nucleus
- with the customer's provided config if desired, optionally provision the test device as an AWS IoT Thing, create and
- attach policies and certificates to it, create TES role and role alias or uses existing ones and attaches
- them to the IoT thing certificate.
+with the customer's provided config if desired, optionally provision the test device as an AWS IoT Thing, create and
+attach policies and certificates to it, create TES role and role alias or uses existing ones and attaches
+them to the IoT thing certificate.
 
 
 ## Getting the jar
@@ -35,6 +35,10 @@ OPTIONS
                                 thing. If a deployment targets this thing group, this core device receives that deployment
                                 when it connects to AWS IoT Greengrass. If the thing group with this name doesn't exist in your
                                 AWS account, then the AWS IoT Greengrass Core software creates it. Defaults to no thing group.
+--thing-policy-name, -tpn       (Optional) If specified, then the supplied thing-policy-name is attached to the provisioned IoT Thing.
+                                Otherwise a policy called GreengrassV2IoTThingPolicy is used instead. If the policy with
+                                this name doesn't exist in your AWS account, the AWS IoT Greengrass Core software creates it
+                                with a default policy document.
 —-tes-role-name, -trn           (Optional) The name of the IAM role to use to acquire AWS credentials that let the device interact
                                 with AWS services. If the role with this name doesn't exist in your AWS account, then the AWS IoT
                                 Greengrass Core software creates it with the GreengrassV2TokenExchangeRoleAccess policy. This role

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -92,17 +92,17 @@ class GreengrassSetupTest {
 
     @Test
     void GIVEN_setup_script_WHEN_script_is_used_THEN_setup_actions_are_performed() throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name",
-                        "--thing-group-name", "mock_thing_group_name", "--tes-role-name", "mock_tes_role_name",
-                        "--tes-role-alias-name", "mock_tes_role_alias_name", "--provision", "y", "--aws-region",
-                        "us-east-1", "-ss", "false");
+                        "--thing-group-name", "mock_thing_group_name", "--thing-policy-name", "mock_thing_policy_name",
+                        "--tes-role-name", "mock_tes_role_name", "--tes-role-alias-name", "mock_tes_role_alias_name",
+                        "--provision", "y", "--aws-region","us-east-1", "-ss", "false");
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);
-        verify(deviceProvisioningHelper, times(1)).createThing(any(), any());
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
@@ -351,8 +351,24 @@ class GreengrassSetupTest {
     }
 
     @Test
+    void GIVEN_setup_script_WHEN_no_thing_policy_name_args_provided_THEN_policy_setup_with_default() throws Exception {
+        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
+        greengrassSetup =
+                new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
+                        "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name",
+                        "-trn", "mock_tes_role_name", "--provision", "y", "--aws-region", "us-east-1", "-ss", "false");
+        greengrassSetup.parseArgs();
+        greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
+        greengrassSetup.provision(kernel);
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any());
+    }
+
+    @Test
     void GIVEN_setup_script_WHEN_no_tes_role_args_provided_THEN_tes_setup_with_default() throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name", "--provision",
@@ -360,7 +376,7 @@ class GreengrassSetupTest {
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);
-        verify(deviceProvisioningHelper, times(1)).createThing(any(), any());
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any());
@@ -369,7 +385,7 @@ class GreengrassSetupTest {
     @Test
     void GIVEN_setup_script_WHEN_script_is_used_with_short_arg_notations_THEN_setup_actions_are_performed()
             throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup = new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "-i",
                 "mock_config_path", "-r", "mock_root", "-tn", "mock_thing_name", "-tgn", "mock_thing_group_name",
                 "-trn", "mock_tes_role_name", "-tra", "mock_tes_role_alias_name", "-p", "y", "-ar", "us-east-1", "-ss",
@@ -377,7 +393,7 @@ class GreengrassSetupTest {
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);
-        verify(deviceProvisioningHelper, times(1)).createThing(any(), any());
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());


### PR DESCRIPTION
**Issue #, if available:**
#1015

**Description of changes:**
Have added the --thing-name-policy to the installer argument options. This argument has a default value of GreengrassV2IoTThingPolicy and is passed by parameter to the createThing method. No changes have been made to the process of creating or attaching policies. Updated appropriate README and help message.

**Why is this change necessary:**
Addresses the feature request in Issue #1015 for providing a policy name to apply to the provisinoed IoT Thing.

**How was this change tested:**
Unit tests run. Manually provisioned inside an ubuntu vm and on a raspberry pi, testing for creation of custom named resource and correctly attaching an existing policy.

**Any additional information or context required to review the change:**

**Checklist:**
 - [x] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
