### PR TITLE
fix(windows): get proper utf-16 charset for Windows credentials

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
@@ -25,7 +25,6 @@ import vendored.com.microsoft.alm.storage.windows.internal.WindowsCredUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
@@ -66,8 +65,10 @@ public class BaseITCase {
         // To test runWith on Windows, need to prepare user and credential
         createWindowsTestUser(WINDOWS_TEST_UESRNAME, WINDOWS_TEST_PASSWORD);
         createWindowsTestUser(WINDOWS_TEST_UESRNAME_2, WINDOWS_TEST_PASSWORD);
-        WindowsCredUtils.add(WINDOWS_TEST_UESRNAME, WINDOWS_TEST_PASSWORD.getBytes(StandardCharsets.UTF_8));
-        WindowsCredUtils.add(WINDOWS_TEST_UESRNAME_2, WINDOWS_TEST_PASSWORD.getBytes(StandardCharsets.UTF_8));
+        WindowsCredUtils.add(WINDOWS_TEST_UESRNAME,
+                WINDOWS_TEST_PASSWORD.getBytes(WindowsCredUtils.getCharsetForSystem()));
+        WindowsCredUtils.add(WINDOWS_TEST_UESRNAME_2,
+                WINDOWS_TEST_PASSWORD.getBytes(WindowsCredUtils.getCharsetForSystem()));
         // mock runas path
         KernelAlternatives mockKernelAlts = mock(KernelAlternatives.class);
         when(mockKernelAlts.getBinDir()).thenReturn(Paths.get("scripts").toAbsolutePath());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -138,6 +138,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     private static final ObjectMapper OBJECT_MAPPER =
             new ObjectMapper().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
                     .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    private static final AtomicInteger deploymentCount = new AtomicInteger();
 
     private static Logger logger;
     private static DependencyResolver dependencyResolver;
@@ -152,7 +153,6 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     private static DeploymentDocumentDownloader deploymentDocumentDownloader;
     private static Path rootDir;
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
-    private final AtomicInteger deploymentCount = new AtomicInteger();
     private DeploymentDocument sampleJobDocument;
     private CountDownLatch countDownLatch;
     private Topics groupToRootComponentsTopics;
@@ -260,6 +260,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         if (!PlatformResolver.isWindows) {
             assumeCanSudoShell(kernel);
         }
+        kernel.getContext().waitForPublishQueueToClear();
     }
 
     @AfterEach
@@ -404,7 +405,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     }
 
     @Test
-    @Order(2)
+    @Order(4)
     void GIVEN_multiple_deployments_with_config_update_WHEN_submitted_to_deployment_task_THEN_configs_are_updated()
             throws Exception {
 
@@ -602,7 +603,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                 IsMapContaining.hasEntry("leafKey", "default value of /path/leafKey"));
 
         // verify interpolation result
-        assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+        assertThat("The stdout should be captured within seconds.", countDownLatch.await(20, TimeUnit.SECONDS));
         String stdout = stdouts.get(0);
 
         assertThat(stdout, containsString("Value for /singleLevelKey: default value of singleLevelKey."));
@@ -617,7 +618,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     }
 
     @Test
-    @Order(2)
+    @Order(6)
     void GIVEN_initial_deployment_with_config_update_WHEN_submitted_to_deployment_task_THEN_configs_updates_on_default()
             throws Exception {
 
@@ -693,7 +694,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     }
 
     @Test
-    @Order(2)
+    @Order(5)
     void GIVEN_a_deployment_with_dependency_has_config_WHEN_submitted_THEN_dependency_configs_are_interpolated()
             throws Exception {
         // Set up stdout listener to capture stdout for verify #2 interpolation
@@ -731,7 +732,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     }
 
     @Test
