### PR TITLE
Open up named pipe (for discussion only)

### DIFF
--- a/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsPlatformTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsPlatformTest.java
@@ -48,6 +48,8 @@ import static com.sun.jna.platform.win32.WinNT.DACL_SECURITY_INFORMATION;
 import static com.sun.jna.platform.win32.WinNT.FILE_FLAG_OVERLAPPED;
 import static com.sun.jna.platform.win32.WinNT.GROUP_SECURITY_INFORMATION;
 import static com.sun.jna.platform.win32.WinNT.OWNER_SECURITY_INFORMATION;
+import static com.sun.jna.platform.win32.WinNT.WRITE_DAC;
+import static com.sun.jna.platform.win32.WinNT.WRITE_OWNER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -251,7 +253,7 @@ class WindowsPlatformTest {
         // Create a named pipe, passing null as lpSecurityAttributes (sane as Device SDK)
         String namedPipe = windowsPlatform.prepareIpcFilepath(tempDir);
         WinNT.HANDLE handle = Kernel32.INSTANCE.CreateNamedPipe(namedPipe,  // lpName
-                PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,  // dwOpenMode
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | WRITE_DAC,  // dwOpenMode
                 PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_ACCEPT_REMOTE_CLIENTS, // dwPipeMode
                 PIPE_UNLIMITED_INSTANCES, // nMaxInstances
                 512, // nOutBufferSize
@@ -286,9 +288,9 @@ class WindowsPlatformTest {
         // windowsPlatform.setIpcFilePermissions(tempDir);
         ret = Advapi32.INSTANCE.SetSecurityInfo(handle,
                 SE_KERNEL_OBJECT,
-                infoType,
-                ppsidOwner.getValue(),
-                ppsidGroup.getValue(),
+                DACL_SECURITY_INFORMATION,
+                null,
+                null,
 
                 // https://docs.microsoft.com/en-us/windows/win32/secauthz/access-control-lists
                 // "If the object does not have a DACL, the system grants full access to everyone."
@@ -331,7 +333,7 @@ class WindowsPlatformTest {
 
         WinNT.HANDLE hFile = Kernel32.INSTANCE.CreateFile(
                 filePath,
-                WinNT.GENERIC_ALL | WinNT.WRITE_OWNER | WinNT.WRITE_DAC,
+                WinNT.GENERIC_ALL | WRITE_OWNER | WRITE_DAC,
                 WinNT.FILE_SHARE_READ,
                 new WinBase.SECURITY_ATTRIBUTES(),
                 WinNT.OPEN_EXISTING,


### PR DESCRIPTION
I am trying to use `SetSecurityInfo` on a named pipe handle. However I am getting access denied error even when I am the owner of the handle and I am using the same handle returned by `CreateNamedPipe`. I am posting this PR for discussion.


**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
