### PR TITLE
fix: service listen to windowsUser topic

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentRemovingUser.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentRemovingUser.json
@@ -6,7 +6,8 @@
       "ResolvedVersion": "1.0.0",
       "RootComponent": true,
       "RunWith":  {
-        "PosixUser": null
+        "PosixUser": null,
+        "WindowsUser": null
       }
     }
   ],

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_1.json
@@ -7,6 +7,7 @@
       "RootComponent": true,
       "RunWith":  {
         "PosixUser": "nobody",
+        "WindowsUser": "integ-tester",
         "systemResourceLimits": {
           "memory": 1024000,
           "cpus": 1.5

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/SampleJobDocumentWithUser_2.json
@@ -6,7 +6,8 @@
       "ResolvedVersion": "1.0.0",
       "RootComponent": true,
       "RunWith":  {
-        "PosixUser": "%s"
+        "PosixUser": "%s",
+        "WindowsUser": "%s"
       }
     }
   ],

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/CustomerAppStartupShutdown-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/CustomerAppStartupShutdown-1.0.0.yaml
@@ -12,7 +12,15 @@ ComponentDependencies:
 
 Manifests:
   - Platform:
-      os: all
+      os: windows
+    Lifecycle:
+      startup: echo starting app with user %USERNAME%
+      shutdown: echo stopping app with user %USERNAME%
+      install:
+        RequiresPrivilege: true
+        script: echo installing app with user %USERNAME%
+  - Platform:
+      os: '*'
     Lifecycle:
       startup: echo "starting app with user `id -u -n`"
       shutdown: echo "stopping app with user `id -u -n`"

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -94,6 +94,7 @@ public class GenericExternalService extends GreengrassService {
         this(c, privateSpace, Platform.getInstance());
     }
 
+    @SuppressWarnings("PMD.UselessParentheses")
     protected GenericExternalService(Topics c, Topics privateSpace, Platform platform) {
         super(c, privateSpace);
         this.platform = platform;
@@ -122,7 +123,7 @@ public class GenericExternalService extends GreengrassService {
 
             // Reinstall for changes to the install script or if the package version changed, or runWith user changed
             if (child.childOf(Lifecycle.LIFECYCLE_INSTALL_NAMESPACE_TOPIC) || child.childOf(VERSION_CONFIG_KEY)
-                    || child.childOf(RUN_WITH_NAMESPACE_TOPIC) && !child.childOf(SYSTEM_RESOURCE_LIMITS_TOPICS)) {
+                    || (child.childOf(RUN_WITH_NAMESPACE_TOPIC) && !child.childOf(SYSTEM_RESOURCE_LIMITS_TOPICS))) {
                 logger.atInfo("service-config-change").kv("configNode", child.getFullName())
                         .log("Requesting reinstallation for component");
                 requestReinstall();

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -120,9 +120,9 @@ public class GenericExternalService extends GreengrassService {
                 updateSystemResourceLimits();
             }
 
-            // Reinstall for changes to the install script or if the package version changed, or posixUser has changed
+            // Reinstall for changes to the install script or if the package version changed, or runWith user changed
             if (child.childOf(Lifecycle.LIFECYCLE_INSTALL_NAMESPACE_TOPIC) || child.childOf(VERSION_CONFIG_KEY)
-                    || child.childOf(POSIX_USER_KEY)) {
+                    || child.childOf(POSIX_USER_KEY) || child.childOf(WINDOWS_USER_KEY)) {
                 logger.atInfo("service-config-change").kv("configNode", child.getFullName())
                         .log("Requesting reinstallation for component");
                 requestReinstall();

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -122,7 +122,7 @@ public class GenericExternalService extends GreengrassService {
 
             // Reinstall for changes to the install script or if the package version changed, or runWith user changed
             if (child.childOf(Lifecycle.LIFECYCLE_INSTALL_NAMESPACE_TOPIC) || child.childOf(VERSION_CONFIG_KEY)
-                    || child.childOf(POSIX_USER_KEY) || child.childOf(WINDOWS_USER_KEY)) {
+                    || child.childOf(RUN_WITH_NAMESPACE_TOPIC) && !child.childOf(SYSTEM_RESOURCE_LIMITS_TOPICS)) {
                 logger.atInfo("service-config-change").kv("configNode", child.getFullName())
                         .log("Requesting reinstallation for component");
                 requestReinstall();

--- a/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/converter/DeploymentDocumentConverterTest.java
@@ -89,6 +89,7 @@ class DeploymentDocumentConverterTest {
         Map<String, RunWithInfo> componentToRunWithInfo = new HashMap<>();
         RunWithInfo runWithInfo = new RunWithInfo();
         runWithInfo.setPosixUser("foo:bar");
+        runWithInfo.setWindowsUser("testWindowsUser");
         SystemResourceLimits limits = new SystemResourceLimits();
         limits.setMemory(102400L);
         limits.setCpus(1.5);
@@ -96,6 +97,7 @@ class DeploymentDocumentConverterTest {
         componentToRunWithInfo.put(NEW_ROOT_COMPONENT, runWithInfo);
         runWithInfo = new RunWithInfo();
         runWithInfo.setPosixUser("1234");
+        runWithInfo.setWindowsUser("testWindowsUser2");
         componentToRunWithInfo.put(DEPENDENCY_COMPONENT, runWithInfo);
 
         // Existing: ROOT_COMPONENT_TO_REMOVE_1-1.0.0, ROOT_COMPONENT_TO_REMOVE_2-2.0.0, EXISTING_ROOT_COMPONENT-2.0.0
@@ -141,6 +143,7 @@ class DeploymentDocumentConverterTest {
         assertThat(newRootComponentConfig.getResolvedVersion(), is("2.0.0"));
         assertNull(newRootComponentConfig.getConfigurationUpdateOperation());
         assertEquals("foo:bar", newRootComponentConfig.getRunWith().getPosixUser());
+        assertEquals("testWindowsUser", newRootComponentConfig.getRunWith().getWindowsUser());
         assertEquals(1.5, newRootComponentConfig.getRunWith().getSystemResourceLimits().getCpus());
         assertEquals(102400L, newRootComponentConfig.getRunWith().getSystemResourceLimits().getMemory());
 
@@ -203,6 +206,7 @@ class DeploymentDocumentConverterTest {
         assertThat(componentConfiguration.getPackageName(), equalTo("CustomerApp2"));
         assertThat(componentConfiguration.getRunWith(), is(notNullValue()));
         assertThat(componentConfiguration.getRunWith().getPosixUser(), is(nullValue()));
+        assertThat(componentConfiguration.getRunWith().getWindowsUser(), is(nullValue()));
         assertThat(componentConfiguration.getRunWith().getSystemResourceLimits(), is(nullValue()));
         assertThat(componentConfiguration.getRunWith().hasPosixUserValue(), is(true));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- GenericExternalService also requests reinstall if windowsUser config changes, which is same behavior as posixUser
- Update tests

**Why is this change necessary:**
- Fix component not reinstalling on windows when windowsUser config changes.

**How was this change tested:**
CI

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
