### PR TITLE
fix(windows): graceful stop re-attach to original console

### DIFF
--- a/scripts/loader.cmd
+++ b/scripts/loader.cmd
@@ -92,8 +92,13 @@ FOR /L %%i IN (1,1,%MAX_RETRIES%) DO (
         echo Stopping
         EXIT /B 0
     ) ELSE (
+    rem normal exit code when using ctrl+c
+    IF !KERNEL_EXIT_CODE! EQU -1073741510 (
+        echo Stopping
+        EXIT /B 0
+    ) ELSE (
         ECHO Nucleus exited !KERNEL_EXIT_CODE!. Attempt %%i out of %MAX_RETRIES%
-    ))))
+    )))))
 )
 
 CALL :directory_is_symlink "%GG_ROOT%\alts\old" IS_SYMLINK

--- a/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessBuilderForWin32.java
+++ b/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessBuilderForWin32.java
@@ -16,6 +16,8 @@
  */
 package vendored.org.apache.dolphinscheduler.common.utils.process;
 
+import com.sun.jna.platform.win32.WinBase;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -176,6 +178,19 @@ public class ProcessBuilderForWin32 {
     private boolean redirectErrorStream;
     private ProcessBuilderForWin32.Redirect[] redirects;
 
+    /*
+     * Begin Amazon addition.
+     */
+
+    private static final int PROCESS_CREATION_FLAGS_DEFAULT = WinBase.CREATE_UNICODE_ENVIRONMENT  // use unicode
+            | WinBase.CREATE_NEW_CONSOLE;     // create new console to send ctrl-c to the process
+    private int processCreationFlags = PROCESS_CREATION_FLAGS_DEFAULT;
+
+    /*
+     * End Amazon addition.
+     */
+
+
     /**
      * Constructs a process builder with the specified operating
      * system program and arguments.  This constructor does <i>not</i>
@@ -212,6 +227,24 @@ public class ProcessBuilderForWin32 {
             this.command.add(arg);
         }
     }
+
+    /*
+     * Begin Amazon addition.
+     */
+
+    /**
+     * Override the process creation flags to use when calling create process APIs.
+     * @param flags same as dwCreationFlags argument in create process APIs.
+     * @return this process builder
+     */
+    public ProcessBuilderForWin32 processCreationFlags(int flags) {
+        processCreationFlags = flags;
+        return this;
+    }
+
+    /*
+     * End Amazon addition.
+     */
 
     /**
      * set username and password for process
@@ -1081,7 +1114,8 @@ public class ProcessBuilderForWin32 {
                     environment,
                     dir,
                     redirects,
-                    redirectErrorStream);
+                    redirectErrorStream,
+                    processCreationFlags);
         } catch (IOException | IllegalArgumentException e) {
             String exceptionInfo = ": " + e.getMessage();
             Throwable cause = e;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Add a ProcessBuilderForWin32 setting `processCreationFlags`
- Use 0 as the `processCreationFlags` when creating the graceful stop holder process, so that it inherits the same console. Before the change, we use Java's ProcessBuilder which [uses the CREATE_NO_WINDOW flag](https://github.com/openjdk/jdk/blob/d8f6b6c19a591512ff4e956823cb87a83e088ae8/src/java.base/windows/native/libjava/ProcessImpl_md.c#L319). That effectively creates a new console based on our experiments (calling [GetConsoleProcessList](https://docs.microsoft.com/en-us/windows/console/getconsoleprocesslist)). Which prevented us from sending Ctrl-C to nucleus because it's no longer attached to its original console after gracefully stopping a component.
- Windows loader script accepts -1073741510 (0xC000013A) as ctrl-c exit code. [Official doc](https://support.microsoft.com/en-us/topic/how-to-troubleshoot-scheduled-tasks-in-windows-xp-and-in-windows-server-2003-4f0878e1-91a0-681f-7927-058096807ffe)

**Why is this change necessary:**
- Fix Nucleus not able to receive Ctrl-C signal.

**How was this change tested:**
Local workspace.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
