### PR TITLE
fix(windows): prevent race condition in windows createProcess

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
@@ -104,7 +104,10 @@ public class WindowsExec extends Exec {
             winPb.environment().clear();
         }
         winPb.environment().putAll(environment);
-        Process process = winPb.directory(dir).command(commands).start();
+        winPb.directory(dir).command(commands);
+        synchronized (Kernel32.INSTANCE) {
+            process = winPb.start();
+        }
         // calling attachConsole right after a process is launched will fail with invalid handle error
         // waiting a bit ensures that we get the process handle from the pid
         try {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add a synchronized block in windows createProcess() to remove race condition.

**Why is this change necessary:**
When two processes are created at the same time in windows, they might inherit handles they are not supposed to inherit.
https://www.betaarchive.com/wiki/index.php/Microsoft_KB_Archive/315939

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
