### PR TITLE
fix: windows stopGracefully synchronization

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
@@ -151,23 +151,23 @@ public class WindowsExec extends Exec {
         if (!process.isAlive()) {
             return;
         }
-        // First, start a separate process that holds the console alive
-        // so that later gg can re-attach to this same console
-        Process holderProc;
-        int holderProcPid;
-        try {
-            // This will call CreateProcessW and inherit the same console
-            // The pause command waits indefinitely for a keystroke
-            holderProc = new ProcessBuilderForWin32("cmd", "/C", "pause").processCreationFlags(0).start();
-            holderProcPid = ((ProcessImplForWin32) holderProc).getPid();
-        } catch (IOException e) {
-            logger.atError(STOP_GRACEFULLY_EVENT).cause(e)
-                    .log("Failed to start holder process. Cannot stop gracefully");
-            return;
-        }
 
         boolean sentConsoleCtrlEvent = false;
         synchronized (Kernel32.INSTANCE) {
+            // First, start a separate process that holds the console alive
+            // so that later gg can re-attach to this same console
+            Process holderProc;
+            int holderProcPid;
+            try {
+                // This will call CreateProcessW and inherit the same console
+                // The pause command waits indefinitely for a keystroke
+                holderProc = new ProcessBuilderForWin32("cmd", "/C", "pause").processCreationFlags(0).start();
+                holderProcPid = ((ProcessImplForWin32) holderProc).getPid();
+            } catch (IOException e) {
+                logger.atError(STOP_GRACEFULLY_EVENT).cause(e)
+                        .log("Failed to start holder process. Cannot stop gracefully");
+                return;
+            }
 
             Kernel32 k32 = Kernel32.INSTANCE;
             try {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Also put holder process creation into synced block.

**Why is this change necessary:**
Concurrent `stopGracefully` causes nucleus to attach to wrong console.

e.g. 1st invocation attached to the target process' console, then 2nd invocation starts the holder in that console. In the end of the 2nd invocation, nucleus will re-attach to the wrong console.

**How was this change tested:**
Local workspace.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
