### PR TITLE
chore(deps): update device SDK version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019, windows-latest]
     name: Build on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -35,14 +35,14 @@ jobs:
           TEMP: "C:\\Temp"
         run: "mvn -ntp -U verify -Djava.io.tmpdir=C:\\Temp"
         shell: cmd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os != 'ubuntu-latest'
       - name: Build with Maven (not Windows)
         env:
           AWS_REGION: us-west-2
         run: |
           sudo -E mvn -ntp -U verify
           sudo chown -R runner target
-        if: matrix.os != 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
       - name: Upload Failed Test Report
         uses: actions/upload-artifact@v1.0.0
         if: failure()

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     name: Build on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.5.3-WINDOWS-SNAPSHOT</version>
+            <version>1.7.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
@@ -484,7 +484,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
 
         assertEquals(SUCCESSFUL, deploymentResult.getDeploymentStatus());
         GreengrassService main = kernel.locate("main");
-        assertThat(main::getState, eventuallyEval(is(State.RUNNING)));
+        assertThat(main::getState, eventuallyEval(is(State.RUNNING), Duration.ofSeconds(30)));
         GreengrassService sleeperB = kernel.locate("sleeperB");
         assertEquals(State.RUNNING, sleeperB.getState());
         // ensure context finish all tasks

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -138,6 +138,8 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             new ObjectMapper().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
                     .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     private static final AtomicInteger deploymentCount = new AtomicInteger();
+    private static final int STDOUT_TIMEOUT = 20;
+    private static final int DEPLOYMENT_TIMEOUT = 60;
 
     private static Logger logger;
     private static DependencyResolver dependencyResolver;
@@ -282,7 +284,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture1 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc1.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result1 = resultFuture1.get(30, TimeUnit.SECONDS);
+        DeploymentResult result1 = resultFuture1.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result1.getDeploymentStatus());
 
         // version 2 should not exist now. preload it before deployment. we'll do the same for later deployments
@@ -293,7 +295,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture2 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc2.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result2 = resultFuture2.get(30, TimeUnit.SECONDS);
+        DeploymentResult result2 = resultFuture2.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result2.getDeploymentStatus());
 
         // both 1 and 2 should exist in component store at this point
@@ -305,7 +307,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture3 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc3.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result3 = resultFuture3.get(30, TimeUnit.SECONDS);
+        DeploymentResult result3 = resultFuture3.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result3.getDeploymentStatus());
 
         // version 1 removed by preemptive cleanup
@@ -316,7 +318,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture4 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc4.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result4 = resultFuture4.get(30, TimeUnit.SECONDS);
+        DeploymentResult result4 = resultFuture4.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result4.getDeploymentStatus());
 
         // version 2 removed by preemptive cleanup
@@ -337,19 +339,19 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture1 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc1.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture1.get(30, TimeUnit.SECONDS);
+        resultFuture1.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
 
         preloadLocalStoreContent(SIMPLE_APP_NAME, "2.0.0");
         Future<DeploymentResult> resultFuture2 = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc2.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture2.get(30, TimeUnit.SECONDS);
+        resultFuture2.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
 
         // deploy V1 again
         Future<DeploymentResult> resultFuture1Again = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("SimpleAppJobDoc1.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture1Again.get(30, TimeUnit.SECONDS);
+        resultFuture1Again.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         assertRecipeArtifactExists(simpleApp1);
 
         // load files again for the subsequent tests
@@ -470,7 +472,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertThat((Map<String, String>) resultConfig.get("path"), IsMapWithSize.aMapWithSize(1));  // no more keys
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             String stdout = stdouts.get(0);
 
             assertTrue(stdouts.get(0).contains("Value for /singleLevelKey: updated value of singleLevelKey."));
@@ -512,7 +514,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertThat((Map<String, String>) resultConfig.get("path"), IsMapWithSize.aMapWithSize(2));  // no more keys
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             stdout = stdouts.get(0);
 
             assertThat(stdout, containsString("Value for /singleLevelKey: updated value of singleLevelKey."));
@@ -556,7 +558,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertThat((Map<String, String>) resultConfig.get("path"), IsMapWithSize.aMapWithSize(1));  // no more keys
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             stdout = stdouts.get(0);
 
             assertThat(stdout, containsString("Value for /singleLevelKey: updated value of singleLevelKey."));
@@ -601,7 +603,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                 IsMapContaining.hasEntry("leafKey", "default value of /path/leafKey"));
 
         // verify interpolation result
