### PR TITLE
fix: credential provider should not use TES service directly

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/LazyCredentialProvider.java
+++ b/src/main/java/com/aws/greengrass/tes/LazyCredentialProvider.java
@@ -5,32 +5,23 @@
 
 package com.aws.greengrass.tes;
 
-import com.aws.greengrass.lifecyclemanager.Kernel;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 
 import javax.inject.Inject;
-
-import static com.aws.greengrass.tes.TokenExchangeService.TOKEN_EXCHANGE_SERVICE_TOPICS;
+import javax.inject.Provider;
 
 public class LazyCredentialProvider implements AwsCredentialsProvider {
 
-    private final Kernel kernel;
-
     @Inject
-    public LazyCredentialProvider(Kernel kernel) {
-        this.kernel = kernel;
-    }
+    Provider<CredentialRequestHandler> credentialRequestHandlerProvider;
 
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
-    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
     @Override
     public AwsCredentials resolveCredentials() {
         try {
-            AwsCredentials creds =
-                    ((TokenExchangeService) kernel.locate(TOKEN_EXCHANGE_SERVICE_TOPICS)).resolveCredentials();
+            AwsCredentials creds = credentialRequestHandlerProvider.get().getAwsCredentials();
             if (creds != null) {
                 return creds;
             }

--- a/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
+++ b/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
@@ -65,16 +65,7 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
 
         deviceConfiguration.getIotRoleAlias().subscribe((why, newv) -> {
             iotRoleAlias = Coerce.toString(newv);
-            credentialRequestHandler.clearCache();
-            credentialRequestHandler.setIotCredentialsPath(iotRoleAlias);
         });
-        deviceConfiguration.getThingName().subscribe((why, newv) -> {
-            credentialRequestHandler.clearCache();
-            credentialRequestHandler.setThingName(Coerce.toString(newv));
-        });
-        deviceConfiguration.getCertificateFilePath().subscribe((why, newv) -> credentialRequestHandler.clearCache());
-        deviceConfiguration.getRootCAFilePath().subscribe((why, newv) -> credentialRequestHandler.clearCache());
-        deviceConfiguration.getPrivateKeyFilePath().subscribe((why, newv) -> credentialRequestHandler.clearCache());
 
         this.authZHandler = authZHandler;
         this.credentialRequestHandler = credentialRequestHandler;

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -39,14 +39,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
-import static com.aws.greengrass.deployment.DeviceConfiguration.AWS_IOT_THING_NAME_ENV;
 import static com.aws.greengrass.deployment.DeviceConfiguration.COMPONENT_STORE_MAX_SIZE_BYTES;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_CERTIFICATE_FILE_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PRIVATE_KEY_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROOT_CA_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.IOT_ROLE_ALIAS_TOPIC;
 import static com.aws.greengrass.deployment.DeviceConfiguration.NUCLEUS_CONFIG_LOGGING_TOPICS;
 import static com.aws.greengrass.deployment.DeviceConfiguration.SYSTEM_NAMESPACE_KEY;
@@ -108,14 +103,9 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         Topics servicesTopics = Topics.of(context, SERVICES_NAMESPACE_TOPIC, null);
         Topic componentTypeTopic = Topic.of(context, SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.name());
         Topic componentStoreSizeLimitTopic = Topic.of(context, COMPONENT_STORE_MAX_SIZE_BYTES, 10_000_000_000L);
-        Topic thingName = Topic.of(context, SYSTEM_NAMESPACE_KEY, "abc");
-        Topic privateKeyPath = Topic.of(context, DEVICE_PARAM_PRIVATE_KEY_PATH, "key.key");
-        Topic certPath = Topic.of(context, DEVICE_PARAM_CERTIFICATE_FILE_PATH, "cert.crt");
-        Topic caPath = Topic.of(context, DEVICE_PARAM_ROOT_CA_PATH, "ca.pem");
         Topic deploymentPollingFrequency = Topic.of(context, SERVICE_TYPE_TOPIC_KEY, 15L);
         Topic mainDependenciesTopic = Topic.of(context, SERVICE_DEPENDENCIES_NAMESPACE_TOPIC,
                 DEFAULT_NUCLEUS_COMPONENT_NAME);
-        Topic thingNameEnv = Topic.of(context, AWS_IOT_THING_NAME_ENV, "abc");
         Topics root = mock(Topics.class);
         when(root.findOrDefault(new ArrayList<>(), SERVICES_NAMESPACE_TOPIC, MAIN_SERVICE_NAME,
                 SERVICE_DEPENDENCIES_NAMESPACE_TOPIC)).thenReturn(new ArrayList<String>());
@@ -129,13 +119,8 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
                 NUCLEUS_CONFIG_LOGGING_TOPICS)).thenReturn(mock(Topics.class));
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 DEPLOYMENT_POLLING_FREQUENCY_SECONDS)).thenReturn(deploymentPollingFrequency);
-        when(configuration.lookup(SYSTEM_NAMESPACE_KEY, DEVICE_PARAM_THING_NAME)).thenReturn(thingName);
-        when(configuration.lookup(SYSTEM_NAMESPACE_KEY, DEVICE_PARAM_PRIVATE_KEY_PATH)).thenReturn(privateKeyPath);
-        when(configuration.lookup(SYSTEM_NAMESPACE_KEY, DEVICE_PARAM_CERTIFICATE_FILE_PATH)).thenReturn(certPath);
-        when(configuration.lookup(SYSTEM_NAMESPACE_KEY, DEVICE_PARAM_ROOT_CA_PATH)).thenReturn(caPath);
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, MAIN_SERVICE_NAME, SERVICE_DEPENDENCIES_NAMESPACE_TOPIC))
                 .thenReturn(mainDependenciesTopic);
-        when(configuration.lookup(SETENV_CONFIG_NAMESPACE, AWS_IOT_THING_NAME_ENV)).thenReturn(thingNameEnv);
 
         when(topics.subscribe(any())).thenReturn(topics);
         when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY)).thenReturn(topics);
@@ -149,7 +134,7 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
 
     @AfterAll
     static void tearDown() {
-        executorService.shutdown();
+        executorService.shutdownNow();
     }
 
     @ParameterizedTest
@@ -200,9 +185,6 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         } else {
             assertEquals(port, uri.getPort());
         }
-
-        verify(mockCredentialHandler).setIotCredentialsPath(stringArgumentCaptor.capture());
-        assertEquals(MOCK_ROLE_ALIAS, stringArgumentCaptor.getValue());
 
         verify(mockAuthZHandler).registerComponent(stringArgumentCaptor.capture(), operationsCaptor.capture());
         assertEquals(TOKEN_EXCHANGE_SERVICE_TOPICS, stringArgumentCaptor.getValue());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
LazyCredentialProvider was using TokenExchangeService directly which caused TES to be created and stored in the Context. However, since TES wasn't depended on by anything, it was not known by the Nucleus to be a component which shouldn't be removed. Therefore, when a deployment came it, that deployment would remove the config namespace for TES, however TES still had pointers to that now-removed namespace. Because of this, the in-memory representation that TES had about itself differed from the representation of any component outside of TES. In this case, TES believed that it was version 0.0.0, while anyone outside of TES (not going through TES's outdated pointers) would see that the version was properly set to 2.0.3. 
The fix in this change is to have the LazyCredentialProvider _not_ use TES, but instead go to the source for the credentials. TES was only redirecting the calls, so now this is more clear and will resolve the issue of TES being constructed and holding onto outdated pointers.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
