### PR TITLE
fix(exec): switch to ProcessBuilder, fix environment for Windows commands

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
@@ -52,16 +52,16 @@ public class DefaultDockerClient {
     public void login(Registry registry)
             throws DockerLoginException, UserNotAuthorizedForDockerException, DockerServiceUnavailableException,
             IOException {
-        Map<String, CharSequence> credEnvMap = new HashMap<>();
+        Map<String, String> credEnvMap = new HashMap<>();
         credEnvMap.put("username", registry.getCredentials().getUsername());
         credEnvMap.put("password", registry.getCredentials().getPassword());
         CliResponse response =
                 runDockerCmd(String.format("docker login %s -u $username -p $password", registry.getEndpoint()),
                         credEnvMap);
 
-        Optional userAuthorizationError = checkUserAuthorizationError(response);
+        Optional<UserNotAuthorizedForDockerException> userAuthorizationError = checkUserAuthorizationError(response);
         if (userAuthorizationError.isPresent()) {
-            throw (UserNotAuthorizedForDockerException) userAuthorizationError.get();
+            throw userAuthorizationError.get();
         }
 
         if (response.exit.isPresent()) {
@@ -96,9 +96,9 @@ public class DefaultDockerClient {
             UserNotAuthorizedForDockerException, IOException {
         CliResponse response = runDockerCmd(String.format("docker pull %s", image.getImageFullName()));
 
-        Optional userAuthorizationError = checkUserAuthorizationError(response);
+        Optional<UserNotAuthorizedForDockerException> userAuthorizationError = checkUserAuthorizationError(response);
         if (userAuthorizationError.isPresent()) {
-            throw (UserNotAuthorizedForDockerException) userAuthorizationError.get();
+            throw userAuthorizationError.get();
         }
 
         if (response.exit.isPresent()) {
@@ -127,14 +127,14 @@ public class DefaultDockerClient {
         return runDockerCmd(cmd, Collections.emptyMap());
     }
 
-    private CliResponse runDockerCmd(String cmd, Map<String, CharSequence> envs) {
+    private CliResponse runDockerCmd(String cmd, Map<String, String> envs) {
         Throwable cause = null;
         StringBuilder output = new StringBuilder();
         StringBuilder error = new StringBuilder();
         Optional<Integer> exit = Optional.empty();
         try (Exec exec = new Exec()) {
             exec.withExec(cmd.split(" ")).withShell().withOut(output::append).withErr(error::append);
-            for (Map.Entry<String, CharSequence> env : envs.entrySet()) {
+            for (Map.Entry<String, String> env : envs.entrySet()) {
                 exec.setenv(env.getKey(), env.getValue());
             }
             exit = exec.exec();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Switches Exec to use ProcessBuilder to have nicer access to `environment` as a map instead of string array. Fixes the PATH environment variable to use the correct separator to ensure that environment is properly passed down to child processes.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
