### PR TITLE
fix: reduce retry when getting group info for local deployment

### DIFF
--- a/.github/workflows/externalPR.yml
+++ b/.github/workflows/externalPR.yml
@@ -59,6 +59,8 @@ jobs:
           skip_covered: false
           # Minimum allowed coverage percentage as an integer.
           minimum_coverage: 65
+          # Fail the action when the minimum coverage was not met.
+          fail_below_threshold: false
           # Show line rate as specific column.
           show_line: true
           # Show branch rate as specific column.
@@ -80,6 +82,8 @@ jobs:
           skip_covered: false
           # Minimum allowed coverage percentage as an integer.
           minimum_coverage: 58
+          # Fail the action when the minimum coverage was not met.
+          fail_below_threshold: false
           # Show line rate as specific column.
           show_line: true
           # Show branch rate as specific column.

--- a/.github/workflows/externalPR.yml
+++ b/.github/workflows/externalPR.yml
@@ -48,7 +48,7 @@ jobs:
           python3 .github/scripts/binaryCompatibility.py --input japicmp/default-cli.xml
           --token "${{ github.token }}" --pr "${{ env.PR }}" --sha "${{ env.SHA }}"
       - name: cobertura-report-unit-test
-        uses: 5monkeys/cobertura-action@master
+        uses: 5monkeys/cobertura-action@v9
         continue-on-error: true
         with:
           # The GITHUB_TOKEN for this repo
@@ -71,7 +71,7 @@ jobs:
           report_name: Unit Tests Coverage Report
           pull_request_number: ${{ steps.outputs.outputs.PR }}
       - name: cobertura-report-integration-test
-        uses: 5monkeys/cobertura-action@master
+        uses: 5monkeys/cobertura-action@v9
         continue-on-error: true
         with:
           # The GITHUB_TOKEN for this repo

--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -45,7 +45,6 @@ import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverte
  * A task of deploying a configuration specified by a deployment document to a Greengrass device.
  */
 public class DefaultDeploymentTask implements DeploymentTask {
-    private static final int FINITE_RETRY_COUNT = 10;
     private static final int INFINITE_RETRY_COUNT = Integer.MAX_VALUE;
 
     private static final String DEPLOYMENT_TASK_EVENT_TYPE = "deployment-task-execution";
@@ -189,7 +188,8 @@ public class DefaultDeploymentTask implements DeploymentTask {
         // hierarchy and fall back to hierarchy stored previously in worst case. For cloud deployment, use infinite
         // retries by default similar/to all other cloud interactions.
         boolean isLocalDeployment = Deployment.DeploymentType.LOCAL.equals(deployment.getDeploymentType());
-        int retryCount = isLocalDeployment ? FINITE_RETRY_COUNT : INFINITE_RETRY_COUNT;
+        // SDK already retries with RetryMode.STANDARD. For local deployment we don't retry on top of that
+        int retryCount = isLocalDeployment ? 1 : INFINITE_RETRY_COUNT;
 
         Optional<Set<String>> groupsForDeviceOpt;
         try {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- No retry on top of SDK standard retry when getting thing group info during local deployment

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
