### PR TITLE
fix(windows): handle paths correctly

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/provisioning/ProvisionFromTestPlugin.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/provisioning/ProvisionFromTestPlugin.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.mqtt.MqttException;
 
+import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -257,12 +257,11 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         return configTemplate;
     }
 
-    private void addProvisioningPlugin(String jarName) throws IOException, URISyntaxException {
+    private void addProvisioningPlugin(String jarName) throws IOException {
         Path trustedPluginsDir = kernel.getNucleusPaths().pluginPath().resolve("trusted");
-        URL testPluginJarPath = getClass().getResource(jarName);
+        Path testPluginJarPath = new File(getClass().getResource(jarName).getFile()).toPath();
         Files.createDirectories(trustedPluginsDir);
-        Files.copy(Paths.get(testPluginJarPath.toURI()),
-                trustedPluginsDir.resolve(Utils.namePart(testPluginJarPath.getPath())));
+        Files.copy(testPluginJarPath, trustedPluginsDir.resolve(Utils.namePart(testPluginJarPath.toString())));
     }
 
     private void deleteProvisioningPlugins() throws IOException {

--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -218,7 +218,7 @@ public final class Utils {
         return FilenameUtils.getExtension(s);
     }
 
-    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Spotbugs false positive")
     public static String namePart(String s) {
         return s == null ? "" : Paths.get(s).getFileName().toString();
     }

--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.util;
 
 import com.aws.greengrass.config.PlatformResolver;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.BufferedReader;
@@ -217,8 +218,9 @@ public final class Utils {
         return FilenameUtils.getExtension(s);
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public static String namePart(String s) {
-        return s == null ? "" : s.substring(s.lastIndexOf('/') + 1);
+        return s == null ? "" : Paths.get(s).getFileName().toString();
     }
 
     public static CharSequence deepToString(Object o) {

--- a/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
@@ -72,7 +72,7 @@ class IPCEventStreamServiceTest {
     private AuthenticationHandler mockAuthenticationHandler;
 
     @BeforeEach
-    public void setup() throws UnauthenticatedException {
+    public void setup() throws UnauthenticatedException, InterruptedException {
         when(mockKernel.getNucleusPaths()).thenReturn(nucleusPaths);
         when(nucleusPaths.rootPath()).thenReturn(mockRootPath);
         when(config.getRoot()).thenReturn(mockRootTopics);
@@ -83,6 +83,7 @@ class IPCEventStreamServiceTest {
         ipcEventStreamService = new IPCEventStreamService(mockKernel, new GreengrassCoreIPCService(), config,
                 mockAuthenticationHandler);
         ipcEventStreamService.startup();
+        Thread.sleep(5000);
     }
 
     @AfterEach


### PR DESCRIPTION
**Issue #, if available:**
Use Paths to get the file name.

**How was this change tested:**
Tested on dev machine and windows ws

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
