### PR TITLE
fix(logging): remove incorrect log for bad path on Windows

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
@@ -24,6 +24,8 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -147,10 +149,15 @@ public final class ClientConfigurationUtils {
             }
             return u.toString();
         } catch (URISyntaxException e) {
+            Path p = Paths.get(path);
+            if (!Files.exists(p)) {
+                logger.atDebug()
+                        .setCause(e)
+                        .kv("path", path)
+                        .log("can't parse path string as URI and no file exists at the path");
+            }
             // if can't parse the path string as URI, try it as Path and use URI default provider "file"
-            logger.atDebug().setCause(e)
-                    .kv("path", path).log("can't parse path string as URI");
-            return Paths.get(path).toUri().toString();
+            return p.toUri().toString();
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix confusingly wrong log when the path isn't a file:// URI on Windows.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
