### PR TITLE
fix(WindowsExec): env var loading order

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecIntegTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.util;
+
+import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.util.Exec;
+import com.aws.greengrass.util.platforms.Platform;
+import com.sun.jna.platform.win32.Advapi32Util;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ExecIntegTest extends BaseITCase {
+
+    private static final String TEST_ENV_ENTRY = "integ_test_env";
+    private static final String SYSTEM_ENV_REG_KEY = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+
+    private static String testUserEnvRegKey;
+
+    @AfterAll
+    static void cleanup() throws IOException, InterruptedException {
+        deleteRegistryEntry(SYSTEM_ENV_REG_KEY, TEST_ENV_ENTRY);
+        if (testUserEnvRegKey != null) {
+            deleteRegistryEntry(testUserEnvRegKey, TEST_ENV_ENTRY);
+        }
+    }
+
+    private static void deleteRegistryEntry(String key, String entry) throws IOException, InterruptedException {
+        // reg command reference https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg
+        Process p = new ProcessBuilder("reg", "delete", key, "/f", "/v", entry).start();
+        if (!p.waitFor(20, TimeUnit.SECONDS)) {
+            p.destroyForcibly();
+            fail("delete registry entry timeout");
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void GIVEN_windows_exec_WHEN_set_env_vars_from_multiple_sources_THEN_precedence_is_correct()
+            throws IOException, InterruptedException {
+        // Check setting default env works
+        // setDefaultEnv is static and will persist throughout this test.
+        String expectedVal = "Exec default";
+        Exec.setDefaultEnv(TEST_ENV_ENTRY, expectedVal);
+        try (Exec exec = Platform.getInstance().createNewProcessRunner()) {
+            String output = exec.cd("C:\\")  // cd in case test user doesn't have permission to access current directory
+                    .withUser(WINDOWS_TEST_UESRNAME)
+                    .withShell("echo", "%" + TEST_ENV_ENTRY + "%")
+                    .execAndGetStringOutput();
+            assertEquals(expectedVal, output);
+        }
+
+        // Set system-level env var via registry. should override the default
+        expectedVal = "system env var";
+        try (Exec exec = Platform.getInstance().createNewProcessRunner()) {
+            String output = exec
+                    .withShell("reg", "add", SYSTEM_ENV_REG_KEY,
+                            "/f", "/v", TEST_ENV_ENTRY, "/t", "REG_SZ", "/d", expectedVal)
+                    .execAndGetStringOutput();
+            assertThat(output, containsString("completed successfully"));
+        }
+
+        try (Exec exec = Platform.getInstance().createNewProcessRunner()) {
+            String output = exec.cd("C:\\").withUser(WINDOWS_TEST_UESRNAME)
+                    .withShell("echo", "%" + TEST_ENV_ENTRY + "%").execAndGetStringOutput();
+            assertEquals(expectedVal, output);
+        }
+
+        // Set user-level env var via registry. should override the system-level setting
+        // FYI: Usually, user-level setting has higher precedence than system-level. PATH is special.
+        // User PATH is appended to system-level PATH by windows.
+        expectedVal = "user account env var";
+        String testUserSid = Advapi32Util.getAccountByName(WINDOWS_TEST_UESRNAME).sidString;
+        testUserEnvRegKey = String.format("HKU\\%s\\Environment", testUserSid);
+        try (Exec exec = Platform.getInstance().createNewProcessRunner()) {
+            String output = exec
+                    .cd("C:\\")
+                    .withUser(WINDOWS_TEST_UESRNAME)
+                    .withShell("reg", "add", testUserEnvRegKey, "/f", "/v", TEST_ENV_ENTRY, "/t", "REG_SZ", "/d", expectedVal)
+                    .execAndGetStringOutput();
+            assertThat(output, containsString("completed successfully"));
+        }
+
+        try (Exec exec = Platform.getInstance().createNewProcessRunner()) {
+            String output = exec.cd("C:\\").withUser(WINDOWS_TEST_UESRNAME)
+                    .withShell("echo", "%" + TEST_ENV_ENTRY + "%").execAndGetStringOutput();
+            assertEquals(expectedVal, output);
+        }
+
+        // Use setenv, which overrides everything
+        expectedVal = "setenv override";
+        try (Exec exec = Platform.getInstance().createNewProcessRunner()) {
+            String output = exec.cd("C:\\").withUser(WINDOWS_TEST_UESRNAME).setenv(TEST_ENV_ENTRY, expectedVal)
+                    .withShell("echo", "%" + TEST_ENV_ENTRY + "%").execAndGetStringOutput();
+            assertEquals(expectedVal, output);
+        }
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecIntegTest.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.platforms.Platform;
 import com.sun.jna.platform.win32.Advapi32Util;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -31,9 +32,11 @@ public class ExecIntegTest extends BaseITCase {
 
     @AfterAll
     static void cleanup() throws IOException, InterruptedException {
-        deleteRegistryEntry(SYSTEM_ENV_REG_KEY, TEST_ENV_ENTRY);
-        if (testUserEnvRegKey != null) {
-            deleteRegistryEntry(testUserEnvRegKey, TEST_ENV_ENTRY);
+        if (SystemUtils.IS_OS_WINDOWS) {
+            deleteRegistryEntry(SYSTEM_ENV_REG_KEY, TEST_ENV_ENTRY);
+            if (testUserEnvRegKey != null) {
+                deleteRegistryEntry(testUserEnvRegKey, TEST_ENV_ENTRY);
+            }
         }
     }
 
@@ -48,7 +51,7 @@ public class ExecIntegTest extends BaseITCase {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
-    void GIVEN_windows_exec_WHEN_set_env_vars_from_multiple_sources_THEN_precedence_is_correct()
+    void GIVEN_windows_exec_with_user_WHEN_set_env_vars_from_multiple_sources_THEN_precedence_is_correct()
             throws IOException, InterruptedException {
         // Check setting default env works
         // setDefaultEnv is static and will persist throughout this test.

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecTest.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.integrationtests.util;
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.platforms.Platform;
-import com.sun.jna.platform.win32.Advapi32Util;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -27,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -142,21 +140,6 @@ class ExecTest {
         // closing again should be no op, it should not throw
         exec.close();
         assertFalse(exec.isRunning());
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    @SuppressWarnings("PMD.CloseResource")
-    // TODO Just experimenting with GitHub runner. Do not merge
-    void experiement() throws IOException, InterruptedException {
-        String currSid = Advapi32Util.getAccountByName(System.getProperty("user.name")).sidString;
-        String envRegKey = String.format("HKU\\%s\\Environment", currSid);  // /f /v unit_test /t REG_SZ /d hello123
-        Exec exec = Platform.getInstance().createNewProcessRunner();
-        String output = exec
-                .withShell("reg", "add", envRegKey, "/f", "/v", "unit_test", "/t", "REG_SZ", "/d", "\"Hello Registry\"")
-                .execAndGetStringOutput();
-        assertThat(output, containsString("completed successfully"));
-        exec.close();
     }
 
     @Test

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsExec.java
@@ -47,7 +47,6 @@ public class WindowsExec extends Exec {
         super();
         // Windows env var keys are case-insensitive. Use case-insensitive map to avoid collision
         environment = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        environment.putAll(defaultEnvironment);
         String pathExt = System.getenv("PATHEXT");
         pathext = Arrays.asList(pathExt.split(File.pathSeparator));
     }
@@ -120,6 +119,7 @@ public class WindowsExec extends Exec {
             // Clear the env in this case because later we'll load the given user's env instead
             winPb.environment().clear();
         }
+        winPb.setDefaultEnvironment(defaultEnvironment);
         winPb.environment().putAll(environment);
         winPb.directory(dir).command(commands);
         synchronized (Kernel32.INSTANCE) {

--- a/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessBuilderForWin32.java
+++ b/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessBuilderForWin32.java
@@ -17,6 +17,7 @@
 package vendored.org.apache.dolphinscheduler.common.utils.process;
 
 import com.sun.jna.platform.win32.WinBase;
+import lombok.Setter;
 
 import java.io.File;
 import java.io.IOException;
@@ -182,6 +183,9 @@ public class ProcessBuilderForWin32 {
      * Begin Amazon addition.
      */
 
+    // Separate out the defaultEnvironment so that we can control env var precedence later in ProcessImplForWin32
+    @Setter
+    private Map<String,String> defaultEnvironment;
     private static final int PROCESS_CREATION_FLAGS_DEFAULT = WinBase.CREATE_UNICODE_ENVIRONMENT  // use unicode
             | WinBase.CREATE_NEW_CONSOLE;     // create new console to send ctrl-c to the process
     private int processCreationFlags = PROCESS_CREATION_FLAGS_DEFAULT;
@@ -1111,6 +1115,7 @@ public class ProcessBuilderForWin32 {
                     username,
                     password,
                     cmdarray,
+                    defaultEnvironment,
                     environment,
                     dir,
                     redirects,

--- a/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
+++ b/src/main/java/vendored/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
@@ -172,7 +172,8 @@ public class ProcessImplForWin32 extends Process {
     static Process start(String username,
                          char[] password,
                          String[] cmdarray,
-                         java.util.Map<String,String> envMap,
+                         java.util.Map<String,String> defaultEnv,
+                         java.util.Map<String,String> overrideEnv,
                          String dir,
                          ProcessBuilderForWin32.Redirect[] redirects,
                          boolean redirectErrorStream,
@@ -220,7 +221,8 @@ public class ProcessImplForWin32 extends Process {
                 }
             }
 
-            return new ProcessImplForWin32(username, password, cmdarray, envMap, dir, stdHandles, redirectErrorStream, processCreationFlags);
+            return new ProcessImplForWin32(username, password, cmdarray, defaultEnv, overrideEnv, dir, stdHandles,
+                    redirectErrorStream, processCreationFlags);
         } finally {
             // In theory, close() can throw IOException
             // (although it is rather unlikely to happen here)
@@ -467,7 +469,8 @@ public class ProcessImplForWin32 extends Process {
             String username,
             char[] password,
             String[] cmd,
-            final java.util.Map<String,String> envMap,
+            final java.util.Map<String,String> defaultEnv,
+            final java.util.Map<String,String> overrideEnv,
             final String path,
             final long[] stdHandles,
             final boolean redirectErrorStream,
@@ -534,7 +537,8 @@ public class ProcessImplForWin32 extends Process {
                     cmd);
         }
 
-        handle = create(username, password, cmdstr, envMap, path, stdHandles, redirectErrorStream, processCreationFlags);
+        handle = create(username, password, cmdstr, defaultEnv, overrideEnv, path, stdHandles, redirectErrorStream,
+                processCreationFlags);
 
         AccessController.doPrivileged(
                 new PrivilegedAction<Void>() {
@@ -828,20 +832,28 @@ public class ProcessImplForWin32 extends Process {
     private synchronized WinNT.HANDLE create(String username,
                                              char[] password,
                                              String cmd,
-                                             java.util.Map<String,String> envMap,
+                                             java.util.Map<String,String> defaultEnv,
+                                             java.util.Map<String,String> overrideEnv,
                                              final String path,
                                              final long[] stdHandles,
                                              final boolean redirectErrorStream,
                                              final int processCreationFlags) throws ProcessCreationException {
         String envblock;
         ProcessCreationExtras extraInfo = new ProcessCreationExtras();
-        if (envMap == null) {
-            envMap = Collections.emptyMap();
+        if (defaultEnv == null) {
+            defaultEnv = Collections.emptyMap();
+        }
+        if (overrideEnv == null) {
+            overrideEnv = Collections.emptyMap();
         }
         if (username == null) {
-            envblock = Advapi32Util.getEnvironmentBlock(envMap);
+            // Windows env var keys are case-insensitive. Use case-insensitive map to avoid collision
+            Map<String, String> mergedEnv = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            mergedEnv.putAll(defaultEnv);
+            mergedEnv.putAll(overrideEnv);
+            envblock = Advapi32Util.getEnvironmentBlock(mergedEnv);
         } else {
-            envblock = setupRunAsAnotherUser(username, password, envMap, extraInfo);
+            envblock = setupRunAsAnotherUser(username, password, defaultEnv, overrideEnv, extraInfo);
         }
 
         // init handles
@@ -951,8 +963,9 @@ public class ProcessImplForWin32 extends Process {
      * Preparation for running process as another user. Populates the given extraInfo if applicable.
      * @return environment block for CreateProcess* APIs
      */
-    private String setupRunAsAnotherUser(String username, char[] password, Map<String, String> envMap,
-                                         ProcessCreationExtras extraInfo) throws ProcessCreationException {
+    private String setupRunAsAnotherUser(String username, char[] password, Map<String, String> defaultEnv,
+                                         Map<String, String> overrideEnv, ProcessCreationExtras extraInfo)
+            throws ProcessCreationException {
         // Get and cache process token and isService state
         synchronized (Advapi32.INSTANCE) {
             if (processToken.get() == null) {
@@ -1028,7 +1041,7 @@ public class ProcessImplForWin32 extends Process {
                     lastErrorRuntimeException());
         }
 
-        String envblock = computeEnvironmentBlock(userTokenHandle.getValue(), envMap);
+        String envblock = computeEnvironmentBlock(userTokenHandle.getValue(), defaultEnv, overrideEnv);
         Kernel32Util.closeHandleRefs(userTokenHandle);
         return envblock;
     }
@@ -1098,8 +1111,8 @@ public class ProcessImplForWin32 extends Process {
      * @return environment block for starting a process
      * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-createenvironmentblock">docs</a>
      */
-    private static String computeEnvironmentBlock(WinNT.HANDLE userTokenHandle, Map<String, String> additionalEnv)
-            throws ProcessCreationException {
+    private static String computeEnvironmentBlock(WinNT.HANDLE userTokenHandle, Map<String, String> defaultEnv,
+                                                  Map<String, String> overrideEnv) throws ProcessCreationException {
         PointerByReference lpEnv = new PointerByReference();
         // Get user's env vars, inheriting current process env
         // It returns pointer to a block of null-terminated strings. It ends with two nulls (\0\0).
@@ -1108,7 +1121,12 @@ public class ProcessImplForWin32 extends Process {
         }
 
         // Windows env var keys are case-insensitive. Use case-insensitive map to avoid collision
-        Map<String, String> userEnvMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        // The resulting env is merged from defaultEnv, the given user's env (returned by CreateEnvironmentBlock),
+        // and overrideEnv. They are merged in that order so that later envs have higher precedence in case
+        // a key is defined in multiple places.
+        Map<String, String> mergedEnv = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        mergedEnv.putAll(defaultEnv);
+
         int offset = 0;
         while (true) {
             String s = lpEnv.getValue().getWideString(offset);
@@ -1118,17 +1136,16 @@ public class ProcessImplForWin32 extends Process {
             // wide string uses 2 bytes per char. +2 to skip the terminating null
             offset += s.length() * 2 + 2;
             int splitInd = s.indexOf('=');
-            userEnvMap.put(s.substring(0, splitInd), s.substring(splitInd + 1));
+            mergedEnv.put(s.substring(0, splitInd), s.substring(splitInd + 1));
         }
 
         if (!UserEnv.INSTANCE.DestroyEnvironmentBlock(lpEnv.getValue())) {
             throw lastErrorProcessCreationException("DestroyEnvironmentBlock");
         }
 
-        // Set additional envs on top of user default env
-        userEnvMap.putAll(additionalEnv);
+        mergedEnv.putAll(overrideEnv);
 
-        return Advapi32Util.getEnvironmentBlock(userEnvMap);
+        return Advapi32Util.getEnvironmentBlock(mergedEnv);
     }
 
     private static class ProcessCreationExtras {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Add a new field `defaultEnvironment` to ProcessBuilderForWin32 and accessible via setter.
- In ProcessImplForWin32, apply default env before the env returned by CreateEnvironmentBlock, so that the default does not override user's env.

**Why is this change necessary:**
- Fix default PATH always overriding PATH in user's env
- If we have more default env vars in the future, it'll be handled correctly as well.

**How was this change tested:**
- Added a new integ test

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
