### PR TITLE
fix: windows hard coded well-known group name

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
@@ -72,9 +72,14 @@ public class WindowsPlatform extends Platform {
     private static final String NAMED_PIPE_PREFIX = "\\\\.\\pipe\\NucleusNamedPipe-";
     private static final String NAMED_PIPE_UUID_SUFFIX = UUID.randomUUID().toString();
     private static final int MAX_NAMED_PIPE_LEN = 256;
+    // Well-known SIDs reference
+    // https://docs.microsoft.com/pt-PT/windows/security/identity-protection/access-control/security-identifiers#well-known-sids
+    protected static final String EVERYONE_SID = "S-1-1-0";
     protected static final String LOCAL_SYSTEM_SID = "S-1-5-18";
     protected static final String ADMINISTRATORS_SID = "S-1-5-32-544";
     protected static final String LOCAL_SYSTEM_USERNAME = "SYSTEM";
+    private static final String EVERYONE_GROUP_NAME = Advapi32Util.getAccountBySid(EVERYONE_SID).name;
+    private static final String ADMINISTRATORS_GROUP_NAME = Advapi32Util.getAccountBySid(ADMINISTRATORS_SID).name;
     protected static final WindowsUserAttributes LOCAL_SYSTEM_USER_ATTRIBUTES =
             WindowsUserAttributes.builder().superUser(true).superUserKnown(true)
                     .principalIdentifier(LOCAL_SYSTEM_SID).principalName(LOCAL_SYSTEM_USERNAME)
@@ -158,7 +163,7 @@ public class WindowsPlatform extends Platform {
 
     @Override
     public String getPrivilegedGroup() {
-        return "Administrators";
+        return ADMINISTRATORS_GROUP_NAME;
     }
 
     @Override
@@ -410,7 +415,7 @@ public class WindowsPlatform extends Platform {
             }
 
             // Other
-            GroupPrincipal everyone = userPrincipalLookupService.lookupPrincipalByGroupName("Everyone");
+            GroupPrincipal everyone = userPrincipalLookupService.lookupPrincipalByGroupName(EVERYONE_GROUP_NAME);
             if (permission.isOtherRead()) {
                 aclEntries.add(AclEntry.newBuilder()
                         .setType(AclEntryType.ALLOW)

--- a/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsPlatformTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/windows/WindowsPlatformTest.java
@@ -203,7 +203,7 @@ class WindowsPlatformTest {
         int everyoneAclCount = 0;
         for (AclEntry aclEntry : initialOwnerAcl.getAcl()) {
             String name = aclEntry.principal().getName();
-            if (name.contains(EVERYONE_GROUP_NAME)) {
+            if (name.equals("\\" + EVERYONE_GROUP_NAME)) {
                 everyoneAclCount++;
             }
             if (name.contains(platform.getPrivilegedGroup())) {
@@ -235,7 +235,7 @@ class WindowsPlatformTest {
             everyoneAclCount = 0;
             for (AclEntry aclEntry : updatedAcl) {
                 String name = aclEntry.principal().getName();
-                if (name.contains(EVERYONE_GROUP_NAME)) {
+                if (name.equals("\\" + EVERYONE_GROUP_NAME)) {
                     everyoneAclCount++;
                 }
                 if (name.contains(platform.getPrivilegedGroup())) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`WindowsPlatform.java`: Lookup Windows group name "Everyone" and "Administrators" by SID instead of the hard-coded English string.

**Why is this change necessary:**
Non-English Windows versions can have localized name for groups such as "Everyone" and "Administrators". On those Windows versions, nucleus won't be able to install or function.

**How was this change tested:**
Manual test with German language Windows EC2 (AMI: `Windows_Server-2019-German-Full-Base-2021.09.15`)
Without this fix the test will fail:

```
[ERROR] Failures:
[ERROR]   WindowsPlatformTest.GIVEN_a_well_known_group_sid_WHEN_lookupGroupByIdentifier_THEN_succeed:292
Expected: "Everyone"
     but: was "Jeder"
```

**Any additional information or context required to review the change:**
To re-produce/test this, seems a non-English windows installation is required. If the system is English based, changing display language or system locale won't change the group names to localized ones.

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
