### PR TITLE
fix(loader): handle exit codes correctly

### DIFF
--- a/scripts/loader.cmd
+++ b/scripts/loader.cmd
@@ -60,21 +60,24 @@ SET /A MAX_RETRIES=3
 @REM Attempt to start the nucleus 3 times
 FOR /L %%i IN (1,1,%MAX_RETRIES%) DO (
     java -Dlog.store=FILE %JVM_OPTIONS% -jar "%LAUNCH_DIR%\distro\lib\Greengrass.jar" %OPTIONS%
-    SET KERNEL_EXIT_CODE=%ERRORLEVEL%
+    SET KERNEL_EXIT_CODE=!ERRORLEVEL!
 
-    IF KERNEL_EXIT_CODE EQU 0 (
+    IF !KERNEL_EXIT_CODE! EQU 0 (
         ECHO Restarting Nucleus
-        %LAUNCH_DIR%\distroy\bin\loader.cmd
+        %LAUNCH_DIR%\distro\bin\loader.cmd
+        EXIT /B !ERRORLEVEL!
     ) ELSE (
-    IF KERNEL_EXIT_CODE EQU 100 (
+    IF !KERNEL_EXIT_CODE! EQU 100 (
         ECHO Restarting Nucleus
-        %LAUNCH_DIR%\distroy\bin\loader.cmd
+        %LAUNCH_DIR%\distro\bin\loader.cmd
+        EXIT /B !ERRORLEVEL!
     ) ELSE (
-    IF KERNEL_EXIT_CODE EQU 101 (
+    IF !KERNEL_EXIT_CODE! EQU 101 (
         ECHO Rebooting host
         SHUTDOWN /R
+        EXIT /B 0
     ) ELSE (
-        ECHO Nucleus exited %KERNEL_EXIT_CODE%. Attempt %%i out of %MAX_RETRIES%
+        ECHO Nucleus exited !KERNEL_EXIT_CODE!. Attempt %%i out of %MAX_RETRIES%
     )))
 )
 
@@ -87,7 +90,7 @@ IF !IS_SYMLINK! EQU 1 (
     )
 )
 
-EXIT /B %KERNEL_EXIT_CODE%
+EXIT /B !KERNEL_EXIT_CODE!
 
 @REM ==========================================================
 @REM ================== FUNCTION DEFINITIONS ==================


### PR DESCRIPTION
**Description of changes:**
Loader.cmd handles the nucleus exit codes properly. 

**How was this change tested:**
Tested manually on windows dev desktop

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
