### PR TITLE
fix: make reading pointer value work for 32bit Java

### DIFF
--- a/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
+++ b/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
@@ -69,6 +69,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.sun.jna.Native.POINTER_SIZE;
 import static com.sun.jna.platform.win32.WinBase.INVALID_HANDLE_VALUE;
 import static com.sun.jna.platform.win32.WinBase.STILL_ACTIVE;
 import static java.util.Objects.requireNonNull;
@@ -849,10 +850,17 @@ public class ProcessImplForWin32 extends Process {
         }
 
         for (int i = 0; i < stdHandles.length; i++) {
-            stdHandles[i] = handles[i].getPointer().getLong(0);
+            stdHandles[i] = getPointerLongValue(handles[i].getPointer());
         }
 
         return ret;
+    }
+
+    private static long getPointerLongValue(Pointer p) {
+        if (POINTER_SIZE == 4) {
+            return p.getInt(0);
+        }
+        return p.getLong(0);
     }
 
     private static int getExitCodeProcess(WinNT.HANDLE handle) {
@@ -910,7 +918,7 @@ public class ProcessImplForWin32 extends Process {
             if (handle == WinBase.INVALID_HANDLE_VALUE) {
                 throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
             }
-            return handle.getPointer().getLong(0);
+            return getPointerLongValue(handle.getPointer());
         }
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Trying `getLong(0)` on 32 bit Java installations will fail because the pointer size is only 4 bytes and not 8 bytes. This change adds a check and conversion to use `getInt(0)` when needed.

**Why is this change necessary:**

**How was this change tested:**
Tested on windows workspace which previously failed using a 32 bit JVM.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
