### PR TITLE
refactor: use char array for password. log pid after process is created

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -11,6 +11,8 @@ import com.aws.greengrass.util.platforms.Platform;
 import com.aws.greengrass.util.platforms.ShellDecorator;
 import com.aws.greengrass.util.platforms.UserDecorator;
 import lombok.Getter;
+import org.zeroturnaround.process.Processes;
+import vendored.org.apache.dolphinscheduler.common.utils.process.ProcessImplForWin32;
 
 import java.io.BufferedReader;
 import java.io.Closeable;
@@ -314,6 +316,11 @@ public abstract class Exec implements Closeable {
             throw new InterruptedException();
         }
         process = createProcess();
+
+        logger.debug("Created process with pid {}",
+                process instanceof ProcessImplForWin32 ? ((ProcessImplForWin32) process).getPid()
+                        : Processes.newPidProcess(process).getPid());
+
         stderrc = new Copier(process.getErrorStream(), stderr);
         stdoutc = new Copier(process.getInputStream(), stdout);
         stderrc.start();

--- a/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessBuilderForWin32.java
+++ b/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessBuilderForWin32.java
@@ -169,7 +169,7 @@ import java.util.Map;
 public class ProcessBuilderForWin32 {
 
     private String username;
-    private String password;
+    private char[] password;
     private List<String> command;
     private File directory;
     private Map<String,String> environment;
@@ -220,7 +220,7 @@ public class ProcessBuilderForWin32 {
      * @param password password
      * @return this process builder
      */
-    public ProcessBuilderForWin32 user(String username, String password) {
+    public ProcessBuilderForWin32 user(String username, char[] password) {
         this.username = username;
         this.password = password;
         return this;

--- a/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
+++ b/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
@@ -168,7 +168,7 @@ public class ProcessImplForWin32 extends Process {
 
     // System-dependent portion of ProcessBuilderForWindows.start()
     static Process start(String username,
-                         String password,
+                         char[] password,
                          String[] cmdarray,
                          java.util.Map<String,String> envMap,
                          String dir,
@@ -462,7 +462,7 @@ public class ProcessImplForWin32 extends Process {
 
     private ProcessImplForWin32(
             String username,
-            String password,
+            char[] password,
             String[] cmd,
             final java.util.Map<String,String> envMap,
             final String path,
@@ -695,7 +695,7 @@ public class ProcessImplForWin32 extends Process {
      * Method modified by Amazon to be able to call CreateProcessAsUser when running as a Windows service
      */
     private WinNT.HANDLE processCreate(String username,
-                                       String password,
+                                       char[] password,
                                        String cmd,
                                        final String envblock,
                                        final String path,
@@ -793,9 +793,10 @@ public class ProcessImplForWin32 extends Process {
                         createProcContext = "CreateProcessWithLogonW";
 
                         WTypes.LPWSTR lpEnvironment = envblock == null ? new WTypes.LPWSTR() : new WTypes.LPWSTR(envblock);
-                        createProcSuccess = Advapi32.INSTANCE.CreateProcessWithLogonW(username, null, password,
-                                Advapi32.LOGON_WITH_PROFILE, null, cmd, PROCESS_CREATION_FLAGS,
-                                lpEnvironment.getPointer(), path, si, pi);
+                        createProcSuccess =
+                                Advapi32.INSTANCE.CreateProcessWithLogonW(username, null, new String(password),
+                                        Advapi32.LOGON_WITH_PROFILE, null, cmd, PROCESS_CREATION_FLAGS,
+                                        lpEnvironment.getPointer(), path, si, pi);
                         createProcError = Kernel32.INSTANCE.GetLastError();
                     }
 
@@ -820,7 +821,7 @@ public class ProcessImplForWin32 extends Process {
      * Method modified by Amazon to be able to call CreateProcessAsUser when running as a Windows service
      */
     private synchronized WinNT.HANDLE create(String username,
-                                             String password,
+                                             char[] password,
                                              String cmd,
                                              java.util.Map<String,String> envMap,
                                              final String path,
@@ -944,7 +945,7 @@ public class ProcessImplForWin32 extends Process {
      * Preparation for running process as another user. Populates the given extraInfo if applicable.
      * @return environment block for CreateProcess* APIs
      */
-    private String setupRunAsAnotherUser(String username, String password, Map<String, String> envMap,
+    private String setupRunAsAnotherUser(String username, char[] password, Map<String, String> envMap,
                                          ProcessCreationExtras extraInfo) throws ProcessCreationException {
         // Get and cache process token and isService state
         synchronized (Advapi32.INSTANCE) {
@@ -970,7 +971,7 @@ public class ProcessImplForWin32 extends Process {
         int[] logonTypes =
                 {Kernel32.LOGON32_LOGON_INTERACTIVE, Kernel32.LOGON32_LOGON_SERVICE, Kernel32.LOGON32_LOGON_BATCH};
         for (int logonType : logonTypes) {
-            if (Advapi32.INSTANCE.LogonUser(username, null, password, logonType,
+            if (Advapi32.INSTANCE.LogonUser(username, null, new String(password), logonType,
                     Kernel32.LOGON32_PROVIDER_DEFAULT, userTokenHandle)) {
                 logonSuccess = true;
                 break;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- use char array for password during windows process creation
- log pid after process is created

**Why is this change necessary:**
- reduce password presence as much as possible

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
