### PR TITLE
feat(windows): add nucleus bootstrap script

### DIFF
--- a/conf/recipe.yaml
+++ b/conf/recipe.yaml
@@ -9,7 +9,7 @@ ComponentName: aws.greengrass.Nucleus
 ComponentType: aws.greengrass.nucleus
 ComponentDescription: Core functionality for device side orchestration of deployments and lifecycle management for execution of Greengrass components and applications. This includes features such as starting, stopping, and monitoring execution of components and apps, inter-process communication server for communication between components, component installation and configuration management. This is a fundamental cornerstone of open-sourcing Greengrass, providing documentation and ability to debug Greengrass Core.
 ComponentPublisher: AWS
-ComponentVersion: '2.4.0'
+ComponentVersion: '2.5.0'
 ComponentConfiguration:
   DefaultConfiguration:
     iotDataEndpoint: ""
@@ -55,3 +55,17 @@ Manifests:
           exit 100
   - Platform:
       os: windows
+    Lifecycle:
+      bootstrap:
+        RequiresPrivilege: true
+        script: >-
+          powershell -command "& { Set-StrictMode -Version Latest;
+          $ErrorActionPreference = \"Stop\";
+          $PSDefaultParameterValues['*:ErrorAction']=\"Stop\";
+          $KernelRoot = \"{kernel:rootPath}\";
+          $UnpackDir = \"{artifacts:decompressedPath}\aws.greengrass.nucleus\";
+          $CurrentDir = Join-Path -Path $KernelRoot -ChildPath \"alts\current\";
+          Get-ChildItem -Path $CurrentDir -Force -Recurse | ForEach-Object { $_.Delete() };
+          echo {configuration:/jvmOptions} > \"$CurrentDir\launch.params\";
+          New-Item -Path \"$CurrentDir\distro\" -ItemType SymbolicLink -Value \"$UnpackDir\";
+          exit 100; }"


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
Adding bootstrap script for Windows to nucleus recipe

**Why is this change necessary:**
Required for OTA to work on Windows

**How was this change tested:**
Related acceptance test on Windows passes

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
