### PR TITLE
consider empty or pkcs11-type uri case for certificateFilePath validations

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -776,7 +776,7 @@ public class DeviceConfiguration {
         if (Utils.isEmpty(thingName)) {
             errors.add(DEVICE_PARAM_THING_NAME + CANNOT_BE_EMPTY);
         }
-        if (Utils.isEmpty(certificateFilePath)) {
+        if (!Utils.isPkcs11Uri(privateKeyPath) && Utils.isEmpty(certificateFilePath)) {
             errors.add(DEVICE_PARAM_CERTIFICATE_FILE_PATH + CANNOT_BE_EMPTY);
         }
         if (Utils.isEmpty(privateKeyPath)) {

--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -199,8 +199,24 @@ public final class SecurityService {
         return uriFromPossibleFileURIString(Coerce.toString(deviceConfiguration.getPrivateKeyFilePath()));
     }
 
+    /**
+     * Get URI for configured certificate-path.
+     * Configured certificate-path can be empty for PKCS11-type keys.
+     *
+     * @return URI of device-identity certificate
+     */
     public URI getDeviceIdentityCertificateURI() {
-        return uriFromPossibleFileURIString(Coerce.toString(deviceConfiguration.getCertificateFilePath()));
+        try {
+            String certPath = Coerce.toString(deviceConfiguration.getCertificateFilePath());
+            if (Utils.isNotEmpty(certPath)) {
+                return uriFromPossibleFileURIString(Coerce.toString(deviceConfiguration.getCertificateFilePath()));
+            }
+            // certificate path can be empty in case of PKCS11 keys
+            return new URI("");
+        } catch (URISyntaxException ignored) {
+            // unreachable null, provided downstream (uriFromPossibleFileURIString()) handles URISyntaxException
+            return null;
+        }
     }
 
     private CryptoKeySpi selectCryptoKeyProvider(URI uri) throws ServiceUnavailableException {

--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -51,6 +51,7 @@ public final class Utils {
     private static final int BASE_10 = 10;
     private static final String TRUNCATED_STRING = "...";
     private static final String FILE_URL_PREFIX = "file://";
+    private static final String PKCS11_URI_SCHEME = "pkcs11";
     private static final Map<Runnable, Boolean> onceMap = new ConcurrentHashMap<>();
     private static SecureRandom random;
 
@@ -707,6 +708,27 @@ public final class Utils {
     public static String loadParamMaybeFile(String param) throws URISyntaxException, IOException {
         return param.startsWith(FILE_URL_PREFIX) ? new String(Files.readAllBytes(Paths.get(new URI(param))),
                 StandardCharsets.UTF_8) : param;
+    }
+
+    /**
+     * Check if the given string is a PKCS11-type URI.
+     *
+     * @param str String
+     * @return boolean showing whether given string is a PKCS11-type URI
+     */
+    public static boolean isPkcs11Uri(String str) {
+        if (Utils.isEmpty(str)) {
+            return false;
+        }
+        try {
+            URI uri = new URI(str);
+            if (Utils.isNotEmpty(uri.getScheme()) && PKCS11_URI_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+                return true;
+            }
+        } catch (URISyntaxException e) {
+            return false;
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/util/UtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/UtilsTest.java
@@ -129,6 +129,15 @@ class UtilsTest {
     }
 
     @Test
+    void testStringIsPkcs11Uri() {
+        assertTrue(Utils.isPkcs11Uri("pkcs11:object=iotkey;type=private"));
+        assertFalse(Utils.isPkcs11Uri("file:///random/path/"));
+        assertFalse(Utils.isPkcs11Uri("pkcs:object=iotkey;type=private"));
+        assertFalse(Utils.isPkcs11Uri(""));
+        assertFalse(Utils.isPkcs11Uri(null));
+    }
+
+    @Test
     void immutableMapWrite() {
         Map<String, Integer> map = Utils.immutableMap("a", 1);
         assertThat(map.get("a"), is(equalTo(1)));


### PR DESCRIPTION
**Description of changes:**
- Modifies validations for `certificateFilePath` to allow the case when certificateFilePath value could be empty (for PKCS11-type keys).
- Requires `certificateFilePath`  to be non-empty only if privateKey path is file-type.

**Why is this change necessary:**
 - `certificateFilePath` is ignored while building MQTT client if privateKey and certificate are stored onto an HSM (PKCS11) device. Certificate is accessed using the same label as the privateKey stored in PKCS11. So user may not configure certificateFilePath in case of PKCS11-type keys
- for reference: https://github.com/aws-greengrass/aws-greengrass-pkcs11-provider/pull/13


**How was this change tested:**
- unit tests
- integration tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
