### PR TITLE
fix(authz): use getServiceName instead of getName to allow for on-demand lambdas

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCAuthorizationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCAuthorizationTest.java
@@ -5,13 +5,16 @@
 
 package com.aws.greengrass.integrationtests.ipc;
 
+import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import com.aws.greengrass.util.Coerce;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,10 +35,17 @@ import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.TEST_SERVICE_
 import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.getEventStreamRpcConnection;
 import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.prepareKernelFromConfigFile;
 import static com.aws.greengrass.ipc.AuthenticationHandler.AUTHENTICATION_TOKEN_LOOKUP_KEY;
+import static com.aws.greengrass.ipc.AuthenticationHandler.registerAuthenticationToken;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.PRIVATE_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, UniqueRootPathExtension.class})
 class IPCAuthorizationTest extends BaseITCase {
@@ -100,6 +110,28 @@ class IPCAuthorizationTest extends BaseITCase {
                 () -> validateAuthorizationToken(authTokenTopic.getName()));
         assertEquals(UnauthorizedError.class, executionException.getCause().getClass());
 
+    }
+
+    @Test
+    void GIVEN_authorizationClient_WHEN_valid_ondemand_lambda_token_provided_THEN_succeeds() {
+        GreengrassService mockService = mock(GreengrassService.class);
+        when(mockService.getServiceName()).thenReturn("ABCService");
+        lenient().when(mockService.getName()).thenReturn("ABCService#1"); // Pretend to be instance #1 of a lambda
+        when(mockService.getServiceConfig()).thenReturn(kernel.findServiceTopic("ServiceName"));
+        when(mockService.getPrivateConfig()).thenReturn(kernel.findServiceTopic("ServiceName")
+                .lookupTopics(PRIVATE_STORE_NAMESPACE_TOPIC));
+        registerAuthenticationToken(mockService);
+        Topics authTokensArray = kernel.findServiceTopic(AUTHENTICATION_TOKEN_LOOKUP_KEY);
+        boolean found = false;
+        for (Node node : authTokensArray) {
+            if ("ABCService".equals(Coerce.toString(node))) {
+                if (found) {
+                    fail("Duplicate entry!");
+                }
+                found = true;
+            }
+        }
+        assertTrue(found);
     }
 
     private boolean validateAuthorizationToken(String token) throws Exception {

--- a/src/main/java/com/aws/greengrass/ipc/AuthenticationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthenticationHandler.java
@@ -47,7 +47,7 @@ public class AuthenticationHandler implements InjectionActions {
         // If the authentication token was already registered, that's an issue, so we will retry
         // generating a new token in that case
         if (tokenTopic.getOnce() == null) {
-            tokenTopic.withValue(s.getName());
+            tokenTopic.withValue(s.getServiceName());
         } else {
             registerAuthenticationToken(s);
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
On-demand lambdas append an instance number to their name so that we can tell them apart. Authorization, however, must know the name of the service so that we can lookup the correct accessControl block for the component. This change fixes on-demand lambda authorization by switching registerAuthenticationToken to storing the service's real name via getServiceName.

**Why is this change necessary:**

**How was this change tested:**
Added new test.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
