### PR TITLE
Feat: Only interpolate system parameter in component configuration section, not configuration parameter

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -162,8 +162,8 @@ public class KernelConfigResolver {
                 Object existingConfiguration = ((Map) servicesConfig.get(resolvedComponentsToDeploy.getName()))
                         .get(CONFIGURATION_CONFIG_KEY);
 
-                Object interpolatedConfiguration = interpolate(existingConfiguration, resolvedComponentsToDeploy,
-                        componentRecipe.getDependencies().keySet(), servicesConfig);
+                Object interpolatedConfiguration = interpolateSystemParametersOnly(existingConfiguration,
+                        resolvedComponentsToDeploy, componentRecipe.getDependencies().keySet(), servicesConfig);
 
                 ((Map) servicesConfig.get(resolvedComponentsToDeploy.getName()))
                         .put(CONFIGURATION_CONFIG_KEY, interpolatedConfiguration);
@@ -238,7 +238,7 @@ public class KernelConfigResolver {
         }
 
         Map<String, Object> resolvedConfiguration = resolveConfigurationToApply(optionalConfigUpdate.orElse(null),
-                componentRecipe, document, componentIdentifier);
+                componentRecipe, document);
 
         // merge resolved param and resolved configuration for backward compatibility
         resolvedServiceConfig