-    @Order(2)
+    @Order(7)
     void GIVEN_a_deployment_has_component_use_system_config_WHEN_submitted_THEN_system_configs_are_interpolated()
             throws Exception {
 
@@ -794,7 +795,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
      * @throws Exception
      */
     @Test
-    @Order(5)
+    @Order(8)
     void GIVEN_services_running_WHEN_service_added_and_deleted_THEN_add_remove_service_accordingly() throws Exception {
 
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
@@ -835,7 +836,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
      * the process and starts the new one.
      */
     @Test
-    @Order(5) // deploy before tests that break services
+    @Order(9) // deploy before tests that break services
     @EnabledOnOs(OS.LINUX)
     void GIVEN_a_deployment_with_runwith_config_WHEN_submitted_THEN_runwith_updated() throws Exception {
         ((Map) kernel.getContext().getvIfExists(Kernel.SERVICE_TYPE_TO_CLASS_MAP_KEY).get())
@@ -937,7 +938,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
      * @throws Exception
      */
     @Test
-    @Order(6)
+    @Order(10)
     void GIVEN_services_running_WHEN_new_service_breaks_failure_handling_policy_do_nothing_THEN_service_stays_broken(
             ExtensionContext context) throws Exception {
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
@@ -983,7 +984,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
      * @throws Exception
      */
     @Test
-    @Order(7)
+    @Order(11)
     void GIVEN_services_running_WHEN_new_service_breaks_failure_handling_policy_rollback_THEN_services_are_rolled_back(
             ExtensionContext context) throws Exception {
         Map<String, Object> pkgDetails = new HashMap<>();
@@ -1030,7 +1031,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
      * one, but fails for a different reason and rolls back, then it is able to roll back successfully.
      */
     @Test
-    @Order(8)
+    @Order(12)
     void GIVEN_broken_service_WHEN_new_service_breaks_failure_handling_policy_rollback_THEN_services_are_rolled_back(
             ExtensionContext context) throws Exception {
         ignoreExceptionUltimateCauseOfType(context, ServiceUpdateException.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/provisioning/ProvisionFromTestPlugin.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/provisioning/ProvisionFromTestPlugin.java
@@ -128,7 +128,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         String configBody = new String(Files.readAllBytes(Paths.get(filepath.toURI())), StandardCharsets.UTF_8);
         String generatedCertFilePath = Files.createTempFile(certFilePath, null, ".pem")
                 .toAbsolutePath().toString();
-        configBody = replaceConfgPrameters(configBody, generatedCertFilePath, "InvalidNumber");
+        configBody = replaceConfigParameters(configBody, generatedCertFilePath, "InvalidNumber");
         Path configFilePath = Paths.get(String.valueOf(configurationFilePath), "config.yaml");
         Files.write(configFilePath, configBody.getBytes(StandardCharsets.UTF_8));
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel, configFilePath.toUri().toURL());
@@ -161,7 +161,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         String configBody = new String(Files.readAllBytes(Paths.get(filepath.toURI())), StandardCharsets.UTF_8);
         String generatedCertFilePath = Files.createTempFile(certFilePath, null, ".pem")
                 .toAbsolutePath().toString();
-        configBody = replaceConfgPrameters(configBody, generatedCertFilePath, "5000");
+        configBody = replaceConfigParameters(configBody, generatedCertFilePath, "5000");
         Path configFilePath = Paths.get(String.valueOf(configurationFilePath), "config.yaml");
         Files.write(configFilePath, configBody.getBytes(StandardCharsets.UTF_8));
 
@@ -183,7 +183,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         String configBody = new String(Files.readAllBytes(Paths.get(filepath.toURI())), StandardCharsets.UTF_8);
         String generatedCertFilePath = Files.createTempFile(certFilePath, null, ".pem.crt")
                 .toAbsolutePath().toString();
-        configBody = replaceConfgPrameters(configBody, generatedCertFilePath, "5000");
+        configBody = replaceConfigParameters(configBody, generatedCertFilePath, "5000");
         Path configFilePath = Paths.get(String.valueOf(configurationFilePath), "config.yaml");
         Files.write(configFilePath, configBody.getBytes(StandardCharsets.UTF_8));
 
@@ -204,6 +204,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         })) {
             kernel.launch();
             assertTrue(logLatch.await(7, TimeUnit.SECONDS));
+            kernel.getContext().waitForPublishQueueToClear();
             DeviceConfiguration deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
             assertEquals("test.us-east-1.iot.data.endpoint", Coerce.toString(deviceConfiguration.getIotDataEndpoint()));
             assertEquals(generatedCertFilePath, Coerce.toString(deviceConfiguration.getCertificateFilePath()));
@@ -220,7 +221,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         String configBody = new String(Files.readAllBytes(Paths.get(filepath.toURI())), StandardCharsets.UTF_8);
         String generatedCertFilePath = Files.createTempFile(certFilePath, null, ".pem.crt")
                 .toAbsolutePath().toString();
-        configBody = replaceConfgPrameters(configBody, generatedCertFilePath, "0");
+        configBody = replaceConfigParameters(configBody, generatedCertFilePath, "0");
         Path configFilePath = Paths.get(String.valueOf(configurationFilePath), "config.yaml");
         Files.write(configFilePath, configBody.getBytes(StandardCharsets.UTF_8));
 
@@ -240,13 +241,14 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         })) {
             kernel.launch();
             assertTrue(logLatch.await(7, TimeUnit.SECONDS));
+            kernel.getContext().waitForPublishQueueToClear();
             DeviceConfiguration deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
             assertEquals("test.us-east-1.iot.data.endpoint", Coerce.toString(deviceConfiguration.getIotDataEndpoint()));
             assertEquals(generatedCertFilePath, Coerce.toString(deviceConfiguration.getCertificateFilePath()));
         }
     }
 
