### PR TITLE
fix: process output reader treat \r as \n

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/util/ExecTest.java
@@ -155,7 +155,7 @@ class ExecTest {
         exec.withShell(command).withOut(stdoutConsumer).withErr(stderrConsumer);
         assertTrue(exec.successful(false));
         // new line for shell
-        assertEquals(expectedOutput.length() + System.lineSeparator().length(), stdout.length());
+        assertEquals(expectedOutput.length() + 1, stdout.length());
         assertEquals(0, stderr.length());
 
         // reinit consumers
@@ -167,7 +167,7 @@ class ExecTest {
         assertFalse(exec.successful(false));
         assertEquals(0, stdout.length());
         // new line for shell and 1 more for windows because it actually includes the trailing space before the 1>&2
-        assertEquals(expectedOutput.length() + System.lineSeparator().length() + (PlatformResolver.isWindows ? 1 : 0),
+        assertEquals(expectedOutput.length() + 1 + (PlatformResolver.isWindows ? 1 : 0),
                 stderr.length());
         exec.close();
     }

--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -442,12 +442,23 @@ public abstract class Exec implements Closeable {
         public void run() {
             try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8), 200)) {
                 StringBuilder sb = new StringBuilder();
+                boolean cr = false;
                 while (true) {
                     int c;
-                    for (c = br.read(); c >= 0 && c != '\n'; c = br.read()) {
+                    for (c = br.read(); c >= 0 && c != '\n' && c != '\r'; c = br.read()) {
                         sb.append((char) c);
+                        cr = false;
                     }
-                    if (c >= 0) {
+
+                    // Append a newline to our builder if we get \n or if we are seeing \r for the first time.
+                    // This prevents \r\n from causing 2 lines to be logged.
+                    // If cr is true and we see another \r, we will append a newline (\r\r is 2 lines).
+                    if (c >= 0 && !cr || c == '\r') {
+                        // Split on cr too, this protects us from having crazy long lines from a console application
+                        // which is using \r to rewrite the last line, ex updating download status.
+                        if (c == '\r') {
+                            cr = true;
+                        }
                         sb.append('\n');
                         nlines++;
                     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
In console applications `\r` is commonly used to overwrite the previous message and update it, such as when downloading with wget. This can be an issue for Greengrass as we wait for `\n` to trigger the end of line and flush the string builder to the log. This change updates our stdout/stderr reader to treat `\r` more like `\n`. `\r\n` is treated as a single newline as would be expected.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
