### PR TITLE
fix(log-config): update log config on startup, not only on changes

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -440,6 +440,8 @@ public class DeviceConfiguration {
     public synchronized void handleLoggingConfigurationChanges(WhatHappened what, Node node) {
         logger.atDebug().kv("logging-change-what", what).kv("logging-change-node", node).log();
         switch (what) {
+            case initialized:
+                // fallthrough
             case childChanged:
                 LogConfigUpdate logConfigUpdate;
                 try {

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -248,9 +248,6 @@ class LogManagerHelperTest {
         LogConfig testLogConfig = LogManager.getLogConfigurations().get(mockServiceName);
         PersistenceConfig defaultConfig = new PersistenceConfig(LOG_FILE_EXTENSION, LOGS_DIRECTORY);
 
-        // apply non-default configs
-        deviceConfiguration.handleLoggingConfigurationChanges(WhatHappened.childChanged, loggingConfig);
-
         // assert non-default configs
         assertEquals(LogStore.CONSOLE, testLogConfig.getStore());
         assertEquals(LogFormat.JSON, testLogConfig.getFormat());
@@ -315,8 +312,7 @@ class LogManagerHelperTest {
         when(configuration.lookupTopics(anyString())).thenReturn(topics);
         when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY)).thenReturn(topics);
         when(configuration.lookupTopics(SYSTEM_NAMESPACE_KEY)).thenReturn(topics);
-        DeviceConfiguration deviceConfiguration = new DeviceConfiguration(kernel);
-        deviceConfiguration.handleLoggingConfigurationChanges(WhatHappened.childChanged, loggingConfig);
+        new DeviceConfiguration(kernel);
 
         assertEquals(Level.TRACE, LogManager.getRootLogConfiguration().getLevel());
         assertEquals(LogStore.FILE, LogManager.getRootLogConfiguration().getStore());
@@ -345,15 +341,12 @@ class LogManagerHelperTest {
         lenient().when(kernel.getNucleusPaths()).thenReturn(nucleusPaths);
         Topics topic = mock(Topics.class);
         Topics topics = Topics.of(mock(Context.class), SERVICES_NAMESPACE_TOPIC, mock(Topics.class));
-        when(topic.subscribe(childChangedArgumentCaptor.capture())).thenReturn(topic);
+        when(topic.subscribe(any())).thenReturn(topic);
         when(configuration.lookupTopics(anyString(), anyString(), anyString(), anyString())).thenReturn(topic);
         when(configuration.lookupTopics(anyString())).thenReturn(topics);
         when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY)).thenReturn(topics);
         when(configuration.lookupTopics(SYSTEM_NAMESPACE_KEY)).thenReturn(topics);
-        DeviceConfiguration deviceConfiguration = new DeviceConfiguration(kernel);
-        deviceConfiguration.handleLoggingConfigurationChanges(WhatHappened.childChanged, null);
-
-        childChangedArgumentCaptor.getValue().childChanged(WhatHappened.childChanged, null);
+        new DeviceConfiguration(kernel);
 
         assertEquals(Level.INFO, LogManager.getRootLogConfiguration().getLevel());
         assertEquals("greengrass", LogManager.getRootLogConfiguration().getFileName());


### PR DESCRIPTION
**Issue #, if available:**
Closes https://github.com/aws-greengrass/aws-greengrass-cli/issues/133

**Description of changes:**
Fix logging configuration initialization which was not updating the logger on startup, only upon changes.
Regression introduced in #959.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
