### PR TITLE
fix: remove potential race condition resulting in NPE

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -709,10 +709,11 @@ public class DeviceConfiguration {
         try {
             validate(true);
             deviceConfigValidateCachedResult.set(true);
+            return true;
         } catch (DeviceConfigurationException e) {
             deviceConfigValidateCachedResult.set(false);
+            return false;
         }
-        return deviceConfigValidateCachedResult.get();
     }
 
     private Topic getTopic(String parameterName) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
E2E tests somehow got a NPE when calling `get` on the atomic reference on L715. To help avoiding that, return the boolean we just set.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