-    private String replaceConfgPrameters(String configTemplate, String generatedCertFilePath, String waitimeInMs) throws IOException {
+    private String replaceConfigParameters(String configTemplate, String generatedCertFilePath, String waitTimeInMS) throws IOException {
         configTemplate = configTemplate.replace("$certfilepath", generatedCertFilePath);
         configTemplate = configTemplate.replace("$privatekeypath", Files.createTempFile(privateKeyPath, null,
                 ".pem.key")
@@ -254,7 +256,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         configTemplate = configTemplate.replace("$rootcapath", Files.createTempFile(rootCAPath, null,
                 ".pem.crt")
                 .toAbsolutePath().toString());
-        configTemplate = configTemplate.replace("$waittimems", waitimeInMs);
+        configTemplate = configTemplate.replace("$waittimems", waitTimeInMS);
         return configTemplate;
     }
 

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -172,7 +172,7 @@ public class KernelLifecycle {
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void executeProvisioningPlugin(DeviceIdentityInterface provisioningPlugin) {
-        logger.atDebug().log("Found provisioning plugin to run");
+        logger.atDebug().kv("plugin", provisioningPlugin.name()).log("Found provisioning plugin to run");
         RetryUtils.RetryConfig retryConfig = RetryUtils.RetryConfig.builder()
                 .maxAttempt(MAX_PROVISIONING_PLUGIN_RETRY_ATTEMPTS)
                 .retryableExceptions(Collections.singletonList(RetryableProvisioningException.class))
@@ -219,7 +219,7 @@ public class KernelLifecycle {
                         provisioningPluginNames.add(c.getName());
                     }
                 } catch (InstantiationException | IllegalAccessException e) {
-                    logger.atError().kv("Plugin", c.getName()).setCause(e.getCause())
+                    logger.atError().kv("Plugin", c.getName()).setCause(e)
                             .log("Error instantiating a provisioning plugin");
                 }
             });

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -104,7 +103,7 @@ public class WindowsExec extends Exec {
 
         byte[] credBlob = WindowsCredUtils.read(username);
         ByteBuffer bb = ByteBuffer.wrap(credBlob);
-        CharBuffer cb = StandardCharsets.UTF_8.decode(bb);
+        CharBuffer cb = WindowsCredUtils.getCharsetForSystem().decode(bb);
 
         // Prepend runas arguments to use it for running commands as different user
         List<String> args = new ArrayList<>();

--- a/src/main/java/vendored/com/microsoft/alm/storage/windows/internal/WindowsCredUtils.java
+++ b/src/main/java/vendored/com/microsoft/alm/storage/windows/internal/WindowsCredUtils.java
@@ -9,6 +9,9 @@ import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class WindowsCredUtils {
@@ -69,6 +72,13 @@ public class WindowsCredUtils {
             cred.CredentialBlob.clear(blob.length);
             Arrays.fill(blob, (byte) 0);
         }
+    }
+
+    public static Charset getCharsetForSystem() {
+        if (ByteOrder.BIG_ENDIAN.equals(ByteOrder.nativeOrder())) {
+            return StandardCharsets.UTF_16BE;
+        }
+        return StandardCharsets.UTF_16LE;
     }
 
     private static CredAdvapi32.CREDENTIAL buildCred(String key, byte[] credentialBlob) {

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -134,6 +134,8 @@ class TelemetryAgentTest extends GGServiceTestUtil {
     void cleanUp() throws IOException, InterruptedException {
         TelemetryConfig.getInstance().closeContext();
         telemetryAgent.shutdown();
+        context.waitForPublishQueueToClear();
+        Thread.sleep(1000);
         ses.shutdownNow();
         executorService.shutdownNow();
         context.close();

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.testcommons.testutilities;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
+import com.aws.greengrass.provisioning.ProvisioningPluginFactory;
 import com.aws.greengrass.util.Utils;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -144,6 +145,8 @@ public class ExceptionLogProtector implements BeforeEachCallback, AfterEachCallb
 
         ignoreExceptionOfType(context, RejectedExecutionException.class);
         ignoreExceptionOfType(context, ClosedByInterruptException.class);
+        ignoreExceptionWithStackTraceContaining(context, IllegalAccessException.class,
+                ProvisioningPluginFactory.class.getName());
     }
 
     @Override

--- a/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsCredUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsCredUtilsTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.condition.OS;
 import vendored.com.microsoft.alm.storage.windows.internal.WindowsCredUtils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -29,14 +28,14 @@ class WindowsCredUtilsTest {
         String password2 = RandomStringUtils.randomAlphanumeric(20);
 
         // Create and read
-        WindowsCredUtils.add(key, password.getBytes(StandardCharsets.UTF_8));
+        WindowsCredUtils.add(key, password.getBytes(WindowsCredUtils.getCharsetForSystem()));
         byte[] cred = WindowsCredUtils.read(key);
-        assertArrayEquals(password.getBytes(StandardCharsets.UTF_8), cred);
+        assertArrayEquals(password.getBytes(WindowsCredUtils.getCharsetForSystem()), cred);
 
         // Update
-        WindowsCredUtils.add(key, password2.getBytes(StandardCharsets.UTF_8));
+        WindowsCredUtils.add(key, password2.getBytes(WindowsCredUtils.getCharsetForSystem()));
         byte[] cred2 = WindowsCredUtils.read(key);
-        assertArrayEquals(password2.getBytes(StandardCharsets.UTF_8), cred2);
+        assertArrayEquals(password2.getBytes(WindowsCredUtils.getCharsetForSystem()), cred2);
 
         // Delete
         WindowsCredUtils.delete(key);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When using cmdkey to insert credentials on the command line, Windows stores it using UTF-16LE. This change now accounts for that by getting the proper charset based on the system.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
