### PR TITLE
fix(deployment): parse non-target group component requirements as requirements, not version

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -818,7 +818,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         groupToRootComponentsTopics.lookupTopics("CustomerApp")
                 .replaceAndWait(ImmutableMap.of(GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
         groupToRootComponentsTopics.lookupTopics("YellowSignal")
-                .replaceAndWait(ImmutableMap.of(GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+                .replaceAndWait(ImmutableMap.of(GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, ">=1.0.0"));
         resultFuture = submitSampleJobDocument(
                 DeploymentTaskIntegrationTest.class.getResource("YellowAndRedSignal.json").toURI(),
                 System.currentTimeMillis());

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.componentmanager.exceptions.NoAvailableComponentVersio
 import com.aws.greengrass.componentmanager.exceptions.PackagingException;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.ComponentMetadata;
+import com.aws.greengrass.componentmanager.models.ComponentRequirementIdentifier;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.deployment.model.DeploymentPackageConfiguration;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
@@ -71,7 +72,7 @@ public class DependencyResolver {
      * @throws InterruptedException                 InterruptedException
      */
     public List<ComponentIdentifier> resolveDependencies(DeploymentDocument document,
-                                                         Map<String, Set<ComponentIdentifier>>
+                                                         Map<String, Set<ComponentRequirementIdentifier>>
                                                                  otherGroupsToRootComponents)
             throws NoAvailableComponentVersionException, PackagingException, InterruptedException {
 
@@ -182,7 +183,8 @@ public class DependencyResolver {
         }
     }
 
-    private Set<String> getOtherGroupsTargetComponents(Map<String, Set<ComponentIdentifier>> otherGroupsRootComponents,
+    private Set<String> getOtherGroupsTargetComponents(Map<String, Set<ComponentRequirementIdentifier>>
+                                                               otherGroupsRootComponents,
                                                        Map<String, Map<String, Requirement>>
                                                                componentNameToVersionConstraints) {
         Set<String> targetComponents = new HashSet<>();
@@ -190,8 +192,8 @@ public class DependencyResolver {
             rootPackages.forEach(component -> {
                 targetComponents.add(component.getName());
                 componentNameToVersionConstraints.putIfAbsent(component.getName(), new HashMap<>());
-                componentNameToVersionConstraints.get(component.getName()).put(groupName, Requirement
-                        .buildNPM(component.getVersion().toString()));
+                componentNameToVersionConstraints.get(component.getName())
+                        .put(groupName, component.getVersionRequirement());
             });
         });
         return targetComponents;

--- a/src/main/java/com/aws/greengrass/componentmanager/models/ComponentRequirementIdentifier.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/models/ComponentRequirementIdentifier.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.models;
+
+import com.vdurmont.semver4j.Requirement;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor
+public class ComponentRequirementIdentifier {
+    String name;
+    Requirement versionRequirement;
+
+    @Override
+    public String toString() {
+        return String.format("%s-v%s", name, versionRequirement);
+    }
+}

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.componentmanager.exceptions.PackagingException;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.ComponentMetadata;
 import com.aws.greengrass.componentmanager.models.ComponentRecipe;
+import com.aws.greengrass.componentmanager.models.ComponentRequirementIdentifier;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
@@ -662,10 +663,10 @@ class DependencyResolverTest {
                 "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
 
-        Map<String, Set<ComponentIdentifier>> otherGroupRootPackages = new HashMap<>();
-        Set<ComponentIdentifier> rootPackages = new HashSet<>();
-        rootPackages.add(new ComponentIdentifier(componentX,new Semver("2.0.0")));
-        otherGroupRootPackages.put("mockGroup2",rootPackages);
+        Map<String, Set<ComponentRequirementIdentifier>> otherGroupRootPackages = new HashMap<>();
+        Set<ComponentRequirementIdentifier> rootPackages = new HashSet<>();
+        rootPackages.add(new ComponentRequirementIdentifier(componentX, Requirement.buildNPM("2.0.0")));
+        otherGroupRootPackages.put("mockGroup2", rootPackages);
 
         context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
A local deployment allows you to specify version requirements for root components such as ">0.0.0". This works fine, but subsequent non-local deployments failed in `getNonTargetGroupToRootPackagesMap` due to trying to parse `>0.0.0` as a version instead of a version requirement. We ultimately built a requirement from the version in DependencyResolver, so now we just properly construct the version requirement earlier on.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
