### PR TITLE
fix(windows): add loader.cmd to copy files

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -394,7 +394,7 @@ public class DeviceConfiguration {
         logger.atInfo().kv("source", src).kv("destination", dst).log("Copy Nucleus artifacts to component store");
         List<String> directories = Arrays.asList("bin", "lib", "conf");
         List<String> files = Arrays.asList("LICENSE", "NOTICE", "README.md", "THIRD-PARTY-LICENSES",
-                "greengrass.service.template", "loader", "Greengrass.jar", "recipe.yaml");
+                "greengrass.service.template", "loader", "loader.cmd", "Greengrass.jar", "recipe.yaml");
 
         Files.walkFileTree(src, new SimpleFileVisitor<Path>() {
             @Override


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add *loader.cmd* to list of files for copying.

**Why is this change necessary:**
*loader.cmd* is currently left out and Windows platforms require that file.

**How was this change tested:**
Ran `mvn -U -ntp clean install` without the change and saw that *loader.cmd* was missing from **bin** folder.

Ran `mvn -U -ntp clean install` with the change and saw that *loader.cmd* was included in **bin** folder.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
