### PR TITLE
fix(logging): drop log level for many log messages

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DynamicComponentConfigurationValidationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DynamicComponentConfigurationValidationTest.java
@@ -21,6 +21,7 @@ import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.event.Level;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.model.ConfigurationValidityReport;
 import software.amazon.awssdk.aws.greengrass.model.ConfigurationValidityStatus;
@@ -148,11 +150,13 @@ class DynamicComponentConfigurationValidationTest extends BaseITCase {
         if (kernel != null) {
             kernel.shutdown();
         }
+        LogConfig.getRootLogConfig().reset();
     }
 
     @Test
     void GIVEN_deployment_changes_component_config_WHEN_component_validates_config_THEN_deployment_is_successful()
             throws Throwable {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         // Subscribe to config validation on behalf of the running service
         CountDownLatch eventReceivedByClient = new CountDownLatch(1);
         Topics servicePrivateConfig = kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC, "OldService",

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
@@ -25,6 +25,8 @@ import com.aws.greengrass.util.IamSdkClientFactory;
 import com.aws.greengrass.util.IotSdkClientFactory;
 import com.aws.greengrass.util.RegionUtils;
 import com.aws.greengrass.util.Utils;
+import com.aws.greengrass.util.platforms.Platform;
+import com.aws.greengrass.util.platforms.unix.DarwinPlatform;
 import com.vdurmont.semver4j.Semver;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -226,7 +228,11 @@ public class BaseE2ETestCase implements AutoCloseable {
     }
 
     public static void setDefaultRunWithUser(Kernel kernel) {
-        new DeviceConfiguration(kernel).getRunWithDefaultPosixUser().dflt("nobody");
+        String user = "nobody";
+        if (Platform.getInstance() instanceof DarwinPlatform) {
+            user = System.getProperty("user.name");
+        }
+        new DeviceConfiguration(kernel).getRunWithDefaultPosixUser().dflt(user);
     }
 
     protected void initKernel()

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/DeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/DeploymentE2ETest.java
@@ -504,7 +504,7 @@ class DeploymentE2ETest extends BaseE2ETestCase {
             CountDownLatch updateRegistered = new CountDownLatch(1);
             CountDownLatch deploymentCancelled = new CountDownLatch(1);
             logListener = m -> {
-                if ("register-service-update-action" .equals(m.getEventType())) {
+                if ("register-service-update-action".equals(m.getEventType())) {
                     updateRegistered.countDown();
                 }
                 if (m.getMessage() != null && m.getMessage().contains("Deployment was cancelled")) {
@@ -646,7 +646,7 @@ class DeploymentE2ETest extends BaseE2ETestCase {
             CountDownLatch updateRegistered = new CountDownLatch(1);
             CountDownLatch deploymentCancelled = new CountDownLatch(1);
             logListener = m -> {
-                if ("register-service-update-action" .equals(m.getEventType())) {
+                if ("register-service-update-action".equals(m.getEventType())) {
                     updateRegistered.countDown();
                 }
                 if (m.getMessage() != null && m.getMessage().contains("Deployment was cancelled")) {

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCPubSubTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCPubSubTest.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
+import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
@@ -20,6 +21,7 @@ import com.aws.greengrass.util.Pair;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.event.Level;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToTopicRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToTopicResponse;
@@ -120,6 +123,11 @@ class IPCPubSubTest {
         kernel.shutdown();
     }
 
+    @AfterEach
+    void afterEach() {
+        LogConfig.getRootLogConfig().reset();
+    }
+
     @Test
     void GIVEN_pubsubclient_WHEN_subscribe_and_publish_is_authorized_THEN_succeeds() throws Exception {
         try(EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
@@ -165,6 +173,7 @@ class IPCPubSubTest {
     @Test
     @Order(1)
     void GIVEN_pubsubclient_WHEN_subscribe_authorization_changes_to_authorized_THEN_succeeds() throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         try(EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
                 "OnlyPublish")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -209,6 +218,7 @@ class IPCPubSubTest {
     @Test
     @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
     void GIVEN_PubSubEventStreamClient_WHEN_subscribe_and_unsubscribe_THEN_publishes_only_once() throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         String topicName = "topicName";
         SubscribeToTopicRequest subscribeToTopicRequest = new SubscribeToTopicRequest();
         subscribeToTopicRequest.setTopic(topicName);
@@ -307,6 +317,7 @@ class IPCPubSubTest {
     @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
     @Test
     void GIVEN_pubsubclient_with_event_stream_WHEN_subscribe_authorization_changes_to_authorized_THEN_succeeds() throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         String topicName = "topicName";
         SubscribeToTopicRequest subscribeToTopicRequest = new SubscribeToTopicRequest();
         subscribeToTopicRequest.setTopic(topicName);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCServicesTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCServicesTest.java
@@ -15,17 +15,20 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
+import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.Pair;
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.event.Level;
 import software.amazon.awssdk.aws.greengrass.GetConfigurationResponseHandler;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.SubscribeToComponentUpdatesResponseHandler;
@@ -119,6 +122,11 @@ class IPCServicesTest {
         }
     }
 
+    @AfterEach
+    void afterEach() {
+        LogConfig.getRootLogConfig().reset();
+    }
+
     @BeforeEach
     void beforeEach(ExtensionContext context) {
         ignoreExceptionWithMessage(context, "Connection reset by peer");
@@ -170,6 +178,7 @@ class IPCServicesTest {
     @Test
     void GIVEN_ConfigStoreEventStreamClient_WHEN_report_config_validation_status_THEN_inform_validation_requester()
             throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         CountDownLatch cdl = new CountDownLatch(1);
         String authToken = IPCTestUtils.getAuthTokeForService(kernel, TEST_SERVICE_NAME);
         try (EventStreamRPCConnection clientConnection =
@@ -252,6 +261,7 @@ class IPCServicesTest {
     @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException"})
     @Test
     void GIVEN_ConfigStoreEventStreamClient_WHEN_update_config_request_THEN_config_is_updated() throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         Topics configuration = kernel.findServiceTopic("ServiceName").createInteriorChild(CONFIGURATION_CONFIG_KEY);
         Topic configToUpdate = configuration.lookup("SomeKeyToUpdate").withNewerValue(0, "InitialValue");
         CountDownLatch cdl = new CountDownLatch(1);
@@ -313,6 +323,7 @@ class IPCServicesTest {
     @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException"})
     @Test
     void GIVEN_ConfigStoreEventStreamClient_WHEN_update_leaf_node_to_container_node_THEN_config_is_updated2() throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         Topics configuration = kernel.findServiceTopic("ServiceName").createInteriorChild(CONFIGURATION_CONFIG_KEY);
         Topic configToUpdate = configuration.lookup("SomeKeyToUpdate").withNewerValue(0, "InitialValue");
         CountDownLatch cdl = new CountDownLatch(1);
@@ -379,6 +390,7 @@ class IPCServicesTest {
     @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException"})
     @Test
     void GIVEN_ConfigStoreEventStreamClient_WHEN_adding_new_leaf_node_to_existing_container_node_THEN_config_is_updated3() throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         Topics configuration = kernel.findServiceTopic("ServiceName").createInteriorChild(CONFIGURATION_CONFIG_KEY);
         configuration.createInteriorChild("SomeContainerKeyToUpdate").createLeafChild("SomeContainerValue").withValue("InitialValue");
         Topics configToUpdate = configuration.lookupTopics("SomeContainerKeyToUpdate");

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -54,6 +54,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SYSTEM_RESOU
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.SudoUtil.assumeCanSudoShell;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.createCloseableLogListener;
+import static com.aws.greengrass.util.platforms.unix.UnixPlatform.STDOUT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -484,7 +485,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         List<String> stdouts = new CopyOnWriteArrayList<>();
         try (AutoCloseable l = createCloseableLogListener((m) -> {
             String messageOnStdout = m.getMessage();
-            if (messageOnStdout != null
+            if (STDOUT.equals(m.getEventType()) && messageOnStdout != null
                     && (messageOnStdout.contains("run as")
                         || messageOnStdout.contains("install as") )) {
                 stdouts.add(messageOnStdout);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
@@ -128,6 +128,7 @@ class IotJobsFleetStatusServiceTest extends BaseITCase {
             jobResponseConsumer.accept(mockJobExecutionResponse);
             return cf;
         });
+        lenient().when(mqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
         kernel = new Kernel();
 
         NoOpPathOwnershipHandler.register(kernel);

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationPolicyParser.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationPolicyParser.java
@@ -47,7 +47,7 @@ public final class AuthorizationPolicyParser {
         Topics allServices = kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC);
 
         if (allServices == null) {
-            logger.atInfo("load-authorization-all-services-component-config-retrieval-error")
+            logger.atWarn("load-authorization-all-services-component-config-retrieval-error")
                     .log("Unable to retrieve services config");
             return primaryAuthorizationPolicyMap;
         }

--- a/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
@@ -354,7 +354,7 @@ public class ConfigStoreIPCEventStreamAgent {
 
         @Override
         protected void onStreamClosed() {
-            logger.atInfo().kv(SERVICE_NAME, serviceName)
+            logger.atDebug().kv(SERVICE_NAME, serviceName)
                     .log("Stream closed for subscribeToConfigurationUpdate for {}", serviceName);
             if (subscribedToNode != null) {
                 subscribedToNode.remove(subscribedToWatcher);
@@ -391,7 +391,8 @@ public class ConfigStoreIPCEventStreamAgent {
                     throw new ResourceNotFoundError(KEY_NOT_FOUND_ERROR_MESSAGE);
                 }
 
-                logger.atInfo().kv(SERVICE_NAME, serviceName).log("{} subscribed to configuration update", serviceName);
+                logger.atDebug().kv(SERVICE_NAME, serviceName)
+                        .log("{} subscribed to configuration update", serviceName);
                 subscribedToNode = subscribeTo;
                 subscribedToWatcher = watcher.get();
                 configUpdateListeners.putIfAbsent(serviceName, ConcurrentHashMap.newKeySet());
@@ -446,7 +447,7 @@ public class ConfigStoreIPCEventStreamAgent {
                 valueChangedEvent.setComponentName(componentName);
                 valueChangedEvent.setKeyPath(Arrays.asList(changedKeyPath));
                 configurationUpdateEvents.setConfigurationUpdateEvent(valueChangedEvent);
-                logger.atInfo().kv(SERVICE_NAME, serviceName)
+                logger.atDebug().kv(SERVICE_NAME, serviceName)
                         .log("Sending component {}'s updated config key {}", componentName, changedKeyPath);
 
                 this.sendStreamEvent(configurationUpdateEvents);
@@ -483,7 +484,7 @@ public class ConfigStoreIPCEventStreamAgent {
             return translateExceptions(() -> {
                 // TODO: [P32540011]: All IPC service requests need input validation
                 configValidationListeners.computeIfAbsent(serviceName, key -> sendConfigValidationEvent());
-                logger.atInfo().kv(SERVICE_NAME, serviceName).log("Config IPC subscribe to config validation request");
+                logger.atDebug().kv(SERVICE_NAME, serviceName).log("Config IPC subscribe to config validation request");
                 return new SubscribeToValidateConfigurationUpdatesResponse();
             });
         }

--- a/src/main/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgent.java
@@ -64,7 +64,7 @@ import static com.aws.greengrass.ipc.modules.LifecycleIPCService.LIFECYCLE_SERVI
 
 public class LifecycleIPCEventStreamAgent {
     private static final String COMPONENT_NAME = "componentName";
-    private static final Logger logger = LogManager.getLogger(LifecycleIPCEventStreamAgent.class);
+    private static final Logger log = LogManager.getLogger(LifecycleIPCEventStreamAgent.class);
 
     @Getter(AccessLevel.PACKAGE)
     private final ConcurrentHashMap<String, Set<StreamEventPublisher<ComponentUpdatePolicyEvents>>>
@@ -79,8 +79,6 @@ public class LifecycleIPCEventStreamAgent {
     @Getter(AccessLevel.PACKAGE)
     private final Map<Pair<String, String>, CompletableFuture<DeferComponentUpdateRequest>> deferUpdateFuturesMap =
             new ConcurrentHashMap<>();
-
-    private static final Logger log = LogManager.getLogger(LifecycleIPCEventStreamAgent.class);
 
     @Inject
     @Setter(AccessLevel.PACKAGE)
@@ -130,7 +128,7 @@ public class LifecycleIPCEventStreamAgent {
         @SuppressWarnings("PMD.PreserveStackTrace")
         public UpdateStateResponse handleRequest(UpdateStateRequest request) {
             return translateExceptions(() -> {
-                log.atInfo().log("Got update state request for component " + serviceName);
+                log.atDebug().log("Got update state request for component " + serviceName);
                 GreengrassService service;
                 try {
                     service = kernel.locate(serviceName);
@@ -169,7 +167,7 @@ public class LifecycleIPCEventStreamAgent {
 
         @Override
         protected void onStreamClosed() {
-            log.atInfo().log("Stream closed for subscribeToComponentUpdate");
+            log.atDebug().log("Stream closed for subscribeToComponentUpdate");
             componentUpdateListeners.get(serviceName).remove(this);
             if (componentUpdateListeners.get(serviceName).isEmpty()) {
                 componentUpdateListeners.remove(serviceName);
@@ -193,7 +191,7 @@ public class LifecycleIPCEventStreamAgent {
                 }
                 componentUpdateListeners.putIfAbsent(serviceName, new HashSet<>());
                 componentUpdateListeners.get(serviceName).add(this);
-                log.atInfo().log("{} subscribed to component update", serviceName);
+                log.atDebug().log("{} subscribed to component update", serviceName);
                 return SubscribeToComponentUpdatesResponse.VOID;
             });
         }
@@ -223,7 +221,6 @@ public class LifecycleIPCEventStreamAgent {
         public DeferComponentUpdateResponse handleRequest(DeferComponentUpdateRequest request) {
             return translateExceptions(() -> {
                 // TODO: [P32540011]: All IPC service requests need input validation
-                logger.atInfo().log("Entering defer request handler");
                 if (!componentUpdateListeners.containsKey(serviceName)) {
                     throw new InvalidArgumentsError("Component is not subscribed to component update events");
                 }
@@ -236,9 +233,10 @@ public class LifecycleIPCEventStreamAgent {
                 if (deferComponentUpdateRequestFuture == null) {
                     throw new ServiceError("Time limit to respond to PreComponentUpdateEvent exceeded");
                 } else {
+                    log.atDebug().log("Processing deployment deferral from {} for deployment {}", serviceName,
+                            request.getDeploymentId());
                     deferComponentUpdateRequestFuture.complete(request);
                 }
-                logger.atInfo().log("Exiting defer request handler");
                 return new DeferComponentUpdateResponse();
             });
         }
@@ -263,7 +261,7 @@ public class LifecycleIPCEventStreamAgent {
                 .entrySet()) {
             String serviceName = entry.getKey();
             entry.getValue().forEach(subscribeHandler -> {
-                log.atInfo().kv(COMPONENT_NAME, serviceName).log("Sending preComponentUpdate event");
+                log.atTrace().kv(COMPONENT_NAME, serviceName).log("Sending preComponentUpdate event");
                 ComponentUpdatePolicyEvents componentUpdatePolicyEvents = new ComponentUpdatePolicyEvents();
                 componentUpdatePolicyEvents.setPreUpdateEvent(preComponentUpdateEvent);
 
@@ -344,7 +342,6 @@ public class LifecycleIPCEventStreamAgent {
         @Override
         public PauseComponentResponse handleRequest(PauseComponentRequest request) {
             return translateExceptions(() -> {
-                logger.atDebug().log("Entering pause request handler");
                 // TODO : Platform check for linux only
 
                 String componentName = request.getComponentName();
@@ -373,6 +370,7 @@ public class LifecycleIPCEventStreamAgent {
                     throw new InvalidArgumentsError("Only generic components can be paused.");
                 }
 
+                log.atDebug().log("Handling component pause for {}", componentName);
                 if (State.RUNNING.equals(target.getState())) {
                     try {
                         target.pause();
@@ -384,7 +382,6 @@ public class LifecycleIPCEventStreamAgent {
                     throw new InvalidArgumentsError(String.format("Component %s is not running", componentName));
                 }
 
-                logger.atDebug().log("Exiting pause request handler");
                 return new PauseComponentResponse();
             });
         }
@@ -412,7 +409,6 @@ public class LifecycleIPCEventStreamAgent {
         @SuppressWarnings("PMD.PreserveStackTrace")
         @Override
         public ResumeComponentResponse handleRequest(ResumeComponentRequest request) {
-            logger.atDebug().log("Entering resume request handler");
             // TODO : Platform check for linux only
 
             String componentName = request.getComponentName();
@@ -441,6 +437,7 @@ public class LifecycleIPCEventStreamAgent {
                 throw new InvalidArgumentsError("Only generic components can be resumed.");
             }
 
+            log.atDebug().log("Handling component resume for {}", componentName);
             if (target.isPaused()) {
                 try {
                     target.resume();
@@ -452,7 +449,6 @@ public class LifecycleIPCEventStreamAgent {
                 throw new InvalidArgumentsError(String.format("Component %s is not paused", componentName));
             }
 
-            logger.atDebug().log("Exiting resume request handler");
             return new ResumeComponentResponse();
         }
 

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -92,7 +92,7 @@ public class PubSubIPCEventStreamAgent {
             return objects.isEmpty() ? null : objects;
         });
         if (removed.get()) {
-            log.atInfo().kv(COMPONENT_NAME, serviceName).log("Unsubscribed from topic {}", topic);
+            log.atDebug().kv(COMPONENT_NAME, serviceName).log("Unsubscribed from topic {}", topic);
         }
     }
 
@@ -158,7 +158,7 @@ public class PubSubIPCEventStreamAgent {
     private void handleSubscribeToTopicRequest(String topic, String serviceName, Object handler) {
         // TODO: [P32540011]: All IPC service requests need input validation
         if (listeners.computeIfAbsent(topic, k -> ConcurrentHashMap.newKeySet()).add(handler)) {
-            log.atInfo().kv(COMPONENT_NAME, serviceName).log("Subscribed to topic {}", topic);
+            log.atDebug().kv(COMPONENT_NAME, serviceName).log("Subscribed to topic {}", topic);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -124,7 +124,7 @@ public class ComponentManager implements InjectionActions {
 
     ComponentMetadata resolveComponentVersion(String componentName, Map<String, Requirement> versionRequirements)
             throws InterruptedException, PackagingException {
-        logger.atInfo().setEventType("resolve-component-version-start").kv(COMPONENT_STR, componentName)
+        logger.atDebug().setEventType("resolve-component-version-start").kv(COMPONENT_STR, componentName)
                 .kv("versionRequirements", versionRequirements).log("Resolving component version starts");
 
         // Find best local candidate
@@ -149,11 +149,11 @@ public class ComponentManager implements InjectionActions {
         } else {
             // Otherwise try to negotiate with cloud
             if (deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
-                logger.atInfo().setEventType("negotiate-version-with-cloud-start")
+                logger.atDebug().setEventType("negotiate-version-with-cloud-start")
                         .log("Negotiating version with cloud");
                 resolvedComponentId = negotiateVersionWithCloud(componentName, versionRequirements,
                         localCandidateOptional.orElse(null));
-                logger.atInfo().setEventType("negotiate-version-with-cloud-end").log("Negotiated version with cloud");
+                logger.atDebug().setEventType("negotiate-version-with-cloud-end").log("Negotiated version with cloud");
             } else {
                 // Device running offline. Use the local candidate if present, otherwise fails
                 if (localCandidateOptional.isPresent()) {
@@ -279,7 +279,7 @@ public class ComponentManager implements InjectionActions {
     private Optional<ComponentIdentifier> findBestCandidateLocally(String componentName,
                                                                    Map<String, Requirement> versionRequirements)
             throws PackagingException {
-        logger.atInfo().kv("ComponentName", componentName).kv("VersionRequirements", versionRequirements)
+        logger.atDebug().kv("ComponentName", componentName).kv("VersionRequirements", versionRequirements)
                 .log("Searching for best candidate locally on the device.");
 
         Requirement req = mergeVersionRequirements(versionRequirements);
@@ -375,7 +375,7 @@ public class ComponentManager implements InjectionActions {
         try {
             ComponentRecipe pkg = componentStore.getPackageRecipe(componentIdentifier);
             prepareArtifacts(componentIdentifier, pkg.getArtifacts());
-            logger.atInfo("prepare-package-finished").kv(PACKAGE_IDENTIFIER, componentIdentifier).log();
+            logger.atDebug("prepare-package-finished").kv(PACKAGE_IDENTIFIER, componentIdentifier).log();
         } catch (SizeLimitException e) {
             logger.atError().log("Size limit reached", e);
             throw e;

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -163,8 +163,8 @@ public class ComponentStore {
                 return false;
             }
             String digest = Digest.calculate(recipeContent.get());
-            logger.atInfo("plugin-load").log("Digest from store: " + Coerce.toString(expectedDigest));
-            logger.atInfo("plugin-load").log("Digest from recipe: " + Coerce.toString(digest));
+            logger.atTrace("plugin-load").log("Digest from store: " + Coerce.toString(expectedDigest));
+            logger.atTrace("plugin-load").log("Digest from recipe: " + Coerce.toString(digest));
             if (!Digest.isEqual(digest, expectedDigest)) {
                 logger.atError("plugin-load-error")
                         .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
@@ -224,7 +224,7 @@ public class ComponentStore {
      * @throws PackageLoadingException if deletion of the component failed
      */
     void deleteComponent(@NonNull ComponentIdentifier compId) throws PackageLoadingException {
-        logger.atInfo("delete-component-start").kv("componentIdentifier", compId).log();
+        logger.atDebug("delete-component-start").kv("componentIdentifier", compId).log();
         IOException exception = null;
         // delete recipe
         try {

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
@@ -107,7 +107,7 @@ public class S3Downloader extends ArtifactDownloader {
     @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
     @Override
     public Long getDownloadSize() throws InterruptedException, PackageDownloadException {
-        logger.atInfo().setEventType("get-download-size-from-s3").log();
+        logger.atDebug().setEventType("get-download-size-from-s3").log();
         // Parse artifact path
         String key = s3ObjectPath.key;
         String bucket = s3ObjectPath.bucket;

--- a/src/main/java/com/aws/greengrass/config/Configuration.java
+++ b/src/main/java/com/aws/greengrass/config/Configuration.java
@@ -186,13 +186,13 @@ public class Configuration {
         if (!configUnderUpdate.get()) {
             return;
         }
-        logger.atInfo().log("Configuration currently updating, will wait for the update to complete.");
+        logger.atDebug().log("Configuration currently updating, will wait for the update to complete.");
         synchronized (configUpdateNotifier) {
             while (configUnderUpdate.get()) {
                 configUpdateNotifier.wait(5000);
             }
         }
-        logger.atInfo().log("Config update finished.");
+        logger.atDebug().log("Config update finished.");
     }
 
     public Map<String, Object> toPOJO() {

--- a/src/main/java/com/aws/greengrass/dependency/Context.java
+++ b/src/main/java/com/aws/greengrass/dependency/Context.java
@@ -66,7 +66,6 @@ public class Context implements Closeable {
                     Runnable task = serialized.takeFirst();
                     task.run();
                 } catch (InterruptedException ie) {
-                    logger.atInfo().log("Interrupted while running tasks. Publish thread will exit now.");
                     return;
                 } catch (Throwable t) {
                     logger.atError().setEventType("run-on-publish-queue-error").setCause(t).log();

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -125,7 +125,7 @@ public class DeploymentDocumentDownloader {
                 .build();
 
         // url is not logged for security concerns
-        logger.atInfo().kv("DeploymentId", deploymentId)
+        logger.atDebug().kv("DeploymentId", deploymentId)
                 .log("Making HTTP request to the presigned url");
 
         try (SdkHttpClient client = httpClientProvider.getSdkHttpClient()) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -183,12 +183,9 @@ public class DeploymentService extends GreengrassService {
     @Override
     @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
     protected void startup() throws InterruptedException {
-        logger.info("Starting up the Deployment Service");
         // Reset shutdown signal since we're trying to startup here
         this.receivedShutdown.set(false);
-
         reportState(State.RUNNING);
-        logger.info("Running deployment service");
 
         while (!receivedShutdown.get()) {
             if (currentDeploymentTaskMetadata != null && currentDeploymentTaskMetadata.getDeploymentResultFuture()

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -361,7 +361,6 @@ public class IotJobsHelper implements InjectionActions {
                     logger.atWarn().log("Interrupted while subscribing to Iot Jobs topics");
                     return;
                 }
-                logger.atInfo().log("Connection established to IoT cloud");
                 this.isSubscribedToIotJobsTopics.set(true);
                 deploymentStatusKeeper.publishPersistedStatusUpdates(DeploymentType.IOT_JOBS);
                 this.fleetStatusService.updateFleetStatusUpdateForAllComponents();
@@ -496,7 +495,6 @@ public class IotJobsHelper implements InjectionActions {
      * Unsubscribe from Iot Jobs topics.
      */
     public void unsubscribeFromIotJobsTopics() {
-        logger.atInfo().log("Unsubscribing from Iot Jobs topics");
         unsubscribeFromEventNotifications();
         unsubscribeFromJobDescription();
         this.isSubscribedToIotJobsTopics.set(false);
@@ -534,7 +532,7 @@ public class IotJobsHelper implements InjectionActions {
                                 QualityOfService.AT_LEAST_ONCE, consumerReject);
                 subscribed.get(mqttClient.getMqttOperationTimeoutMillis(), TimeUnit.MILLISECONDS);
 
-                logger.atInfo().log("Subscribed to deployment job execution update.");
+                logger.atDebug().log("Subscribed to deployment job execution update.");
                 break;
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
@@ -595,7 +593,7 @@ public class IotJobsHelper implements InjectionActions {
             try {
                 subscribed.get(mqttClient.getMqttOperationTimeoutMillis(), TimeUnit.MILLISECONDS);
 
-                logger.atInfo().log("Subscribed to deployment job event notifications.");
+                logger.atDebug().log("Subscribed to deployment job event notifications.");
                 break;
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -246,13 +246,13 @@ public class ShadowDeploymentListener implements InjectionActions {
                                 updateShadowResponse.state.reported, updateShadowResponse.version),
                         (e) -> logger.atError().log("Error processing updateShadowResponse", e))
                         .get(TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
-                logger.info("Subscribed to update named shadow accepted topic");
+                logger.debug("Subscribed to update named shadow accepted topic");
                 iotShadowClient.SubscribeToUpdateNamedShadowRejected(updateNamedShadowSubscriptionRequest,
                         QualityOfService.AT_LEAST_ONCE,
                         updateShadowRejected -> handleNamedShadowRejectedEvent(),
                         (e) -> logger.atError().log("Error processing named shadow update rejected response", e))
                         .get(TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
-                logger.info("Subscribed to update named shadow rejected topic");
+                logger.debug("Subscribed to update named shadow rejected topic");
 
                 GetNamedShadowSubscriptionRequest getNamedShadowSubscriptionRequest
                         = new GetNamedShadowSubscriptionRequest();
@@ -264,7 +264,7 @@ public class ShadowDeploymentListener implements InjectionActions {
                                 getShadowResponse.state.reported, getShadowResponse.version),
                         (e) -> logger.atError().log("Error processing getShadowResponse", e))
                         .get(TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
-                logger.info("Subscribed to get named shadow topic");
+                logger.debug("Subscribed to get named shadow topic");
                 return;
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
@@ -324,7 +324,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         getNamedShadowRequest.shadowName = DEPLOYMENT_SHADOW_NAME;
         getNamedShadowRequest.thingName = thingName;
         iotShadowClient.PublishGetNamedShadow(getNamedShadowRequest, QualityOfService.AT_LEAST_ONCE);
-        logger.info("Published to get named shadow topic");
+        logger.debug("Published to get named shadow topic");
     }
 
     @SuppressFBWarnings
@@ -381,7 +381,7 @@ public class ShadowDeploymentListener implements InjectionActions {
 
     protected void shadowUpdated(Map<String, Object> desired, Map<String, Object> reported, Integer version) {
         if (lastVersion.get() > version) {
-            logger.atInfo().kv("SHADOW_VERSION", version)
+            logger.atDebug().kv("SHADOW_VERSION", version)
                     .log("Received an older version of shadow. Ignoring...");
             return;
         }
@@ -475,7 +475,7 @@ public class ShadowDeploymentListener implements InjectionActions {
     private void syncShadowDeploymentStatus(Map<String, Object> reported) {
         // device does not have anything to report
         if (lastDeploymentStatus.get() == null) {
-            logger.info("Last known deployment status is empty, nothing to report");
+            logger.debug("Last known deployment status is empty, nothing to report");
             return;
         }
         if (!reported.get(ARN_FOR_STATUS_KEY).equals(lastDeploymentStatus.get().get(DEPLOYMENT_ID_KEY_NAME))

--- a/src/main/java/com/aws/greengrass/ipc/modules/LifecycleIPCService.java
+++ b/src/main/java/com/aws/greengrass/ipc/modules/LifecycleIPCService.java
@@ -54,10 +54,7 @@ public class LifecycleIPCService implements Startable, InjectionActions {
     @Override
     public void startup() {
         greengrassCoreIPCService.setUpdateStateHandler(
-                (context) -> {
-                    logger.atInfo().log("Executing the lambda");
-                    return eventStreamAgent.getUpdateStateOperationHandler(context);
-                });
+                (context) -> eventStreamAgent.getUpdateStateOperationHandler(context));
         greengrassCoreIPCService.setSubscribeToComponentUpdatesHandler(
                 (context) -> eventStreamAgent.getSubscribeToComponentUpdateHandler(context));
         greengrassCoreIPCService.setDeferComponentUpdateHandler(

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
@@ -164,7 +164,7 @@ public class GreengrassService implements InjectionActions {
                 return;
             }
             Collection<String> depList = (Collection<String>) node.getOnce();
-            logger.atInfo().log("Setting up dependencies again {}", String.join(",", depList));
+            logger.atDebug().log("Setting up dependencies again {}", String.join(",", depList));
             try {
                 setupDependencies(depList);
             } catch (ServiceLoadException | InputValidationException e) {
@@ -595,7 +595,7 @@ public class GreengrassService implements InjectionActions {
                 .filter(e -> !keptDependencies.containsKey(e.getKey()) && !e.getValue().isDefaultDependency)
                 .map(Map.Entry::getKey).collect(Collectors.toSet());
         if (!removedDependencies.isEmpty()) {
-            logger.atInfo("removing-unused-dependencies").kv("removedDependencies", removedDependencies).log();
+            logger.atDebug("removing-unused-dependencies").kv("removedDependencies", removedDependencies).log();
 
             removedDependencies.forEach(dependency -> {
                 DependencyInfo dependencyInfo = dependencies.remove(dependency);

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -479,7 +479,7 @@ public class Kernel {
                             .withNewerValue(0L, clazz.getAnnotation(ImplementsService.class).version());
                 }
 
-                logger.atInfo("service-loaded").kv(GreengrassService.SERVICE_NAME_KEY, ret.getName())
+                logger.atDebug("service-loaded").kv(GreengrassService.SERVICE_NAME_KEY, ret.getName())
                         .log();
                 return ret;
             } catch (Throwable ex) {
@@ -495,7 +495,7 @@ public class Kernel {
         // if not found, initialize GenericExternalService
         try {
             ret = new GenericExternalService(serviceRootTopics);
-            logger.atInfo("generic-service-loaded").kv(GreengrassService.SERVICE_NAME_KEY, ret.getName()).log();
+            logger.atDebug("generic-service-loaded").kv(GreengrassService.SERVICE_NAME_KEY, ret.getName()).log();
         } catch (Throwable ex) {
             throw new ServiceLoadException("Can't create generic service instance " + name, ex);
         }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelAlternatives.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelAlternatives.java
@@ -323,7 +323,7 @@ public class KernelAlternatives {
 
         setupLinkToDirectory(currentDir, newLaunchDir);
         Files.delete(newDir);
-        logger.atInfo().log("Finish setup of launch directory for new Nucleus");
+        logger.atInfo().log("Finished setup of launch directory for new Nucleus");
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -157,7 +157,7 @@ public class Lifecycle {
      *                 actual state
      */
     private synchronized void internalReportState(State newState) {
-        logger.atInfo("service-report-state").kv(NEW_STATE_METRIC_NAME, newState).log();
+        logger.atDebug("service-report-state").kv(NEW_STATE_METRIC_NAME, newState).log();
         lastReportedState.set(newState);
 
         if (getState().equals(State.STARTING) && newState.equals(State.FINISHED)) {
@@ -477,9 +477,8 @@ public class Lifecycle {
 
         replaceBackingTask(() -> {
             try {
-                logger.atInfo("service-awaiting-start").log("waiting for dependencies to start");
+                logger.atDebug("service-awaiting-start").log("waiting for dependencies to start");
                 greengrassService.waitForDependencyReady();
-                logger.atInfo("service-starting").log();
                 internalReportState(State.STARTING);
             } catch (InterruptedException e) {
                 logger.atWarn("service-dependency-error").log("Got interrupted while waiting for dependency ready");
@@ -783,7 +782,7 @@ public class Lifecycle {
         if (isClosed.get()) {
             return false;
         }
-        logger.atInfo().log("Waiting for the desired state list");
+        logger.atTrace().log("Waiting for the desired state list");
         synchronized (desiredStateList) {
             // If there are no more desired states and the service is currently new, then do not
             // restart. Only restart when the service is "RUNNING" (which includes several states)
@@ -800,7 +799,7 @@ public class Lifecycle {
             desiredStateList.subList(index + 1, desiredStateList.size()).clear();
             desiredStateList.add(State.RUNNING);
         }
-        logger.atInfo().log("Returning true from request restart");
+        logger.atTrace().log("Returning true from request restart");
         return true;
     }
 

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/UpdateSystemPolicyService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/UpdateSystemPolicyService.java
@@ -134,7 +134,6 @@ public class UpdateSystemPolicyService extends GreengrassService {
                     continue;
                 }
             }
-            logger.atInfo().setEventType("get-available-service-update").log();
             logger.atDebug().setEventType("service-update-pending").addKeyValue("numOfUpdates", pendingActions.size())
                     .log();
 

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -239,7 +239,7 @@ public class MqttClient implements Closeable {
                     return;
                 }
 
-                logger.atInfo().kv("modifiedNode", node.getFullName()).kv("changeType", what)
+                logger.atDebug().kv("modifiedNode", node.getFullName()).kv("changeType", what)
                         .log("Reconfiguring MQTT clients");
 
                 // Reconnect in separate thread to not block publish thread

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -109,13 +109,15 @@ public class GreengrassServiceClientFactory {
 
             if (!Utils.isEmpty(greengrassServiceEndpoint)) {
                 // Region and endpoint are both required when updating endpoint config
-                logger.atInfo("initialize-greengrass-client").addKeyValue("service-endpoint", greengrassServiceEndpoint)
-                        .addKeyValue("service-region", region).log();
+                logger.atDebug("initialize-greengrass-client")
+                        .kv("service-endpoint", greengrassServiceEndpoint)
+                        .kv("service-region", region).log();
                 clientBuilder.endpointOverride(URI.create(greengrassServiceEndpoint));
                 clientBuilder.region(Region.of(region));
             } else {
                 // This section is to override default region if needed
-                logger.atInfo("initialize-greengrass-client").addKeyValue("service-region", region).log();
+                logger.atDebug("initialize-greengrass-client")
+                        .kv("service-region", region).log();
                 clientBuilder.region(Region.of(region));
             }
         }

--- a/src/main/java/com/aws/greengrass/util/MqttChunkedPayloadPublisher.java
+++ b/src/main/java/com/aws/greengrass/util/MqttChunkedPayloadPublisher.java
@@ -54,7 +54,11 @@ public class MqttChunkedPayloadPublisher<T> {
                 this.mqttClient.publish(PublishRequest.builder()
                         .qos(QualityOfService.AT_LEAST_ONCE)
                         .topic(this.updateTopic)
-                        .payload(SERIALIZER.writeValueAsBytes(chunkablePayload)).build());
+                        .payload(SERIALIZER.writeValueAsBytes(chunkablePayload)).build())
+                        .exceptionally((t) -> {
+                            logger.atWarn().log("MQTT publish failed", t);
+                            return 0;
+                        });
             }
         } catch (JsonProcessingException e) {
             logger.atError().cause(e).kv("topic", updateTopic).log("Unable to publish data via topic.");

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -56,9 +56,11 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_SERVICE_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_NAME_KEY;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
 import static java.util.Collections.emptyMap;
@@ -162,7 +164,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     private void startDeploymentServiceInAnotherThread() throws InterruptedException {
         CountDownLatch cdl = new CountDownLatch(1);
         Consumer<GreengrassLogMessage> listener = m -> {
-            if (m.getMessage() != null && m.getMessage().equals("Running deployment service")) {
+            if (m.getContexts() != null && m.getContexts().containsKey(SERVICE_NAME_KEY) && m.getContexts()
+                    .get(SERVICE_NAME_KEY).equalsIgnoreCase(DEPLOYMENT_SERVICE_TOPICS)) {
                 cdl.countDown();
             }
         };

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -126,6 +127,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         lenient().when(config.lookup(FLEET_STATUS_SEQUENCE_NUMBER_TOPIC)).thenReturn(sequenceNumberTopic);
         Topic lastPeriodicUpdateTime = Topic.of(context, FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC, Instant.now().toEpochMilli());
         lenient().when(config.lookup(FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC)).thenReturn(lastPeriodicUpdateTime);
+        lenient().when(mockMqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
     }
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -123,6 +124,7 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         configurationTopics.createLeafChild("periodicAggregateMetricsIntervalSeconds").withValue(100);
         configurationTopics.createLeafChild("periodicPublishMetricsIntervalSeconds").withValue(300);
         lenient().when(mockDeviceConfiguration.getTelemetryConfigurationTopics()).thenReturn(configurationTopics);
+        lenient().when(mockMqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
         lenient().doNothing().when(mockMqttClient).addToCallbackEvents(mqttClientConnectionEventsArgumentCaptor.capture());
         telemetryAgent = new TelemetryAgent(config, mockMqttClient, mockDeviceConfiguration, ma, sme, kme, ses, executorService,
                 3, 1);


### PR DESCRIPTION
**Issue #, if available:**
Resolves #1002 

**Description of changes:**
Dropping log level from info to debug or trace when appropriate. This reduces the amount of logs that we and customer need to troll through when debugging. Logs are of course still available to debug or trace level if we need to dig deeper.

In our unit and integ tests run by GitHub this PR reduces the number of log lines by 25% from ~42,000 to 32,000.

**Why is this change necessary:**

**How was this change tested:**
Verified E2E tests locally

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
