### PR TITLE
feat: add configuration for SDK client socket and connection timeouts

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -876,4 +876,8 @@ public class DeviceConfiguration {
     public KeyManager[] getDeviceIdentityKeyManagers() throws TLSAuthException {
         return kernel.getContext().get(SecurityService.class).getDeviceIdentityKeyManagers();
     }
+
+    public Topics getHttpClientOptions() {
+        return getTopics("httpClient");
+    }
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -650,7 +650,7 @@ public class Kernel {
     }
 
     private void setupProxy() {
-        ProxyUtils.setProxyProperties(context.get(DeviceConfiguration.class));
+        ProxyUtils.setDeviceConfiguration(context.get(DeviceConfiguration.class));
     }
 
     /*

--- a/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
@@ -198,7 +198,7 @@ class ConfigurationTest {
             }
         });
         installTopic.withValue("Install");
-        assertTrue(childChangedCorrectly.await(100, TimeUnit.MILLISECONDS));
+        assertTrue(childChangedCorrectly.await(200, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
@@ -109,7 +109,7 @@ class DeviceProvisioningHelperTest {
 
     private String getThingArn() {
         return Arn.builder().service("testService")
-                .region(TEST_REGION).accountId("12345").partition("testPartition").resource("testResoruce")
+                .region(TEST_REGION).accountId("12345").partition("testPartition").resource("testResource")
                 .build().toString();
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add configurable section of Nucleus for http client options. These options are used by all HTTP clients made by the Nucleus. This can help us to debug and aid customers with slower networks.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
