### PR TITLE
test: disable rate limiting in AwsIotMqttClientTest

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -127,6 +127,12 @@ class AwsIotMqttClient implements Closeable {
         this.ses = ses;
     }
 
+    void disableRateLimiting() {
+        connectLimiter.setRate(Double.MAX_VALUE);
+        bandwidthLimiter.setRate(Double.MAX_VALUE);
+        transactionLimiter.setRate(Double.MAX_VALUE);
+    }
+
     long getThrottlingWaitTimeMicros() {
         // Return the worst possible wait time.
         // Time to wait is independent of how many permits we need because future transactions

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -106,6 +106,7 @@ class AwsIotMqttClientTest {
             throws ExecutionException, InterruptedException {
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
         assertNull(client.disconnect().get());
     }
 
@@ -121,6 +122,7 @@ class AwsIotMqttClientTest {
 
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
         assertThrows(ExecutionException.class, () -> {
             client.subscribe("test", QualityOfService.AT_MOST_ONCE).get();
         });
@@ -138,6 +140,7 @@ class AwsIotMqttClientTest {
 
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
         assertFalse(client.connected());
 
         when(builder.build()).thenReturn(connection);
@@ -177,6 +180,7 @@ class AwsIotMqttClientTest {
 
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
         when(builder.build()).thenReturn(connection);
 
         Map<String, QualityOfService> expectedSubs = new HashMap<>();
@@ -210,6 +214,7 @@ class AwsIotMqttClientTest {
 
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
         when(builder.build()).thenReturn(connection);
         client.publish(new MqttMessage("A", new byte[0]), QualityOfService.AT_MOST_ONCE, false).get();
         verify(connection, times(1)).publish(any(), any(), anyBoolean());
@@ -225,6 +230,7 @@ class AwsIotMqttClientTest {
         when(builder.build()).thenReturn(connection);
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
 
         //initial connect, client connects, disconnects and then connects
         client.subscribe("A", QualityOfService.AT_LEAST_ONCE);
@@ -258,6 +264,7 @@ class AwsIotMqttClientTest {
 
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
         assertFalse(client.connected());
 
         when(builder.build()).thenReturn(connection);
@@ -277,8 +284,10 @@ class AwsIotMqttClientTest {
 
         AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client1.disableRateLimiting();
         AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", mockTopic,
                 callbackEventManager, executorService, ses);
+        client2.disableRateLimiting();
         boolean sessionPresent = false;
         // callbackEventManager.hasCallBacked is originally set as False
         assertFalse(callbackEventManager.hasCallbacked());
@@ -305,8 +314,10 @@ class AwsIotMqttClientTest {
 
         AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
                 callbackEventManager, executorService, ses);
+        client1.disableRateLimiting();
         AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", mockTopic,
                 callbackEventManager, executorService, ses);
+        client2.disableRateLimiting();
         callbackEventManager.runOnConnectionResumed(false);
         assertTrue(callbackEventManager.hasCallbacked());
         int errorCode = 0;
@@ -335,6 +346,7 @@ class AwsIotMqttClientTest {
         ExecutorService mockExecutor = mock(ExecutorService.class);
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
                 callbackEventManager, mockExecutor, ses);
+        client.disableRateLimiting();
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
         when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
@@ -354,6 +366,7 @@ class AwsIotMqttClientTest {
         AwsIotMqttClient.setWaitTimeJitterMaxMillis(10);
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
 
         when(mockTopic.findOrDefault(any(), any())).thenReturn(1000);
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
@@ -391,6 +404,7 @@ class AwsIotMqttClientTest {
         AwsIotMqttClient.setWaitTimeJitterMaxMillis(1);
         AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
                 callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
 
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
         when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Speedup AwsIotMqttClientTest from 175 seconds to 7 seconds.
Total time for github CI: 21:13 --> 17:48

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
