### PR TITLE
feat: support calling V1 TES when useTesV1 Nucleus config is true

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019, windows-latest]
     name: Build on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -35,14 +35,14 @@ jobs:
           TEMP: "C:\\Temp"
         run: "mvn -ntp -U verify -Djava.io.tmpdir=C:\\Temp"
         shell: cmd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os != 'ubuntu-latest'
       - name: Build with Maven (not Windows)
         env:
           AWS_REGION: us-west-2
         run: |
           sudo -E mvn -ntp -U verify
           sudo chown -R runner target
-        if: matrix.os != 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
       - name: Upload Failed Test Report
         uses: actions/upload-artifact@v1.0.0
         if: failure()

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -138,6 +138,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             new ObjectMapper().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
                     .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     private static final AtomicInteger deploymentCount = new AtomicInteger();
+    private static final int STDOUT_TIMEOUT = 20;
 
     private static Logger logger;
     private static DependencyResolver dependencyResolver;
@@ -470,7 +471,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertThat((Map<String, String>) resultConfig.get("path"), IsMapWithSize.aMapWithSize(1));  // no more keys
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             String stdout = stdouts.get(0);
 
             assertTrue(stdouts.get(0).contains("Value for /singleLevelKey: updated value of singleLevelKey."));
@@ -512,7 +513,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertThat((Map<String, String>) resultConfig.get("path"), IsMapWithSize.aMapWithSize(2));  // no more keys
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             stdout = stdouts.get(0);
 
             assertThat(stdout, containsString("Value for /singleLevelKey: updated value of singleLevelKey."));
@@ -556,7 +557,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertThat((Map<String, String>) resultConfig.get("path"), IsMapWithSize.aMapWithSize(1));  // no more keys
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             stdout = stdouts.get(0);
 
             assertThat(stdout, containsString("Value for /singleLevelKey: updated value of singleLevelKey."));
@@ -601,7 +602,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                 IsMapContaining.hasEntry("leafKey", "default value of /path/leafKey"));
 
         // verify interpolation result
-        assertThat("The stdout should be captured within seconds.", countDownLatch.await(20, TimeUnit.SECONDS));
+        assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
         String stdout = stdouts.get(0);
 
         assertThat(stdout, containsString("Value for /singleLevelKey: default value of singleLevelKey."));
@@ -670,7 +671,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                     IsMapContaining.hasEntry("leafKey", "default value of /path/leafKey"));
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(20, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             String stdout = stdouts.get(0);
 
             // verify updated value, as specified from ComponentConfigTest_InitialDocumentWithUpdate.json
@@ -718,7 +719,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             resultFuture.get(10, TimeUnit.SECONDS);
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             String stdout = stdouts.get(0);
             assertThat(stdout, containsString("Value for /singleLevelKey: default value of singleLevelKey."));
             assertThat(stdout, containsString("Value for /path/leafKey: default value of /path/leafKey."));
@@ -763,7 +764,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             String otherComponentName = "GreenSignal";
             String otherComponentVer = "1.0.0";
 
-            assertThat("has output", stdoutLatch.await(10, TimeUnit.SECONDS), is(true));
+            assertThat("has output", stdoutLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS), is(true));
 
             // verify interpolation result
             assertThat(stdouts.get(0), containsString("I'm kernel's root path: " + rootDir.toAbsolutePath()));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -139,6 +139,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                     .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     private static final AtomicInteger deploymentCount = new AtomicInteger();
     private static final int STDOUT_TIMEOUT = 20;
+    private static final int DEPLOYMENT_TIMEOUT = 60;
 
     private static Logger logger;
     private static DependencyResolver dependencyResolver;
@@ -283,7 +284,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture1 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc1.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result1 = resultFuture1.get(30, TimeUnit.SECONDS);
+        DeploymentResult result1 = resultFuture1.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result1.getDeploymentStatus());
 
         // version 2 should not exist now. preload it before deployment. we'll do the same for later deployments
@@ -294,7 +295,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture2 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc2.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result2 = resultFuture2.get(30, TimeUnit.SECONDS);
+        DeploymentResult result2 = resultFuture2.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result2.getDeploymentStatus());
 
         // both 1 and 2 should exist in component store at this point
@@ -306,7 +307,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture3 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc3.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result3 = resultFuture3.get(30, TimeUnit.SECONDS);
+        DeploymentResult result3 = resultFuture3.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result3.getDeploymentStatus());
 
         // version 1 removed by preemptive cleanup
@@ -317,7 +318,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture4 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc4.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result4 = resultFuture4.get(30, TimeUnit.SECONDS);
+        DeploymentResult result4 = resultFuture4.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result4.getDeploymentStatus());
 
         // version 2 removed by preemptive cleanup
