### PR TITLE
fix(easysetup): remove DescribeCertificate permission that isn't needed

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -104,7 +104,6 @@ public class DeviceProvisioningHelper {
                     + "        {\n"
                     + "            \"Effect\": \"Allow\",\n"
                     + "            \"Action\": [\n"
-                    + "                \"iot:DescribeCertificate\",\n"
                     + "                \"logs:CreateLogGroup\",\n"
                     + "                \"logs:CreateLogStream\",\n"
                     + "                \"logs:PutLogEvents\",\n"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Permission was thought to be needed for GGAD, but after GGAD redesign it is not required.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
