### PR TITLE
fix(resource-mgt): Fixing a few cases for resource limits and hibernation

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -550,12 +550,23 @@ class GenericExternalServiceIntegTest extends BaseITCase {
 
         kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, componentName, RUN_WITH_NAMESPACE_TOPIC,
                 SYSTEM_RESOURCE_LIMITS_TOPICS, "cpus").withValue(0.5);
-        //Block until events are completed
+        // Block until events are completed
         kernel.getContext().waitForPublishQueueToClear();
 
         assertResourceLimits(componentName, 102400l * 1024, 0.5);
 
-        // remove component resource limit
+        // Run with updated component resource limit
+        kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, componentName, RUN_WITH_NAMESPACE_TOPIC,
+                SYSTEM_RESOURCE_LIMITS_TOPICS, "memory").withValue(51200l);
+        kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, componentName, RUN_WITH_NAMESPACE_TOPIC,
+                SYSTEM_RESOURCE_LIMITS_TOPICS, "cpus").withValue(0.35);
+        kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, componentName, VERSION_CONFIG_KEY).withValue("2.0.0");
+        // Block until events are completed
+        kernel.getContext().waitForPublishQueueToClear();
+
+        assertResourceLimits(componentName, 51200l * 1024, 0.35);
+
+        // Remove component resource limit, should fall back to default
         kernel.getConfig().lookupTopics(SERVICES_NAMESPACE_TOPIC, componentName, RUN_WITH_NAMESPACE_TOPIC,
                 SYSTEM_RESOURCE_LIMITS_TOPICS).remove();
         kernel.getContext().waitForPublishQueueToClear();

--- a/src/main/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgent.java
@@ -370,7 +370,7 @@ public class LifecycleIPCEventStreamAgent {
                 if (component instanceof GenericExternalService) {
                     target = (GenericExternalService) component;
                 } else {
-                    throw new InvalidArgumentsError("Only external components can be paused.");
+                    throw new InvalidArgumentsError("Only generic components can be paused.");
                 }
 
                 if (State.RUNNING.equals(target.getState())) {
@@ -438,7 +438,7 @@ public class LifecycleIPCEventStreamAgent {
             if (component instanceof GenericExternalService) {
                 target = (GenericExternalService) component;
             } else {
-                throw new InvalidArgumentsError("Only external components can be resumed.");
+                throw new InvalidArgumentsError("Only generic components can be resumed.");
             }
 
             if (target.isPaused()) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -363,6 +363,7 @@ public class GenericExternalService extends GreengrassService {
                 && State.STARTING.equals(getState())) {
             handleRunScript();
         } else if (result.getRight() != null) {
+            updateSystemResourceLimits();
             systemResourceController.addComponentProcess(this, result.getRight().getProcess());
         }
     }
@@ -466,6 +467,7 @@ public class GenericExternalService extends GreengrassService {
             return;
         } else if (result.getRight() != null) {
             reportState(State.RUNNING);
+            updateSystemResourceLimits();
             systemResourceController.addComponentProcess(this, result.getRight().getProcess());
         }
 


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
- Change error message for pause/resume requests for non generic components.
- Reconfigure system resource limits on startup/run script execution in case limits got cleaned up during last shutdown
- Add another case in resource limit update test
- Include a fix from mainline in handling names for pooled threads


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
