### PR TITLE
fix(mqtt): increase connect throttling to 11 seconds from 10 seconds

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -83,7 +83,7 @@ class AwsIotMqttClient implements Closeable {
     // Limit TPS to 1 which is IoT Core's limit for connect requests per client-id
     // IoT was throttling connect calls even at 1 TPS because the limit is actually 0.1 when
     // the same host is hit with the request.
-    private final RateLimiter connectLimiter = RateLimiter.create(0.1);
+    private final RateLimiter connectLimiter = RateLimiter.create(0.09);
 
 
     @Getter(AccessLevel.PACKAGE)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Increase CONNECT throttling to avoid IoT Core throttling. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
