### PR TITLE
fix(message): improve NoAvailableComponentVersionException messaging

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -161,9 +161,9 @@ public class ComponentManager implements InjectionActions {
                             + "local candidate as the resolved version without negotiating with cloud.");
                     resolvedComponentId = localCandidateOptional.get();
                 } else {
-                    throw new NoAvailableComponentVersionException(String.format(
-                            "Device is configured to run offline and no local applicable version found for component"
-                                    + " '%s' satisfying requirement '%s'.", componentName, versionRequirements));
+                    throw new NoAvailableComponentVersionException(
+                            "Device is configured to run offline and no local component version satisfies the "
+                                    + "requirements.", componentName, versionRequirements);
                 }
             }
         }
@@ -185,7 +185,7 @@ public class ComponentManager implements InjectionActions {
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException", "PMD.NullAssignment",
-            "PMD.AvoidInstanceofChecksInCatchClause"})
+            "PMD.AvoidInstanceofChecksInCatchClause", "PMD.PreserveStackTrace"})
     private ComponentIdentifier negotiateVersionWithCloud(String componentName,
             Map<String, Requirement> versionRequirements,
             ComponentIdentifier localCandidate)
@@ -207,16 +207,27 @@ public class ComponentManager implements InjectionActions {
                         .kv("versionRequirement", versionRequirements)
                         .log("Failed to negotiate version with cloud and no local version to fall back to");
 
-                throw new NoAvailableComponentVersionException(String.format(
-                        "Failed to negotiate component '%s' version with cloud and no local applicable version "
-                                + "satisfying requirement '%s'.", componentName, versionRequirements), e);
+                // If it is NoAvailableComponentVersionException then we do not need to set the cause, because we
+                // know what the cause is.
+                if (e instanceof NoAvailableComponentVersionException) {
+                    throw new NoAvailableComponentVersionException(
+                            "No local or cloud component version satisfies the requirements.", componentName,
+                            versionRequirements);
+                } else {
+                    throw new NoAvailableComponentVersionException(
+                            "No local or cloud component version satisfies the requirements.", componentName,
+                            versionRequirements, e);
+                }
             }
         } else {
             try {
                 resolvedComponentVersion = componentServiceHelper
                         .resolveComponentVersion(componentName, localCandidate.getVersion(), versionRequirements);
             } catch (Exception e) {
-                logger.atInfo().setCause(e).kv(COMPONENT_NAME, componentName)
+                // Don't bother logging the full stacktrace when it is NoAvailableComponentVersionException since we
+                // know the reason for that error
+                logger.atInfo().setCause(e instanceof NoAvailableComponentVersionException ? null : e)
+                        .kv(COMPONENT_NAME, componentName)
                         .kv("versionRequirement", versionRequirements).kv("localVersion", localCandidate)
                         .log("Failed to negotiate version with cloud and fall back to use the local version");
                 return localCandidate;
@@ -608,8 +619,8 @@ public class ComponentManager implements InjectionActions {
         Optional<ComponentMetadata> componentMetadataOptional =
                 findActiveAndSatisfiedPackageMetadata(componentName, requirement);
         if (!componentMetadataOptional.isPresent()) {
-            throw new NoAvailableComponentVersionException(
-                    String.format("There is no version of component %s satisfying %s", componentName, requirement));
+            throw new NoAvailableComponentVersionException("No local component version satisfies the requirement.",
+                    componentName, requirement);
         }
 
         return componentMetadataOptional.get();

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
@@ -49,6 +49,7 @@ public class ComponentServiceHelper {
      * @return resolved component version and recipe
      * @throws NoAvailableComponentVersionException if no applicable version available in cloud service
      */
+    @SuppressWarnings("PMD.PreserveStackTrace")
     ResolvedComponentVersion resolveComponentVersion(String componentName, Semver localCandidateVersion,
             Map<String, Requirement> versionRequirements) throws NoAvailableComponentVersionException {
 
@@ -68,10 +69,9 @@ public class ComponentServiceHelper {
             result = clientFactory.getGreengrassV2DataClient().resolveComponentCandidates(request);
         } catch (ResourceNotFoundException e) {
             logger.atDebug().kv("componentName", componentName).kv("versionRequirements", versionRequirements)
-                    .log("No applicable version found in cloud registry");
-            throw new NoAvailableComponentVersionException(String.format(
-                    "No applicable version found in cloud registry for component: '%s' satisfying requirement: '%s'.",
-                    componentName, versionRequirements), e);
+                    .log("No applicable version found in cloud registry", e);
+            throw new NoAvailableComponentVersionException("No cloud component version satisfies the requirements.",
+                    componentName, versionRequirements);
         }
 
         Validate.isTrue(

--- a/src/main/java/com/aws/greengrass/componentmanager/exceptions/NoAvailableComponentVersionException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/exceptions/NoAvailableComponentVersionException.java
@@ -5,15 +5,45 @@
 
 package com.aws.greengrass.componentmanager.exceptions;
 
+import com.vdurmont.semver4j.Requirement;
+
+import java.util.Map;
+
 public class NoAvailableComponentVersionException extends PackagingException {
 
     static final long serialVersionUID = -3387516993124229948L;
 
-    public NoAvailableComponentVersionException(String message) {
-        super(message);
+    public NoAvailableComponentVersionException(String initialMessage, String componentName, Requirement requirement) {
+        super(String.format("%s Component: %s version: %s", initialMessage.trim(), componentName,
+                requirement.toString()));
     }
 
-    public NoAvailableComponentVersionException(String message, Throwable cause) {
-        super(message, cause);
+    public NoAvailableComponentVersionException(String initialMessage, String componentName,
+                                                Map<String, Requirement> requirements) {
+        super(makeMessage(initialMessage, componentName, requirements));
+    }
+
+    public NoAvailableComponentVersionException(String initialMessage, String componentName,
+                                                Map<String, Requirement> requirements, Throwable cause) {
+        super(makeMessage(initialMessage, componentName, requirements), cause);
+    }
+
+    private static String makeMessage(String initialMessage, String componentName,
+                                      Map<String, Requirement> requirements) {
+        StringBuilder sb = new StringBuilder(initialMessage.trim());
+        sb.append(" Check whether the version constraints conflict and that the component exists in your AWS "
+                        + "account with a version that matches the version constraints. "
+                        + "If the version constraints conflict, revise deployments to resolve the conflict. Component ")
+                .append(componentName).append(" version constraints:");
+
+        for (Map.Entry<String, Requirement> req : requirements.entrySet()) {
+            sb.append(' ').append(req.getKey()).append(" requires ").append(req.getValue().toString()).append(',');
+        }
+        if (sb.charAt(sb.length() - 1) == ',') {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        sb.append('.');
+
+        return sb.toString();
     }
 }

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
@@ -108,7 +108,9 @@ class ComponentServiceHelperTest {
                 .resolveComponentVersion(COMPONENT_A, v1_0_0,
                         Collections.singletonMap("X", Requirement.buildNPM("^1.0"))));
 
-        assertThat(exp.getMessage(), containsString("No applicable version found in cloud registry for component: 'A'"
-                + " satisfying requirement: '{X=>=1.0.0 <2.0.0}'."));
+        assertThat(exp.getMessage(),
+                containsString("Component A version constraints: X requires >=1.0.0 <2.0.0."));
+        assertThat(exp.getMessage(),
+                containsString("No cloud component version satisfies the requirements"));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Improving error message for NoAvailableComponentVersionException to be more understandable by our users.
Now looks like 
```NoAvailableComponentVersionException: No cloud component satisfies the requirements. Check whether the version constraints conflict and that the component exists in your AWS account with a version that matches the version constraints. If the version constraints conflict, revise deployments to resolve the conflict. Component myComponent version constraints: compC requires <1.0.0, someOtherComponent requires >1.0.0, thinggroup/abc requires =1.1.0.```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
