### PR TITLE
chore: adding cluster operation authz

### DIFF
--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -45,8 +45,10 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PAU
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_TOPIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.RESUME_COMPONENT;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_CLUSTER_STATE_EVENTS;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_TOPIC;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_CLUSTER_STATE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_THING_SHADOW;
 
 /**
@@ -64,6 +66,7 @@ public class AuthorizationHandler  {
     public static final String ANY_REGEX = "*";
     public static final String SECRETS_MANAGER_SERVICE_NAME = "aws.greengrass.SecretManager";
     public static final String SHADOW_MANAGER_SERVICE_NAME = "aws.greengrass.ShadowManager";
+    public static final String HA_CONTROLLER_SERVICE_NAME = "aws.greengrass.HAController";
     private static final Logger logger = LogManager.getLogger(AuthorizationHandler.class);
     private final ConcurrentHashMap<String, Set<String>> componentToOperationsMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, List<AuthorizationPolicy>>
@@ -97,6 +100,9 @@ public class AuthorizationHandler  {
                 UPDATE_THING_SHADOW, DELETE_THING_SHADOW, LIST_NAMED_SHADOWS_FOR_THING, ANY_REGEX)));
         componentToOperationsMap.put(LIFECYCLE_SERVICE_NAME, new HashSet<>(Arrays.asList(PAUSE_COMPONENT,
                 RESUME_COMPONENT, ANY_REGEX)));
+        componentToOperationsMap.put(HA_CONTROLLER_SERVICE_NAME, new HashSet<>(Arrays.asList(
+                UPDATE_CLUSTER_STATE, SUBSCRIBE_TO_CLUSTER_STATE_EVENTS, ANY_REGEX
+        )));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(
                 kernel);

--- a/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java
@@ -447,7 +447,8 @@ public class ConfigStoreIPCEventStreamAgent {
                 valueChangedEvent.setComponentName(componentName);
                 valueChangedEvent.setKeyPath(Arrays.asList(changedKeyPath));
                 configurationUpdateEvents.setConfigurationUpdateEvent(valueChangedEvent);
-                logger.atDebug().kv(SERVICE_NAME, serviceName)
+                logger.atDebug()
+                        .kv(SERVICE_NAME, serviceName)
                         .log("Sending component {}'s updated config key {}", componentName, changedKeyPath);
 
                 this.sendStreamEvent(configurationUpdateEvents);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adding `AuthorizationHandler` support for a couple of the cluster operations, namely:
- `UpdateClusterState`
- `SubscribeToClusterStateEvents`

**Why is this change necessary:**

Ideally, a plugin can control the authorization for the IPC operations they provide. For now, without this change, the plugin cannot authorize the operations it supports.

**How was this change tested:**

```
mvn test
```

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
