### PR TITLE
feat: add optional setting to enable interpolation in configuration during deployments

### DIFF
--- a/README_CONFIG_SCHEMA.md
+++ b/README_CONFIG_SCHEMA.md
@@ -158,6 +158,7 @@ services:
       awsRegion: "us-east-1"
       componentStoreMaxSizeBytes: 10000000000
       deploymentPollingFrequencySeconds: 15
+      interpolateComponentConfiguration: false
       iotCredEndpoint: "xxxxxx.credentials.iot.us-east-1.amazonaws.com"
       iotDataEndpoint: "xxxxxx-ats.iot.us-east-1.amazonaws.com"
       iotRoleAlias: "tes_alias"

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -85,7 +85,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 /**
  * Class for providing device configuration information.
  */
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessivePublicCount"})
 @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
 public class DeviceConfiguration {
 
@@ -99,6 +99,7 @@ public class DeviceConfiguration {
     public static final String DEVICE_PARAM_PRIVATE_KEY_PATH = "privateKeyPath";
     public static final String DEVICE_PARAM_CERTIFICATE_FILE_PATH = "certificateFilePath";
     public static final String DEVICE_PARAM_ROOT_CA_PATH = "rootCaPath";
+    public static final String DEVICE_PARAM_INTERPOLATE_COMPONENT_CONFIGURATION = "interpolateComponentConfiguration";
     public static final String SYSTEM_NAMESPACE_KEY = "system";
     public static final String PLATFORM_OVERRIDE_TOPIC = "platformOverride";
     public static final String DEVICE_PARAM_AWS_REGION = "awsRegion";
@@ -583,6 +584,10 @@ public class DeviceConfiguration {
     public Topic getRootCAFilePath() {
         return kernel.getConfig().lookup(SYSTEM_NAMESPACE_KEY, DEVICE_PARAM_ROOT_CA_PATH).dflt("")
                 .addValidator(deTildeValidator);
+    }
+
+    public Topic getInterpolateComponentConfiguration() {
+        return getTopic(DEVICE_PARAM_INTERPOLATE_COMPONENT_CONFIGURATION).dflt(false);
     }
 
     public Topic getIotDataEndpoint() {


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Added a new setting, `interpolateConfiguration` to nucleus config that allows configuration to be interpolated during a deployment. Extended interpolation to handle lists.

**Why is this change necessary:**
We want to be able to deploy the LegacySubscriptionRouter in a thinggroup deployment, but have it create subscriptions to device specific topics. For example, we may wish to create a subscription to the thing's shadow topics which currently would either require subscribing all greengrass devices to all thing's shadow changes (through a wildcard subscription) which is obviously untenable, or deploy the LegacySubscriptionRouter component individually to each device. The latter option however means that we have to build up a separate infrastructure for keeping those deployments up to date any time we need to add a new subscription across to the devices in our fleet. By allowing interpolation inside configuration, we could create a single fleet-wide deployment which references `{iot:thingName}`.

**How was this change tested:**

I have done some preliminary testing using our real world scenario, as well having added several unit tests to confirm the behavior of the interpolation. To keep the change backwards compatible, the new behavior defaults to off.

**Any additional information or context required to review the change:**

**Checklist:**
 - [X] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
