### PR TITLE
feat: define CryptoKeySpi and security service interface

### DIFF
--- a/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
+++ b/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.security;
+
+import com.aws.greengrass.security.exceptions.KeyLoadingException;
+import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
+
+import javax.net.ssl.KeyManager;
+
+public interface CryptoKeySpi {
+
+    KeyManager[] getKeyManagers(String keyUri) throws ServiceUnavailableException, KeyLoadingException;
+
+    String supportedKeyType();
+}

--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.security;
+
+import com.aws.greengrass.config.CaseInsensitiveString;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.security.exceptions.KeyLoadingException;
+import com.aws.greengrass.security.exceptions.ServiceProviderConflictException;
+import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.net.ssl.KeyManager;
+
+public class SecurityService {
+    private static final Logger logger = LogManager.getLogger(SecurityService.class);
+    private static final String KEY_TYPE = "keyType";
+    private static final String KEY_URI = "keyUri";
+
+    @Getter(AccessLevel.PACKAGE)
+    private final ConcurrentMap<CaseInsensitiveString, CryptoKeySpi> cryptoKeyProviderMap;
+
+    public SecurityService() {
+        this.cryptoKeyProviderMap = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Register crypto key provider for the key type.
+     *
+     * @param keyProvider Crypto key provider
+     * @throws ServiceProviderConflictException if key type is already registered
+     */
+    public void registerCryptoKeyProvider(CryptoKeySpi keyProvider) throws ServiceProviderConflictException {
+        CaseInsensitiveString keyType = new CaseInsensitiveString(keyProvider.supportedKeyType());
+        logger.atInfo().kv(KEY_TYPE, keyType).log("Register crypto key service provider");
+        CryptoKeySpi provider = cryptoKeyProviderMap.computeIfAbsent(keyType, k -> keyProvider);
+        if (!provider.equals(keyProvider)) {
+            logger.atError().kv(KEY_TYPE, keyType)
+                    .log("Crypto key service provider for the key type is already registered");
+            throw new ServiceProviderConflictException(String.format("Key type %s provider is registered", keyType));
+        }
+    }
+
+    /**
+     * Deregister crypto key provide for the key type.
+     *
+     * @param keyProvider Crypto key provider
+     */
+    public void deregisterCryptoKeyProvider(CryptoKeySpi keyProvider) {
+        CaseInsensitiveString keyType = new CaseInsensitiveString(keyProvider.supportedKeyType());
+        boolean removed = cryptoKeyProviderMap.remove(keyType, keyProvider);
+        if (!removed) {
+            logger.atInfo().kv(KEY_TYPE, keyType).log("Crypto key service provider is either removed or not the same"
+                    + " provider");
+        }
+    }
+
+    /**
+     * Get JSSE KeyManagers, used for https TLS handshake.
+     *
+     * @param keyUri private key URI
+     * @return KeyManagers that manage the specified private key
+     * @throws ServiceUnavailableException if crypto key provider service is unavailable
+     * @throws KeyLoadingException if crypto key provider service fails to load key
+     * @throws URISyntaxException if key URI syntax error
+     */
+    public KeyManager[] getKeyManagers(String keyUri)
+            throws ServiceUnavailableException, KeyLoadingException, URISyntaxException {
+        logger.atTrace().kv(KEY_URI, keyUri).log("Get key managers by key URI");
+        CryptoKeySpi provider = selectCryptoKeyProvider(keyUri);
+        return provider.getKeyManagers(keyUri);
+    }
+
+    private CryptoKeySpi selectCryptoKeyProvider(String keyUri) throws URISyntaxException, ServiceUnavailableException {
+        URI uri = new URI(keyUri);
+        CaseInsensitiveString keyType = new CaseInsensitiveString(uri.getScheme());
+        CryptoKeySpi provider = cryptoKeyProviderMap.getOrDefault(keyType, null);
+        if (provider == null) {
+            logger.atError().kv(KEY_TYPE, keyType).log("Crypto key service provider for the key type is unavailable");
+            throw new ServiceUnavailableException(String.format("Crypto key service for %s is unavailable", keyType));
+        }
+        return provider;
+    }
+}

--- a/src/main/java/com/aws/greengrass/security/exceptions/KeyLoadingException.java
+++ b/src/main/java/com/aws/greengrass/security/exceptions/KeyLoadingException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.security.exceptions;
+
+public class KeyLoadingException extends Exception {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public KeyLoadingException(String message) {
+        super(message);
+    }
+
+    public KeyLoadingException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/com/aws/greengrass/security/exceptions/ServiceProviderConflictException.java
+++ b/src/main/java/com/aws/greengrass/security/exceptions/ServiceProviderConflictException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.security.exceptions;
+
+public class ServiceProviderConflictException extends Exception {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public ServiceProviderConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aws/greengrass/security/exceptions/ServiceUnavailableException.java
+++ b/src/main/java/com/aws/greengrass/security/exceptions/ServiceUnavailableException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.security.exceptions;
+
+public class ServiceUnavailableException extends Exception {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public ServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    public ServiceUnavailableException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -39,6 +39,12 @@ class SecurityServiceTest {
         assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
         assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("file"),
                 mockKeyProvider));
+        CryptoKeySpi providerB = mock(CryptoKeySpi.class);
+        when(providerB.supportedKeyType()).thenReturn("PKCS11");
+        service.registerCryptoKeyProvider(providerB);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(2));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("pkcs11"),
+                providerB));
     }
 
     @Test
