### PR TITLE
feat: add interface to enable blocking service state transitions by a plugin

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/StateTransitionAllowerService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/StateTransitionAllowerService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.lifecyclemanager;
+
+import com.aws.greengrass.dependency.State;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+
+public final class StateTransitionAllowerService {
+    private final Set<StateTransitionAllower> stateTransitionAllowerSet = Collections.synchronizedSet(new HashSet<>());
+
+    @Inject
+    public StateTransitionAllowerService() {
+    }
+
+    public void registerStateTransitionAllower(StateTransitionAllower allower) {
+        stateTransitionAllowerSet.add(allower);
+    }
+
+    public void deregisterStateTransitionAllower(StateTransitionAllower allower) {
+        stateTransitionAllowerSet.remove(allower);
+    }
+
+    /**
+     * Check if the state transition is allowed.
+     *
+     * @param service the service which wants to change state
+     * @param from state to transition from
+     * @param to state to transition to
+     * @return false if the state transition is not allowed.
+     */
+    public boolean isStateTransitionAllowed(GreengrassService service, State from, State to) {
+        for (StateTransitionAllower allower : stateTransitionAllowerSet) {
+            if (!allower.allowStateTransition(service, from, to)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @FunctionalInterface
+    public interface StateTransitionAllower {
+        boolean allowStateTransition(GreengrassService service, State oldState, State newState);
+    }
+}

--- a/src/test/greengrass-nucleus-benchmark/pom.xml
+++ b/src/test/greengrass-nucleus-benchmark/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.aws.greengrass</groupId>
     <artifactId>greengrass-nucleus-benchmark</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.0-CLUSTER-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JMH benchmark sample: Java</name>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.6.0-CLUSTER-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -99,6 +99,9 @@ class LifecycleTest {
         context.put(ThreadPoolExecutor.class, ses);
         context.put(Clock.class, Clock.systemUTC());
         context.put(Kernel.class, mock(Kernel.class));
+        StateTransitionAllowerService sta = mock(StateTransitionAllowerService.class);
+        lenient().when(sta.isStateTransitionAllowed(any(), any(), any())).thenReturn(true);
+        context.put(StateTransitionAllowerService.class, sta);
 
         Topics rootConfig = new Configuration(context).getRoot();
         config = rootConfig.createInteriorChild(GreengrassService.SERVICES_NAMESPACE_TOPIC)

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/GGServiceTestUtil.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/GGServiceTestUtil.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
+import com.aws.greengrass.lifecyclemanager.StateTransitionAllowerService;
 import com.aws.greengrass.lifecyclemanager.UpdateSystemPolicyService;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,6 +24,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.PRIVATE_STOR
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.Lifecycle.STATE_TOPIC_NAME;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -57,6 +59,9 @@ public class GGServiceTestUtil {
     @Mock
     private KernelAlternatives kernelAlternatives;
 
+    @Mock
+    private StateTransitionAllowerService stateTransitionAllowerService;
+
     public Topics initializeMockedConfig() {
         lenient().when(config.lookupTopics(eq(RUNTIME_STORE_NAMESPACE_TOPIC), anyString(), anyString()))
                 .thenReturn(runtimeStoreTopic);
@@ -74,6 +79,8 @@ public class GGServiceTestUtil {
         lenient().when(context.get(Kernel.class)).thenReturn(mock(Kernel.class));
         lenient().when(context.get(eq(UpdateSystemPolicyService.class))).thenReturn(updateSystemPolicyService);
         lenient().when(context.get(KernelAlternatives.class)).thenReturn(kernelAlternatives);
+        lenient().when(stateTransitionAllowerService.isStateTransitionAllowed(any(), any(), any())).thenReturn(true);
+        lenient().when(context.get(StateTransitionAllowerService.class)).thenReturn(stateTransitionAllowerService);
         return config;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add an interface to allow a plugin to prevent the state transition of Greengrass services. If any registered allower disallows the state transition, then the state transition will not be allowed to proceed.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
