### PR TITLE
fix: log runtime exceptions occurred while setting up Shadow communications

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -199,6 +199,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         setupShadowCommunications();
     }
 
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void setupShadowCommunications() {
 
         if (subscriptionFuture != null && !subscriptionFuture.isDone()) {
@@ -219,10 +220,14 @@ public class ShadowDeploymentListener implements InjectionActions {
                             + "Shadow subscriptions");
                     return;
                 }
-                subscribeToShadowTopics();
-                this.isSubscribedToShadowTopics.set(true);
-                // Get the shadow state when kernel starts up by publishing to get topic
-                publishToGetDeviceShadowTopic();
+                try {
+                    subscribeToShadowTopics();
+                    this.isSubscribedToShadowTopics.set(true);
+                    // Get the shadow state when kernel starts up by publishing to get topic
+                    publishToGetDeviceShadowTopic();
+                } catch (RuntimeException e) {
+                    logger.atError().setCause(e).log("Error while setting up Device Shadow communications");
+                }
             });
         }
     }


### PR DESCRIPTION
**Issue #, if available:** When kernel starts up, subscribing to Device-Shadow topics task is [executed through an ExecutorService](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/main/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java#L214-L226). Runtime exceptions while executing this task are currently not handled/logged. One such exception is thrown when it [fails to create MqttConnectionBuilder](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/main/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java#L177) while [subscribing to shadow topics](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/3537c0a4169d05240eed2cac61e8cabac98da4d2/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java#L754) when kernel starts up. Absence of logs for such exceptions makes it hard to debug issues.

**Description of changes:** Adds error-log for runtime exceptions occurred during subscribe/publish to Shadow topics. I believe such exceptions are non-retryable.

**How was this change tested:** `mvn verify`

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
