### PR TITLE
feat: pubsub wildcard support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.5.3-WINDOWS-SNAPSHOT</version>
+            <version>1.6.0-PUBSUB-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.6.0-PUBSUB-SNAPSHOT</version>
+            <version>1.5.3-WINDOWS-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/pubsub.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/pubsub.yaml
@@ -29,6 +29,7 @@ services:
       - OnlyPublish
       - DoAll1
       - DoAll2
+      - SubscribeAndPublishWildcard
     lifecycle:
       run:
         windows:
@@ -115,3 +116,21 @@ services:
               - '*'
             resources:
               - '*'
+
+  SubscribeAndPublishWildcard:
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.ipc.pubsub:
+          policyId7:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+              - 'aws.greengrass#PublishToTopic'
+            resources:
+              - /to*/#

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -121,6 +121,7 @@ public class PubSubIPCEventStreamAgent {
             // Still technically successful, just no one was subscribed
             return new PublishToTopicResponse();
         }
+        // TODO: include topic name in message after updating Smithy model
         SubscriptionResponseMessage message = new SubscriptionResponseMessage();
         PublishEvent publishedEvent = PublishEvent.builder().topic(topic).build();
         if (jsonMessage.isPresent()) {

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -121,12 +121,12 @@ public class PubSubIPCEventStreamAgent {
             // Still technically successful, just no one was subscribed
             return new PublishToTopicResponse();
         }
+        // TODO: include topic in message when new sdk is ready
         SubscriptionResponseMessage message = new SubscriptionResponseMessage();
         PublishEvent publishedEvent = PublishEvent.builder().topic(topic).build();
         if (jsonMessage.isPresent()) {
             JsonMessage message1 = new JsonMessage();
             message1.setMessage(jsonMessage.get());
-            message1.setEventTopic(topic);
             message.setJsonMessage(message1);
             try {
                 publishedEvent.setPayload(SERIALIZER.writeValueAsBytes(jsonMessage.get()));
@@ -138,7 +138,6 @@ public class PubSubIPCEventStreamAgent {
         if (binaryMessage.isPresent()) {
             BinaryMessage binaryMessage1 = new BinaryMessage();
             binaryMessage1.setMessage(binaryMessage.get());
-            binaryMessage1.setEventTopic(topic);
             message.setBinaryMessage(binaryMessage1);
             publishedEvent.setPayload(binaryMessage.get());
         }

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -34,8 +34,6 @@ import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 
@@ -50,7 +48,7 @@ public class PubSubIPCEventStreamAgent {
     private static final String GLOB_WILDCARD = "*";
     private static final ObjectMapper SERIALIZER = new ObjectMapper();
     @Getter(AccessLevel.PACKAGE)
-    private final Map<String, Set<Object>> listeners = new ConcurrentHashMap<>();
+    private final SubscriptionTrie listeners = new SubscriptionTrie();
 
     private final OrderedExecutorService orderedExecutorService;
     private final AuthorizationHandler authorizationHandler;
@@ -89,12 +87,7 @@ public class PubSubIPCEventStreamAgent {
      * @param serviceName name of the service unsubscribing.
      */
     public void unsubscribe(String topic, Consumer<PublishEvent> cb, String serviceName) {
-        AtomicBoolean removed = new AtomicBoolean(false);
-        listeners.computeIfPresent(topic, (s, objects) -> {
-            removed.set(objects.remove(cb));
-            return objects.isEmpty() ? null : objects;
-        });
-        if (removed.get()) {
+        if (listeners.remove(topic, cb)) {
             log.atDebug().kv(COMPONENT_NAME, serviceName).log("Unsubscribed from topic {}", topic);
         }
     }
@@ -164,7 +157,8 @@ public class PubSubIPCEventStreamAgent {
 
     private void handleSubscribeToTopicRequest(String topic, String serviceName, Object handler) {
         // TODO: [P32540011]: All IPC service requests need input validation
-        if (listeners.computeIfAbsent(topic, k -> ConcurrentHashMap.newKeySet()).add(handler)) {
+        validateSubTopic(topic);
+        if (listeners.add(topic, handler)) {
             log.atDebug().kv(COMPONENT_NAME, serviceName).log("Subscribed to topic {}", topic);
         }
     }
@@ -225,9 +219,8 @@ public class PubSubIPCEventStreamAgent {
 
         @Override
         protected void onStreamClosed() {
-            if (Utils.isNotEmpty(subscribeTopic) && listeners.containsKey(subscribeTopic)) {
-                listeners.computeIfPresent(subscribeTopic,
-                        (s, objects) -> objects.remove(this) && objects.isEmpty() ? null : objects);
+            if (Utils.isNotEmpty(subscribeTopic)) {
+                listeners.remove(subscribeTopic, this);
             }
         }
 
@@ -250,6 +243,13 @@ public class PubSubIPCEventStreamAgent {
         @Override
         public void handleStreamEvent(EventStreamJsonMessage streamRequestEvent) {
             // NA
+        }
+    }
+
+    private void validateSubTopic(String topic) {
+        // TODO: regex validation? size limit?
+        if (Utils.isEmpty(topic)) {
+            throw new InvalidArgumentsError("Subscribe topic must not be empty");
         }
     }
 

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -121,12 +121,12 @@ public class PubSubIPCEventStreamAgent {
             // Still technically successful, just no one was subscribed
             return new PublishToTopicResponse();
         }
-        // TODO: include topic name in message after updating Smithy model
         SubscriptionResponseMessage message = new SubscriptionResponseMessage();
         PublishEvent publishedEvent = PublishEvent.builder().topic(topic).build();
         if (jsonMessage.isPresent()) {
             JsonMessage message1 = new JsonMessage();
             message1.setMessage(jsonMessage.get());
+            message1.setEventTopic(topic);
             message.setJsonMessage(message1);
             try {
                 publishedEvent.setPayload(SERIALIZER.writeValueAsBytes(jsonMessage.get()));
@@ -138,6 +138,7 @@ public class PubSubIPCEventStreamAgent {
         if (binaryMessage.isPresent()) {
             BinaryMessage binaryMessage1 = new BinaryMessage();
             binaryMessage1.setMessage(binaryMessage.get());
+            binaryMessage1.setEventTopic(topic);
             message.setBinaryMessage(binaryMessage1);
             publishedEvent.setPayload(binaryMessage.get());
         }

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -248,7 +248,6 @@ public class PubSubIPCEventStreamAgent {
     }
 
     private void validateSubTopic(String topic) {
-        // TODO: regex validation? size limit?
         if (Utils.isEmpty(topic)) {
             throw new InvalidArgumentsError("Subscribe topic must not be empty");
         }

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.builtin.services.pubsub;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Trie to manage subscriptions.
+ */
+public class SubscriptionTrie {
+    private static final String TOPIC_LEVEL_SEPARATOR = "/";
+    private static final String SINGLE_LEVEL_WILDCARD = "+";
+    private static final String MULTI_LEVEL_WILDCARD = "#";
+
+    private final Map<String, SubscriptionTrie> children = new ConcurrentHashMap<>();
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    private final String value;
+    private final Set<Object> callbacks;
+
+    /**
+     * Construct.
+     */
+    public SubscriptionTrie() {
+        this("");
+    }
+
+    private SubscriptionTrie(String value) {
+        this.value = value;
+        this.callbacks = ConcurrentHashMap.newKeySet();
+    }
+
+    private SubscriptionTrie lookup(String topic) {
+        SubscriptionTrie current = this;
+        for (String topicLevel : topic.split(TOPIC_LEVEL_SEPARATOR)) {
+            current = current.children.get(topicLevel);
+            if (current == null) {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    /**
+     * Check if trie contains a topic.
+     *
+     * @param topic topic
+     * @return if trie contains topic
+     */
+    public boolean containsKey(String topic) {
+        return lookup(topic) != null;
+    }
+
+    /**
+     * Remove entry for one callback.
+     *
+     * @param topic topic
+     * @param cb    callback
+     * @return if changed after removal
+     */
+    public boolean remove(String topic, Object cb) {
+        return remove(topic, Collections.singleton(cb));
+    }
+
+    /**
+     * Remove entry for a set of callbacks.
+     *
+     * @param topic topic
+     * @param cbs   callbacks
+     * @return if changed after removal
+     */
+    public boolean remove(String topic, Set<Object> cbs) {
+        SubscriptionTrie sub = lookup(topic);
+        if (sub == null) {
+            return false;
+        }
+        return sub.callbacks.removeAll(cbs);
+    }
+
+    /**
+     * Size of trie.
+     *
+     * @return size
+     */
+    public int size() {
+        int[] size = {this.callbacks.size()};
+        children.forEach((s, t) -> {
+            size[0] += t.size();
+        });
+        return size[0];
+    }
+
+    /**
+     * Add a topic callback.
+     *
+     * @param topic topic
+     * @param cb    callback
+     * @return true
+     */
+    public boolean add(String topic, Object cb) {
+        ConcurrentHashMap.KeySetView<Object, Boolean> cbs = ConcurrentHashMap.newKeySet();
+        cbs.add(cb);
+        put(topic, cbs);
+        return true;
+    }
+
+    /**
+     * Add a topic and a set of callbacks.
+     *
+     * @param topic topic
+     * @param cbs   callbacks
+     */
+    public void put(String topic, Set<Object> cbs) {
+        SubscriptionTrie[] current = {this};
+        for (String topicLevel : topic.split(TOPIC_LEVEL_SEPARATOR)) {
+            current[0] = current[0].children.computeIfAbsent(topicLevel, SubscriptionTrie::new);
+        }
+        current[0].callbacks.addAll(cbs);
+    }
+
+    private Set<SubscriptionTrie> getMatchingPaths(String topicLevel, Set<Object> result) {
+        Set<SubscriptionTrie> paths = new LinkedHashSet<>();
+
+        SubscriptionTrie childPath = this.children.get(topicLevel);
+        if (childPath != null) {
+            paths.add(childPath);
+        }
+
+        SubscriptionTrie childPlusPath = this.children.get(SINGLE_LEVEL_WILDCARD);
+        if (childPlusPath != null) {
+            paths.add(childPlusPath);
+        }
+
+        SubscriptionTrie childPoundPath = this.children.get(MULTI_LEVEL_WILDCARD);
+        if (childPoundPath != null) {
+            paths.add(childPoundPath);
+            result.addAll(childPoundPath.callbacks);
+        }
+
+        return paths;
+    }
+
+    /**
+     * Get callback objects given a topic.
+     *
+     * @param topic topic
+     * @return a set of callback objects
+     */
+    public Set<Object> get(String topic) {
+        String[] topicLevels = topic.split(TOPIC_LEVEL_SEPARATOR);
+        Set<Object> result = new LinkedHashSet<>();
+        Set<SubscriptionTrie> paths = this.getMatchingPaths(topicLevels[0], result);
+
+        for (int iter = 1; iter < topicLevels.length && !paths.isEmpty(); iter++) {
+            Set<SubscriptionTrie> newPaths = new LinkedHashSet<>();
+            for (SubscriptionTrie path : paths) {
+                Set<SubscriptionTrie> childrenPath = path.getMatchingPaths(topicLevels[iter], result);
+                newPaths.addAll(childrenPath);
+            }
+            paths = newPaths;
+        }
+
+        for (SubscriptionTrie path : paths) {
+            result.addAll(path.callbacks);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
@@ -83,7 +83,7 @@ public class SubscriptionTrie {
      */
     public int size() {
         int size = this.callbacks.size();
-        for (SubscriptionTrie child: children.values()) {
+        for (SubscriptionTrie child : children.values()) {
             size += child.size();
         }
         return size;

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
@@ -82,11 +82,11 @@ public class SubscriptionTrie {
      * @return size
      */
     public int size() {
-        int[] size = {this.callbacks.size()};
-        children.forEach((s, t) -> {
-            size[0] += t.size();
-        });
-        return size[0];
+        int size = this.callbacks.size();
+        for (SubscriptionTrie child: children.values()) {
+            size += child.size();
+        }
+        return size;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrie.java
@@ -17,9 +17,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * Trie to manage subscriptions.
  */
 public class SubscriptionTrie {
-    private static final String TOPIC_LEVEL_SEPARATOR = "/";
-    private static final String SINGLE_LEVEL_WILDCARD = "+";
-    private static final String MULTI_LEVEL_WILDCARD = "#";
+    private static final char TOPIC_LEVEL_SEPARATOR = '/';
+    private static final char SINGLE_LEVEL_WILDCARD = '+';
+    private static final char MULTI_LEVEL_WILDCARD = '#';
 
     private final Map<String, SubscriptionTrie> children = new ConcurrentHashMap<>();
     @SuppressWarnings("PMD.UnusedPrivateField")
@@ -41,7 +41,7 @@ public class SubscriptionTrie {
 
     private SubscriptionTrie lookup(String topic) {
         SubscriptionTrie current = this;
-        for (String topicLevel : topic.split(TOPIC_LEVEL_SEPARATOR)) {
+        for (String topicLevel : topic.split(String.valueOf(TOPIC_LEVEL_SEPARATOR))) {
             current = current.children.get(topicLevel);
             if (current == null) {
                 return null;
@@ -121,7 +121,7 @@ public class SubscriptionTrie {
      */
     public void put(String topic, Set<Object> cbs) {
         SubscriptionTrie[] current = {this};
-        for (String topicLevel : topic.split(TOPIC_LEVEL_SEPARATOR)) {
+        for (String topicLevel : topic.split(String.valueOf(TOPIC_LEVEL_SEPARATOR))) {
             current[0] = current[0].children.computeIfAbsent(topicLevel, SubscriptionTrie::new);
         }
         current[0].callbacks.addAll(cbs);
@@ -135,12 +135,12 @@ public class SubscriptionTrie {
             paths.add(childPath);
         }
 
-        SubscriptionTrie childPlusPath = this.children.get(SINGLE_LEVEL_WILDCARD);
+        SubscriptionTrie childPlusPath = this.children.get(String.valueOf(SINGLE_LEVEL_WILDCARD));
         if (childPlusPath != null) {
             paths.add(childPlusPath);
         }
 
-        SubscriptionTrie childPoundPath = this.children.get(MULTI_LEVEL_WILDCARD);
+        SubscriptionTrie childPoundPath = this.children.get(String.valueOf(MULTI_LEVEL_WILDCARD));
         if (childPoundPath != null) {
             paths.add(childPoundPath);
             result.addAll(childPoundPath.callbacks);
@@ -156,7 +156,7 @@ public class SubscriptionTrie {
      * @return a set of callback objects
      */
     public Set<Object> get(String topic) {
-        String[] topicLevels = topic.split(TOPIC_LEVEL_SEPARATOR);
+        String[] topicLevels = topic.split(String.valueOf(TOPIC_LEVEL_SEPARATOR));
         Set<Object> result = new LinkedHashSet<>();
         Set<SubscriptionTrie> paths = this.getMatchingPaths(topicLevels[0], result);
 

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -148,7 +148,6 @@ class PubSubIPCEventStreamAgentTest {
             assertNull(message.getJsonMessage());
             assertNotNull(message.getBinaryMessage());
             assertEquals("ABCD", new String(message.getBinaryMessage().getMessage()));
-            assertEquals(TEST_TOPIC, message.getBinaryMessage().getEventTopic());
         }
     }
 
@@ -190,7 +189,6 @@ class PubSubIPCEventStreamAgentTest {
             assertNotNull(responseMessage.getJsonMessage());
             assertNull(responseMessage.getBinaryMessage());
             assertThat(responseMessage.getJsonMessage().getMessage(), IsMapContaining.hasEntry("SomeKey", "SomValue"));
-            assertEquals(TEST_TOPIC, responseMessage.getJsonMessage().getEventTopic());
         }
     }
 
@@ -232,7 +230,6 @@ class PubSubIPCEventStreamAgentTest {
             assertNull(message.getJsonMessage());
             assertNotNull(message.getBinaryMessage());
             assertEquals("ABCD", new String(message.getBinaryMessage().getMessage()));
-            assertEquals("Test/A/Topic/B/C", message.getBinaryMessage().getEventTopic());
         }
     }
 
@@ -282,7 +279,6 @@ class PubSubIPCEventStreamAgentTest {
                 assertNotNull(responseMessage.getJsonMessage());
                 assertNull(responseMessage.getBinaryMessage());
                 assertThat(responseMessage.getJsonMessage().getMessage(), IsMapContaining.hasEntry("SomeKey", i));
-                assertEquals(TEST_TOPIC, responseMessage.getJsonMessage().getEventTopic());
                 i++;
             }
         }
@@ -332,7 +328,6 @@ class PubSubIPCEventStreamAgentTest {
                 assertNull(responseMessage.getJsonMessage());
                 assertNotNull(responseMessage.getBinaryMessage());
                 assertEquals(String.valueOf(i), new String(responseMessage.getBinaryMessage().getMessage()));
-                assertEquals(TEST_TOPIC, responseMessage.getBinaryMessage().getEventTopic());
                 i++;
             }
         }
@@ -387,7 +382,7 @@ class PubSubIPCEventStreamAgentTest {
                 assertNull(responseMessage.getJsonMessage());
                 assertNotNull(responseMessage.getBinaryMessage());
                 assertEquals(String.valueOf(i), new String(responseMessage.getBinaryMessage().getMessage()));
-                assertEquals(String.format(subTopic, i), responseMessage.getBinaryMessage().getEventTopic());
+
                 i++;
             }
         }

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -117,7 +117,7 @@ class PubSubIPCEventStreamAgentTest {
         StreamEventPublisher publisher = mock(StreamEventPublisher.class);
         Set<Object> set = new HashSet<>();
         set.add(publisher);
-        pubSubIPCEventStreamAgent.getListeners().put(TEST_TOPIC, set);
+        pubSubIPCEventStreamAgent.getListeners().add(TEST_TOPIC, set);
         when(publisher.sendStreamEvent(subscriptionResponseMessageCaptor.capture())).thenReturn(new CompletableFuture());
 
         PublishToTopicRequest publishToTopicRequest = new PublishToTopicRequest();
@@ -156,7 +156,7 @@ class PubSubIPCEventStreamAgentTest {
         StreamEventPublisher publisher = mock(StreamEventPublisher.class);
         Set<Object> set = new HashSet<>();
         set.add(publisher);
-        pubSubIPCEventStreamAgent.getListeners().put(TEST_TOPIC, set);
+        pubSubIPCEventStreamAgent.getListeners().add(TEST_TOPIC, set);
         when(publisher.sendStreamEvent(subscriptionResponseMessageCaptor.capture())).thenReturn(new CompletableFuture());
 
         PublishToTopicRequest publishToTopicRequest = new PublishToTopicRequest();
@@ -197,7 +197,7 @@ class PubSubIPCEventStreamAgentTest {
         StreamEventPublisher publisher = mock(StreamEventPublisher.class);
         Set<Object> set = new HashSet<>();
         set.add(publisher);
-        pubSubIPCEventStreamAgent.getListeners().put(TEST_TOPIC, set);
+        pubSubIPCEventStreamAgent.getListeners().add(TEST_TOPIC, set);
         when(publisher.sendStreamEvent(subscriptionResponseMessageCaptor.capture())).thenReturn(new CompletableFuture());
 
         List<PublishToTopicRequest> publishToTopicRequests = new ArrayList<>();
@@ -248,7 +248,7 @@ class PubSubIPCEventStreamAgentTest {
         StreamEventPublisher publisher = mock(StreamEventPublisher.class);
         Set<Object> set = new HashSet<>();
         set.add(publisher);
-        pubSubIPCEventStreamAgent.getListeners().put(TEST_TOPIC, set);
+        pubSubIPCEventStreamAgent.getListeners().add(TEST_TOPIC, set);
         when(publisher.sendStreamEvent(subscriptionResponseMessageCaptor.capture())).thenReturn(new CompletableFuture());
 
         List<PublishToTopicRequest> publishToTopicRequests = new ArrayList<>();

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 import software.amazon.awssdk.aws.greengrass.model.BinaryMessage;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 import software.amazon.awssdk.aws.greengrass.model.JsonMessage;
 import software.amazon.awssdk.aws.greengrass.model.PublishMessage;
 import software.amazon.awssdk.aws.greengrass.model.PublishToTopicRequest;
@@ -51,6 +52,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -304,6 +306,15 @@ class PubSubIPCEventStreamAgentTest {
 
         pubSubIPCEventStreamAgent.unsubscribe(TEST_TOPIC, consumer, TEST_SERVICE);
         assertEquals(0, pubSubIPCEventStreamAgent.getListeners().size());
+    }
+
+    @Test
+    void GIVEN_subscribed_consumer_WHEN_invalid_topic_THEN_throws() {
+        Consumer<PublishEvent> consumer = mock(Consumer.class);
+        assertThrows(InvalidArgumentsError.class, () -> pubSubIPCEventStreamAgent.subscribe("", consumer,
+                TEST_SERVICE));
+        assertThrows(InvalidArgumentsError.class, () -> pubSubIPCEventStreamAgent.subscribe(null, consumer,
+                TEST_SERVICE));
     }
 
     private static Consumer<PublishEvent> getConsumer(CountDownLatch cdl) {

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
@@ -5,8 +5,10 @@
 
 package com.aws.greengrass.builtin.services.pubsub;
 
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+@ExtendWith({GGExtension.class})
 public class SubscriptionTrieTest {
 
     SubscriptionTrie trie;
@@ -51,10 +54,10 @@ public class SubscriptionTrieTest {
         return Stream.of(
                 arguments("foo", singletonList("foo")),
                 arguments("foo/bar", singletonList("foo/bar")),
-//                // multilevel wildcard #
+                // multilevel wildcard #
                 arguments("#", asList("foo", "foo/bar", "foo/bar/baz", "$foo/bar")),
                 arguments("foo/#", asList("foo/bar", "foo/bar/baz", "foo/bar/#", "foo/+")),
-//                // single level wildcard +
+                // single level wildcard +
                 arguments("+", asList("+", "foo", "foo/", "$foo")),
                 arguments("foo/+/baz", singletonList("foo/bar/baz")),
                 arguments("foo/+/baz/#", asList("foo//baz/bar", "foo/bar/baz/bat", "foo/bar/baz/bat/#"))

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
@@ -114,13 +114,19 @@ public class SubscriptionTrieTest {
         assertEquals(0, trie.size());
         Object cb1 = new Object();
         Object cb2 = new Object();
+        Object cb3 = new Object();
         String topic = "foo/+/bar/#";
         trie.add(topic, cb1);
         trie.add(topic, cb2);
+        trie.add("foo/#", cb3);
         assertTrue(trie.containsKey(topic));
-        assertThat(trie.get(topic), containsInAnyOrder(cb1, cb2));
-        assertEquals(2, trie.size());
+        assertThat(trie.get(topic), containsInAnyOrder(cb1, cb2, cb3));
+        assertThat(trie.get("foo/#"), containsInAnyOrder(cb3));
+        assertEquals(3, trie.size());
 
+        assertThat("remove topic", trie.remove("foo/#", cb3), is(true));
+        assertThat(trie.get("foo/#"), is(empty()));
+        assertEquals(2, trie.size());
         assertThat("remove topic", trie.remove(topic, cb1), is(true));
         assertThat(trie.get(topic), contains(cb2));
         assertEquals(1, trie.size());

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
@@ -51,12 +51,12 @@ public class SubscriptionTrieTest {
         return Stream.of(
                 arguments("foo", singletonList("foo")),
                 arguments("foo/bar", singletonList("foo/bar")),
-                // multilevel wildcard #
+//                // multilevel wildcard #
                 arguments("#", asList("foo", "foo/bar", "foo/bar/baz", "$foo/bar")),
-                arguments("foo/#", asList("foo/bar", "foo/bar/baz", "foo/bar/#")),
-                // single level wildcard +
-                arguments("+", asList("foo", "foo/", "$foo")),
-                arguments("foo/+/baz", asList("foo/bar/baz")),
+                arguments("foo/#", asList("foo/bar", "foo/bar/baz", "foo/bar/#", "foo/+")),
+//                // single level wildcard +
+                arguments("+", asList("+", "foo", "foo/", "$foo")),
+                arguments("foo/+/baz", singletonList("foo/bar/baz")),
                 arguments("foo/+/baz/#", asList("foo//baz/bar", "foo/bar/baz/bat", "foo/bar/baz/bat/#"))
         );
     }
@@ -88,6 +88,7 @@ public class SubscriptionTrieTest {
 
     @Test
     public void GIVEN_subscription_WHEN_remove_topic_THEN_no_matches() {
+        assertEquals(0, trie.size());
         Object cb1 = new Object();
         Object cb2 = new Object();
         String topic = "foo";
@@ -95,18 +96,19 @@ public class SubscriptionTrieTest {
         trie.add(topic, cb2);
         assertTrue(trie.containsKey(topic));
         assertThat(trie.get(topic), containsInAnyOrder(cb1, cb2));
-        assertEquals(trie.size(), 2);
+        assertEquals(2, trie.size());
 
         assertThat("remove topic", trie.remove(topic, cb1), is(true));
         assertThat(trie.get(topic), contains(cb2));
-        assertEquals(trie.size(), 1);
+        assertEquals(1, trie.size());
         assertThat("remove topic", trie.remove(topic, cb2), is(true));
         assertThat(trie.get(topic), is(empty()));
-        assertEquals(trie.size(), 0);
+        assertEquals(0, trie.size());
     }
 
     @Test
     public void GIVEN_subscription_wildcard_WHEN_remove_topic_THEN_no_matches() {
+        assertEquals(0, trie.size());
         Object cb1 = new Object();
         Object cb2 = new Object();
         String topic = "foo/+/bar/#";
@@ -114,13 +116,13 @@ public class SubscriptionTrieTest {
         trie.add(topic, cb2);
         assertTrue(trie.containsKey(topic));
         assertThat(trie.get(topic), containsInAnyOrder(cb1, cb2));
-        assertEquals(trie.size(), 2);
+        assertEquals(2, trie.size());
 
         assertThat("remove topic", trie.remove(topic, cb1), is(true));
         assertThat(trie.get(topic), contains(cb2));
-        assertEquals(trie.size(), 1);
+        assertEquals(1, trie.size());
         assertThat("remove topic", trie.remove(topic, cb2), is(true));
         assertThat(trie.get(topic), is(empty()));
-        assertEquals(trie.size(), 0);
+        assertEquals(0, trie.size());
     }
 }

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.builtin.services.pubsub;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class SubscriptionTrieTest {
+
+    SubscriptionTrie trie;
+
+    @BeforeEach
+    void setup() {
+        trie = new SubscriptionTrie();
+    }
+
+    @ParameterizedTest
+    @MethodSource("subscriptionMatch")
+    public void GIVEN_subscription_THEN_match(String subscription, List<String> topics) {
+        Object cb1 = new Object();
+        Object cb2 = new Object();
+        trie.add(subscription, cb1);
+        trie.add(subscription, cb2);
+        for (String topic : topics) {
+            assertThat(trie.get(topic), containsInAnyOrder(cb1, cb2));
+        }
+    }
+
+    static Stream<Arguments> subscriptionMatch() {
+        return Stream.of(
+                arguments("foo", singletonList("foo")),
+                arguments("foo/bar", singletonList("foo/bar")),
+                // multilevel wildcard #
+                arguments("#", asList("foo", "foo/bar", "foo/bar/baz", "$foo/bar")),
+                arguments("foo/#", asList("foo/bar", "foo/bar/baz", "foo/bar/#")),
+                // single level wildcard +
+                arguments("+", asList("foo", "foo/", "$foo")),
+                arguments("foo/+/baz", asList("foo/bar/baz")),
+                arguments("foo/+/baz/#", asList("foo//baz/bar", "foo/bar/baz/bat", "foo/bar/baz/bat/#"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("subscriptionNotMatch")
+    public void GIVEN_subscription_THEN_do_not_match(String subscription, List<String> topics) {
+        Object cb1 = new Object();
+        Object cb2 = new Object();
+        trie.add(subscription, cb1);
+        trie.add(subscription, cb2);
+
+        for (String topic : topics) {
+            assertThat(trie.get(topic), not(containsInAnyOrder(cb1, cb2)));
+        }
+    }
+
+    static Stream<Arguments> subscriptionNotMatch() {
+        return Stream.of(
+                arguments("foo", asList("fo", "foo/bar", "abc")),
+                arguments("foo/bar", asList("foo", "foo/bar/baz", "fo/bar")),
+                // multilevel wildcard # does not match parent topic
+                arguments("foo/#", asList("foo", "foo/")),
+                // single level wildcard +
+                arguments("+", asList("/foo", "foo/bar")),
+                arguments("foo/+/baz", asList("foo", "foo/baz", "foo/bar/bat/baz"))
+        );
+    }
+
+    @Test
+    public void GIVEN_subscription_WHEN_remove_topic_THEN_no_matches() {
+        Object cb1 = new Object();
+        Object cb2 = new Object();
+        String topic = "foo";
+        trie.add(topic, cb1);
+        trie.add(topic, cb2);
+        assertTrue(trie.containsKey(topic));
+        assertThat(trie.get(topic), containsInAnyOrder(cb1, cb2));
+        assertEquals(trie.size(), 2);
+
+        assertThat("remove topic", trie.remove(topic, cb1), is(true));
+        assertThat(trie.get(topic), contains(cb2));
+        assertEquals(trie.size(), 1);
+        assertThat("remove topic", trie.remove(topic, cb2), is(true));
+        assertThat(trie.get(topic), is(empty()));
+        assertEquals(trie.size(), 0);
+    }
+
+    @Test
+    public void GIVEN_subscription_wildcard_WHEN_remove_topic_THEN_no_matches() {
+        Object cb1 = new Object();
+        Object cb2 = new Object();
+        String topic = "foo/+/bar/#";
+        trie.add(topic, cb1);
+        trie.add(topic, cb2);
+        assertTrue(trie.containsKey(topic));
+        assertThat(trie.get(topic), containsInAnyOrder(cb1, cb2));
+        assertEquals(trie.size(), 2);
+
+        assertThat("remove topic", trie.remove(topic, cb1), is(true));
+        assertThat(trie.get(topic), contains(cb2));
+        assertEquals(trie.size(), 1);
+        assertThat("remove topic", trie.remove(topic, cb2), is(true));
+        assertThat(trie.get(topic), is(empty()));
+        assertEquals(trie.size(), 0);
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Support MQTT style wildcard in PubSub subscriptions (using + and #) 
Implement a SubscriptionTrie to manage topic insert/search
Update device sdk to 1.6.0-PUBSUB-SNAPSHOT that includes model change for `JsonMessage` and `BinaryMessage` to include `eventTopic`

**Why is this change necessary:**
Now we can only subscribe to some specific topic which does not scale well. With the change we can subscribe to a set of topics using + and # wildcards. e.g. to subscribe to a set of shadow topics for different shadows and operations

**How was this change tested:**
mvn -U -ntp verify

**Any additional information or context required to review the change:**
Referenced [POC](https://github.com/aws-greengrass/aws-greengrass-nucleus/commit/492407c4972ad4cce1de9117cff4de00bb46c84b), current [MqttTopic](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/e8be1f23516d22d3e38726d753e752cd08707f76/src/main/java/com/aws/greengrass/mqttclient/MqttTopic.java) implementation and v1 [routing](https://github.com/aws-greengrass/aws-greengrass-lambda-manager/blob/main/src/main/java/com/aws/greengrass/lambdamanager/system/v1subscription/RouteTrie.java) implementation in lambda manager.
The PubSub wildcard will differ from [MQTT Spec](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) in several ways, including
-  "#" does note match parent level
-  "$" has no special meaning

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
