### PR TITLE
fix(windows): use Administrators group instead of SYSTEM account for default permissions

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -520,7 +520,8 @@ public class GreengrassSetup {
     @SuppressWarnings("PMD.PreserveStackTrace")
     private void setComponentDefaultUserAndGroup(DeviceConfiguration deviceConfiguration) {
         if (PlatformResolver.isWindows) {
-            outStream.println("Default user is only supported on Linux platforms");
+            outStream.println("Default user creation is only supported on Linux platforms, Greengrass will not make a"
+                    + " user for you. Ensure that the user exists and password is stored. Continuing...");
             return;
         }
         try {

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -166,8 +167,14 @@ public class WindowsExec extends Exec {
         }
         // check if same as current user
         UserPlatform.UserAttributes currUser = Platform.getInstance().lookupCurrentUser();
-        return !(currUser.getPrincipalName().equals(userDecorator.getUser()) || currUser.getPrincipalIdentifier()
-                .equals(userDecorator.getUser()));
+        boolean isCurrentUser = currUser.getPrincipalName().equals(userDecorator.getUser())
+                || currUser.getPrincipalIdentifier().equals(userDecorator.getUser());
+        boolean wantsPrivileges = Objects.equals(userDecorator.getGroup(),
+                WindowsPlatform.getInstance().getPrivilegedGroup());
+
+        // If the command is not requesting privileges and is not requesting some other user,
+        // then we need to switch users
+        return !wantsPrivileges && !isCurrentUser;
     }
 
     private static boolean isAbsolutePath(String p) {

--- a/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsPlatformTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsPlatformTest.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -83,7 +82,7 @@ class WindowsPlatformTest {
         // No permission
         List<AclEntry> aclEntryList = WindowsPlatform.WindowsFileSystemPermissionView
                 .aclEntries(FileSystemPermission.builder().build(), tempDir);
-        assertThat(aclEntryList, empty());
+        assertThat(aclEntryList, hasSize(1));
 
         // Owner
         AclFileAttributeView view = Files.getFileAttributeView(tempDir, AclFileAttributeView.class,
@@ -126,7 +125,7 @@ class WindowsPlatformTest {
                 .ownerGroup(ownerGroup)
                 .groupRead(true)
                 .build(), tempDir);
-        assertThat(aclEntryList, hasSize(1));
+        assertThat(aclEntryList, hasSize(2));
         assertThat(aclEntryList.get(0).principal(), equalTo(groupPrincipal));
         assertThat(aclEntryList.get(0).type(), equalTo(AclEntryType.ALLOW));
         assertThat(aclEntryList.get(0).permissions(), containsInAnyOrder(WindowsPlatform.READ_PERMS.toArray()));
@@ -135,7 +134,7 @@ class WindowsPlatformTest {
                 .ownerGroup(ownerGroup)
                 .groupWrite(true)
                 .build(), tempDir);
-        assertThat(aclEntryList, hasSize(1));
+        assertThat(aclEntryList, hasSize(2));
         assertThat(aclEntryList.get(0).principal(), equalTo(groupPrincipal));
         assertThat(aclEntryList.get(0).type(), equalTo(AclEntryType.ALLOW));
         assertThat(aclEntryList.get(0).permissions(), containsInAnyOrder(WindowsPlatform.WRITE_PERMS.toArray()));
@@ -144,7 +143,7 @@ class WindowsPlatformTest {
                 .ownerGroup(ownerGroup)
                 .groupExecute(true)
                 .build(), tempDir);
-        assertThat(aclEntryList, hasSize(1));
+        assertThat(aclEntryList, hasSize(2));
         assertThat(aclEntryList.get(0).principal(), equalTo(groupPrincipal));
         assertThat(aclEntryList.get(0).type(), equalTo(AclEntryType.ALLOW));
         assertThat(aclEntryList.get(0).permissions(), containsInAnyOrder(WindowsPlatform.EXECUTE_PERMS.toArray()));
@@ -155,7 +154,7 @@ class WindowsPlatformTest {
         aclEntryList = WindowsPlatform.WindowsFileSystemPermissionView.aclEntries(FileSystemPermission.builder()
                 .otherRead(true)
                 .build(), tempDir);
-        assertThat(aclEntryList, hasSize(1));
+        assertThat(aclEntryList, hasSize(2));
         assertThat(aclEntryList.get(0).principal(), equalTo(everyone));
         assertThat(aclEntryList.get(0).type(), equalTo(AclEntryType.ALLOW));
         assertThat(aclEntryList.get(0).permissions(), containsInAnyOrder(WindowsPlatform.READ_PERMS.toArray()));
@@ -163,7 +162,7 @@ class WindowsPlatformTest {
         aclEntryList = WindowsPlatform.WindowsFileSystemPermissionView.aclEntries(FileSystemPermission.builder()
                 .otherWrite(true)
                 .build(), tempDir);
-        assertThat(aclEntryList, hasSize(1));
+        assertThat(aclEntryList, hasSize(2));
         assertThat(aclEntryList.get(0).principal(), equalTo(everyone));
         assertThat(aclEntryList.get(0).type(), equalTo(AclEntryType.ALLOW));
         assertThat(aclEntryList.get(0).permissions(), containsInAnyOrder(WindowsPlatform.WRITE_PERMS.toArray()));
@@ -171,7 +170,7 @@ class WindowsPlatformTest {
         aclEntryList = WindowsPlatform.WindowsFileSystemPermissionView.aclEntries(FileSystemPermission.builder()
                 .otherExecute(true)
                 .build(), tempDir);
-        assertThat(aclEntryList, hasSize(1));
+        assertThat(aclEntryList, hasSize(2));
         assertThat(aclEntryList.get(0).principal(), equalTo(everyone));
         assertThat(aclEntryList.get(0).type(), equalTo(AclEntryType.ALLOW));
         assertThat(aclEntryList.get(0).permissions(), containsInAnyOrder(WindowsPlatform.EXECUTE_PERMS.toArray()));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
In a previous pull request, I added full control to the SYSTEM account assuming that Greengrass would always run as SYSTEM. This pull request changes it so we give permissions to the Administrators group instead. SYSTEM is a member of Administrators, but importantly so are our accounts we use for testing in our workspace. 
Also updated the needToSwitch user logic so that it will use the privileges of Greengrass if the user has set the requiresPrivilege flag.

Without this change, Runtime-1-T8 fails running in my workspace. With the change it is able to pass.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
