### PR TITLE
build: use add-opens in jar to prevent error on JDK 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -629,6 +629,9 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.aws.greengrass.easysetup.GreengrassSetup</mainClass>
+                                    <manifestEntries>
+                                        <Add-Opens>java.base/java.io</Add-Opens>
+                                    </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add Add-Opens into the jar manifest in order to allow us to use reflection on Windows to set the FileDescriptor handle field.
Without this change, JDK 17 users on Windows are unable to use Greengrass without adding `--add-opens ...` to their Java command.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
