### PR TITLE
test: deployment will succeed if `listThingGroupsForDevice` throws 403

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.util.Coerce;
 import com.vdurmont.semver4j.Semver;
 import lombok.Getter;
+import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 
 import java.io.IOException;
@@ -196,7 +197,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
         try {
             groupsForDeviceOpt = thingGroupHelper.listThingGroupsForDevice(retryCount);
         } catch (GreengrassV2DataException e) {
-            if (e.statusCode() == 403) {
+            if (e.statusCode() == HttpStatusCode.FORBIDDEN) {
                 // Getting group hierarchy requires permission to call the ListThingGroupsForCoreDevice API which
                 // may not be configured on existing IoT Thing policy in use for current device, log a warning in
                 // that case and move on.

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.io.IOException;
@@ -48,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;
@@ -90,7 +93,7 @@ class DeploymentTaskTest {
     private DefaultDeploymentTask deploymentTask;
 
     @Mock
-    private ThingGroupHelper thingGroupHelper;
+    private ThingGroupHelper mockThingGroupHelper;
 
     @BeforeAll
     static void setupContext() {
@@ -117,7 +120,7 @@ class DeploymentTaskTest {
                 new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager, mockKernelConfigResolver,
                         mockDeploymentConfigMerger, logger,
                         new Deployment(deploymentDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
-                        mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, thingGroupHelper);
+                        mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, mockThingGroupHelper);
     }
 
     @Test
@@ -129,6 +132,24 @@ class DeploymentTaskTest {
         when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(null));
         deploymentTask.call();
+        verify(mockComponentManager).preparePackages(anyList());
+        verify(mockKernelConfigResolver).resolve(anyList(), eq(deploymentDocument), anyList());
+        verify(mockDeploymentConfigMerger).mergeInNewConfig(any(), any());
+    }
+
+    @Test
+    void GIVEN_deploymentDocument_WHEN_thingGroupHelper_return_forbidden_THEN_succeeds(ExtensionContext context) throws Exception {
+        ignoreExceptionUltimateCauseOfType(context, GreengrassV2DataException.class);
+        when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
+        when(mockExecutorService.submit(any(Callable.class)))
+                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+        when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
+                .thenThrow(GreengrassV2DataException.builder().statusCode(HttpStatusCode.FORBIDDEN).build());
+
+        deploymentTask.call();
+
         verify(mockComponentManager).preparePackages(anyList());
         verify(mockKernelConfigResolver).resolve(anyList(), eq(deploymentDocument), anyList());
         verify(mockDeploymentConfigMerger).mergeInNewConfig(any(), any());


### PR DESCRIPTION
* Given: Deployment Document
* When: `thingGroupHelper.ListThingGroupsForCoreDevice` throws 403 exception
* Then: deployment succeed

**Issue #, if available:**

**Description of changes:**
Adding test for quick fix done [here](https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1137). Behavior for the test explained above (GIVEN-WHEN-THEN). In the test, `thingGroupHelper.ListThingGroupsForCoreDevice` mocked to throw `GreengrassV2DataException` with status code 403.

**Why is this change necessary:**
The test covers the case where `greengrass:ListThingGroupsForCoreDevice` not granted the deployment will still succeed.

**How was this change tested:**
* Manual test by using debugger to double check code run as expected
* `mvn -U -ntp verify` passed

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
