### PR TITLE
feat: decouple metric collection from emission

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelMetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelMetricsEmitter.java
@@ -14,8 +14,11 @@ import com.aws.greengrass.telemetry.impl.MetricFactory;
 import com.aws.greengrass.telemetry.models.TelemetryAggregation;
 import com.aws.greengrass.telemetry.models.TelemetryUnit;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 
@@ -41,81 +44,116 @@ public class KernelMetricsEmitter extends PeriodicMetricsEmitter {
      */
     @Override
     public void emitMetrics() {
+        List<Metric> retrievedMetrics = getMetrics();
+        for (Metric retrievedMetric : retrievedMetrics) {
+            mf.putMetricData(retrievedMetric);
+        }
+    }
+
+    /**
+     * Retrieve kernel component state metrics.
+     * @return a list of {@link Metric}
+     */
+    @Override
+    public List<Metric> getMetrics() {
         Map<State, Integer> stateCount = new EnumMap<>(State.class);
         Collection<GreengrassService> services = kernel.orderedDependencies();
         for (GreengrassService service : services) {
             stateCount.put(service.getState(), stateCount.getOrDefault(service.getState(), 0) + 1);
         }
+
+        List<Metric> metricsList = new ArrayList<>();
+        long timestamp = Instant.now().toEpochMilli();
         Metric metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsStarting")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.STARTING, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.STARTING, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsInstalled")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.INSTALLED, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.INSTALLED, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsStateless")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.STATELESS, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.STATELESS, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsStopping")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.STOPPING, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.STOPPING, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsBroken")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.BROKEN, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.BROKEN, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsRunning")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.RUNNING, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.RUNNING, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsErrored")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.ERRORED, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.ERRORED, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsNew")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.NEW, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.NEW, 0));
+        metricsList.add(metric);
 
         metric = Metric.builder()
                 .namespace(NAMESPACE)
                 .name("NumberOfComponentsFinished")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Average)
+                .value(stateCount.getOrDefault(State.FINISHED, 0))
+                .timestamp(timestamp)
                 .build();
-        mf.putMetricData(metric, stateCount.getOrDefault(State.FINISHED, 0));
+        metricsList.add(metric);
+
+        return metricsList;
     }
 }

--- a/src/main/java/com/aws/greengrass/telemetry/PeriodicMetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/telemetry/PeriodicMetricsEmitter.java
@@ -5,6 +5,9 @@
 
 package com.aws.greengrass.telemetry;
 
+import com.aws.greengrass.telemetry.impl.Metric;
+
+import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 
 public abstract class PeriodicMetricsEmitter {
@@ -12,6 +15,12 @@ public abstract class PeriodicMetricsEmitter {
 
     /**
      * This method will be scheduled to run. So this method typically assigns values to the metrics and emit them.
+     * Uses getMetrics() to get the raw metric data.
      */
     public abstract void emitMetrics();
+
+    /**
+     * This method can be called on demand. So this method typically returns raw metric data.
+     */
+    public abstract List<Metric> getMetrics();
 }


### PR DESCRIPTION
**Description of changes:**
* Split up telemetry metric collection from metric emission

**Why is this change necessary:**
* This is needed in order to make metrics available to plugins in Greengrass v2.5.0 onwards

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