@@ -315,7 +315,7 @@ public class KernelConfigResolver {
     @SuppressWarnings("PMD.ConfusingTernary")
     private Map<String, Object> resolveConfigurationToApply(
             @Nullable ConfigurationUpdateOperation configurationUpdateOperation, ComponentRecipe componentRecipe,
-            DeploymentDocument document, ComponentIdentifier componentIdentifier) {
+            DeploymentDocument document) {
 
         // try read the running service config
         try (Context context = new Context()) {
@@ -344,40 +344,18 @@ public class KernelConfigResolver {
                 removeKeysFromConfigWhichAreReset(currentRunningConfig, configurationUpdateOperation.getPathsToReset());
             }
 
-            // The static config for interpolation
-            Configuration staticConfig = new Configuration(context);
-            Map defaultConfig = MAPPER.convertValue(
-                    Optional.ofNullable(componentRecipe.getComponentConfiguration())
-                            .map(ComponentConfiguration::getDefaultConfiguration)
-                            .orElse(MAPPER.createObjectNode()),
-                    Map.class
-            );  // init null to be empty default config
             // Merge in the defaults with timestamp 1 so that they don't overwrite any pre-existing values
-            staticConfig.mergeMap(1, defaultConfig);
-
-            Map updateConfig = Optional.ofNullable(configurationUpdateOperation)
-                    .map(ConfigurationUpdateOperation::getValueToMerge)
-                    .orElse(null);
-            // Merge in the requested config updates to static config if not null
-            if (Objects.nonNull(updateConfig)) {
-                staticConfig.mergeMap(document.getTimestamp(), updateConfig);
-            }
-
-            if (Coerce.toBoolean(deviceConfiguration.getInterpolateComponentConfiguration())) {
-                defaultConfig = (Map) interpolate(defaultConfig,
-                                componentIdentifier, componentRecipe.getDependencies().keySet(), staticConfig.toPOJO());
-                if (Objects.nonNull(updateConfig)) {
-                    updateConfig = (Map) interpolate(updateConfig,
-                            componentIdentifier, componentRecipe.getDependencies().keySet(), staticConfig.toPOJO());
-                }
-            }
+            JsonNode defaultConfig = Optional.ofNullable(componentRecipe.getComponentConfiguration())
+                    .map(ComponentConfiguration::getDefaultConfiguration)
+                    .orElse(MAPPER.createObjectNode()); // init null to be empty default config
 
             // Merge in the defaults from the recipe using timestamp 1 to denote a default
-            currentRunningConfig.mergeMap(1, defaultConfig);
+            currentRunningConfig.mergeMap(1, MAPPER.convertValue(defaultConfig, Map.class));
             currentRunningConfig.context.waitForPublishQueueToClear();
+
             // Merge in the requested config updates
-            if (Objects.nonNull(updateConfig)) {
-                currentRunningConfig.mergeMap(document.getTimestamp(), updateConfig);
+            if (configurationUpdateOperation != null && configurationUpdateOperation.getValueToMerge() != null) {
+                currentRunningConfig.mergeMap(document.getTimestamp(), configurationUpdateOperation.getValueToMerge());
             }
 
             return currentRunningConfig.toPOJO();
@@ -440,6 +418,22 @@ public class KernelConfigResolver {
     }
 
     /**
+     * Interpolate the lifecycle commands or config with resolved system configuration values.
+     *
+     * @param configValue                 original value; could be Map or String
+     * @param componentIdentifier         target component id
+     * @param dependencies                name set of component's dependencies
+     * @param resolvedKernelServiceConfig resolved kernel configuration under "Services" key
+     * @return the interpolated lifecycle object
+     * @throws IOException for directory issues
+     */
+    public Object interpolateSystemParametersOnly(Object configValue, ComponentIdentifier componentIdentifier,
+                                                 Set<String> dependencies,
+                                                  Map<String, Object> resolvedKernelServiceConfig) throws IOException {
+        return interpolate(configValue, componentIdentifier, dependencies, resolvedKernelServiceConfig, false);
+    }
+
+    /**
      * Interpolate the lifecycle commands or config with resolved component configuration values and system
      * configuration values.
      *
@@ -452,10 +446,30 @@ public class KernelConfigResolver {
      */
     public Object interpolate(Object configValue, ComponentIdentifier componentIdentifier, Set<String> dependencies,
             Map<String, Object> resolvedKernelServiceConfig) throws IOException {
+        return interpolate(configValue, componentIdentifier, dependencies, resolvedKernelServiceConfig, true);
+    }
+
+    /**
+     * Interpolate the lifecycle commands or config with
+     *     * (optional) resolved component configuration values.
+     *     * system configuration values.
+     *
+     * @param configValue                 original value; could be Map or String
+     * @param componentIdentifier         target component id
+     * @param dependencies                name set of component's dependencies
+     * @param resolvedKernelServiceConfig resolved kernel configuration under "Services" key
+     * @param shouldInterpolateConfiguration    flag to enable interpolation with component configuration
+     * @return the interpolated lifecycle object
+     * @throws IOException for directory issues
+     */
+    public Object interpolate(Object configValue, ComponentIdentifier componentIdentifier, Set<String> dependencies,
+            Map<String, Object> resolvedKernelServiceConfig, Boolean shouldInterpolateConfiguration)
+            throws IOException {
         Object result = configValue;
 
         if (configValue instanceof String) {
-            result = replace((String) configValue, componentIdentifier, dependencies, resolvedKernelServiceConfig);
+            result = replace((String) configValue, componentIdentifier, dependencies, resolvedKernelServiceConfig,
+                    shouldInterpolateConfiguration);
         }
         if (configValue instanceof Map) {
             Map<String, Object> childConfigMap = (Map<String, Object>) configValue;
@@ -463,7 +477,7 @@ public class KernelConfigResolver {
             for (Entry<String, Object> childLifecycle : childConfigMap.entrySet()) {
                 resolvedChildConfig.put(childLifecycle.getKey(),
                                         interpolate(childLifecycle.getValue(), componentIdentifier, dependencies,
-                                                    resolvedKernelServiceConfig));
+                                                    resolvedKernelServiceConfig, shouldInterpolateConfiguration));
             }
             result = resolvedChildConfig;
         }
@@ -471,7 +485,7 @@ public class KernelConfigResolver {
             List<Object> resolvedConfigValue = new ArrayList<>();
             for (Object element: (List<Object>) configValue) {
                 resolvedConfigValue.add(interpolate(element, componentIdentifier, dependencies,
-                        resolvedKernelServiceConfig));
+                        resolvedKernelServiceConfig, shouldInterpolateConfiguration));
             }
             result = resolvedConfigValue;
         }
@@ -480,7 +494,8 @@ public class KernelConfigResolver {
     }
 
     private String replace(String stringValue, ComponentIdentifier componentIdentifier, Set<String> dependencies,
-            Map<String, Object> resolvedKernelServiceConfig) throws IOException {
+            Map<String, Object> resolvedKernelServiceConfig, Boolean shouldInterpolateConfiguration)
+            throws IOException {
 
         Matcher matcher;
 
@@ -491,7 +506,7 @@ public class KernelConfigResolver {
             String namespace = matcher.group(1);
             String key = matcher.group(2);
 
-            if (CONFIGURATION_NAMESPACE.equals(namespace)) {
+            if (shouldInterpolateConfiguration && CONFIGURATION_NAMESPACE.equals(namespace)) {
                 Optional<String> configReplacement =
                         lookupConfigurationValueForComponent(componentIdentifier.getName(), key,
                                                              resolvedKernelServiceConfig);
@@ -528,7 +543,8 @@ public class KernelConfigResolver {
                 continue;
             }
 
-            if (!resolvedKernelServiceConfig.containsKey(targetComponent)) {
+            if (!Objects.isNull(resolvedKernelServiceConfig)
+                    && !resolvedKernelServiceConfig.containsKey(targetComponent)) {
                 LOGGER.atError().kv("interpolation text", matcher.group()).kv("target component", targetComponent)
                         .kv("main component", componentIdentifier.getName())
                         .log("Failed to interpolate because the target component is not in resolved Nucleus services."
@@ -536,13 +552,12 @@ public class KernelConfigResolver {
                 continue;
             }
 
-            if (CONFIGURATION_NAMESPACE.equals(namespace)) {
+            if (shouldInterpolateConfiguration && CONFIGURATION_NAMESPACE.equals(namespace)) {
                 Optional<String> configReplacement =
                         lookupConfigurationValueForComponent(targetComponent, key, resolvedKernelServiceConfig);
                 if (configReplacement.isPresent()) {
                     stringValue = stringValue.replace(matcher.group(), configReplacement.get());
                 }
-
             } else if (systemParameters.containsKey(namespace)) {
                 String version =
                         (String) ((Map) resolvedKernelServiceConfig.get(targetComponent)).get(VERSION_CONFIG_KEY);
@@ -578,8 +593,8 @@ public class KernelConfigResolver {
 
         Map componentResolvedConfig;
 
-        if (resolvedKernelServiceConfig.containsKey(componentName) && ((Map) resolvedKernelServiceConfig
-                .get(componentName)).containsKey(CONFIGURATION_CONFIG_KEY)) {
+        if (!Objects.isNull(resolvedKernelServiceConfig) && resolvedKernelServiceConfig.containsKey(componentName)
+                && ((Map) resolvedKernelServiceConfig.get(componentName)).containsKey(CONFIGURATION_CONFIG_KEY)) {
             componentResolvedConfig =
                     (Map) ((Map) resolvedKernelServiceConfig.get(componentName)).get(CONFIGURATION_CONFIG_KEY);
         } else {


### PR DESCRIPTION
**Description of changes:**
Before, nucleus interpolates component config after aggregating config from recipe, deployment update and running config. Running config is dynamic which exposes the risk of attacker can manipulate the running config in a way to be interpolated in next deployment.

This change let nucleus only interpolate system parameter for component configuration, not configuration parameter. For example:
* `{configuration:/paramA}` won't be interpolated in configuration section
* `{iot:thingName}` will be interpolated

This makes the component configuration section interpolation behavior static.

**Why is this change necessary:**
Security risk: enabling interpolation for configuration parameter under configuration section can cause issue like
corrupted running config triggers unexpected behavior by having special combination of variable designator.

**How was this change tested:**
Unit test

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
