### PR TITLE
fix: do not try to validate paths in gg service client

### DIFF
--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -22,8 +22,6 @@ import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClientBuilder;
 
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
@@ -54,9 +52,9 @@ public class GreengrassServiceClientFactory {
             if (WhatHappened.interiorAdded.equals(what) || WhatHappened.timestampUpdated.equals(what)) {
                 return;
             }
-            if (validString(node, DEVICE_PARAM_AWS_REGION) || validPath(node, DEVICE_PARAM_ROOT_CA_PATH) || validPath(
-                    node, DEVICE_PARAM_CERTIFICATE_FILE_PATH) || validPath(node, DEVICE_PARAM_PRIVATE_KEY_PATH)
-                    || validString(node, DEVICE_PARAM_GG_DATA_PLANE_PORT)) {
+            if (validString(node, DEVICE_PARAM_AWS_REGION) || validString(node, DEVICE_PARAM_ROOT_CA_PATH)
+                    || validString(node, DEVICE_PARAM_CERTIFICATE_FILE_PATH) || validString(node,
+                    DEVICE_PARAM_PRIVATE_KEY_PATH) || validString(node, DEVICE_PARAM_GG_DATA_PLANE_PORT)) {
                 validateConfiguration();
                 cleanClient();
             }
@@ -87,10 +85,6 @@ public class GreengrassServiceClientFactory {
 
     private boolean validString(Node node, String key) {
         return node != null && node.childOf(key) && Utils.isNotEmpty(Coerce.toString(node));
-    }
-
-    private boolean validPath(Node node, String key) {
-        return validString(node, key) && Files.exists(Paths.get(Coerce.toString(node)));
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Paths are allowed to be `file://` URIs ever since the PKCS#11 changes, however, those URIs are not acceptable by `Paths.get`. Therefore, the validation in the Greengrass service client is incorrect and will fail when using file URIs.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
