### PR TITLE
fix: add certificate URI input to getKeyPair in CryptoKeySpi

### DIFF
--- a/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
+++ b/src/main/java/com/aws/greengrass/security/CryptoKeySpi.java
@@ -17,7 +17,7 @@ public interface CryptoKeySpi {
     KeyManager[] getKeyManagers(URI privateKeyUri, URI certificateUri) throws ServiceUnavailableException,
             KeyLoadingException;
 
-    KeyPair getKeyPair(URI privateKeyUri) throws ServiceUnavailableException,
+    KeyPair getKeyPair(URI privateKeyUri, URI certificateUri) throws ServiceUnavailableException,
             KeyLoadingException;
 
     String supportedKeyType();

--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -124,15 +124,16 @@ public final class SecurityService {
      * Get JCA KeyManagers, used for Secret manager.
      *
      * @param privateKeyUri private key URI
+     * @param certificateUri certificate URI
      * @return KeyManagers that manage the specified private key
      * @throws ServiceUnavailableException if crypto key provider service is unavailable
      * @throws KeyLoadingException if crypto key provider service fails to load key
      */
-    public KeyPair getKeyPair(URI privateKeyUri)
+    public KeyPair getKeyPair(URI privateKeyUri, URI certificateUri)
             throws ServiceUnavailableException, KeyLoadingException {
         logger.atTrace().kv(KEY_URI, privateKeyUri).log("Get keypair by key URI");
         CryptoKeySpi provider = selectCryptoKeyProvider(privateKeyUri);
-        return provider.getKeyPair(privateKeyUri);
+        return provider.getKeyPair(privateKeyUri, certificateUri);
     }
 
     public URI getDeviceIdentityPrivateKeyURI() {
@@ -213,7 +214,7 @@ public final class SecurityService {
         @Override
         public KeyManager[] getKeyManagers(URI privateKeyUri, URI certificateUri)
                 throws KeyLoadingException {
-            KeyPair keyPair = getKeyPair(privateKeyUri);
+            KeyPair keyPair = getKeyPair(privateKeyUri, certificateUri);
 
             if (!isUriSupportedKeyType(certificateUri)) {
                 logger.atError().kv(CERT_URI, certificateUri).log("Can't process the certificate type");
@@ -241,7 +242,7 @@ public final class SecurityService {
         }
 
         @Override
-        public KeyPair getKeyPair(URI privateKeyUri)
+        public KeyPair getKeyPair(URI privateKeyUri, URI certificateUri)
                 throws KeyLoadingException {
             if (!isUriSupportedKeyType(privateKeyUri)) {
                 logger.atError().kv(KEY_URI, privateKeyUri).log("Can't process the key type");

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -129,7 +129,8 @@ class SecurityServiceTest {
     @Test
     void GIVEN_key_and_cert_uri_WHEN_get_key_managers_from_default_THEN_succeed() throws Exception {
         Path certPath =
-                EncryptionUtilsTest.generateCertificateFile(2048, true, resourcePath.resolve("certificate.pem"), false);
+                EncryptionUtilsTest.generateCertificateFile(2048, true, resourcePath.resolve("certificate.pem"),
+                        false).getLeft();
         Path privateKeyPath =
                 EncryptionUtilsTest.generatePkCS8PrivateKeyFile(2048, true, resourcePath.resolve("privateKey.pem"),
                         false);

--- a/src/test/java/com/aws/greengrass/util/EncryptionUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/EncryptionUtilsTest.java
@@ -73,7 +73,7 @@ public class EncryptionUtilsTest {
             throws Exception {
         Path certificatePath =
                 generateCertificateFile(keySize, pem, encryptionResourcePath.resolve("certificate-" + keySize + ".pem"),
-                        ec);
+                        ec).getLeft();
 
         List<X509Certificate> certificateList = EncryptionUtils.loadX509Certificates(certificatePath);
 
@@ -125,7 +125,8 @@ public class EncryptionUtilsTest {
         assertThrows(IOException.class, () -> EncryptionUtils.loadPrivateKey(privateKeyPath));
     }
 
-    public static Path generateCertificateFile(int keySize, boolean pem, Path filepath, boolean ec) throws Exception {
+    public static Pair<Path, KeyPair> generateCertificateFile(int keySize, boolean pem,
+    Path filepath, boolean ec) throws Exception {
         KeyPair keyPair;
         if (ec) {
             keyPair = generateECKeyPair(keySize);
@@ -161,7 +162,7 @@ public class EncryptionUtilsTest {
             }
         }
 
-        return filepath;
+        return new Pair<>(filepath, keyPair);
     }
 
     private static KeyPair generateRSAKeyPair(int keySize) throws Exception {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
For PKCS#11, it is difficult or impossible to get the public key for a given private key, so this change adds the certificateUri as an input to `getKeyPair`. This then allows us to implement getKeyPair such that the public key will be extracted from the certificate since the certificate will have been signed by the public key and all the public key information exists in the cert.

**Why is this change necessary:**

**How was this change tested:**
Tested with a new test in Secret manager (https://github.com/aws-greengrass/aws-greengrass-secret-manager/pull/60) which verifies that we can encrypt and decrypt secrets using PKCS11.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