-        assertThat("The stdout should be captured within seconds.", countDownLatch.await(20, TimeUnit.SECONDS));
+        assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
         String stdout = stdouts.get(0);
 
         assertThat(stdout, containsString("Value for /singleLevelKey: default value of singleLevelKey."));
@@ -670,7 +672,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                     IsMapContaining.hasEntry("leafKey", "default value of /path/leafKey"));
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(20, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             String stdout = stdouts.get(0);
 
             // verify updated value, as specified from ComponentConfigTest_InitialDocumentWithUpdate.json
@@ -718,7 +720,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             resultFuture.get(10, TimeUnit.SECONDS);
 
             // verify interpolation result
-            assertThat("The stdout should be captured within seconds.", countDownLatch.await(5, TimeUnit.SECONDS));
+            assertThat("The stdout should be captured within seconds.", countDownLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS));
             String stdout = stdouts.get(0);
             assertThat(stdout, containsString("Value for /singleLevelKey: default value of singleLevelKey."));
             assertThat(stdout, containsString("Value for /path/leafKey: default value of /path/leafKey."));
@@ -763,7 +765,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             String otherComponentName = "GreenSignal";
             String otherComponentVer = "1.0.0";
 
-            assertThat("has output", stdoutLatch.await(10, TimeUnit.SECONDS), is(true));
+            assertThat("has output", stdoutLatch.await(STDOUT_TIMEOUT, TimeUnit.SECONDS), is(true));
 
             // verify interpolation result
             assertThat(stdouts.get(0), containsString("I'm kernel's root path: " + rootDir.toAbsolutePath()));
@@ -820,7 +822,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("YellowAndRedSignal.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -981,7 +983,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("YellowAndRedSignal.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         List<String> services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -999,7 +1001,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("FailureDoNothingDeployment.json").toURI(),
                 System.currentTimeMillis());
-        DeploymentResult result = resultFuture.get(30, TimeUnit.SECONDS);
+        DeploymentResult result = resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -1031,7 +1033,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("YellowAndRedSignal.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         List<String> services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());
@@ -1107,7 +1109,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("AddNewServiceWithSafetyCheck.json").toURI(),
                 System.currentTimeMillis());
-        resultFuture.get(30, TimeUnit.SECONDS);
+        resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
 
         String authToken = IPCTestUtils.getAuthTokeForService(kernel, "NonDisruptableService");
         final EventStreamRPCConnection clientConnection =
