### PR TITLE
fix: windowsUser config not resolved

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -56,6 +56,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAM
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SYSTEM_RESOURCE_LIMITS_TOPICS;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.WINDOWS_USER_KEY;
 import static com.aws.greengrass.lifecyclemanager.Kernel.SERVICE_TYPE_TOPIC_KEY;
 
 public class KernelConfigResolver {
@@ -259,15 +260,24 @@ public class KernelConfigResolver {
                 hasExisting = true;
             }
         }
-        if (runWith != null && runWith.hasPosixUserValue()) {
-            if (Utils.isEmpty(runWith.getPosixUser())) {
-                runWithConfig.remove(POSIX_USER_KEY);
-            } else {
-                runWithConfig.put(POSIX_USER_KEY, runWith.getPosixUser());
-            }
-        }
 
         if (runWith != null) {
+            if (runWith.hasPosixUserValue()) {
+                if (Utils.isEmpty(runWith.getPosixUser())) {
+                    runWithConfig.remove(POSIX_USER_KEY);
+                } else {
+                    runWithConfig.put(POSIX_USER_KEY, runWith.getPosixUser());
+                }
+            }
+
+            if (runWith.hasWindowsUserValue()) {
+                if (Utils.isEmpty(runWith.getWindowsUser())) {
+                    runWithConfig.remove(WINDOWS_USER_KEY);
+                } else {
+                    runWithConfig.put(WINDOWS_USER_KEY, runWith.getWindowsUser());
+                }
+            }
+
             if (runWith.getSystemResourceLimits() == null) {
                 runWithConfig.remove(SYSTEM_RESOURCE_LIMITS_TOPICS);
             } else {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Make KernelConfigResolver#updateRunWith handle `windowsUser` as well.

**Why is this change necessary:**
Otherwise the `windowsUser` config is never applied.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
