### PR TITLE
fix(compat): partially revert 609b42, keep compatibility

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -30,11 +30,13 @@ import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.config.LogFormat;
 import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
+import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.FileSystemPermission;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.Permissions;
 import com.aws.greengrass.util.Utils;
+import com.aws.greengrass.util.exceptions.TLSAuthException;
 import com.aws.greengrass.util.platforms.Platform;
 import com.vdurmont.semver4j.Semver;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -63,6 +65,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.net.ssl.KeyManager;
 
 import static com.amazon.aws.iot.greengrass.component.common.SerializerFactory.getRecipeSerializer;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
@@ -139,7 +142,7 @@ public class DeviceConfiguration {
 
     private final Validator deTildeValidator;
     private final Validator regionValidator;
-    private final AtomicReference<Boolean> deviceConfigValidateCachedResult = new AtomicReference();
+    private final AtomicReference<Boolean> deviceConfigValidateCachedResult = new AtomicReference<>();
 
     private Topics loggingTopics;
     private LogConfigUpdate currentConfiguration;
@@ -867,5 +870,9 @@ public class DeviceConfiguration {
             }
         });
         return configUpdate.build();
+    }
+
+    public KeyManager[] getDeviceIdentityKeyManagers() throws TLSAuthException {
+        return kernel.getContext().get(SecurityService.class).getDeviceIdentityKeyManagers();
     }
 }

--- a/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
+++ b/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
@@ -23,21 +23,17 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROO
 
 public class IotConnectionManager implements Closeable {
     private final DeviceConfiguration deviceConfiguration;
-    private final ClientConfigurationUtils configurationUtils;
     private SdkHttpClient client;
 
     /**
      * Constructor.
      *
-     * @param configurationUtils Client configuration utils for getting client builder
      * @param deviceConfiguration Device configuration helper getting cert and keys for mTLS
      */
     @Inject
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public IotConnectionManager(final ClientConfigurationUtils configurationUtils,
-                                final DeviceConfiguration deviceConfiguration) {
+    public IotConnectionManager(final DeviceConfiguration deviceConfiguration) {
         this.deviceConfiguration = deviceConfiguration;
-        this.configurationUtils = configurationUtils;
         reconfigureOnConfigChange();
         this.client = initConnectionManager();
     }
@@ -73,7 +69,7 @@ public class IotConnectionManager implements Closeable {
     }
 
     private SdkHttpClient initConnectionManager() {
-        return configurationUtils.getConfiguredClientBuilder(deviceConfiguration).build();
+        return ClientConfigurationUtils.getConfiguredClientBuilder(deviceConfiguration).build();
     }
 
 

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import lombok.AccessLevel;
 import lombok.Getter;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -41,20 +40,14 @@ public class GreengrassServiceClientFactory {
     private static final Logger logger = LogManager.getLogger(GreengrassServiceClientFactory.class);
     private GreengrassV2DataClient greengrassV2DataClient;
     private String configValidationError;
-    @Getter(AccessLevel.NONE)
-    private final ClientConfigurationUtils configurationUtils;
 
     /**
      * Constructor with custom endpoint/region configuration.
      *
-     * @param configurationUtils        Client configuration utils for getting client builder
      * @param deviceConfiguration       Device configuration
      */
     @Inject
-    public GreengrassServiceClientFactory(ClientConfigurationUtils configurationUtils,
-                                          DeviceConfiguration deviceConfiguration) {
-        this.configurationUtils = configurationUtils;
-
+    public GreengrassServiceClientFactory(DeviceConfiguration deviceConfiguration) {
         deviceConfiguration.onAnyChange((what, node) -> {
             if (WhatHappened.interiorAdded.equals(what) || WhatHappened.timestampUpdated.equals(what)) {
                 return;
@@ -100,7 +93,7 @@ public class GreengrassServiceClientFactory {
 
     private void configureClient(DeviceConfiguration deviceConfiguration) {
         logger.atDebug().log(CONFIGURING_GGV2_INFO_MESSAGE);
-        ApacheHttpClient.Builder httpClient = configurationUtils.getConfiguredClientBuilder(deviceConfiguration);
+        ApacheHttpClient.Builder httpClient = ClientConfigurationUtils.getConfiguredClientBuilder(deviceConfiguration);
         GreengrassV2DataClientBuilder clientBuilder = GreengrassV2DataClient.builder()
                 // Use an empty credential provider because our requests don't need SigV4
                 // signing, as they are going through IoT Core instead
@@ -111,7 +104,7 @@ public class GreengrassServiceClientFactory {
         String region = Coerce.toString(deviceConfiguration.getAWSRegion());
 
         if (!Utils.isEmpty(region)) {
-            String greengrassServiceEndpoint = configurationUtils
+            String greengrassServiceEndpoint = ClientConfigurationUtils
                     .getGreengrassServiceEndpoint(deviceConfiguration);
 
             if (!Utils.isEmpty(greengrassServiceEndpoint)) {

--- a/src/test/java/com/aws/greengrass/iot/IotConnectionManagerTest.java
+++ b/src/test/java/com/aws/greengrass/iot/IotConnectionManagerTest.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.iot;
 
-import com.aws.greengrass.componentmanager.ClientConfigurationUtils;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
@@ -13,10 +12,8 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,17 +22,12 @@ public class IotConnectionManagerTest {
 
     private DeviceConfiguration mockDeviceConfiguration;
 
-    private ClientConfigurationUtils configurationUtils;
-
     private IotConnectionManager iotConnectionManager;
 
     @BeforeEach
     public void setup() {
         mockDeviceConfiguration = mock(DeviceConfiguration.class);
-        configurationUtils = mock(ClientConfigurationUtils.class);
-        ApacheHttpClient.Builder clientBuilder = mock(ApacheHttpClient.Builder.class);
-        when(configurationUtils.getConfiguredClientBuilder(any())).thenReturn(clientBuilder);
-        iotConnectionManager = new IotConnectionManager(configurationUtils, mockDeviceConfiguration);
+        iotConnectionManager = new IotConnectionManager(mockDeviceConfiguration);
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
609b42fb7178d2a9f7ccebde9fb844317ab635e3 changed static methods into instance methods which broke plugin users that depended on it.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
