### PR TITLE
test: reset logging config for all integ tests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.integrationtests;
 
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,7 @@ public class BaseITCase {
     @BeforeEach
     void setRootDir() {
         tempRootDir = Paths.get(System.getProperty("root"));
+        LogConfig.getRootLogConfig().reset();
     }
 
     public static void setDeviceConfig(Kernel kernel, String key, Number value) {

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/FileLoggerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/FileLoggerTest.java
@@ -14,7 +14,7 @@ import com.aws.greengrass.logging.impl.config.LogStore;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -30,8 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class FileLoggerTest extends BaseITCase {
     private Kernel kernel;
 
-    @BeforeAll
-    static void beforeAll() {
+    @BeforeEach
+    void beforeEach() {
         LogManager.getRootLogConfiguration().setStore(LogStore.FILE);
         LogManager.getRootLogConfiguration().setFormat(LogFormat.TEXT);
     }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -389,8 +389,8 @@ class LogManagerHelperTest {
 
             new DeviceConfiguration(kernel);
 
-            logTopics.updateFromMap(Utils.immutableMap("level", "DEBUG"), new UpdateBehaviorTree(
-                    UpdateBehaviorTree.UpdateBehavior.REPLACE, System.currentTimeMillis()));
+            context.runOnPublishQueueAndWait(() -> logTopics.updateFromMap(Utils.immutableMap("level", "DEBUG"),
+                    new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, System.currentTimeMillis())));
             context.waitForPublishQueueToClear();
 
             when(mockGreengrassService.getServiceName()).thenReturn("MockService4");


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Provisioning integ test sets logger to DEBUG level logs which ends up flooding our logs for subsequent tests. This change resets the logger for each integ test so that we start with a known state.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
