### PR TITLE
test: integration test verifying that FSS reacts to DeviceConfig updates

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.status;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.PublishRequest;
+import com.aws.greengrass.status.FleetStatusDetails;
+import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Coerce;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+class FleetStatusServiceSetupTest extends BaseITCase {
+    private static Kernel kernel;
+    private static DeviceConfiguration deviceConfiguration;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private AtomicReference<FleetStatusDetails> fleetStatusDetails;
+    @Mock
+    private MqttClient mqttClient;
+    CountDownLatch fssRunning = new CountDownLatch(1);
+
+    @BeforeEach
+    void setupKernel(ExtensionContext context) throws Exception {
+
+        fleetStatusDetails = new AtomicReference<>();
+        kernel = new Kernel();
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                FleetStatusServiceSetupTest.class.getResource("onlyMain.yaml"));
+        kernel.getContext().put(MqttClient.class, mqttClient);
+
+        when(mqttClient.publish(any(PublishRequest.class))).thenAnswer(i -> {
+            Object argument = i.getArgument(0);
+            PublishRequest publishRequest = (PublishRequest) argument;
+            try {
+                fleetStatusDetails.set(OBJECT_MAPPER.readValue(publishRequest.getPayload(), FleetStatusDetails.class));
+            } catch (JsonMappingException ignored) {
+            }
+            return CompletableFuture.completedFuture(0);
+        });
+
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)) {
+                if (newState.equals(State.RUNNING)) {
+                    fssRunning.countDown();
+                }
+            }
+        });
+    }
+
+    @AfterEach
+    void afterEach() {
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_kernel_is_launched_WHEN_device_provisioning_completes_before_kernel_launches_THEN_thing_details_uploaded_to_cloud()
+            throws Exception {
+
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                "xxxxxx" + ".credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
+                "us-east-1", "roleAliasName");
+        kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
+        kernel.launch();
+
+        assertTrue(fssRunning.await(10, TimeUnit.SECONDS));
+        assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState,
+                eventuallyEval(is(State.RUNNING)));
+        assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
+        assertNotNull(fleetStatusDetails);
+        assertNotNull(fleetStatusDetails.get());
+        assertEquals("ThingName", fleetStatusDetails.get().getThing());
+    }
+
+    @Test
+    void GIVEN_kernel_is_running_WHEN_device_provisioning_completes_after_kernel_has_launched_THEN_thing_details_uploaded_to_cloud()
+            throws Exception {
+        kernel.launch();
+        assertTrue(fssRunning.await(10, TimeUnit.SECONDS));
+        assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState,
+                eventuallyEval(is(State.RUNNING)));
+
+        deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
+        deviceConfiguration.getThingName().withValue("ThingName");
+        deviceConfiguration.getIotDataEndpoint().withValue("xxxxxx-ats.iot.us-east-1.amazonaws.com");
+        deviceConfiguration.getIotCredentialEndpoint().withValue("xxxxxx.credentials.iot.us-east-1.amazonaws.com");
+        deviceConfiguration.getPrivateKeyFilePath().withValue("privKeyFilePath");
+        deviceConfiguration.getCertificateFilePath().withValue("certFilePath");
+        deviceConfiguration.getRootCAFilePath().withValue("caFilePath");
+        deviceConfiguration.getAWSRegion().withValue("us-east-1");
+        deviceConfiguration.getIotRoleAlias().withValue("roleAliasName");
+
+        assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
+        assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -84,9 +85,9 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState, eventuallyEval(is(State.RUNNING)));
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
-        assertNotNull(fleetStatusDetails);
         assertNotNull(fleetStatusDetails.get());
-        assertEquals("ThingName", fleetStatusDetails.get().getThing());
+        assertThat(()-> fleetStatusDetails.get(), eventuallyEval(notNullValue(), Duration.ofSeconds(30)));
+        assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
@@ -39,6 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
@@ -47,6 +50,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
     private static DeviceConfiguration deviceConfiguration;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private AtomicReference<FleetStatusDetails> fleetStatusDetails;
+//    private static FleetStatusService spyFleetStatusService;
     @Mock
     private MqttClient mqttClient;
     CountDownLatch fssRunning = new CountDownLatch(1);
@@ -75,6 +79,8 @@ class FleetStatusServiceSetupTest extends BaseITCase {
                 if (newState.equals(State.RUNNING)) {
                     fssRunning.countDown();
                 }
+//                FleetStatusService fleetStatusService = (FleetStatusService) service;
+//                spyFleetStatusService = Mockito.spy(fleetStatusService);
             }
         });
     }
@@ -123,5 +129,8 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
         assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
+
+        //verify setup code adding listeners only gets called once
+//        verify(spyFleetStatusService, times(1)).schedulePeriodicFleetStatusDataUpdate(false);
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -122,6 +123,6 @@ class FleetStatusServiceSetupTest extends BaseITCase {
         assertEquals("new-ats.iot.us-east-1.amazonaws.com", Coerce.toString(deviceConfiguration.getIotDataEndpoint()));
 
         // Verify publishing happens once each for IoTJobs, ShadowDeploymentService, and FSS
-        verify(mqttClient, times(3)).publish(any(PublishRequest.class));
+        verify(mqttClient, timeout(5000).times(3)).publish(any(PublishRequest.class));
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -85,7 +85,6 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState, eventuallyEval(is(State.RUNNING)));
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
-        assertNotNull(fleetStatusDetails.get());
         assertThat(()-> fleetStatusDetails.get(), eventuallyEval(notNullValue(), Duration.ofSeconds(30)));
         assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -34,7 +34,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -73,7 +73,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
     }
 
     @Test
-    void GIVEN_kernel_deployment_WHEN_device_provisioning_completes_before_kernel_launches_THEN_thing_details_uploaded_to_cloud()
+    void GIVEN_kernel_deployment_WHEN_device_provisioning_completes_before_kernel_launches_and_is_changed_afterTHEN_thing_details_uploaded_to_cloud_exactly_once()
             throws Exception {
 
         deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
@@ -106,17 +106,6 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
         assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
-    }
-
-    @Test
-    void GIVEN_kernel_deployment_WHEN_device_configs_change_THEN_FSSsetup_is_not_rerun()
-            throws Exception {
-        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
-                "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
-                "us-east-1", "roleAliasName");
-        kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
-        kernel.launch();
-        assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState, eventuallyEval(is(State.RUNNING)));
 
         deviceConfiguration.getIotDataEndpoint().withValue("new-ats.iot.us-east-1.amazonaws.com");
         assertEquals("new-ats.iot.us-east-1.amazonaws.com", Coerce.toString(deviceConfiguration.getIotDataEndpoint()));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding integration tests verifying that FSS reacts to DeviceConfig updates and brings itself online

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
