### PR TITLE
fix(win32): set invalid handle value properly on 32 bit systems

### DIFF
--- a/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
+++ b/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
@@ -95,7 +95,11 @@ public class ProcessImplForWin32 extends Process {
 
     private static final int OFFSET_WRITE = 1;
 
-    private static final WinNT.HANDLE JAVA_INVALID_HANDLE_VALUE = new WinNT.HANDLE(Pointer.createConstant(-1));
+    // From https://github.com/java-native-access/jna/blob/cb98ab22196855933eb6315f2663d1b4a03ff261/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java#L51-L53
+    // 4294967295 is 2^32.
+    // Pointer size 8 bytes means 64 bit. 4 bytes would mean 32 bit.
+    private static final WinNT.HANDLE JAVA_INVALID_HANDLE_VALUE =
+            new WinNT.HANDLE(Pointer.createConstant(POINTER_SIZE == 8 ? -1L : 4294967295L));
 
     /*
      * Begin Amazon addition.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Properly set the invalid handle value on 32 bit Windows systems. Based on https://github.com/java-native-access/jna/blob/master/contrib/platform/src/com/sun/jna/platform/win32/WinBase.java#L51-L53

Without this change, our code believes that it does not need to create the standard out/error pipes because it thinks that we're passing in a valid handle already, meaning that the process will write to a file which exists instead of pipes that we need to create first.

**Why is this change necessary:**

**How was this change tested:**
Verified that logs are provided on both 32 and 64 bit JVMs. Without this change only 64 bit JVMs work properly.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
