### PR TITLE
fix: loader script reboot

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -79,6 +79,7 @@ while [ $j -le 3 ] && [ $sigterm_received -eq 0 ];  do
   101)
     echo "Rebooting host"
     sudo reboot
+    exit 0
     ;;
   *)
     echo "Nucleus exited ${kernel_exit_code}. Retrying $j times"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Exit immediately after calling `sudo reboot`. Otherwise the script continues to run until the end. It'll create the `alts/broken` symlink and makes nucleus think it failed.

**Why is this change necessary:**
Without the fix, deployment with any component that requests reboot will fail.

**How was this change tested:**
Manual.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