@@ -338,19 +339,19 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture1 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc1.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture1.get(30, TimeUnit.SECONDS);
+        resultFuture1.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
 
         preloadLocalStoreContent(SIMPLE_APP_NAME, "2.0.0");
         Future<DeploymentResult> resultFuture2 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc2.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture2.get(30, TimeUnit.SECONDS);
+        resultFuture2.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
 
         // deploy V1 again
         Future<DeploymentResult> resultFuture1Again = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc1.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture1Again.get(30, TimeUnit.SECONDS);
+        resultFuture1Again.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertRecipeArtifactExists(simpleApp1);
 
         // load files again for the subsequent tests
@@ -821,7 +822,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("YellowAndRedSignal.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -982,7 +983,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("YellowAndRedSignal.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         List<String> services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -1000,7 +1001,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("FailureDoNothingDeployment.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result = resultFuture.get(30, TimeUnit.SECONDS);
+        DeploymentResult result = resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -1032,7 +1033,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("YellowAndRedSignal.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         List<String> services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -1108,7 +1109,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("AddNewServiceWithSafetyCheck.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
 
         String authToken = IPCTestUtils.getAuthTokeForService(kernel, "NonDisruptableService");
         final EventStreamRPCConnection clientConnection =
@@ -1145,7 +1146,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                             }
                         })).getResponse();
         try {
-            fut.get(30, TimeUnit.SECONDS);
+            fut.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         } catch (Exception e) {
             logger.atError().setCause(e).log("Error when subscribing to component updates");
             fail("Caught exception when subscribing to component updates");
@@ -1178,7 +1179,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertTrue(cdlUpdateStarted.await(40, TimeUnit.SECONDS));
             resultFuture.cancel(true);
 
-            assertTrue(cdlMergeCancelled.await(30, TimeUnit.SECONDS));
+            assertTrue(cdlMergeCancelled.await(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS));
 
             services = kernel.orderedDependencies().stream()
                     .filter(greengrassService -> greengrassService instanceof GenericExternalService)
@@ -1205,7 +1206,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture =
                 submitSampleJobDocument(DeploymentTaskIntegrationTest.class.getResource("SkipPolicyCheck.json").toURI(),
                         System.currentTimeMillis());
-        DeploymentResult result = resultFuture.get(30, TimeUnit.SECONDS);
+        DeploymentResult result = resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         List<String> services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -741,6 +741,11 @@ public class DeviceConfiguration {
         }
     }
 
+    public Topics getNucleusConfig() {
+        return kernel.getConfig()
+                .lookupTopics(SERVICES_NAMESPACE_TOPIC, getNucleusComponentName(), CONFIGURATION_CONFIG_KEY);
+    }
+
     private Topic getTopic(String parameterName) {
         return kernel.getConfig()
                 .lookup(SERVICES_NAMESPACE_TOPIC, getNucleusComponentName(), CONFIGURATION_CONFIG_KEY, parameterName);

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -174,7 +175,7 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         tes.startup();
         tes.shutdown();
 
-        verify(mockUriTopic).withValue(stringArgumentCaptor.capture());
+        verify(mockUriTopic).withNewerValue(anyLong(), stringArgumentCaptor.capture());
         String tesUrl = stringArgumentCaptor.getValue();
         URI uri = new URI(tesUrl);
         assertEquals("localhost", uri.getHost());

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -59,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -160,7 +161,7 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         Topic mockUriTopic = mock(Topic.class);
         Topics mockConfig = mock(Topics.class);
         when(config.getRoot()).thenReturn(mockConfig);
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, PORT_TOPIC)).thenReturn(portTopic);
+        when(config.lookup(eq(CONFIGURATION_CONFIG_KEY), anyString())).thenReturn(portTopic);
         when(mockConfig.lookup(SETENV_CONFIG_NAMESPACE, TES_URI_ENV_VARIABLE_NAME)).thenReturn(mockUriTopic);
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 IOT_ROLE_ALIAS_TOPIC)).thenReturn(roleTopic);
@@ -171,7 +172,6 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
                 executorService, deviceConfigurationWithRoleAlias(MOCK_ROLE_ALIAS));
         tes.postInject();
         tes.startup();
-        Thread.sleep(5000L);
         tes.shutdown();
 
         verify(mockUriTopic).withValue(stringArgumentCaptor.capture());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change adds a new configuration in the Nucleus component config called "useTesV1". When true, the TES URL path is changed to be the path which the Greengrass V1 cloud offers. The customer can use this in conjunction with setting the `iotCredEndpoint` to the Greengrass ats data endpoint in order to retrieve credentials from the V1 TES. If a customer chooses to do this, they must have a Greengrass group setup with the role associated, a core created with the Greengrass V2 thing's certificate ARN, and must have a deployment created for the group.

**Why is this change necessary:**
This is necessary for customers who want to use Greengrass in a VPC with VPCE as IoT Credential Provider doesn't yet support VPCE.

**How was this change tested:**
Added basic E2E test code (not committed) which created a Greengrass group with role and then verified that we got the credentials from it.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
