### PR TITLE
fix(windows): update bootstrap to copy service XML file

### DIFF
--- a/conf/recipe.yaml
+++ b/conf/recipe.yaml
@@ -59,4 +59,4 @@ Manifests:
       bootstrap:
         RequiresPrivilege: true
         script: >-
-          del /q {kernel:rootPath}\alts\current\*&& for /d %x in ({kernel:rootPath}\alts\current\*) do @rd /s /q "%x"&& echo {configuration:/jvmOptions} > {kernel:rootPath}\alts\current\launch.params&& mklink /d {kernel:rootPath}\alts\current\distro {artifacts:decompressedPath}\aws.greengrass.nucleus&& exit 100
+          copy {kernel:rootPath}\alts\current\distro\bin\greengrass.xml {artifacts:decompressedPath}\aws.greengrass.nucleus\bin\greengrass.xml& del /q {kernel:rootPath}\alts\current\*&& for /d %x in ({kernel:rootPath}\alts\current\*) do @rd /s /q "%x"&& echo {configuration:/jvmOptions} > {kernel:rootPath}\alts\current\launch.params&& mklink /d {kernel:rootPath}\alts\current\distro {artifacts:decompressedPath}\aws.greengrass.nucleus&& exit 100


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update the windows bootstrap to copy any existing greengrass.xml file into the new distro location. Without this change, the service will fail to start after updating the Nucleus version on Windows.

**Why is this change necessary:**

**How was this change tested:**
@tilo-chen manually verified the fix using a cloud deployment with the new recipe.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
