### PR TITLE
Minor fixes - Provisioning IAM:GetPolicy fallback, Resource limits race condition, Windows bootstrap script dependency on powershell

### DIFF
--- a/conf/recipe.yaml
+++ b/conf/recipe.yaml
@@ -59,13 +59,4 @@ Manifests:
       bootstrap:
         RequiresPrivilege: true
         script: >-
-          powershell -command "& { Set-StrictMode -Version Latest;
-          $ErrorActionPreference = \"Stop\";
-          $PSDefaultParameterValues['*:ErrorAction']=\"Stop\";
-          $KernelRoot = \"{kernel:rootPath}\";
-          $UnpackDir = \"{artifacts:decompressedPath}\aws.greengrass.nucleus\";
-          $CurrentDir = Join-Path -Path $KernelRoot -ChildPath \"alts\current\";
-          Get-ChildItem -Path $CurrentDir -Force -Recurse | ForEach-Object { $_.Delete() };
-          echo {configuration:/jvmOptions} > \"$CurrentDir\launch.params\";
-          New-Item -Path \"$CurrentDir\distro\" -ItemType SymbolicLink -Value \"$UnpackDir\";
-          exit 100; }"
+          del /q {kernel:rootPath}\alts\current\*&& for /d %x in ({kernel:rootPath}\alts\current\*) do @rd /s /q "%x"&& echo {configuration:/jvmOptions} > {kernel:rootPath}\alts\current\launch.params&& mklink /d {kernel:rootPath}\alts\current\distro {artifacts:decompressedPath}\aws.greengrass.nucleus&& exit 100

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -491,10 +491,11 @@ public class DeviceProvisioningHelper {
             if (e.getMessage().contains("not authorized to perform")) {
                 outStream.printf("Encountered error - %s; No permissions to lookup managed policy, "
                         + "looking for a user defined policy...%n", e.getMessage());
+            } else {
+                outStream.printf("Exiting due to unexpected error while looking up managed policy - %s %n",
+                        e.getMessage());
+                throw e;
             }
-            outStream.printf("Exiting due to unexpected error while looking up managed policy - %s %n",
-                    e.getMessage());
-            throw e;
         }
         // Check if a customer policy exists with the name
         try {
@@ -510,10 +511,11 @@ public class DeviceProvisioningHelper {
                                 + " wish to use an existing policy instead, please make sure the credentials used for "
                                 + "setup have iam::getPolicy permissions for the policy resource and retry...%n",
                         e.getMessage());
+            } else {
+                outStream.printf("Exiting due to unexpected error while looking up user defined policy - %s%n",
+                        e.getMessage());
+                throw e;
             }
-            outStream.printf("Exiting due to unexpected error while looking up user defined policy - %s%n",
-                    e.getMessage());
-            throw e;
         }
         return Optional.empty();
     }

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/linux/LinuxSystemResourceController.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/linux/LinuxSystemResourceController.java
@@ -165,7 +165,7 @@ public class LinuxSystemResourceController implements SystemResourceController {
             throws IOException {
 
         if (!Files.exists(cg.getSubsystemComponentPath(component))) {
-            logger.atInfo().kv(COMPONENT_NAME, component).kv("resource-controller", cg.toString())
+            logger.atDebug().kv(COMPONENT_NAME, component).kv("resource-controller", cg.toString())
                     .log("Resource controller is not enabled");
             return;
         }


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
1. Fix easysetup to not fail on unauthorized error in iam::getPolicy since we have fallback steps in case the IAM getPolicy permissions are not available for provisioning 
2. Make resource limit not enabled log at debug level to reduce noise in logging
3. Fix race condition in adding pid to cgroup, i.e. sometimes a child process is created right when existing pids are being added to the resource limit cgroups, so the child pid is never added to the cgroup by greengrass lifecycle or by linux
4. Nucleus bootstrap command currently uses powershell introducing a hard dependency on it, moving to cmd to avoid that. It includes the same set of steps as linux/earlier powershell script i.e. on bootstrap, remove contents of <root>/alts/current, create a new launch.params file with the new component configuration for launch params, and create a new symlink for distro targeting the newly downloaded nucleus artifact

**Why is this change necessary:**
1. Setup should not fail if the iam::getpolicy permissions are not available but the permissions for the fallback steps i.e. get user policy or createPolicy are present
2. Log for resource limit not enabled case is distracting to customers
3. All component pids started by Greengrass should be added to resource limit cgroups for resource limits to be applied correctly.

**How was this change tested:**
- Unit tests for provisioning fix
- UATs for resource limits passed consistently when run ~15 times
- UATs for OTA workflow pass on windows

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
