### PR TITLE
fix(message): do not log broken pipe in TES

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -144,8 +144,13 @@ public class CredentialRequestHandler implements HttpHandler {
             LOGGER.atInfo().log("Request denied due to invalid token");
             generateError(exchange, HttpURLConnection.HTTP_FORBIDDEN);
         } catch (Throwable e) {
-            // Dont let the server crash, swallow problems with a 5xx
-            LOGGER.atInfo().log("Request failed", e);
+            // Broken pipe is ignorable; it just means that the client went away
+            if ("Broken pipe".equalsIgnoreCase(e.getMessage())) {
+                LOGGER.atDebug().log("Client gave up before we could respond");
+            } else {
+                // Don't let the server crash, swallow problems with a 5xx
+                LOGGER.atWarn().log("Request failed", e);
+            }
             generateError(exchange, HttpURLConnection.HTTP_INTERNAL_ERROR);
         } finally {
             exchange.close();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`IOException: Broken pipe` is logged by TES when a TES client hangs up before TES has a chance to get the credentials and respond. This change stops us from logging a big error message when there isn't anything we can do about it.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
