### PR TITLE
feat: support configuring procd system service for OpenWRT

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -20,6 +20,7 @@
                 <include>loader.cmd</include>
                 <include>loader</include>
                 <include>greengrass.service.template</include>
+                <include>greengrass.service.procd.template</include>
                 <include>greengrass.xml.template</include>
                 <include>greengrass.exe</include>
             </includes>

--- a/scripts/greengrass.service.procd.template
+++ b/scripts/greengrass.service.procd.template
@@ -1,0 +1,28 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=99
+STOP=01
+
+start_service() {
+    procd_open_instance
+
+    # Retry count would be reset to 0 after 3600 seconds.
+    # Retry after 10 seconds.
+    # Always retry.
+    procd_set_param respawn 3600 10 0
+
+    procd_set_param pidfile REPLACE_WITH_GG_LOADER_PID_FILE
+
+    # Redirect stdout to system log.
+    procd_set_param stdout 1
+
+    # Redirect stderr to system log.
+    procd_set_param stderr 1
+
+    # We pass environment variables of Java here because Java may not be installed through opkg. If it's manually installed, we need to provide these variables.
+    procd_set_param command /bin/sh -c "JAVA_HOME=\"REPLACE_WITH_GG_JAVA_HOME\" PATH=\"$PATH:REPLACE_WITH_GG_JAVA_HOME/bin\" exec /bin/sh REPLACE_WITH_GG_LOADER_FILE"
+
+    procd_close_instance
+}

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -398,8 +398,8 @@ public class DeviceConfiguration {
         logger.atInfo().kv("source", src).kv("destination", dst).log("Copy Nucleus artifacts to component store");
         List<String> directories = Arrays.asList("bin", "lib", "conf");
         List<String> files = Arrays.asList("LICENSE", "NOTICE", "README.md", "THIRD-PARTY-LICENSES",
-                "greengrass.service.template", "greengrass.xml.template", "greengrass.exe", "loader",
-                "loader.cmd", "Greengrass.jar", "recipe.yaml");
+                "greengrass.service.template", "greengrass.service.procd.template", "greengrass.xml.template",
+                "greengrass.exe", "loader", "loader.cmd", "Greengrass.jar", "recipe.yaml");
 
         Files.walkFileTree(src, new SimpleFileVisitor<Path>() {
             @Override

--- a/src/main/java/com/aws/greengrass/util/orchestration/ProcdUtils.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/ProcdUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util.orchestration;
+
+import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+public class ProcdUtils implements SystemServiceUtils {
+    protected static final Logger logger = LogManager.getLogger(ProcdUtils.class);
+    private static final String PID_FILE_PARAM = "REPLACE_WITH_GG_LOADER_PID_FILE";
+    private static final String LOADER_FILE_PARAM = "REPLACE_WITH_GG_LOADER_FILE";
+    private static final String JAVA_HOME_PARAM = "REPLACE_WITH_GG_JAVA_HOME";
+    private static final String SERVICE_CONFIG_FILE_PATH = "/etc/init.d/greengrass.service";
+    private static final String LOG_EVENT_NAME = "procd-setup";
+    private static final String PROCD_SERVICE_FILE = "greengrass.service";
+    private static final String PROCD_SERVICE_TEMPLATE = "greengrass.service.procd.template";
+
+    @Override
+    public boolean setupSystemService(KernelAlternatives kernelAlternatives) {
+        logger.atInfo(LOG_EVENT_NAME).log("Start procd setup");
+        try {
+            kernelAlternatives.setupInitLaunchDirIfAbsent();
+
+            Path serviceTemplate = kernelAlternatives.getBinDir().resolve(PROCD_SERVICE_TEMPLATE);
+            if (!Files.exists(serviceTemplate)) {
+                throw new IOException("Missing service template file at: " + serviceTemplate);
+            }
+            Path loaderPath = kernelAlternatives.getLoaderPath();
+            if (!Files.exists(serviceTemplate)) {
+                throw new IOException("Missing loader file at: " + loaderPath);
+            }
+
+            Path serviceConfig = kernelAlternatives.getBinDir().resolve(PROCD_SERVICE_FILE);
+            interpolateServiceTemplate(serviceTemplate, serviceConfig, kernelAlternatives);
+
+            Files.copy(serviceConfig, Paths.get(SERVICE_CONFIG_FILE_PATH), REPLACE_EXISTING);
+            Files.setPosixFilePermissions(Paths.get(SERVICE_CONFIG_FILE_PATH),
+                    PosixFilePermissions.fromString("rwxr-xr-x"));
+
+            // The "service" command of procd is a function instead of an executable daemon, and it's not default
+            // configured in "/bin/sh". So we launch this service through System V style.
+            SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " reload", false);
+            SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " stop", false);
+            SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " enable", false);
+            SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " start", false);
+
+            logger.atInfo(LOG_EVENT_NAME).log("Successfully set up procd service");
+            return true;
+        } catch (IOException ioe) {
+            logger.atError(LOG_EVENT_NAME).log("Failed to set up procd service", ioe);
+        } catch (InterruptedException e) {
+            logger.atError(LOG_EVENT_NAME).log("Interrupted", e);
+            Thread.currentThread().interrupt();
+        }
+        return false;
+    }
+
+    private void interpolateServiceTemplate(Path src, Path dst, KernelAlternatives kernelAlternatives)
+            throws IOException {
+        String javaHome = System.getProperty("java.home");
+        try (BufferedReader r = Files.newBufferedReader(src);
+             BufferedWriter w = Files.newBufferedWriter(dst)) {
+            String line = r.readLine();
+            while (line != null) {
+                w.write(line.replace(PID_FILE_PARAM, kernelAlternatives.getLoaderPidPath().toString())
+                        .replace(LOADER_FILE_PARAM, kernelAlternatives.getLoaderPath().toString())
+                        .replace(JAVA_HOME_PARAM, javaHome));
+                w.newLine();
+                line = r.readLine();
+            }
+            w.flush();
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtilsFactory.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtilsFactory.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -41,8 +42,17 @@ public class SystemServiceUtilsFactory {
                 return context.get(SystemdUtils.class);
             }
         } catch (IOException e) {
-            logger.atError().log("Unable to determine init process type");
+            logger.atDebug().log("Unable to determine init process type");
         }
+
+        if (new File("/sbin/procd").isFile()) {
+            logger.atDebug().log("Detected procd on the device");
+            return context.get(ProcdUtils.class);
+        } else {
+            logger.atDebug().log("No procd is detected");
+        }
+
+        logger.atError().log("Unable to determine system service type");
         return context.get(InitUtils.class);
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Support configuring `procd` system service for OpenWRT.

**Why is this change necessary:**
OpenWRT does not use `systemd` to manage its system services. Instead, it uses `procd`. To support that, we need to add another implementation of `SystemServiceUtils`.

**How was this change tested:**
UT passed.
It's also tested by configuring Greengrass as a system service on a device with OpenWRT OS. Checked if Nucleus is still running after reboot or updating configuration.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
