### PR TITLE
refactor: change security API to accept URI instead of String

### DIFF
--- a/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
+++ b/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
@@ -8,17 +8,17 @@ package com.aws.greengrass.security;
 import com.aws.greengrass.security.exceptions.KeyLoadingException;
 import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
 
-import java.net.URISyntaxException;
+import java.net.URI;
 import java.security.KeyPair;
 import javax.net.ssl.KeyManager;
 
 public interface CryptoKeySpi {
 
-    KeyManager[] getKeyManagers(String privateKeyUri, String certificateUri) throws ServiceUnavailableException,
-            KeyLoadingException, URISyntaxException;
+    KeyManager[] getKeyManagers(URI privateKeyUri, URI certificateUri) throws ServiceUnavailableException,
+            KeyLoadingException;
 
-    KeyPair getKeyPair(String privateKeyUri) throws ServiceUnavailableException,
-            KeyLoadingException, URISyntaxException;
+    KeyPair getKeyPair(URI privateKeyUri) throws ServiceUnavailableException,
+            KeyLoadingException;
 
     String supportedKeyType();
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Using URI instead of a String since we would just convert it to URI anyway in the implementation.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
