### PR TITLE
fix: increase timeout in TelemetryAgentTest to make test more robust

### DIFF
--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -236,7 +236,7 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         });
 
         telemetryAgent.postInject();
-        long timeoutMs = 5000;
+        long timeoutMs = 10000;
         verify(mockMqttClient, timeout(timeoutMs).atLeastOnce()).publish(publishRequestArgumentCaptor.capture());
         PublishRequest request = publishRequestArgumentCaptor.getValue();
         assertEquals(QualityOfService.AT_LEAST_ONCE, request.getQos());

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -237,7 +237,6 @@ class TelemetryAgentTest extends GGServiceTestUtil {
 
         telemetryAgent.postInject();
         long timeoutMs = 10000;
-
         verify(mockMqttClient, timeout(timeoutMs).atLeastOnce()).publish(publishRequestArgumentCaptor.capture());
         PublishRequest request = publishRequestArgumentCaptor.getValue();
         assertEquals(QualityOfService.AT_LEAST_ONCE, request.getQos());

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -237,6 +237,7 @@ class TelemetryAgentTest extends GGServiceTestUtil {
 
         telemetryAgent.postInject();
         long timeoutMs = 10000;
+
         verify(mockMqttClient, timeout(timeoutMs).atLeastOnce()).publish(publishRequestArgumentCaptor.capture());
         PublishRequest request = publishRequestArgumentCaptor.getValue();
         assertEquals(QualityOfService.AT_LEAST_ONCE, request.getQos());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Increasing timeout during test in TelemetryAgentTest

**Why is this change necessary:**
Needed to make test more reliable. Currently it has intermittent failures when it hits the timeout. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