@@ -65,6 +71,9 @@ class SecurityServiceTest {
     void GIVEN_key_service_provider_registered_WHEN_deregister_THEN_removed() throws Exception {
         when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
         service.registerCryptoKeyProvider(mockKeyProvider);
+        service.deregisterCryptoKeyProvider(mockKeyProvider);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(0));
+        // validate idempotency
         service.deregisterCryptoKeyProvider(mockKeyProvider);
         assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(0));
     }

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.security;
+
+import com.aws.greengrass.config.CaseInsensitiveString;
+import com.aws.greengrass.security.exceptions.ServiceProviderConflictException;
+import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.collection.IsMapWithSize;
+import org.hamcrest.core.Is;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.net.ssl.KeyManager;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class SecurityServiceTest {
+
+    private final SecurityService service = new SecurityService();
+
+    @Mock
+    private CryptoKeySpi mockKeyProvider;
+
+    @Test
+    void GIVEN_key_service_provider_WHEN_register_provider_THEN_succeed() throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("file"),
+                mockKeyProvider));
+    }
+
+    @Test
+    void GIVEN_key_service_provider_WHEN_register_provider_multiple_time_THEN_api_idempotent() throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("file"),
+                mockKeyProvider));
+    }
+
+    @Test
+    void GIVEN_key_service_providers_with_same_key_type_WHEN_register_provider_THEN_throw_exception() throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        CryptoKeySpi providerB = mock(CryptoKeySpi.class);
+        when(providerB.supportedKeyType()).thenReturn("file");
+        assertThrows(ServiceProviderConflictException.class, () -> service.registerCryptoKeyProvider(providerB));
+    }
+
+    @Test
+    void GIVEN_key_service_provider_registered_WHEN_deregister_THEN_removed() throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        service.deregisterCryptoKeyProvider(mockKeyProvider);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(0));
+    }
+
+    @Test
+    void GIVEN_key_service_provider_registered_WHEN_deregister_a_different_instance_THEN_the_provider_not_removed() throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        CryptoKeySpi providerB = mock(CryptoKeySpi.class);
+        when(providerB.supportedKeyType()).thenReturn("file");
+        service.deregisterCryptoKeyProvider(providerB);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("file"),
+                mockKeyProvider));
+    }
+
+    @Test
+    void GIVEN_key_service_provider_registered_WHEN_get_key_managers_THEN_delegate_call_to_service_provider() throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        String keyUri = "file:///path/to/file";
+        KeyManager[] mockKeyManagers = {mock(KeyManager.class)};
+        when(mockKeyProvider.getKeyManagers(keyUri)).thenReturn(mockKeyManagers);
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        KeyManager[] keyManagers = service.getKeyManagers(keyUri);
+        assertThat(keyManagers, Is.is(mockKeyManagers));
+    }
+
+    @Test
+    void GIVEN_key_service_provider_not_registered_WHEN_get_key_managers_THEN_throw_exception () {
+        assertThrows(ServiceUnavailableException.class, () -> service.getKeyManagers("file:///path/to/file"));
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Define CryptoKeySpi and security service interface.
Basic structure of register/deregister crypto key provider with security service.

**Why is this change necessary:**
Define the interface for implementing Greengrass v2 TPM support.

**How was this change tested:**
complete unit tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
