### PR TITLE
chore: add unit test for nested namespace in config interpolation

### DIFF
--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -797,6 +797,83 @@ class KernelConfigResolverTest {
     }
 
     @Test
+    void GIVEN_deployment_with_dependencies_WHEN_config_resolution_requested_THEN_in_nested_namespace_cross_component_configuration_interpolated_for_inner_level()
+            throws Exception {
+        // A depends on both B and C
+        // GIVEN
+        ComponentIdentifier componentIdentifierA =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.2.0"));
+        ComponentIdentifier componentIdentifierB =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_B, new Semver("2.3.0"));
+        ComponentIdentifier componentIdentifierC =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_C, new Semver("3.4.0"));
+
+        Map<String, DependencyProperties> componentADependencies = new HashMap<>();
+        componentADependencies.put(TEST_INPUT_PACKAGE_B,
+                DependencyProperties.builder().versionRequirement("2.3").build());
+        componentADependencies.put(TEST_INPUT_PACKAGE_C,
+                DependencyProperties.builder().versionRequirement("3.4").build());
+
+        ComponentRecipe componentRecipeA = new ComponentRecipe(RecipeFormatVersion.JAN_25_2020, TEST_INPUT_PACKAGE_A,
+                componentIdentifierA.getVersion(), "", "", null, new HashMap<String, Object>() {{
+            put(LIFECYCLE_RUN_KEY, "java -jar {configuration:/jarPath}/test.jar");
+        }}, Collections.emptyList(), componentADependencies, null);
+        ComponentRecipe componentRecipeB = new ComponentRecipe(RecipeFormatVersion.JAN_25_2020, TEST_INPUT_PACKAGE_B,
+                componentIdentifierB.getVersion(), "", "", null, null, Collections.emptyList(), Collections.emptyMap(),
+                null);
+        ComponentRecipe componentRecipeC = new ComponentRecipe(RecipeFormatVersion.JAN_25_2020, TEST_INPUT_PACKAGE_C,
+                componentIdentifierC.getVersion(), "", "", null, null, Collections.emptyList(), Collections.emptyMap(),
+                null);
+
+        DeploymentPackageConfiguration componentDeploymentConfigA = DeploymentPackageConfiguration.builder()
+                .packageName(TEST_INPUT_PACKAGE_A)
+                .rootComponent(true)
+                .resolvedVersion("=1.2")
+                .configurationUpdateOperation(new ConfigurationUpdateOperation(
+                        new HashMap<String, Object>() {{
+                            // using work path because only root component supports update config
+                            put("jarPath", String.format("{randomName:{{{%s:work:path}:{%s:work:path}}:randomVal}}",
+                                    TEST_INPUT_PACKAGE_B,
+                                    TEST_INPUT_PACKAGE_C));
+                        }}, new ArrayList<>()))
+                .build();
+
+        DeploymentPackageConfiguration componentDeploymentConfigB = DeploymentPackageConfiguration.builder()
+                .packageName(TEST_INPUT_PACKAGE_B)
+                .rootComponent(false)
+                .resolvedVersion("=2.3")
+                .build();
+        DeploymentPackageConfiguration componentDeploymentConfigC = DeploymentPackageConfiguration.builder()
+                .packageName(TEST_INPUT_PACKAGE_C)
+                .rootComponent(false)
+                .resolvedVersion("=3.4")
+                .build();
+        DeploymentDocument document = DeploymentDocument.builder()
+                .deploymentPackageConfigurationList(Arrays.asList(componentDeploymentConfigA,
+                        componentDeploymentConfigB, componentDeploymentConfigC))
+                .timestamp(10_000L)
+                .build();
+
+        // WHEN
+        Map<ComponentIdentifier, ComponentRecipe> componentsToResolve = new HashMap<>();
+        componentsToResolve.put(componentIdentifierA, componentRecipeA);
+        componentsToResolve.put(componentIdentifierB, componentRecipeB);
+        componentsToResolve.put(componentIdentifierC, componentRecipeC);
+        Path expectedCompBWorkPath = Paths.get("/work/" + TEST_INPUT_PACKAGE_B).toAbsolutePath();
+        Path expectedCompCWorkPath = Paths.get("/work/" + TEST_INPUT_PACKAGE_C).toAbsolutePath();
+        when(nucleusPaths.workPath(TEST_INPUT_PACKAGE_B)).thenReturn(expectedCompBWorkPath);
+        when(nucleusPaths.workPath(TEST_INPUT_PACKAGE_C)).thenReturn(expectedCompCWorkPath);
+        Map<String, Object> servicesConfig = serviceConfigurationProperlyResolved(document, componentsToResolve);
+
+        // THEN
+        String expectedRunCommand = String.format("java -jar {randomName:{{%s:%s}:randomVal}}/test.jar",
+                expectedCompBWorkPath, expectedCompCWorkPath);
+        assertThat("jarPath should be replace by the {randomName:{{/work/PackageB:/work/PackageC}:randomVal}}",
+                getServiceRunCommand(TEST_INPUT_PACKAGE_A, servicesConfig),
+                equalTo(expectedRunCommand));
+    }
+
+    @Test
     void GIVEN_component_has_default_configuration_and_no_running_configuration_WHEN_config_resolution_requested_THEN_correct_value_applied() throws Exception {
         // GIVEN
         ComponentIdentifier rootComponentIdentifier =


### PR DESCRIPTION
**Description of changes:**
Add unit test for config interpolation with nested namespace. Test that for nested variable namespace, the most inner level can still be interpolated. 

Configurations such as `{artifacts:{randomNameSpace:{artifacts:path}}}` will be resolved to `{artifacts:{randomNameSpace:<artifacts-path>}}`

In cross component configuration, `{randomName:{{{PackageB:work:path}:{PackageC:work:path}}:randomVal}}` will be resolved to `{randomName:{{/work/PackageB:/work/PackageC}:randomVal}}`

**Why is this change necessary:**
More test coverage.

**How was this change tested:**

**Any additional information or context required to review the change:**
Note that self referential configs are only resolved one level; for configs `a=artifacts`, `b= {{configuration:/a}:path}`, b will only be resolved to `{artifacts:path}` but not the actual artifacts path.

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
