### PR TITLE
fix: enable FSS to react to DeviceConfig updates and bring itself online

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v2
+      - uses: wagoid/commitlint-github-action@v4
         if: matrix.os == 'ubuntu-latest'
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -725,12 +725,12 @@ public class DeviceConfiguration {
      * Reports if device provisioning values have changed.
      *
      * @param node what may have changed during device provisioning
-     * @param initialSetupDone has initial setup has been done for a given service
+     * @param checkThingNameOnly has initial setup has been done for a given service
      * @return true if any device provisioning values have changed before initial service setup
      *         or if the thing name has changed after
      */
-    public static boolean  provisionInfoNodeChanged(Node node, Boolean initialSetupDone) {
-        if (initialSetupDone) {
+    public static boolean provisionInfoNodeChanged(Node node, Boolean checkThingNameOnly) {
+        if (checkThingNameOnly) {
             return node.childOf(DEVICE_PARAM_THING_NAME);
         } else {
             // List of configuration nodes that may change during device provisioning

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -721,6 +721,26 @@ public class DeviceConfiguration {
         }
     }
 
+    /**
+     * Reports if device provisioning values have changed.
+     *
+     * @param node what may have changed during device provisioning
+     * @param initialSetupDone has initial setup has been done for a given service
+     * @return true if any device provisioning values have changed before initial service setup
+     *         or if the thing name has changed after
+     */
+    public static boolean  provisionInfoNodeChanged(Node node, Boolean initialSetupDone) {
+        if (initialSetupDone) {
+            return node.childOf(DEVICE_PARAM_THING_NAME);
+        } else {
+            // List of configuration nodes that may change during device provisioning
+            return node.childOf(DEVICE_PARAM_THING_NAME) || node.childOf(DEVICE_PARAM_IOT_DATA_ENDPOINT)
+                    || node.childOf(DEVICE_PARAM_PRIVATE_KEY_PATH)
+                    || node.childOf(DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node.childOf(DEVICE_PARAM_ROOT_CA_PATH)
+                    || node.childOf(DEVICE_PARAM_AWS_REGION);
+        }
+    }
+
     private Topic getTopic(String parameterName) {
         return kernel.getConfig()
                 .lookup(SERVICES_NAMESPACE_TOPIC, getNucleusComponentName(), CONFIGURATION_CONFIG_KEY, parameterName);

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -283,7 +283,7 @@ public class IotJobsHelper implements InjectionActions {
         this.iotJobsClientWrapper = iotJobsClientFactory.getIotJobsClientWrapper(connection);
 
         deviceConfiguration.onAnyChange((what, node) -> {
-            if (node != null && what.equals(WhatHappened.childChanged)
+            if (node != null && WhatHappened.childChanged.equals(what)
                     && deviceConfiguration.provisionInfoNodeChanged(node, this.isSubscribedToIotJobsTopics.get())) {
                 try {
                     connectToIotJobs(deviceConfiguration);

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.deployment;
 
-import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.InjectionActions;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
@@ -67,12 +66,6 @@ import javax.inject.Inject;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_CERTIFICATE_FILE_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_DATA_ENDPOINT;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PRIVATE_KEY_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROOT_CA_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.deployment.IotJobsClientWrapper.JOB_DESCRIBE_ACCEPTED_TOPIC;
 import static com.aws.greengrass.deployment.IotJobsClientWrapper.JOB_DESCRIBE_REJECTED_TOPIC;
 import static com.aws.greengrass.deployment.IotJobsClientWrapper.JOB_EXECUTIONS_CHANGED_TOPIC;
@@ -290,7 +283,8 @@ public class IotJobsHelper implements InjectionActions {
         this.iotJobsClientWrapper = iotJobsClientFactory.getIotJobsClientWrapper(connection);
 
         deviceConfiguration.onAnyChange((what, node) -> {
-            if (node != null && what.equals(WhatHappened.childChanged) && relevantNodeChanged(node)) {
+            if (node != null && what.equals(WhatHappened.childChanged)
+                    && deviceConfiguration.provisionInfoNodeChanged(node, this.isSubscribedToIotJobsTopics.get())) {
                 try {
                     connectToIotJobs(deviceConfiguration);
                 } catch (DeviceConfigurationException e) {
@@ -305,18 +299,6 @@ public class IotJobsHelper implements InjectionActions {
         } catch (DeviceConfigurationException e) {
             logger.atWarn().kv("errorMessage", e.getMessage()).log(DEVICE_OFFLINE_MESSAGE);
             return;
-        }
-    }
-
-    private boolean relevantNodeChanged(Node node) {
-        if (this.isSubscribedToIotJobsTopics.get()) {
-            return node.childOf(DEVICE_PARAM_THING_NAME);
-        } else {
-            // List of configuration nodes that may change during device provisioning
-            return node.childOf(DEVICE_PARAM_THING_NAME) || node.childOf(DEVICE_PARAM_IOT_DATA_ENDPOINT)
-                    || node.childOf(DEVICE_PARAM_PRIVATE_KEY_PATH)
-                    || node.childOf(DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node.childOf(DEVICE_PARAM_ROOT_CA_PATH)
-                    || node.childOf(DEVICE_PARAM_AWS_REGION);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.deployment;
 
 import com.amazon.aws.iot.greengrass.configuration.common.Configuration;
-import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.InjectionActions;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
@@ -58,12 +57,6 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_CERTIFICATE_FILE_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_DATA_ENDPOINT;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PRIVATE_KEY_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROOT_CA_PATH;
-import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import static com.aws.greengrass.status.DeploymentInformation.ARN_FOR_STATUS_KEY;
 import static com.aws.greengrass.status.DeploymentInformation.STATUS_DETAILS_KEY;
@@ -163,7 +156,8 @@ public class ShadowDeploymentListener implements InjectionActions {
         mqttClient.addToCallbackEvents(callbacks);
 
         deviceConfiguration.onAnyChange((what, node) -> {
-            if (WhatHappened.childChanged.equals(what) && node != null && relevantNodeChanged(node)) {
+            if (WhatHappened.childChanged.equals(what) && node != null
+                    && deviceConfiguration.provisionInfoNodeChanged(node, isSubscribedToShadowTopics.get())) {
                 try {
                     connectToShadowService(deviceConfiguration);
                 } catch (DeviceConfigurationException e) {
@@ -178,18 +172,6 @@ public class ShadowDeploymentListener implements InjectionActions {
         } catch (DeviceConfigurationException e) {
             logger.atWarn().log(DEVICE_OFFLINE_MESSAGE);
             return;
-        }
-    }
-
-    private boolean relevantNodeChanged(Node node) {
-        if (isSubscribedToShadowTopics.get()) {
-            return node.childOf(DEVICE_PARAM_THING_NAME);
-        } else {
-            // List of configuration nodes that may change during device provisioning
-            return node.childOf(DEVICE_PARAM_THING_NAME) || node.childOf(DEVICE_PARAM_IOT_DATA_ENDPOINT)
-                    || node.childOf(DEVICE_PARAM_PRIVATE_KEY_PATH)
-                    || node.childOf(DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node.childOf(DEVICE_PARAM_ROOT_CA_PATH)
-                    || node.childOf(DEVICE_PARAM_AWS_REGION);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -173,7 +173,7 @@ public class FleetStatusService extends GreengrassService {
         super.postInject();
 
         deviceConfiguration.onAnyChange((what, node) -> {
-            if (node != null && what.equals(WhatHappened.childChanged)
+            if (node != null && WhatHappened.childChanged.equals(what)
                     && deviceConfiguration.provisionInfoNodeChanged(node, false)) {
                 try {
                     setUpFSS();

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -68,7 +68,7 @@ public class FleetStatusService extends GreengrassService {
     static final String FLEET_STATUS_SEQUENCE_NUMBER_TOPIC = "sequenceNumber";
     static final String FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC = "lastPeriodicUpdateTime";
     private static final int MAX_PAYLOAD_LENGTH_BYTES = 128_000;
-    public static final String DEVICE_OFFLINE_MESSAGE = "Device not configured to talk to AWS Iot cloud. "
+    public static final String DEVICE_OFFLINE_MESSAGE = "Device not configured to talk to AWS IoT cloud. "
             + "FleetStatusService is offline";
     private final DeviceConfiguration deviceConfiguration;
 

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -121,7 +121,6 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         lenient().when(mockGreengrassService2.getName()).thenReturn("MockService2");
         lenient().when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        when(mockDeviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         lenient().when(mockDeviceConfiguration.getNucleusVersion()).thenReturn(VERSION);
         Topic sequenceNumberTopic = Topic.of(context, FLEET_STATUS_SEQUENCE_NUMBER_TOPIC, "0");
         lenient().when(config.lookup(FLEET_STATUS_SEQUENCE_NUMBER_TOPIC)).thenReturn(sequenceNumberTopic);
@@ -885,14 +884,18 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
 
     private FleetStatusService createFSS() {
         PlatformResolver platformResolver = new PlatformResolver(null);
-        return new FleetStatusService(config, mockMqttClient,
+        FleetStatusService fleetStatusService = new FleetStatusService(config, mockMqttClient,
                 mockDeploymentStatusKeeper, mockKernel, mockDeviceConfiguration, platformResolver);
+        fleetStatusService.postInject();
+        return fleetStatusService;
     }
 
     private FleetStatusService createFSS(int periodicUpdateIntervalSec) {
         PlatformResolver platformResolver = new PlatformResolver(null);
-        return new FleetStatusService(config, mockMqttClient,
+        FleetStatusService fleetStatusService = new FleetStatusService(config, mockMqttClient,
                 mockDeploymentStatusKeeper, mockKernel, mockDeviceConfiguration, platformResolver,
                 periodicUpdateIntervalSec);
+        fleetStatusService.postInject();
+        return fleetStatusService;
     }
 }


### PR DESCRIPTION
**Description of changes:**
Enable FSS to react to DeviceConfig updates and bring itself online

**Why is this change necessary:**
Currently if device provisioning isn't finished, when FSS starts up, FSS will not be able to start and the device won't be picked up by greengrass cloud. Customers have to restart greengrass to have FSS startup.
This fix enables FSS to watch for changes and bring itself up when provisioning completes.

**How was this change tested:**
Manually installed greengrass with a delay in fleet provisioning. Confirmed that device shows up in greengrass cloud after some time. 


**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
