### PR TITLE
feat(proxy): add support for https proxies

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -288,8 +288,8 @@ public class DeviceProvisioningHelper {
     }
 
     private void removeDuplicateCertificates(File f) {
-        try (InputStream inputStream = Files.newInputStream(f.toPath())) {
-            String certificates = IoUtils.toUtf8String(inputStream);
+        try {
+            String certificates = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
             Set<String> uniqueCertificates =
                     Arrays.stream(certificates.split(EncryptionUtils.CERTIFICATE_PEM_HEADER))
                             .map(s -> s.trim())

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.util.CommitableFile;
+import com.aws.greengrass.util.EncryptionUtils;
 import com.aws.greengrass.util.IamSdkClientFactory;
 import com.aws.greengrass.util.IotSdkClientFactory;
 import com.aws.greengrass.util.IotSdkClientFactory.EnvironmentStage;
@@ -69,20 +70,27 @@ import software.amazon.awssdk.services.iot.model.UpdateCertificateRequest;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
 import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.awssdk.utils.IoUtils;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Provision a device by registering as an IoT thing, creating roles and template first party components.
@@ -261,22 +269,52 @@ public class DeviceProvisioningHelper {
     }
 
     /*
-     * Download root CA to a local file if the file does not exist
+     * Download root CA to a local file.
+     *
+     * To support HTTPS proxies and other custom truststore configurations, append to the file if it exists.
      */
-    private void downloadRootCAToFile(File f) throws IOException {
+    private void downloadRootCAToFile(File f) {
         if (f.exists()) {
-            outStream.printf("Root CA found at \"%s\". Skipping download.%n", f);
-            return;
+            outStream.printf("Root CA file found at \"%s\". Contents will be preserved.%n", f);
         }
         outStream.printf("Downloading Root CA from \"%s\"%n", ROOT_CA_URL);
-        downloadFileFromURL(ROOT_CA_URL, f);
+        try {
+            downloadFileFromURL(ROOT_CA_URL, f, f.exists());
+            removeDuplicateCertificates(f);
+        } catch (IOException e) {
+            // Do not block as the root CA file may have been manually provisioned
+            outStream.printf("Failed to download Root CA - %s%n", e);
+        }
+    }
+
+    private void removeDuplicateCertificates(File f) {
+        try {
+            String certificates = IoUtils.toUtf8String(Files.newInputStream(f.toPath()));
+            Set<String> uniqueCertificates =
+                    Arrays.stream(certificates.split(EncryptionUtils.CERTIFICATE_PEM_HEADER))
+                            .map(s -> s.trim())
+                            .collect(Collectors.toSet());
+
+            try (BufferedWriter bw = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
+                for (String certificate : uniqueCertificates) {
+                    if (certificate.length() > 0) {
+                        bw.write(EncryptionUtils.CERTIFICATE_PEM_HEADER);
+                        bw.newLine();
+                        bw.write(certificate);
+                        bw.newLine();
+                    }
+                }
+            }
+        } catch (IOException e) {
+            outStream.printf("Failed to remove duplicate certificates - %s%n", e);
+        }
     }
 
     /*
      * Download content from a URL to a local file.
      */
     @SuppressWarnings("PMD.AvoidFileStream")
-    private void downloadFileFromURL(String url, File f) throws IOException {
+    private void downloadFileFromURL(String url, File f, boolean appendFile) throws IOException {
         SdkHttpFullRequest request = SdkHttpFullRequest.builder()
                 .uri(URI.create(url))
                 .method(SdkHttpMethod.GET)
@@ -289,8 +327,13 @@ public class DeviceProvisioningHelper {
         try (SdkHttpClient client = getSdkHttpClient()) {
             HttpExecuteResponse executeResponse = client.prepareRequest(executeRequest).call();
 
+            int responseCode = executeResponse.httpResponse().statusCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new IOException("Received invalid response code: " + responseCode);
+            }
+
             try (ReadableByteChannel readableByteChannel = Channels.newChannel(executeResponse.responseBody().get());
-                 FileOutputStream fileOutputStream = new FileOutputStream(f)) {
+                 FileOutputStream fileOutputStream = new FileOutputStream(f, appendFile)) {
                 fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
             }
         }

--- a/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
+++ b/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
@@ -24,6 +24,9 @@ import java.util.List;
 
 public final class EncryptionUtils {
 
+    public static final String CERTIFICATE_PEM_HEADER = "-----BEGIN CERTIFICATE-----";
+    public static final String CERTIFICATE_PEM_FOOTER = "-----END CERTIFICATE-----";
+
     private static final String PKCS_1_PEM_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
     private static final String PKCS_1_PEM_FOOTER = "-----END RSA PRIVATE KEY-----";
     private static final String PKCS_8_PEM_HEADER = "-----BEGIN PRIVATE KEY-----";

--- a/src/test/java/com/aws/greengrass/util/ProxyUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/ProxyUtilsTest.java
@@ -79,7 +79,7 @@ class ProxyUtilsTest {
         when(deviceConfiguration.getProxyUsername()).thenReturn("test-user");
         when(deviceConfiguration.getProxyPassword()).thenReturn("itsasecret");
 
-        HttpProxyOptions httpProxyOptions = ProxyUtils.getHttpProxyOptions(deviceConfiguration);
+        HttpProxyOptions httpProxyOptions = ProxyUtils.getHttpProxyOptions(deviceConfiguration, null);
 
         assertEquals("myproxy", httpProxyOptions.getHost());
         assertEquals(8080, httpProxyOptions.getPort());

--- a/src/test/java/com/aws/greengrass/util/ProxyUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/ProxyUtilsTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
+import software.amazon.awssdk.crt.io.ClientTlsContext;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -79,7 +81,8 @@ class ProxyUtilsTest {
         when(deviceConfiguration.getProxyUsername()).thenReturn("test-user");
         when(deviceConfiguration.getProxyPassword()).thenReturn("itsasecret");
 
-        HttpProxyOptions httpProxyOptions = ProxyUtils.getHttpProxyOptions(deviceConfiguration, null);
+        HttpProxyOptions httpProxyOptions = ProxyUtils.getHttpProxyOptions(deviceConfiguration,
+                new ClientTlsContext(TlsContextOptions.createDefaultClient()));
 
         assertEquals("myproxy", httpProxyOptions.getHost());
         assertEquals(8080, httpProxyOptions.getPort());


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**
Adds support for HTTPS proxies. Simply add the certificate of the CA that issued the proxy TLS certificate to the file specified in rootCaPath and make sure the networkProxy url config value uses the https scheme.

Code updates:
- Make sure the root CA truststore system property is used in the CRT SDK's HttpProxyOptions.
- Make sure the root CA truststore is combined with the JVM default truststore and used in the AWS SDK's SdkHttpClient.
- Modify device provisioning helper to preserve contents of truststore if it exists and remove duplicates.

**Why is this change necessary:**
 This is required in case customers operate in an environment where remote calls must traverse an HTTPS proxy

**How was this change tested:**
Manually tested with squid v4 and `mvn -U -ntp verify`

**Any additional information or context required to review the change:** No

**Checklist:**
 - [x] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [x] Updated or added new end-to-end tests
 - [x] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