@@ -1144,7 +1146,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                             }
                         })).getResponse();
         try {
-            fut.get(30, TimeUnit.SECONDS);
+            fut.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         } catch (Exception e) {
             logger.atError().setCause(e).log("Error when subscribing to component updates");
             fail("Caught exception when subscribing to component updates");
@@ -1177,7 +1179,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
             assertTrue(cdlUpdateStarted.await(40, TimeUnit.SECONDS));
             resultFuture.cancel(true);
 
-            assertTrue(cdlMergeCancelled.await(30, TimeUnit.SECONDS));
+            assertTrue(cdlMergeCancelled.await(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS));
 
             services = kernel.orderedDependencies().stream()
                     .filter(greengrassService -> greengrassService instanceof GenericExternalService)
@@ -1204,7 +1206,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Future<DeploymentResult> resultFuture =
                 submitSampleJobDocument(DeploymentTaskIntegrationTest.class.getResource("SkipPolicyCheck.json").toURI(),
                         System.currentTimeMillis());
-        DeploymentResult result = resultFuture.get(30, TimeUnit.SECONDS);
+        DeploymentResult result = resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
         List<String> services = kernel.orderedDependencies().stream()
                 .filter(greengrassService -> greengrassService instanceof GenericExternalService)
                 .map(GreengrassService::getName).collect(Collectors.toList());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -914,7 +914,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         Files.write(f.toPath(), doc.getBytes(StandardCharsets.UTF_8));
         try (AutoCloseable ignored = TestUtils.createCloseableLogListener(listener)) {
             Future<DeploymentResult> resultFuture = submitSampleJobDocument(f.toURI(), System.currentTimeMillis());
-            resultFuture.get(10, TimeUnit.SECONDS);
+            resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
             String posixUser = Coerce.toString(kernel.findServiceTopic(testServiceName)
                     .find(RUN_WITH_NAMESPACE_TOPIC, POSIX_USER_KEY));
             String windowsUser = Coerce.toString(kernel.findServiceTopic(testServiceName)

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/MultiGroupDeploymentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/MultiGroupDeploymentTest.java
@@ -383,7 +383,7 @@ public class MultiGroupDeploymentTest extends BaseITCase {
         //rolling back will add back red signal/yellow signal. Mapping of groups to root components will also be restored.
         submitSampleJobDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithBrokenService.json")
                 .toURI(), "secondGroup", Deployment.DeploymentType.IOT_JOBS);
-        assertTrue(secondGroupCDL.await(30, TimeUnit.SECONDS));
+        assertTrue(secondGroupCDL.await(60, TimeUnit.SECONDS));
 
         Topics groupToRootTopic = kernel.getConfig().lookupTopics(SERVICES_NAMESPACE_TOPIC, DEPLOYMENT_SERVICE_TOPICS,
                 GROUP_TO_ROOT_COMPONENTS_TOPICS);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -334,7 +334,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         service.getServiceConfig().find(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, "install")
                 .withValue("echo \"Reinstalling service_with_dynamic_config\"");
 
-        assertTrue(serviceReinstalled.await(5, TimeUnit.SECONDS));
+        assertTrue(serviceReinstalled.await(30, TimeUnit.SECONDS));
     }
 
     @Test
@@ -362,7 +362,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         });
         service.getServiceConfig().find(VERSION_CONFIG_KEY).withValue("1.0.1");
 
-        assertTrue(serviceReinstalled.await(5, TimeUnit.SECONDS));
+        assertTrue(serviceReinstalled.await(60, TimeUnit.SECONDS));
     }
 
     @Test
@@ -391,7 +391,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         service.getServiceConfig().find(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, "run")
                 .withValue("echo \"Rerunning service_with_dynamic_config\" && sleep 100");
 
-        assertTrue(serviceRestarted.await(5, TimeUnit.SECONDS));
+        assertTrue(serviceRestarted.await(30, TimeUnit.SECONDS));
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelTest.java
@@ -185,7 +185,7 @@ class KernelTest extends BaseITCase {
                 serviceBroken.countDown();
             }
         });
-        assertTrue(serviceBroken.await(30, TimeUnit.SECONDS));
+        assertTrue(serviceBroken.await(90, TimeUnit.SECONDS));
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
@@ -314,7 +314,8 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_MEDIUM_TIMEOUT, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep).get(10, TimeUnit.SECONDS),
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep).get(30,
+                        TimeUnit.SECONDS),
                 "dependency removed", expectedDepRemoved, unexpectedDuringAllSoftDepChange);
 
 
@@ -332,7 +333,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_LONG_TIMEOUT, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep).get(15, TimeUnit.SECONDS),
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep).get(60, TimeUnit.SECONDS),
                 "dependency added", expectedDepAdded, Collections.emptySet());
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updates device SDK version to a new snapshot for 1.7.0 which is backward compatible with 1.5.0 (our update to 1.6.0 was rolledback due to test failures due to ABI incompatibility).

**Why is this change necessary:**

**How was this change tested:**
Ran this version of the Nucleus which has the newer device SDK with the CLI server that was built against the old version of the Nucleus with the old device SDK. This was previously incompatible due to the changing of the data model setters to return `this`. They no longer return `this` in 1.7.0 which keeps us compatible with 1.5.0.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
