### PR TITLE
feat: set eventTopic in pubsub

### DIFF
--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -121,12 +121,12 @@ public class PubSubIPCEventStreamAgent {
             // Still technically successful, just no one was subscribed
             return new PublishToTopicResponse();
         }
-        // TODO: include topic in message when new sdk is ready
         SubscriptionResponseMessage message = new SubscriptionResponseMessage();
         PublishEvent publishedEvent = PublishEvent.builder().topic(topic).build();
         if (jsonMessage.isPresent()) {
             JsonMessage message1 = new JsonMessage();
             message1.setMessage(jsonMessage.get());
+            message1.setEventTopic(topic);
             message.setJsonMessage(message1);
             try {
                 publishedEvent.setPayload(SERIALIZER.writeValueAsBytes(jsonMessage.get()));
@@ -138,6 +138,7 @@ public class PubSubIPCEventStreamAgent {
         if (binaryMessage.isPresent()) {
             BinaryMessage binaryMessage1 = new BinaryMessage();
             binaryMessage1.setMessage(binaryMessage.get());
+            binaryMessage1.setEventTopic(topic);
             message.setBinaryMessage(binaryMessage1);
             publishedEvent.setPayload(binaryMessage.get());
         }

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -148,6 +148,7 @@ class PubSubIPCEventStreamAgentTest {
             assertNull(message.getJsonMessage());
             assertNotNull(message.getBinaryMessage());
             assertEquals("ABCD", new String(message.getBinaryMessage().getMessage()));
+            assertEquals(TEST_TOPIC, message.getBinaryMessage().getEventTopic());
         }
     }
 
@@ -189,6 +190,7 @@ class PubSubIPCEventStreamAgentTest {
             assertNotNull(responseMessage.getJsonMessage());
             assertNull(responseMessage.getBinaryMessage());
             assertThat(responseMessage.getJsonMessage().getMessage(), IsMapContaining.hasEntry("SomeKey", "SomValue"));
+            assertEquals(TEST_TOPIC, responseMessage.getJsonMessage().getEventTopic());
         }
     }
 
@@ -230,6 +232,7 @@ class PubSubIPCEventStreamAgentTest {
             assertNull(message.getJsonMessage());
             assertNotNull(message.getBinaryMessage());
             assertEquals("ABCD", new String(message.getBinaryMessage().getMessage()));
+            assertEquals("Test/A/Topic/B/C", message.getBinaryMessage().getEventTopic());
         }
     }
 
@@ -279,6 +282,7 @@ class PubSubIPCEventStreamAgentTest {
                 assertNotNull(responseMessage.getJsonMessage());
                 assertNull(responseMessage.getBinaryMessage());
                 assertThat(responseMessage.getJsonMessage().getMessage(), IsMapContaining.hasEntry("SomeKey", i));
+                assertEquals(TEST_TOPIC, responseMessage.getJsonMessage().getEventTopic());
                 i++;
             }
         }
@@ -328,6 +332,7 @@ class PubSubIPCEventStreamAgentTest {
                 assertNull(responseMessage.getJsonMessage());
                 assertNotNull(responseMessage.getBinaryMessage());
                 assertEquals(String.valueOf(i), new String(responseMessage.getBinaryMessage().getMessage()));
+                assertEquals(TEST_TOPIC, responseMessage.getBinaryMessage().getEventTopic());
                 i++;
             }
         }
@@ -382,7 +387,7 @@ class PubSubIPCEventStreamAgentTest {
                 assertNull(responseMessage.getJsonMessage());
                 assertNotNull(responseMessage.getBinaryMessage());
                 assertEquals(String.valueOf(i), new String(responseMessage.getBinaryMessage().getMessage()));
-
+                assertEquals(String.format(subTopic, i), responseMessage.getBinaryMessage().getEventTopic());
                 i++;
             }
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set `eventTopic` in `JsonMessage` and `BinaryMessage` for `SubscriptionResponseMessage`

**Why is this change necessary:**
For a pubsub pulish request`SubscriptionResponseMessage` needs to include the exact topic

**How was this change tested:**

**Any additional information or context required to review the change:**
Complete TODO in https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1148 since SDK is updated

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
