### PR TITLE
fix(recipe): support hyphen in recipe variable regex

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -76,7 +76,7 @@ public class KernelConfigResolver {
     // Group 1 could only be word or dot (.). It is for the namespace such as "artifacts" and "configuration".
     // Group 2 is the key. For namespace "configuration", it needs to support arbitrary JSON pointer.
     // so it can take any character but not be ':' or '}', because these breaks the interpolation placeholder format.
-    private static final Pattern SAME_COMPONENT_INTERPOLATION_REGEX = Pattern.compile("\\{([.\\w]+):([^:}]+)}");
+    private static final Pattern SAME_COMPONENT_INTERPOLATION_REGEX = Pattern.compile("\\{([.\\w-]+):([^:}]+)}");
     // pattern matches {group1:group2:group3}.
     // ex. {aws.iot.aws.iot.gg.test.integ.ComponentConfigTestService:configuration:/singleLevelKey}
     // Group 1 could only be word or dot (.). It is for the component name.
@@ -84,7 +84,7 @@ public class KernelConfigResolver {
     // Group 2 is the key. For namespace "configuration", it needs to support arbitrary JSON pointer.
     // so it can take any character but not be ':' or '}', because these breaks the interpolation placeholder format.
     private static final Pattern CROSS_COMPONENT_INTERPOLATION_REGEX =
-            Pattern.compile("\\{([.\\w]+):([.\\w]+):([^:}]+)}");
+            Pattern.compile("\\{([.\\w-]+):([.\\w-]+):([^:}]+)}");
     // https://tools.ietf.org/html/rfc6901#section-5
     private static final String JSON_POINTER_WHOLE_DOC = "";
     private static final ObjectMapper MAPPER = new ObjectMapper()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Recipe variable regex did not allow for `-` in component names and namespace. This change adds `-` to the supported list.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
