### PR TITLE
fix(windows): move file permissions from old owner to new owner

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 public class BaseITCase {
     protected static final String WINDOWS_TEST_UESRNAME = "integ-tester";
     protected static final String WINDOWS_TEST_UESRNAME_2 = "integ-tester-2";
-    protected static final String WINDOWS_TEST_PASSWORD = "hunter2HUNTER@";
+    public static final String WINDOWS_TEST_PASSWORD = "hunter2HUNTER@";
 
     protected Path tempRootDir;
     private static Context testContext;
@@ -92,7 +92,7 @@ public class BaseITCase {
                 CONFIGURATION_CONFIG_KEY, key).withValue(value);
     }
 
-    private static void createWindowsTestUser(String username, String password)
+    public static void createWindowsTestUser(String username, String password)
             throws IOException, InterruptedException {
         Process p = new ProcessBuilder().command("net", "user", username, password, "/add").start();
         if (!p.waitFor(20, TimeUnit.SECONDS)) {
@@ -107,7 +107,7 @@ public class BaseITCase {
         }
     }
 
-    private static void deleteWindowsTestUser(String username) throws IOException, InterruptedException {
+    public static void deleteWindowsTestUser(String username) throws IOException, InterruptedException {
         Process p = new ProcessBuilder().command("net", "user", username, "/delete").start();
         if (!p.waitFor(20, TimeUnit.SECONDS)) {
             p.destroyForcibly();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/ComponentManagerIntegTest.java
@@ -104,7 +104,8 @@ class ComponentManagerIntegTest extends BaseITCase {
 
         // check perms match what we gave
         FileSystemPermission allRead = FileSystemPermission.builder().ownerRead(true).groupRead(true).otherRead(true)
-                .ownerWrite(!SystemUtils.USER_NAME.equals(ROOT)) // we preserve write permissions for non-root user
+                .ownerWrite(!PlatformResolver.isWindows && !SystemUtils.USER_NAME.equals(ROOT))
+                // we preserve write permissions for non-root user on non-windows platforms
                 .build();
 
         assertThat(zipPath.resolve("zip").resolve("1"), hasPermission(allRead));
@@ -142,13 +143,15 @@ class ComponentManagerIntegTest extends BaseITCase {
         kernel.getContext().get(ComponentManager.class).preparePackages(Collections.singletonList(ident))
                 .get(10, TimeUnit.SECONDS);
         assertThat(nucleusPaths.artifactPath(ident).resolve("script.sh"), hasPermission(
-                FileSystemPermission.builder().ownerRead(true).groupRead(true).otherRead(true).ownerWrite(
-                        !SystemUtils.USER_NAME.equals(ROOT)) // we preserve write permissions for  non-root user
+                FileSystemPermission.builder().ownerRead(true).groupRead(true).otherRead(true)
+                        .ownerWrite(!PlatformResolver.isWindows && !SystemUtils.USER_NAME.equals(ROOT))
+                        // we preserve write permissions for non-root user on non-windows platforms
                         .ownerExecute(true).groupExecute(true).build()));
 
         assertThat(nucleusPaths.artifactPath(ident).resolve("empty.txt"), hasPermission(
-                FileSystemPermission.builder().ownerRead(true).groupRead(true).ownerWrite(
-                        !SystemUtils.USER_NAME.equals(ROOT)) // we preserve write permissions for non-root user
+                FileSystemPermission.builder().ownerRead(true).groupRead(true)
+                        .ownerWrite(!PlatformResolver.isWindows && !SystemUtils.USER_NAME.equals(ROOT))
+                        // we preserve write permissions for non-root user on non-windows platforms
                         .build()));
     }
 

--- a/src/main/java/com/aws/greengrass/util/Permissions.java
+++ b/src/main/java/com/aws/greengrass/util/Permissions.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.util;
 
+import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.util.platforms.Platform;
 
 import java.io.IOException;
@@ -50,9 +51,11 @@ public final class Permissions {
                 }
             }
         } else {
-            if (!platform.lookupCurrentUser().isSuperUser() && !permission.isOwnerWrite()) {
-                // if not a super user, ownership cannot be changed and users can override permissions outside of
-                // Greengrass. Set write permission so the file can be deleted on cleanup of artifacts.
+            if (!PlatformResolver.isWindows && !platform.lookupCurrentUser().isSuperUser()
+                    && !permission.isOwnerWrite()) {
+                // If not running on windows, and not running as a super user, ownership cannot be changed and users
+                // can override permissions outside of Greengrass. Set write permission so the file can be deleted on
+                // cleanup of artifacts.
                 permission = permission.toBuilder().ownerWrite(true).build();
             }
             // don't reset the owner when setting permissions

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
@@ -41,7 +41,6 @@ import java.nio.file.attribute.AclEntryFlag;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
-import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;
@@ -54,6 +53,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUN_WITH_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.WINDOWS_USER_KEY;
@@ -71,9 +73,11 @@ public class WindowsPlatform extends Platform {
     private static final String NAMED_PIPE_UUID_SUFFIX = UUID.randomUUID().toString();
     private static final int MAX_NAMED_PIPE_LEN = 256;
     protected static final String LOCAL_SYSTEM_SID = "S-1-5-18";
+    protected static final String ADMINISTRATORS_SID = "S-1-5-32-544";
     protected static final String LOCAL_SYSTEM_USERNAME = "SYSTEM";
     protected static final WindowsUserAttributes LOCAL_SYSTEM_USER_ATTRIBUTES =
-            WindowsUserAttributes.builder().principalIdentifier(LOCAL_SYSTEM_SID).principalName(LOCAL_SYSTEM_USERNAME)
+            WindowsUserAttributes.builder().superUser(true).superUserKnown(true)
+                    .principalIdentifier(LOCAL_SYSTEM_SID).principalName(LOCAL_SYSTEM_USERNAME)
                     .build();
 
     private final SystemResourceController systemResourceController = new StubResourceController();
@@ -221,12 +225,57 @@ public class WindowsPlatform extends Platform {
 
     @Override
     protected void setOwner(UserPrincipal userPrincipal, GroupPrincipal groupPrincipal, Path path) throws IOException {
-        FileOwnerAttributeView view = Files.getFileAttributeView(path, FileOwnerAttributeView.class,
+        AclFileAttributeView view = Files.getFileAttributeView(path, AclFileAttributeView.class,
                 LinkOption.NOFOLLOW_LINKS);
 
         if (userPrincipal != null && !userPrincipal.equals(view.getOwner())) {
             logger.atTrace().setEventType(SET_PERMISSIONS_EVENT).kv(PATH, path).kv("owner", userPrincipal.toString())
                     .log();
+
+            // Changing ownership on Windows does not automatically grant any rights to the new owner.
+            // To make this behave like Unix we will actually move the permissions from the old owner over to
+            // the new owner.
+
+            UserPrincipal existingOwner = view.getOwner();
+            List<AclEntry> currentAcl = view.getAcl();
+            Set<AclEntry> newAcl = currentAcl.stream()
+                    .filter((a) -> !existingOwner.equals(a.principal()))
+                    .collect(Collectors.toSet());
+
+            Stream<AclEntry> s = currentAcl.stream()
+                    .filter((a) -> existingOwner.equals(a.principal())); // Find all rights of the current owner
+
+            GroupPrincipal greengrassPrincipal = path.getFileSystem().getUserPrincipalLookupService()
+                    .lookupPrincipalByGroupName(getPrivilegedGroup());
+            // If the current owner is the Administrator's group, then we need to do a bit of filtering
+            // so that Greengrass retains all the permissions we require.
+            if (existingOwner.equals(greengrassPrincipal)) {
+                AtomicBoolean removedOne = new AtomicBoolean(false);
+                s = s.filter(a -> {
+                    // Only operate on one ACL with the given principal and permissions.
+                    // If we have explicitly given the owner ALL_PERMS then there will be 2 ACLs
+                    // which match, so we will remap one of these and keep the other one with the Greengrass
+                    // principal.
+                    if (!removedOne.get() && a.principal().equals(existingOwner) && a.permissions().equals(ALL_PERMS)) {
+                        removedOne.set(true);
+                        // Add the permission into the new acl list so that Greengrass retains our permissions
+                        newAcl.add(a);
+                        // Filter out the permission so that we do not remap this permission over to the new owner
+                        return false;
+                    }
+                    return true;
+                });
+            }
+
+            // Copy over the permissions while changing the principal
+            newAcl.addAll(s.map(a -> AclEntry.newBuilder()
+                    .setFlags(a.flags())
+                    .setPermissions(a.permissions())
+                    .setType(a.type())
+                    .setPrincipal(userPrincipal)
+                    .build())
+                    .collect(Collectors.toSet()));
+            view.setAcl(new ArrayList<>(newAcl));
             view.setOwner(userPrincipal);
         }
 
@@ -455,10 +504,19 @@ public class WindowsPlatform extends Platform {
         } catch (Win32Exception e) {
             throw new IOException("Unrecognized user: " + user, e);
         }
+        boolean superUser = false;
+        for (Advapi32Util.Account group : Advapi32Util.getCurrentUserGroups()) {
+            if (ADMINISTRATORS_SID.equalsIgnoreCase(group.sidString)) {
+                superUser = true;
+                break;
+            }
+        }
 
         CURRENT_USER = WindowsUserAttributes.builder()
                 .principalName(account.name)
                 .principalIdentifier(account.sidString)
+                .superUserKnown(true)
+                .superUser(superUser)
                 .build();
         return CURRENT_USER;
     }

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsUserAttributes.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsUserAttributes.java
@@ -17,9 +17,14 @@ import lombok.Value;
 public class WindowsUserAttributes implements UserPlatform.UserAttributes {
     String principalName;
     String principalIdentifier;
+    boolean superUser;
+    boolean superUserKnown;
 
     @Override
     public boolean isSuperUser() {
+        if (superUserKnown) {
+            return superUser;
+        }
         // TODO: It seems on Windows, I can only check if the *current* user is an administrator or not. I cannot check
         // any given user. We may need to change the platform abstraction to only check for the current user.
         return false;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
On Windows, a file/directory's owner does not intrinsically have any permissions. Their permissions still must be granted through an ACL just like any other user. We have code to set the owner of files which we use on Unix to quickly change permissions without knowing what the permissions ought to be (we only know that the new owner should retain the old owner's rights). 
In this change, I implement setowner on Windows to copy the ACL from the old owner over to the new owner so that it effectively works in the same way as it would on unix.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
