### PR TITLE
fix(windows): fix requiresPrivilege for Windows, ensure WinSW runs with privileges

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.lifecyclemanager;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.config.CaseInsensitiveString;
 import com.aws.greengrass.config.Node;
-import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
@@ -758,13 +757,11 @@ public class GenericExternalService extends GreengrassService {
     }
 
     protected Exec addUserGroup(Exec exec, String user, String group) {
-        boolean validUser = !Utils.isEmpty(user);
-        if (validUser) {
+        if (Utils.isNotEmpty(user)) {
             exec = exec.withUser(user);
-            boolean validGroup = !Utils.isEmpty(group);
-            if (validGroup) {
-                exec = exec.withGroup(group);
-            }
+        }
+        if (Utils.isNotEmpty(group)) {
+            exec = exec.withGroup(group);
         }
         return exec;
     }
@@ -776,10 +773,6 @@ public class GenericExternalService extends GreengrassService {
      * @return the exec.
      */
     protected Exec addPrivilegedUser(Exec exec) {
-        if (PlatformResolver.isWindows) {
-            logger.atWarn("Windows lifecycle steps cannot run as different users");
-            return exec;
-        }
         String user = Platform.getInstance().getPrivilegedUser();
         String group = Platform.getInstance().getPrivilegedGroup();
         return addUserGroup(exec, user, group);
@@ -792,9 +785,8 @@ public class GenericExternalService extends GreengrassService {
      * @return the Exec
      */
     protected Exec addShell(Exec exec) {
-        if (PlatformResolver.isWindows) {
-            return exec;
-        }
+        // TODO: On Windows the shell (either cmd or powershell) really needs to be indiviualized to each
+        // lifecycle script, not from runWith
         return exec.usingShell(runWith.getShell());
     }
 

--- a/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtils.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtils.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.util.orchestration;
 
 import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
 import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.platforms.Platform;
 
 import java.io.IOException;
@@ -30,15 +31,20 @@ public interface SystemServiceUtils {
      * @throws IOException for command failure
      * @throws InterruptedException if interrupted while running
      */
+    @SuppressWarnings("PMD.CloseResource")
     static void runCommand(Logger logger, String eventName, String command, boolean ignoreError)
             throws IOException, InterruptedException {
         logger.atDebug(eventName).log(command);
-        boolean success = Platform.getInstance().createNewProcessRunner().withShell(command)
-                .withUser(Platform.getInstance().getPrivilegedUser())
-                .withOut(s -> logger.atWarn(eventName).kv("command", command)
-                        .kv("stdout", s.toString().trim()).log())
-                .withErr(s -> logger.atError(eventName).kv("command", command)
-                        .kv("stderr", s.toString().trim()).log())
+        Exec exec = Platform.getInstance().createNewProcessRunner().withShell(command);
+        if (Platform.getInstance().getPrivilegedUser() != null) {
+            exec.withUser(Platform.getInstance().getPrivilegedUser());
+        }
+        if (Platform.getInstance().getPrivilegedGroup() != null) {
+            exec.withGroup(Platform.getInstance().getPrivilegedGroup());
+        }
+        boolean success = exec
+                .withOut(s -> logger.atWarn(eventName).kv("command", command).kv("stdout", s.toString().trim()).log())
+                .withErr(s -> logger.atError(eventName).kv("command", command).kv("stderr", s.toString().trim()).log())
                 .successful(true);
         if (!success && !ignoreError) {
             throw new IOException(String.format("Command %s failed", command));

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
@@ -485,6 +485,11 @@ public class WindowsPlatform extends Platform {
 
         @Override
         public ShellDecorator withShell(String shell) {
+            if (Utils.isEmpty(shell)) {
+                this.shell = CMD;
+                this.arg = CMD_ARG;
+                return this;
+            }
             switch (shell) {
                 case CMD:
                     this.shell = CMD;
@@ -567,12 +572,6 @@ public class WindowsPlatform extends Platform {
         public String[] decorate(String... command) {
             // Windows decorate does nothing
             return command;
-        }
-
-        @Override
-        public UserDecorator withGroup(String group) {
-            // Windows runas does not support group
-            return this;
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add the privileged user and group to the system service utility runner so that we run as the privileged user and not the default user. Fixed GenericExternalService on windows to allow for requiresPrivilege. Verified that I'm able to install with WinSW.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
