### PR TITLE
feat: implement default file based crypto key service provider

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.util.exceptions.TLSAuthException;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -92,7 +93,7 @@ public final class ClientConfigurationUtils {
 
     private static TrustManager[] createTrustManagers(String rootCAPath) throws TLSAuthException {
         try {
-            List<X509Certificate> trustCertificates = EncryptionUtils.loadX509Certificates(rootCAPath);
+            List<X509Certificate> trustCertificates = EncryptionUtils.loadX509Certificates(Paths.get(rootCAPath));
 
             KeyStore tmKeyStore = KeyStore.getInstance("JKS");
             tmKeyStore.load(null, null);
@@ -112,9 +113,9 @@ public final class ClientConfigurationUtils {
     private static KeyManager[] createKeyManagers(String privateKeyPath, String certificatePath)
             throws TLSAuthException {
         try {
-            List<X509Certificate> certificateChain = EncryptionUtils.loadX509Certificates(certificatePath);
+            List<X509Certificate> certificateChain = EncryptionUtils.loadX509Certificates(Paths.get(certificatePath));
 
-            PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
+            PrivateKey privateKey = EncryptionUtils.loadPrivateKey(Paths.get(privateKeyPath));
 
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
             keyStore.load(null);

--- a/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
+++ b/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
@@ -8,11 +8,13 @@ package com.aws.greengrass.security;
 import com.aws.greengrass.security.exceptions.KeyLoadingException;
 import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
 
+import java.net.URISyntaxException;
 import javax.net.ssl.KeyManager;
 
 public interface CryptoKeySpi {
 
-    KeyManager[] getKeyManagers(String keyUri) throws ServiceUnavailableException, KeyLoadingException;
+    KeyManager[] getKeyManagers(String privateKeyUri, String certificateUri) throws ServiceUnavailableException,
+            KeyLoadingException, URISyntaxException;
 
     String supportedKeyType();
 }

--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -11,25 +11,47 @@ import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.security.exceptions.KeyLoadingException;
 import com.aws.greengrass.security.exceptions.ServiceProviderConflictException;
 import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
+import com.aws.greengrass.util.EncryptionUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
 
-public class SecurityService {
+public final class SecurityService {
     private static final Logger logger = LogManager.getLogger(SecurityService.class);
     private static final String KEY_TYPE = "keyType";
     private static final String KEY_URI = "keyUri";
+    private static final String CERT_URI = "certificateUri";
 
     @Getter(AccessLevel.PACKAGE)
     private final ConcurrentMap<CaseInsensitiveString, CryptoKeySpi> cryptoKeyProviderMap;
 
+    /**
+     * Constructor of security service.
+     */
     public SecurityService() {
         this.cryptoKeyProviderMap = new ConcurrentHashMap<>();
+
+        // instantiate and register the default file based provider
+        CryptoKeySpi defaultProvider = new DefaultCryptoKeyProvider();
+        try {
+            this.registerCryptoKeyProvider(defaultProvider);
+        } catch (ServiceProviderConflictException e) {
+            // it won't happen, it's programming error if it does
+            throw new RuntimeException("Default crypto key provider has been registered", e);
+        }
     }
 
     /**
@@ -66,17 +88,19 @@ public class SecurityService {
     /**
      * Get JSSE KeyManagers, used for https TLS handshake.
      *
-     * @param keyUri private key URI
+     * @param privateKeyUri private key URI
+     * @param certificateUri certificate URI
      * @return KeyManagers that manage the specified private key
      * @throws ServiceUnavailableException if crypto key provider service is unavailable
      * @throws KeyLoadingException if crypto key provider service fails to load key
      * @throws URISyntaxException if key URI syntax error
      */
-    public KeyManager[] getKeyManagers(String keyUri)
+    public KeyManager[] getKeyManagers(String privateKeyUri, String certificateUri)
             throws ServiceUnavailableException, KeyLoadingException, URISyntaxException {
-        logger.atTrace().kv(KEY_URI, keyUri).log("Get key managers by key URI");
-        CryptoKeySpi provider = selectCryptoKeyProvider(keyUri);
-        return provider.getKeyManagers(keyUri);
+        logger.atTrace().kv(KEY_URI, privateKeyUri).kv(CERT_URI, certificateUri)
+                .log("Get key managers by key URI");
+        CryptoKeySpi provider = selectCryptoKeyProvider(privateKeyUri);
+        return provider.getKeyManagers(privateKeyUri, certificateUri);
     }
 
     private CryptoKeySpi selectCryptoKeyProvider(String keyUri) throws URISyntaxException, ServiceUnavailableException {
@@ -88,5 +112,52 @@ public class SecurityService {
             throw new ServiceUnavailableException(String.format("Crypto key service for %s is unavailable", keyType));
         }
         return provider;
+    }
+
+    static class DefaultCryptoKeyProvider implements CryptoKeySpi {
+        private static final Logger logger = LogManager.getLogger(DefaultCryptoKeyProvider.class);
+
+        @Override
+        public KeyManager[] getKeyManagers(String privateKeyUriStr, String certificateUriStr)
+                throws KeyLoadingException, URISyntaxException {
+            URI privateKeyUri = new URI(privateKeyUriStr);
+            if (!isUriSupportedKeyType(privateKeyUri)) {
+                logger.atError().kv(KEY_URI, privateKeyUriStr).log("Can't process the key type");
+                throw new KeyLoadingException(String.format("Only support %s type private key", supportedKeyType()));
+            }
+
+            URI certificateUri = new URI(certificateUriStr);
+            if (!isUriSupportedKeyType(certificateUri)) {
+                logger.atError().kv(CERT_URI, certificateUriStr).log("Can't process the certificate type");
+                throw new KeyLoadingException(String.format("Only support %s type certificate", supportedKeyType()));
+            }
+
+            try {
+                PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyUri.getPath());
+                List<X509Certificate> certificateChain = EncryptionUtils.loadX509Certificates(certificateUri.getPath());
+
+                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                keyStore.load(null);
+                keyStore.setKeyEntry("private-key", privateKey, null, certificateChain.toArray(new Certificate[0]));
+
+                KeyManagerFactory keyManagerFactory =
+                        KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(keyStore, null);
+                return keyManagerFactory.getKeyManagers();
+            } catch (GeneralSecurityException | IOException e) {
+                logger.atError().kv(KEY_URI, privateKeyUriStr).kv(CERT_URI, certificateUriStr)
+                        .log("Exception caught during getting key manager");
+                throw new KeyLoadingException("Failed to get key manager", e);
+            }
+        }
+
+        @Override
+        public String supportedKeyType() {
+            return "file";
+        }
+
+        private boolean isUriSupportedKeyType(URI uri) {
+            return new CaseInsensitiveString(supportedKeyType()).equals(new CaseInsensitiveString(uri.getScheme()));
+        }
     }
 }

--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -36,14 +36,12 @@ public final class SecurityService {
     private static final String CERT_URI = "certificateUri";
 
     @Getter(AccessLevel.PACKAGE)
-    private final ConcurrentMap<CaseInsensitiveString, CryptoKeySpi> cryptoKeyProviderMap;
+    private final ConcurrentMap<CaseInsensitiveString, CryptoKeySpi> cryptoKeyProviderMap = new ConcurrentHashMap<>();
 
     /**
      * Constructor of security service.
      */
     public SecurityService() {
-        this.cryptoKeyProviderMap = new ConcurrentHashMap<>();
-
         // instantiate and register the default file based provider
         CryptoKeySpi defaultProvider = new DefaultCryptoKeyProvider();
         try {
@@ -80,8 +78,8 @@ public final class SecurityService {
         CaseInsensitiveString keyType = new CaseInsensitiveString(keyProvider.supportedKeyType());
         boolean removed = cryptoKeyProviderMap.remove(keyType, keyProvider);
         if (!removed) {
-            logger.atInfo().kv(KEY_TYPE, keyType).log("Crypto key service provider is either removed or not the same"
-                    + " provider");
+            logger.atInfo().kv(KEY_TYPE, keyType).log("Crypto key service provider is either already removed or "
+                    + "unregistered");
         }
     }
 
@@ -116,6 +114,7 @@ public final class SecurityService {
 
     static class DefaultCryptoKeyProvider implements CryptoKeySpi {
         private static final Logger logger = LogManager.getLogger(DefaultCryptoKeyProvider.class);
+        private static final String SUPPORT_KEY_TYPE = "file";
 
         @Override
         public KeyManager[] getKeyManagers(String privateKeyUriStr, String certificateUriStr)
@@ -153,7 +152,7 @@ public final class SecurityService {
 
         @Override
         public String supportedKeyType() {
-            return "file";
+            return SUPPORT_KEY_TYPE;
         }
 
         private boolean isUriSupportedKeyType(URI uri) {

--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -132,8 +133,9 @@ public final class SecurityService {
             }
 
             try {
-                PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyUri.getPath());
-                List<X509Certificate> certificateChain = EncryptionUtils.loadX509Certificates(certificateUri.getPath());
+                PrivateKey privateKey = EncryptionUtils.loadPrivateKey(Paths.get(privateKeyUri));
+                List<X509Certificate> certificateChain =
+                        EncryptionUtils.loadX509Certificates(Paths.get(certificateUri));
 
                 KeyStore keyStore = KeyStore.getInstance("PKCS12");
                 keyStore.load(null);

--- a/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
+++ b/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
@@ -43,9 +43,9 @@ public final class EncryptionUtils {
      * @throws IOException          file IO error
      * @throws CertificateException can't populate certificates
      */
-    public static List<X509Certificate> loadX509Certificates(String certificatePath)
+    public static List<X509Certificate> loadX509Certificates(Path certificatePath)
             throws IOException, CertificateException {
-        try (InputStream certificateInputStream = Files.newInputStream(Paths.get(certificatePath))) {
+        try (InputStream certificateInputStream = Files.newInputStream(certificatePath)) {
             CertificateFactory factory = CertificateFactory.getInstance("X.509");
             return new ArrayList<>(
                     (Collection<? extends X509Certificate>) factory.generateCertificates(certificateInputStream));
@@ -60,8 +60,8 @@ public final class EncryptionUtils {
      * @throws IOException              file IO error
      * @throws GeneralSecurityException can't load private key
      */
-    public static PrivateKey loadPrivateKey(String keyPath) throws IOException, GeneralSecurityException {
-        byte[] keyBytes = Files.readAllBytes(Paths.get(keyPath));
+    public static PrivateKey loadPrivateKey(Path keyPath) throws IOException, GeneralSecurityException {
+        byte[] keyBytes = Files.readAllBytes(keyPath);
         String keyString = new String(keyBytes, StandardCharsets.UTF_8);
 
         if (keyString.contains(PKCS_1_PEM_HEADER)) {

--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.http.apache.ProxyConfiguration;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -266,7 +267,7 @@ public final class ProxyUtils {
             Collections.addAll(certificates, getDefaultRootCertificates());
 
             if (Utils.isNotEmpty(rootCAPath)) {
-                certificates.addAll(EncryptionUtils.loadX509Certificates(rootCAPath));
+                certificates.addAll(EncryptionUtils.loadX509Certificates(Paths.get(rootCAPath)));
             }
 
             KeyStore customKeyStore = KeyStore.getInstance("JKS");

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -137,6 +137,8 @@ class SecurityServiceTest {
         X509KeyManager keyManager = (X509KeyManager) keyManagers[0];
         assertThat(keyManager.getPrivateKey("private-key"), notNullValue());
         assertThat(keyManager.getPrivateKey("private-key").getAlgorithm(), is("RSA"));
+        assertThat(keyManager.getCertificateChain("private-key").length, is(1));
+        assertThat(keyManager.getCertificateChain("private-key")[0].getSigAlgName(), is("SHA256withRSA"));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -6,20 +6,28 @@
 package com.aws.greengrass.security;
 
 import com.aws.greengrass.config.CaseInsensitiveString;
+import com.aws.greengrass.security.exceptions.KeyLoadingException;
 import com.aws.greengrass.security.exceptions.ServiceProviderConflictException;
 import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.EncryptionUtilsTest;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.collection.IsMapWithSize;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.file.Path;
 import javax.net.ssl.KeyManager;
+import javax.net.ssl.X509KeyManager;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,80 +37,128 @@ class SecurityServiceTest {
 
     private final SecurityService service = new SecurityService();
 
+    private final SecurityService.DefaultCryptoKeyProvider defaultProvider =
+            new SecurityService.DefaultCryptoKeyProvider();
+
     @Mock
     private CryptoKeySpi mockKeyProvider;
 
+    @TempDir
+    protected static Path resourcePath;
+
     @Test
     void GIVEN_key_service_provider_WHEN_register_provider_THEN_succeed() throws Exception {
-        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
         service.registerCryptoKeyProvider(mockKeyProvider);
-        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
-        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("file"),
-                mockKeyProvider));
-        CryptoKeySpi providerB = mock(CryptoKeySpi.class);
-        when(providerB.supportedKeyType()).thenReturn("PKCS11");
-        service.registerCryptoKeyProvider(providerB);
         assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(2));
-        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("pkcs11"),
-                providerB));
+        assertThat(service.getCryptoKeyProviderMap(),
+                IsMapContaining.hasEntry(new CaseInsensitiveString("pkcs11"), mockKeyProvider));
+        CryptoKeySpi providerB = mock(CryptoKeySpi.class);
+        when(providerB.supportedKeyType()).thenReturn("PARSEC");
+        service.registerCryptoKeyProvider(providerB);
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(3));
+        assertThat(service.getCryptoKeyProviderMap(),
+                IsMapContaining.hasEntry(new CaseInsensitiveString("parsec"), providerB));
     }
 
     @Test
     void GIVEN_key_service_provider_WHEN_register_provider_multiple_time_THEN_api_idempotent() throws Exception {
-        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
         service.registerCryptoKeyProvider(mockKeyProvider);
-        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(2));
         service.registerCryptoKeyProvider(mockKeyProvider);
-        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
-        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("file"),
-                mockKeyProvider));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(2));
+        assertThat(service.getCryptoKeyProviderMap(),
+                IsMapContaining.hasEntry(new CaseInsensitiveString("pkcs11"), mockKeyProvider));
     }
 
     @Test
     void GIVEN_key_service_providers_with_same_key_type_WHEN_register_provider_THEN_throw_exception() throws Exception {
-        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
         service.registerCryptoKeyProvider(mockKeyProvider);
         CryptoKeySpi providerB = mock(CryptoKeySpi.class);
-        when(providerB.supportedKeyType()).thenReturn("file");
+        when(providerB.supportedKeyType()).thenReturn("pkcs11");
         assertThrows(ServiceProviderConflictException.class, () -> service.registerCryptoKeyProvider(providerB));
     }
 
     @Test
     void GIVEN_key_service_provider_registered_WHEN_deregister_THEN_removed() throws Exception {
-        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
         service.registerCryptoKeyProvider(mockKeyProvider);
         service.deregisterCryptoKeyProvider(mockKeyProvider);
-        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(0));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
         // validate idempotency
         service.deregisterCryptoKeyProvider(mockKeyProvider);
-        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(0));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
     }
 
     @Test
-    void GIVEN_key_service_provider_registered_WHEN_deregister_a_different_instance_THEN_the_provider_not_removed() throws Exception {
-        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
+    void GIVEN_key_service_provider_registered_WHEN_deregister_a_different_instance_THEN_the_provider_not_removed()
+            throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
         service.registerCryptoKeyProvider(mockKeyProvider);
         CryptoKeySpi providerB = mock(CryptoKeySpi.class);
-        when(providerB.supportedKeyType()).thenReturn("file");
+        when(providerB.supportedKeyType()).thenReturn("pkcs11");
         service.deregisterCryptoKeyProvider(providerB);
-        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(1));
-        assertThat(service.getCryptoKeyProviderMap(), IsMapContaining.hasEntry(new CaseInsensitiveString("file"),
-                mockKeyProvider));
+        assertThat(service.getCryptoKeyProviderMap(), IsMapWithSize.aMapWithSize(2));
+        assertThat(service.getCryptoKeyProviderMap(),
+                IsMapContaining.hasEntry(new CaseInsensitiveString("pkcs11"), mockKeyProvider));
     }
 
     @Test
-    void GIVEN_key_service_provider_registered_WHEN_get_key_managers_THEN_delegate_call_to_service_provider() throws Exception {
-        when(mockKeyProvider.supportedKeyType()).thenReturn("FILE");
-        String keyUri = "file:///path/to/file";
+    void GIVEN_key_service_provider_registered_WHEN_get_key_managers_THEN_delegate_call_to_service_provider()
+            throws Exception {
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
+        String keyUri = "pkcs11:object=key-label";
+        String certificateUri = "file:///path/to/certificate";
         KeyManager[] mockKeyManagers = {mock(KeyManager.class)};
-        when(mockKeyProvider.getKeyManagers(keyUri)).thenReturn(mockKeyManagers);
+        when(mockKeyProvider.getKeyManagers(keyUri, certificateUri)).thenReturn(mockKeyManagers);
         service.registerCryptoKeyProvider(mockKeyProvider);
-        KeyManager[] keyManagers = service.getKeyManagers(keyUri);
+        KeyManager[] keyManagers = service.getKeyManagers(keyUri, certificateUri);
         assertThat(keyManagers, Is.is(mockKeyManagers));
     }
 
     @Test
-    void GIVEN_key_service_provider_not_registered_WHEN_get_key_managers_THEN_throw_exception () {
-        assertThrows(ServiceUnavailableException.class, () -> service.getKeyManagers("file:///path/to/file"));
+    void GIVEN_key_service_provider_not_registered_WHEN_get_key_managers_THEN_throw_exception() {
+        assertThrows(ServiceUnavailableException.class,
+                () -> service.getKeyManagers("pkcs11:object=key-label", "file:///path/to/certificate"));
+    }
+
+    @Test
+    void GIVEN_key_and_cert_uri_WHEN_get_key_managers_from_default_THEN_succeed() throws Exception {
+        Path certPath =
+                EncryptionUtilsTest.generateCertificateFile(2048, true, resourcePath.resolve("certificate.pem"));
+        Path privateKeyPath =
+                EncryptionUtilsTest.generatePkCS8PrivateKeyFile(2048, true, resourcePath.resolve("privateKey.pem"));
+
+        KeyManager[] keyManagers =
+                defaultProvider.getKeyManagers(privateKeyPath.toUri().toString(), certPath.toUri().toString());
+        assertThat(keyManagers.length, is(1));
+        X509KeyManager keyManager = (X509KeyManager) keyManagers[0];
+        assertThat(keyManager.getPrivateKey("private-key"), notNullValue());
+        assertThat(keyManager.getPrivateKey("private-key").getAlgorithm(), is("RSA"));
+    }
+
+    @Test
+    void GIVEN_non_compatible_key_uri_WHEN_get_key_managers_from_default_THEN_throw_exception() {
+        Exception e = assertThrows(KeyLoadingException.class,
+                () -> defaultProvider.getKeyManagers("pkcs11:object=key-label", "file:///path"));
+        assertThat(e.getMessage(), containsString("Only support file type private key"));
+    }
+
+    @Test
+    void GIVEN_non_compatible_cert_uri_WHEN_get_key_managers_from_default_THEN_throw_exception() {
+        Exception e = assertThrows(KeyLoadingException.class,
+                () -> defaultProvider.getKeyManagers("file:///path/to/key", "pkcs11:object=key-label"));
+        assertThat(e.getMessage(), containsString("Only support file type certificate"));
+    }
+
+    @Test
+    void GIVEN_invalid_key_PEM_WHEN_get_key_managers_from_default_THEN_throw_exception() throws Exception {
+        Path privateKeyPath = resourcePath.resolve("invalid-key.pem");
+        EncryptionUtilsTest.writePemFile("RSA PRIVATE KEY", "this is private key".getBytes(), privateKeyPath);
+        Exception e = assertThrows(KeyLoadingException.class,
+                () -> defaultProvider.getKeyManagers(privateKeyPath.toUri().toString(), "file:///path/to/certificate"));
+        assertThat(e.getMessage(), containsString( "Failed to get key manager"));
     }
 }

--- a/src/test/java/com/aws/greengrass/util/EncryptionUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/EncryptionUtilsTest.java
@@ -52,8 +52,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_certificate_pem_WHEN_load_x509_certificates_THEN_succeed() throws Exception {
-        String certificatePath = generateCertificateFile(2048, true,
-                encryptionResourcePath.resolve("certificate-2048.pem")).toString();
+        Path certificatePath = generateCertificateFile(2048, true,
+                encryptionResourcePath.resolve("certificate-2048.pem"));
 
         List<X509Certificate> certificateList = EncryptionUtils.loadX509Certificates(certificatePath);
 
@@ -64,8 +64,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_certificate_der_WHEN_load_x509_certificates_THEN_succeed() throws Exception {
-        String certificatePath = generateCertificateFile(2048, false,
-                encryptionResourcePath.resolve("certificate-2048.der")).toString();
+        Path certificatePath = generateCertificateFile(2048, false,
+                encryptionResourcePath.resolve("certificate-2048.der"));
 
         List<X509Certificate> certificateList = EncryptionUtils.loadX509Certificates(certificatePath);
 
@@ -76,8 +76,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_pkcs8_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS8PrivateKeyFile(2048, true,
-                encryptionResourcePath.resolve("pkcs8-2048.pem")).toString();
+        Path privateKeyPath = generatePkCS8PrivateKeyFile(2048, true,
+                encryptionResourcePath.resolve("pkcs8-2048.pem"));
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -87,8 +87,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_pkcs8_der_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS8PrivateKeyFile(2048, false,
-                encryptionResourcePath.resolve("pkcs8-2048.der")).toString();
+        Path privateKeyPath = generatePkCS8PrivateKeyFile(2048, false,
+                encryptionResourcePath.resolve("pkcs8-2048.der"));
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -98,8 +98,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(2048,
-                encryptionResourcePath.resolve("pkcs1-2048.pem")).toString();
+        Path privateKeyPath = generatePkCS1PrivateKeyFile(2048,
+                encryptionResourcePath.resolve("pkcs1-2048.pem"));
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -109,8 +109,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_1024_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(1024,
-                encryptionResourcePath.resolve("pkcs1-1024.pem")).toString();
+        Path privateKeyPath = generatePkCS1PrivateKeyFile(1024,
+                encryptionResourcePath.resolve("pkcs1-1024.pem"));
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -120,8 +120,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_4096_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(4096,
-                encryptionResourcePath.resolve("pkcs1-4096.pem")).toString();
+        Path privateKeyPath = generatePkCS1PrivateKeyFile(4096,
+                encryptionResourcePath.resolve("pkcs1-4096.pem"));
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -131,8 +131,8 @@ public class EncryptionUtilsTest {
 
     @Test
     void GIVEN_512_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(512,
-                encryptionResourcePath.resolve("pkcs1-512.pem")).toString();
+        Path privateKeyPath = generatePkCS1PrivateKeyFile(512,
+                encryptionResourcePath.resolve("pkcs1-512.pem"));
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -145,12 +145,12 @@ public class EncryptionUtilsTest {
         Path privateKeyPath = encryptionResourcePath.resolve("invalid-key.pem");
         writePemFile("RSA PRIVATE KEY", "this is private key".getBytes(), privateKeyPath);
 
-        assertThrows(GeneralSecurityException.class, () -> EncryptionUtils.loadPrivateKey(privateKeyPath.toString()));
+        assertThrows(GeneralSecurityException.class, () -> EncryptionUtils.loadPrivateKey(privateKeyPath));
     }
 
     @Test
     void GIVEN_key_file_not_exist_WHEN_load_private_key_THEN_throw_exception() {
-        String privateKeyPath = encryptionResourcePath.resolve("some-key.pem").toString();
+        Path privateKeyPath = encryptionResourcePath.resolve("some-key.pem");
 
         assertThrows(IOException.class, () -> EncryptionUtils.loadPrivateKey(privateKeyPath));
     }

--- a/src/test/java/com/aws/greengrass/util/EncryptionUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/EncryptionUtilsTest.java
@@ -45,14 +45,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class EncryptionUtilsTest {
+public class EncryptionUtilsTest {
 
     @TempDir
     protected static Path encryptionResourcePath;
 
     @Test
     void GIVEN_2048_certificate_pem_WHEN_load_x509_certificates_THEN_succeed() throws Exception {
-        String certificatePath = generateCertificateFile(2048, true, "certificate-2048.pem").toString();
+        String certificatePath = generateCertificateFile(2048, true,
+                encryptionResourcePath.resolve("certificate-2048.pem")).toString();
 
         List<X509Certificate> certificateList = EncryptionUtils.loadX509Certificates(certificatePath);
 
@@ -63,7 +64,8 @@ class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_certificate_der_WHEN_load_x509_certificates_THEN_succeed() throws Exception {
-        String certificatePath = generateCertificateFile(2048, false, "certificate-2048.der").toString();
+        String certificatePath = generateCertificateFile(2048, false,
+                encryptionResourcePath.resolve("certificate-2048.der")).toString();
 
         List<X509Certificate> certificateList = EncryptionUtils.loadX509Certificates(certificatePath);
 
@@ -74,7 +76,8 @@ class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_pkcs8_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS8PrivateKeyFile(2048, true, "pkcs8-2048.pem").toString();
+        String privateKeyPath = generatePkCS8PrivateKeyFile(2048, true,
+                encryptionResourcePath.resolve("pkcs8-2048.pem")).toString();
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -84,7 +87,8 @@ class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_pkcs8_der_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS8PrivateKeyFile(2048, false, "pkcs8-2048.der").toString();
+        String privateKeyPath = generatePkCS8PrivateKeyFile(2048, false,
+                encryptionResourcePath.resolve("pkcs8-2048.der")).toString();
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -94,7 +98,8 @@ class EncryptionUtilsTest {
 
     @Test
     void GIVEN_2048_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(2048, "pkcs1-2048.pem").toString();
+        String privateKeyPath = generatePkCS1PrivateKeyFile(2048,
+                encryptionResourcePath.resolve("pkcs1-2048.pem")).toString();
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -104,7 +109,8 @@ class EncryptionUtilsTest {
 
     @Test
     void GIVEN_1024_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(1024, "pkcs1-1024.pem").toString();
+        String privateKeyPath = generatePkCS1PrivateKeyFile(1024,
+                encryptionResourcePath.resolve("pkcs1-1024.pem")).toString();
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -114,7 +120,8 @@ class EncryptionUtilsTest {
 
     @Test
     void GIVEN_4096_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(4096, "pkcs1-4096.pem").toString();
+        String privateKeyPath = generatePkCS1PrivateKeyFile(4096,
+                encryptionResourcePath.resolve("pkcs1-4096.pem")).toString();
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -124,7 +131,8 @@ class EncryptionUtilsTest {
 
     @Test
     void GIVEN_512_pkcs1_pem_WHEN_load_private_key_THEN_succeed() throws Exception {
-        String privateKeyPath = generatePkCS1PrivateKeyFile(512, "pkcs1-512.pem").toString();
+        String privateKeyPath = generatePkCS1PrivateKeyFile(512,
+                encryptionResourcePath.resolve("pkcs1-512.pem")).toString();
 
         PrivateKey privateKey = EncryptionUtils.loadPrivateKey(privateKeyPath);
 
@@ -147,7 +155,7 @@ class EncryptionUtilsTest {
         assertThrows(IOException.class, () -> EncryptionUtils.loadPrivateKey(privateKeyPath));
     }
 
-    private Path generateCertificateFile(int keySize, boolean pem, String filename) throws Exception {
+    public static Path generateCertificateFile(int keySize, boolean pem, Path filepath) throws Exception {
         KeyPair keyPair = generateRSAKeyPair(keySize);
         X500Name name = new X500Name("CN=ROOT");
         SubjectPublicKeyInfo subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
@@ -161,8 +169,6 @@ class EncryptionUtilsTest {
         X509CertificateHolder holder = builder.build(signer);
         X509Certificate certificate =
                 new JcaX509CertificateConverter().setProvider(new BouncyCastleProvider()).getCertificate(holder);
-
-        Path filepath = encryptionResourcePath.resolve(filename);
 
         if (pem) {
             try (PrintWriter out = new PrintWriter(filepath.toFile())) {
@@ -179,17 +185,15 @@ class EncryptionUtilsTest {
         return filepath;
     }
 
-    private KeyPair generateRSAKeyPair(int keySize) throws Exception {
+    private static KeyPair generateRSAKeyPair(int keySize) throws Exception {
         KeyPairGenerator keygen = KeyPairGenerator.getInstance("RSA");
         keygen.initialize(keySize);
         return keygen.generateKeyPair();
     }
 
-    private Path generatePkCS8PrivateKeyFile(int keySize, boolean pem, String filename) throws Exception {
+    public static Path generatePkCS8PrivateKeyFile(int keySize, boolean pem, Path filepath) throws Exception {
         KeyPair pair = generateRSAKeyPair(keySize);
         byte[] privateKey = pair.getPrivate().getEncoded();
-
-        Path filepath = encryptionResourcePath.resolve(filename);
 
         if (pem) {
             writePemFile("PRIVATE KEY", privateKey, filepath);
@@ -202,7 +206,7 @@ class EncryptionUtilsTest {
         return filepath;
     }
 
-    private Path generatePkCS1PrivateKeyFile(int keySize, String filename) throws Exception {
+    public static Path generatePkCS1PrivateKeyFile(int keySize, Path filepath) throws Exception {
         KeyPair pair = generateRSAKeyPair(keySize);
         byte[] privateKey = pair.getPrivate().getEncoded();
         PrivateKeyInfo keyInfo = PrivateKeyInfo.getInstance(privateKey);
@@ -210,13 +214,12 @@ class EncryptionUtilsTest {
         ASN1Primitive primitive = encodable.toASN1Primitive();
         privateKey = primitive.getEncoded();
 
-        Path filepath = encryptionResourcePath.resolve(filename);
         writePemFile("RSA PRIVATE KEY", privateKey, filepath);
 
         return filepath;
     }
 
-    private void writePemFile(String type, byte[] content, Path filepath) throws Exception {
+    public static void writePemFile(String type, byte[] content, Path filepath) throws Exception {
         PemObject pemObject = new PemObject(type, content);
         try (PrintWriter printWriter = new PrintWriter(filepath.toFile());
              PemWriter pemWriter = new PemWriter(printWriter)) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Implement default file based crypto key service provider.
register it with SecurityService at the construction time so it's always available.

**Why is this change necessary:**
Default file based crypto key provider will keep the existing key loading process same.

**How was this change tested:**
Added unit test. The code is not added to use case code path yet.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
