### PR TITLE
fix(install): relink KernelAlternatives to component store during first install

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -324,8 +324,9 @@ public class DeviceConfiguration {
         kernel.getConfig().lookup(SETENV_CONFIG_NAMESPACE, GGC_VERSION_ENV).dflt(nucleusComponentVersion);
     }
 
-    void initializeComponentStore(String nucleusComponentName, Semver componentVersion, Path recipePath,
-                                          Path unpackDir) throws IOException, PackageLoadingException {
+    void initializeComponentStore(KernelAlternatives kernelAlts, String nucleusComponentName,
+                                  Semver componentVersion, Path recipePath,
+                                  Path unpackDir) throws IOException, PackageLoadingException {
         // Copy recipe to component store
         ComponentStore componentStore = kernel.getContext().get(ComponentStore.class);
         ComponentIdentifier componentIdentifier = new ComponentIdentifier(nucleusComponentName, componentVersion);
@@ -345,6 +346,10 @@ public class DeviceConfiguration {
         Permissions.setArtifactPermission(destinationArtifactPath, FileSystemPermission.builder()
                 .ownerRead(true).ownerExecute(true).groupRead(true).groupExecute(true)
                 .otherRead(true).otherExecute(true).build());
+        // Relink the alts init path to point to the artifact since we've just installed. This will allow the
+        // customer to delete their unzipped Nucleus distribution. This will not change the "current" symlink
+        // so that if current points to something other than init, we won't be messing with that.
+        kernelAlts.relinkInitLaunchDir(destinationArtifactPath, false);
     }
 
     /**
@@ -375,7 +380,7 @@ public class DeviceConfiguration {
             componentVersion = componentRecipe.getVersion();
             initializeNucleusLifecycleConfig(nucleusComponentName, componentRecipe);
 
-            initializeComponentStore(nucleusComponentName, componentVersion, recipePath, unpackDir);
+            initializeComponentStore(kernelAlts, nucleusComponentName, componentVersion, recipePath, unpackDir);
 
         } catch (IOException | URISyntaxException | PackageLoadingException e) {
             logger.atError().log("Unable to set up Nucleus from build recipe file", e);

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -242,8 +242,8 @@ class DeviceConfigurationTest {
         doReturn(context).when(mockKernel).getContext();
 
         DeviceConfiguration spyDeviceConfig = spy(deviceConfiguration);
-        spyDeviceConfig.initializeComponentStore(nucleusComponentName, nucleusComponentVersion, recipePath,
-                tempDir);
+        spyDeviceConfig.initializeComponentStore(mock(KernelAlternatives.class),
+                nucleusComponentName, nucleusComponentVersion, recipePath, tempDir);
         verify(spyDeviceConfig, times(0)).copyUnpackedNucleusArtifacts(any(), any());
         verify(componentStore, times(0)).savePackageRecipe(any(), any());
     }
@@ -270,8 +270,8 @@ class DeviceConfigurationTest {
                         .recipeFormatVersion(RecipeFormatVersion.JAN_25_2020).build());
         mockNucleusUnpackDir.setup(mockRecipeContent);
 
-        deviceConfiguration.initializeComponentStore(nucleusComponentName, nucleusComponentVersion,
-                mockNucleusUnpackDir.getConfRecipe(), unpackDir);
+        deviceConfiguration.initializeComponentStore(mock(KernelAlternatives.class), nucleusComponentName,
+                nucleusComponentVersion, mockNucleusUnpackDir.getConfRecipe(), unpackDir);
 
         ComponentIdentifier componentIdentifier = new ComponentIdentifier(nucleusComponentName,
                 nucleusComponentVersion);
@@ -310,8 +310,8 @@ class DeviceConfigurationTest {
         mockNucleusUnpackDir.setup(mockRecipeContent);
 
         // Should only copy artifact files to component store
-        deviceConfiguration.initializeComponentStore(nucleusComponentName, nucleusComponentVersion,
-                mockNucleusUnpackDir.getConfRecipe(), unpackDir);
+        deviceConfiguration.initializeComponentStore(mock(KernelAlternatives.class), nucleusComponentName,
+                nucleusComponentVersion, mockNucleusUnpackDir.getConfRecipe(), unpackDir);
 
         ComponentIdentifier componentIdentifier = new ComponentIdentifier(nucleusComponentName,
                 nucleusComponentVersion);

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelAlternativesTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelAlternativesTest.java
@@ -25,11 +25,13 @@ import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.BOO
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.KERNEL_ACTIVATION;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.KERNEL_ROLLBACK;
+import static com.aws.greengrass.lifecyclemanager.KernelAlternatives.KERNEL_DISTRIBUTION_DIR;
 import static com.aws.greengrass.lifecyclemanager.KernelAlternatives.LAUNCH_PARAMS_FILE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingFileOrDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -100,6 +102,42 @@ class KernelAlternativesTest {
         kernelAlternatives.activationSucceeds();
         assertThat(kernelAlternatives.getOldDir().toFile(), not(anExistingFileOrDirectory()));
         assertThat(initPath.toFile(), not(anExistingFileOrDirectory()));
+    }
+
+    @Test
+    void GIVEN_initDirPointingWrongLocation_WHEN_redirectInitDir_THEN_dirIsRedirectedCorrectly() throws Exception {
+        Path outsidePath = createRandomDirectory();
+        Path unpackPath = createRandomDirectory();
+        Files.createDirectories(unpackPath.resolve("bin"));
+        Files.createFile(unpackPath.resolve("bin").resolve("loader"));
+
+        Path distroPath = kernelAlternatives.getInitDir().resolve(KERNEL_DISTRIBUTION_DIR);
+        Files.createDirectories(kernelAlternatives.getInitDir());
+        // current -> init
+        kernelAlternatives.setupLinkToDirectory(kernelAlternatives.getCurrentDir(), kernelAlternatives.getInitDir());
+        // init/distro -> outsidePath
+        kernelAlternatives.setupLinkToDirectory(distroPath, outsidePath);
+        assertEquals(kernelAlternatives.getInitDir(), Files.readSymbolicLink(kernelAlternatives.getCurrentDir()));
+        assertEquals(outsidePath, Files.readSymbolicLink(distroPath));
+
+        // current -> some random path
+        Files.deleteIfExists(kernelAlternatives.getCurrentDir());
+        Path random = createRandomDirectory();
+        Files.createDirectories(random.resolve(KERNEL_DISTRIBUTION_DIR).resolve("bin"));
+        Files.createFile(random.resolve(KERNEL_DISTRIBUTION_DIR).resolve("bin").resolve("loader"));
+        kernelAlternatives.setupLinkToDirectory(kernelAlternatives.getCurrentDir(), random);
+
+        // Relink without changing the current dir location
+        kernelAlternatives.relinkInitLaunchDir(unpackPath, false);
+        // Ensure we didn't change the current path, only the init path
+        assertNotEquals(kernelAlternatives.getInitDir(), Files.readSymbolicLink(kernelAlternatives.getCurrentDir()));
+        assertEquals(unpackPath, Files.readSymbolicLink(distroPath));
+
+        // Relink and change the current dir to point to init
+        kernelAlternatives.relinkInitLaunchDir(unpackPath, true);
+        // Ensure this time we did change the current path
+        assertEquals(kernelAlternatives.getInitDir(), Files.readSymbolicLink(kernelAlternatives.getCurrentDir()));
+        assertEquals(unpackPath, Files.readSymbolicLink(distroPath));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently our installation copies the artifacts into the proper artifact storage, however the KernelAlternatives are not moved to symlink to that location, instead they point to the initial location. This is error prone as customers may delete these files, thus breaking their installation.

Only the `init` path will be changed. The `init` path is only ever used during the setup, and `current` will point to init or whichever is the proper place for it to be pointing. This change ensures that `current` will never be redirected to point to `init` except during the very first setup which is how it works prior to this change.

**Why is this change necessary:**

**How was this change tested:**
Manually tested that the symlink points to the proper location inside the unarchive path.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
