### PR TITLE
feat: change wildcard behaviour in Authz

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/pubsub.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/pubsub.yaml
@@ -133,4 +133,4 @@ services:
               - 'aws.greengrass#SubscribeToTopic'
               - 'aws.greengrass#PublishToTopic'
             resources:
-              - /to*/#
+              - /to*/*

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -65,11 +65,6 @@ public class AuthorizationHandler  {
     public static final String SECRETS_MANAGER_SERVICE_NAME = "aws.greengrass.SecretManager";
     public static final String SHADOW_MANAGER_SERVICE_NAME = "aws.greengrass.ShadowManager";
 
-    public enum ResourceLookupPolicy {
-        STANDARD,
-        MQTT_STYLE
-    }
-
     private static final Logger logger = LogManager.getLogger(AuthorizationHandler.class);
     private final ConcurrentHashMap<String, Set<String>> componentToOperationsMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, List<AuthorizationPolicy>>
@@ -175,11 +170,10 @@ public class AuthorizationHandler  {
      *
      * @param destination Destination component which is being accessed.
      * @param permission  container for principal, operation and resource.
-     * @param resourceLookupPolicy whether to match MQTT wildcards or not.
      * @return whether the input combination is a valid flow.
      * @throws AuthorizationException when flow is not authorized.
      */
-    public boolean isAuthorized(String destination, Permission permission, ResourceLookupPolicy resourceLookupPolicy)
+    public boolean isAuthorized(String destination, Permission permission)
             throws AuthorizationException {
         String principal = permission.getPrincipal();
         String operation = permission.getOperation();
@@ -202,7 +196,7 @@ public class AuthorizationHandler  {
                                 .principal(combination[1])
                                 .operation(combination[2])
                                 .resource(combination[3])
-                                .build(), resourceLookupPolicy)) {
+                                .build())) {
                     logger.atDebug().log("Hit policy with principal {}, operation {}, resource {}",
                             combination[1],
                             combination[2],
@@ -219,10 +213,6 @@ public class AuthorizationHandler  {
                         resource));
     }
 
-    public boolean isAuthorized(String destination, Permission permission) throws AuthorizationException {
-        return isAuthorized(destination, permission, ResourceLookupPolicy.STANDARD);
-    }
-
     /**
      * Get allowed resources for the combination of destination, principal and operation.
      * Also returns resources covered by permissions with * operation/principal.
@@ -230,7 +220,7 @@ public class AuthorizationHandler  {
      * @param destination destination
      * @param principal   principal (cannot be *)
      * @param operation   operation (cannot be *)
-     * @return list of allowed resources
+     * @return Set of allowed resources
      * @throws AuthorizationException when arguments are invalid
      */
     public Set<String> getAuthorizedResources(String destination, @NonNull String principal, @NonNull String operation)

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationModule.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationModule.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.authorization;
 
-import com.aws.greengrass.authorization.AuthorizationHandler.ResourceLookupPolicy;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.util.DefaultConcurrentHashMap;
 import com.aws.greengrass.util.Utils;
@@ -66,12 +65,11 @@ public class AuthorizationModule {
      * Check if the combination of destination,principal,operation,resource exists in the table.
      * @param destination destination value
      * @param permission set of principal, operation and resource.
-     * @param resourceLookupPolicy whether to match MQTT wildcards or not.
      * @return true if the input combination is present.
      * @throws AuthorizationException when arguments are invalid
      */
     @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
-    public boolean isPresent(String destination, Permission permission, ResourceLookupPolicy resourceLookupPolicy)
+    public boolean isPresent(String destination, Permission permission)
             throws AuthorizationException {
         if (Utils.isEmpty(permission.getPrincipal())
                 || Utils.isEmpty(destination)
@@ -88,16 +86,11 @@ public class AuthorizationModule {
             if (destMap.containsKey(permission.getPrincipal())) {
                 Map<String, WildcardTrie> principalMap = destMap.get(permission.getPrincipal());
                 if (principalMap.containsKey(permission.getOperation())) {
-                    return principalMap.get(permission.getOperation()).matches(permission.getResource(),
-                            resourceLookupPolicy);
+                    return principalMap.get(permission.getOperation()).matches(permission.getResource());
                 }
             }
         }
         return false;
-    }
-
-    public boolean isPresent(String destination, Permission permission) throws AuthorizationException {
-        return isPresent(destination, permission, ResourceLookupPolicy.STANDARD);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/authorization/WildcardTrie.java
+++ b/src/main/java/com/aws/greengrass/authorization/WildcardTrie.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.authorization;
 
-import com.aws.greengrass.authorization.AuthorizationHandler.ResourceLookupPolicy;
 import com.aws.greengrass.util.DefaultConcurrentHashMap;
 
 import java.util.HashMap;
@@ -15,37 +14,21 @@ import java.util.Map;
  * A Wildcard trie node which contains properties to identify the Node and a map of all it's children.
  * - isTerminal: If the node is a terminal node while adding a resource. It might not necessarily be a leaf node as we
  *   are adding multiple resources having same prefix but terminating on different points.
- * - isTerminalLevel: If the node is the last level before a valid use "#" wildcard (eg: "abc/123/#", 123/ would be the
- *   terminalLevel).
- * - isWildcard: If current Node is a valid glob wildcard (*)
- * - isWildcard: If current Node is a valid MQTT wildcard (#, +)
- * - matchAll: if current node should match everything. Could be MQTTWildcard or a wildcard and will always be a
- *   terminal Node.
+ * - isWildcard: If current Node is glob wildcard (*)
  */
 public class WildcardTrie {
     protected static final String GLOB_WILDCARD = "*";
-    protected static final String MQTT_MULTILEVEL_WILDCARD = "#";
-    protected static final String MQTT_SINGLELEVEL_WILDCARD = "+";
-    protected static final String MQTT_LEVEL_SEPARATOR = "/";
     protected static final char wildcardChar = GLOB_WILDCARD.charAt(0);
-    protected static final char multiLevelWildcardChar = MQTT_MULTILEVEL_WILDCARD.charAt(0);
-    protected static final char singleLevelWildcardChar = MQTT_SINGLELEVEL_WILDCARD.charAt(0);
-    protected static final char levelSeparatorChar = MQTT_LEVEL_SEPARATOR.charAt(0);
 
     private boolean isTerminal;
-    private boolean isTerminalLevel;
     private boolean isWildcard;
-    private boolean isMQTTWildcard;
-    private boolean matchAll;
     private final Map<String, WildcardTrie> children =
             new DefaultConcurrentHashMap<>(WildcardTrie::new);
 
     /**
      * Add allowed resources for a particular operation.
-     * - A new node is created for every occurrence of a wildcard (*, #, +).
-     * - Only nodes with valid usage of wildcards are marked with isWildcard or isMQTTWildcard.
+     * - A new node is created for every occurrence of a wildcard *
      * - Any other characters are grouped together to form a node.
-     * - Just a '*' or '#' creates a Node setting matchAll to true and would match all resources
      *
      * @param subject resource pattern
      */
@@ -53,32 +36,6 @@ public class WildcardTrie {
         if (subject == null) {
             return;
         }
-        if (subject.equals(GLOB_WILDCARD)) {
-            WildcardTrie initial = this.children.get(GLOB_WILDCARD);
-            initial.matchAll = true;
-            initial.isTerminal = true;
-            initial.isWildcard = true;
-            return;
-        }
-        if (subject.equals(MQTT_MULTILEVEL_WILDCARD)) {
-            WildcardTrie initial = this.children.get(MQTT_MULTILEVEL_WILDCARD);
-            initial.matchAll = true;
-            initial.isTerminal = true;
-            initial.isMQTTWildcard = true;
-            return;
-        }
-        if (subject.equals(MQTT_SINGLELEVEL_WILDCARD)) {
-            WildcardTrie initial = this.children.get(MQTT_SINGLELEVEL_WILDCARD);
-            initial.isTerminal = true;
-            initial.isMQTTWildcard = true;
-            return;
-        }
-        if (subject.startsWith(MQTT_SINGLELEVEL_WILDCARD + MQTT_LEVEL_SEPARATOR)) {
-            WildcardTrie initial = this.children.get(MQTT_SINGLELEVEL_WILDCARD);
-            initial.isMQTTWildcard = true;
-            initial.add(subject.substring(1), true);
-        }
-
         add(subject, true);
     }
 
@@ -93,8 +50,7 @@ public class WildcardTrie {
         StringBuilder sb = new StringBuilder(subjectLength);
         for (int i = 0; i < subjectLength; i++) {
             char currentChar = subject.charAt(i);
-            // Create separate Nodes for wildcards *, # and +
-            // Also tag them wildcard if its a valid usage
+            // Create separate Nodes for wildcards * and tag them wildcard
             if (currentChar == wildcardChar) {
                 current = current.add(sb.toString(), false);
                 current = current.children.get(GLOB_WILDCARD);
@@ -103,41 +59,6 @@ public class WildcardTrie {
                 if (i == subjectLength - 1) {
                     current.isTerminal = isTerminal;
                     return current;
-                }
-                return current.add(subject.substring(i + 1), true);
-            }
-            if (currentChar == multiLevelWildcardChar) {
-                WildcardTrie terminalLevel = current.add(sb.toString(), false);
-                current = terminalLevel.children.get(MQTT_MULTILEVEL_WILDCARD);
-                if (i == subjectLength - 1) {
-                    current.isTerminal = true;
-                    // check if # wildcard usage is valid
-                    if (i > 0 && subject.charAt(i - 1) == levelSeparatorChar) {
-                        current.isMQTTWildcard = true;
-                        current.matchAll = true;
-                        terminalLevel.isTerminalLevel = true;
-                    }
-                    return current;
-                }
-                return current.add(subject.substring(i + 1), true);
-            }
-            if (currentChar == singleLevelWildcardChar) {
-                current = current.add(sb.toString(), false);
-                current = current.children.get(MQTT_SINGLELEVEL_WILDCARD);
-                if (i == subjectLength - 1) {
-                    current.isTerminal = true;
-                    // check if '+' wildcard usage is valid
-                    // if it's used at the last level
-                    if (i > 0 && subject.charAt(i - 1) == levelSeparatorChar) {
-                        current.isMQTTWildcard = true;
-                    }
-                    return current;
-                }
-                // check if '+' wildcard usage is valid
-                // if it's used in middle levels
-                if (i > 0 && subject.charAt(i - 1) == levelSeparatorChar
-                        && subject.charAt(i + 1) == levelSeparatorChar) {
-                    current.isMQTTWildcard = true;
                 }
                 return current.add(subject.substring(i + 1), true);
             }
@@ -150,18 +71,16 @@ public class WildcardTrie {
     }
 
     /**
-     * Match given string to the corresponding allowed resources trie. MQTT wildcards are not processed.
+     * Match given string to the corresponding allowed resources trie.
      *
      * @param str string to match.
      */
     @SuppressWarnings({"PMD.UselessParentheses", "PMD.CollapsibleIfStatements"})
-    public boolean matchesStandard(String str) {
+    public boolean matches(String str) {
         if (str == null) {
             return true;
         }
-        if ((matchAll && isWildcard)
-                || (isTerminal && str.isEmpty())
-                || (isWildcard && isTerminal && (str.indexOf(MQTT_LEVEL_SEPARATOR) == -1))) {
+        if ((isTerminal && str.isEmpty()) || (isWildcard && isTerminal)) {
             return true;
         }
 
@@ -177,13 +96,13 @@ public class WildcardTrie {
 
             // Process * wildcards
             if (key.equals(GLOB_WILDCARD)) {
-                hasMatch = value.matchesStandard(str);
+                hasMatch = value.matches(str);
                 continue;
             }
 
             // Match normal characters
             if (str.startsWith(key)) {
-                hasMatch = value.matchesStandard(str.substring(key.length()));
+                hasMatch = value.matches(str.substring(key.length()));
                 // Succeed fast
                 if (hasMatch) {
                     return true;
@@ -194,10 +113,9 @@ public class WildcardTrie {
             if (isWildcard) {
                 int foundChildIndex = str.indexOf(key);
                 int keyLength = key.length();
-                // Matched characters inside * should not contain a "/"
-                if ((foundChildIndex >= 0)
-                        && (str.substring(0, foundChildIndex).indexOf(MQTT_LEVEL_SEPARATOR) == -1)) {
+                while (foundChildIndex >= 0) {
                     matchingChildren.put(str.substring(foundChildIndex + keyLength), value);
+                    foundChildIndex = str.indexOf(key, foundChildIndex + 1);
                 }
             }
         }
@@ -206,110 +124,9 @@ public class WildcardTrie {
             return true;
         }
         if (isWildcard && !matchingChildren.isEmpty()) {
-            return matchingChildren.entrySet().stream().anyMatch((e) -> e.getValue().matchesStandard(e.getKey()));
+            return matchingChildren.entrySet().stream().anyMatch((e) -> e.getValue().matches(e.getKey()));
         }
 
         return false;
-    }
-
-    /**
-     * Match given string to the corresponding allowed resources trie. MQTT wildcards are processed only if
-     * its a valid usage, otherwise treated as normal characters.
-     *
-     * @param str string to match
-     */
-    @SuppressWarnings({"PMD.UselessParentheses", "PMD.CollapsibleIfStatements"})
-    public boolean matchesMQTT(String str) {
-        if (str == null) {
-            return true;
-        }
-        if ((matchAll && isWildcard)
-                || (isTerminal && str.isEmpty())
-                || (isWildcard && isTerminal && (str.indexOf(MQTT_LEVEL_SEPARATOR) == -1))) {
-            return true;
-        }
-        if (isMQTTWildcard) {
-            if (matchAll || (isTerminal && (str.indexOf(MQTT_LEVEL_SEPARATOR) == -1))) {
-                return true;
-            }
-        }
-
-        boolean hasMatch = false;
-        Map<String, WildcardTrie> matchingChildren = new HashMap<>();
-        for (Map.Entry<String, WildcardTrie> e : children.entrySet()) {
-            // Succeed fast
-            if (hasMatch) {
-                return true;
-            }
-            String key = e.getKey();
-            WildcardTrie value = e.getValue();
-
-            // Process *, # and + wildcards (only process MQTT wildcards that have valid usages)
-            if (key.equals(GLOB_WILDCARD) || value.isMQTTWildcard && (key.equals(MQTT_SINGLELEVEL_WILDCARD)
-                    || key.equals(MQTT_MULTILEVEL_WILDCARD))) {
-                hasMatch = value.matchesMQTT(str);
-                continue;
-            }
-
-            // Match normal characters
-            if (str.startsWith(key)) {
-                hasMatch = value.matchesMQTT(str.substring(key.length()));
-                // Succeed fast
-                if (hasMatch) {
-                    return true;
-                }
-            }
-
-            // Check if it's terminalLevel to allow matching of string without "/" in the end
-            // eg: Just "abc" should match "abc/#"
-            String terminalKey = key.substring(0, key.length() - 1);
-            if (value.isTerminalLevel && str.equals(terminalKey)) {
-                return true;
-            }
-
-            // If I'm a wildcard, then I need to maybe chomp many characters to match my children
-            if (isWildcard) {
-                int foundChildIndex = str.indexOf(key);
-                int keyLength = key.length();
-                if (value.isTerminalLevel && str.endsWith(terminalKey)) {
-                    foundChildIndex = str.indexOf(terminalKey);
-                    keyLength = terminalKey.length();
-                }
-                // Matched characters inside * should not contain a "/"
-                if ((foundChildIndex >= 0)
-                        && (str.substring(0, foundChildIndex).indexOf(MQTT_LEVEL_SEPARATOR) == -1)) {
-                    matchingChildren.put(str.substring(foundChildIndex + keyLength), value);
-                }
-            }
-            if (isMQTTWildcard) {
-                int foundChildIndex = str.indexOf(key);
-                int keyLength = key.length();
-                if (value.isTerminalLevel && str.endsWith(terminalKey)) {
-                    foundChildIndex = str.indexOf(terminalKey);
-                    keyLength = terminalKey.length();
-                }
-                // Matched characters inside + should not contain a "/", also next match should have string starting
-                // with a "/"
-                if (foundChildIndex >= 0
-                        && (str.substring(0,foundChildIndex).indexOf(MQTT_LEVEL_SEPARATOR) == -1)
-                        && key.startsWith(MQTT_LEVEL_SEPARATOR)) {
-                    matchingChildren.put(str.substring(foundChildIndex + keyLength), value);
-                }
-            }
-        }
-        // Succeed fast
-        if (hasMatch) {
-            return true;
-        }
-        if ((isWildcard || isMQTTWildcard) && !matchingChildren.isEmpty()) {
-            return matchingChildren.entrySet().stream().anyMatch((e) -> e.getValue().matchesMQTT(e.getKey()));
-        }
-
-        return false;
-    }
-
-    public boolean matches(String str, ResourceLookupPolicy lookupPolicy) {
-        return lookupPolicy == ResourceLookupPolicy.MQTT_STYLE ? matchesMQTT(str)
-                : matchesStandard(str);
     }
 }

--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.MqttTopic;
 import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.mqttclient.SubscribeRequest;
 import com.aws.greengrass.mqttclient.UnsubscribeRequest;
@@ -34,6 +35,7 @@ import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +43,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.authorization.AuthorizationHandler.ANY_REGEX;
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
 
@@ -234,9 +237,20 @@ public class MqttProxyIPCAgent {
 
     void doAuthorization(String opName, String serviceName, String topic) throws AuthorizationException {
         if (authorizationHandler.isAuthorized(MQTT_PROXY_SERVICE_NAME,
-                Permission.builder().operation(opName).principal(serviceName).resource(topic).build(),
-                AuthorizationHandler.ResourceLookupPolicy.MQTT_STYLE)) {
+                Permission.builder().operation(opName).principal(serviceName).resource(topic).build())) {
             return;
+        }
+        Set<String> authorizedResources =
+                authorizationHandler.getAuthorizedResources(MQTT_PROXY_SERVICE_NAME, serviceName, opName);
+
+        for (String topicFilter : authorizedResources) {
+            if (topicFilter.equals(ANY_REGEX) || MqttTopic.topicIsSupersetOf(topicFilter, topic)) {
+                LOGGER.atDebug().log("Hit policy with principal {}, operation {}, resource {}",
+                        MQTT_PROXY_SERVICE_NAME,
+                        opName,
+                        topicFilter);
+                return;
+            }
         }
         throw new AuthorizationException(
                 String.format("Principal %s is not authorized to perform %s:%s on resource %s", serviceName,

--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.builtin.services.mqttproxy;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
-import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -236,10 +235,6 @@ public class MqttProxyIPCAgent {
     }
 
     void doAuthorization(String opName, String serviceName, String topic) throws AuthorizationException {
-        if (authorizationHandler.isAuthorized(MQTT_PROXY_SERVICE_NAME,
-                Permission.builder().operation(opName).principal(serviceName).resource(topic).build())) {
-            return;
-        }
         Set<String> authorizedResources =
                 authorizationHandler.getAuthorizedResources(MQTT_PROXY_SERVICE_NAME, serviceName, opName);
 

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -113,7 +113,7 @@ public class PubSubIPCEventStreamAgent {
         }
         if (topic.contains(MQTT_SINGLELEVEL_WILDCARD) || topic.contains(MQTT_MULTILEVEL_WILDCARD)
                 || topic.contains(GLOB_WILDCARD)) {
-            throw new InvalidArgumentsError("Publish topic must not contain a wildcard.");
+            throw new InvalidArgumentsError("Publish topic must not contain a wildcard");
         }
         Set<Object> contexts = listeners.get(topic);
         if (contexts == null || contexts.isEmpty()) {
@@ -256,7 +256,6 @@ public class PubSubIPCEventStreamAgent {
 
     private void doAuthorization(String opName, String serviceName, String topic) throws AuthorizationException {
         authorizationHandler.isAuthorized(PUB_SUB_SERVICE_NAME,
-                Permission.builder().principal(serviceName).operation(opName).resource(topic).build(),
-                AuthorizationHandler.ResourceLookupPolicy.MQTT_STYLE);
+                Permission.builder().principal(serviceName).operation(opName).resource(topic).build());
     }
 }

--- a/src/test/java/com/aws/greengrass/authorization/AuthorizationHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/AuthorizationHandlerTest.java
@@ -121,7 +121,7 @@ class AuthorizationHandlerTest {
                 .policyDescription("Test policy")
                 .principals(new HashSet<>(Arrays.asList("compA")))
                 .operations(new HashSet<>(Arrays.asList("OpA")))
-                .resources(new HashSet<>(Arrays.asList("abc*/xyz*4/*")))
+                .resources(new HashSet<>(Arrays.asList("abc*/+/*xyz*4/#")))
                 .build();
     }
 
@@ -405,8 +405,9 @@ class AuthorizationHandlerTest {
         AuthorizationPolicy policy = getStarWildcardResourceAuthZPolicy();
         authorizationHandler.loadAuthorizationPolicies("ServiceA", Collections.singletonList(policy),
                 false);
+
         assertTrue(authorizationHandler.isAuthorized("ServiceA",
-                Permission.builder().principal("compA").operation("OpA").resource("abc/def/-123/xyz1234/q/w/e").build()));
+                Permission.builder().principal("compA").operation("OpA").resource("abc/def/+/-123/xyz123/1/w/e4/#").build()));
 
         // Random resource which doesn't match the full pattern
         assertThrows(AuthorizationException.class, () -> authorizationHandler.isAuthorized("ServiceA",

--- a/src/test/java/com/aws/greengrass/authorization/WildcardTrieTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/WildcardTrieTest.java
@@ -16,282 +16,63 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WildcardTrieTest {
     @Test
     void testGlobWildcardMatching() {
+        // no wildcards
         WildcardTrie rt = new WildcardTrie();
-        rt.add("abc*xyz*");
-        assertTrue(rt.matchesMQTT("abc1234asdxyz456" ));
-        assertTrue(rt.matchesMQTT("abcdxyz"));
-        assertFalse(rt.matchesMQTT("abc123xyz456/89"));
-        assertFalse(rt.matchesMQTT(""));
+        rt.add("nowildcard");
+        rt.add("nowildcard2");
+        assertTrue(rt.matches("nowildcard"));
+        assertTrue(rt.matches("nowildcard"));
+        assertFalse(rt.matches("topic"));
 
-        assertTrue(rt.matchesStandard("abc1234asdxyz456" ));
-        assertTrue(rt.matchesStandard("abcdxyz"));
-        assertFalse(rt.matchesStandard("abc123xyz456/89"));
-        assertFalse(rt.matchesStandard(""));
+        // Test wildcards in middle
+        rt.add("abc*xy*z");
+        assertTrue(rt.matches("abc123xyabc!@#$%^&*()_+-=z" ));
+        assertTrue(rt.matches("abcxyz"));
+        assertTrue(rt.matches("abcxy7895z"));
+        assertTrue(rt.matches("abc123xy90zABCz"));
+        assertTrue(rt.matches("abc123xy90zABCxyABCz"));
 
-        rt.add("*/def");
-        assertTrue(rt.matchesMQTT("/def"));
-        assertTrue(rt.matchesMQTT("12345/def"));
-        assertTrue(rt.matchesMQTT(null));
-        assertFalse(rt.matchesMQTT("2/3/def"));
+        assertFalse(rt.matches("ab789xyz123"));
+        assertFalse(rt.matches("abc789xy56z123"));
+        assertFalse(rt.matches("abc123xy90zABCzz0"));
+        assertFalse(rt.matches("abc123yx90z"));
+        assertFalse(rt.matches(""));
 
-        assertTrue(rt.matchesStandard("/def"));
-        assertTrue(rt.matchesStandard("12345/def"));
-        assertTrue(rt.matchesStandard(null));
-        assertFalse(rt.matchesStandard("2/3/def"));
+        // Test multiple terminal points
+        rt.add("abc*xy*23");
+        assertTrue(rt.matches("abc789xy56z123"));
+        rt.add("abc*xy*");
+        assertTrue(rt.matches("abc123xy90zABCzz0"));
+        rt.add("abc*yx*z");
+        assertTrue(rt.matches("abc123yx90z"));
+
+        // Test Edge wildcards
+        WildcardTrie rt1 = new WildcardTrie();
+        rt1.add("*qwe*90*");
+
+        assertTrue(rt1.matches("abcqwe12390abcde" ));
+        assertTrue(rt1.matches("qwe90"));
+        assertTrue(rt1.matches("qwe9012"));
+        assertTrue(rt1.matches("789qwe-+9qwe-+90ABC"));
+
+        assertFalse(rt1.matches("789qwe-+9A"));
+        assertFalse(rt1.matches("ABC89078"));
+
+        rt1.add("*90*");
+        assertTrue(rt1.matches("ABC89078"));
 
         // Only '*' should match all resources
-        WildcardTrie rt1 = new WildcardTrie();
-        rt1.add("*wer");
-        assertFalse(rt1.matchesMQTT("9999/88"));
-        rt1.add("*");
-        assertTrue(rt1.matchesMQTT("9999/88"));
-        assertTrue(rt1.matchesStandard("9999/88"));
-
         WildcardTrie rt2 = new WildcardTrie();
-        rt2.add("a/*/*/d");
-        assertTrue(rt2.matchesMQTT("a/12/34/d"));
-        assertFalse(rt2.matchesMQTT("a/2/3/4/d"));
+        rt2.add("*wer");
+        assertFalse(rt2.matches("123werX"));
+        rt2.add("*");
+        assertTrue(rt2.matches("123werX"));
+        assertTrue(rt2.matches("9999/88"));
 
-        assertTrue(rt2.matchesStandard("a/12/34/d"));
-        assertFalse(rt2.matchesStandard("a/2/3/4/d"));
-
-        rt2.add("**/abc");
-        assertTrue(rt2.matchesMQTT("78/abc"));
-        assertFalse(rt2.matchesMQTT("7/8/abc"));
-
-        assertTrue(rt2.matchesStandard("78/abc"));
-        assertFalse(rt2.matchesStandard("7/8/abc"));
-    }
-
-    @Test
-    void testMQTTMultilevelWildcardMatching() {
-        //test MQTT wildcard usages according to MQTT V5.0 spec (https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html)
-        // Test Valid usages
-        WildcardTrie rt = new WildcardTrie();
-        rt.add("abc/#");
-        assertTrue(rt.matchesMQTT("abc/1/2/3"));
-        assertTrue(rt.matchesMQTT("abc"));
-        assertTrue(rt.matchesMQTT("abc/"));
-        assertTrue(rt.matchesMQTT("abc/4/5/6"));
-        assertFalse(rt.matchesMQTT("abcd/e/f123/4/5/6"));
-
-        assertFalse(rt.matchesStandard("abc/1/2/3"));
-        assertFalse(rt.matchesStandard("abc"));
-        assertFalse(rt.matchesStandard("abc/"));
-        assertFalse(rt.matchesStandard("abc/4/5/6"));
-        assertFalse(rt.matchesStandard("abcd/e/f123/4/5/6"));
-        assertTrue(rt.matchesStandard("abc/#"));
-
-        rt.add("123/#/xyz/#");
-        assertTrue(rt.matchesMQTT("123/#/xyz"));
-        assertTrue(rt.matchesMQTT("123/#/xyz/1/2/345"));
-        assertFalse(rt.matchesMQTT("123/4/5/6/xyz/abc"));
-        assertFalse(rt.matchesMQTT("12/34/zzz/45"));
-
-        assertFalse(rt.matchesStandard("123/#/xyz"));
-        assertFalse(rt.matchesStandard("123/#/xyz/1/2/345"));
-        assertFalse(rt.matchesStandard("123/4/5/6/xyz/abc"));
-        assertFalse(rt.matchesStandard("12/34/zzz/45"));
-        assertTrue(rt.matchesStandard("123/#/xyz/#"));
-
-        rt.add("#/zzz/45");
-        assertFalse(rt.matchesMQTT("x/zzz/45"));
-        assertTrue(rt.matchesMQTT("#/zzz/45"));
-
-        assertTrue(rt.matchesStandard("#/zzz/45"));
-
-        // Only '#' should match all resources
-        WildcardTrie rt1 = new WildcardTrie();
-        rt1.add("#");
-        assertTrue(rt1.matchesMQTT("asdu76/asdas/23"));
-        assertTrue(rt1.matchesMQTT("**90io"));
-
-        assertFalse(rt1.matchesStandard("asdu76/asdas/23"));
-        assertFalse(rt1.matchesStandard("**90io"));
-        assertTrue(rt1.matchesStandard("#"));
-
-        WildcardTrie rt2 = new WildcardTrie();
-        rt2.add("/#");
-        assertTrue(rt2.matchesMQTT(""));
-        assertTrue(rt2.matchesMQTT("/a/b/c/d/e"));
-        assertFalse(rt2.matchesMQTT("a/b/c/d"));
-        assertFalse(rt2.matchesMQTT("asd"));
-
-        assertFalse(rt2.matchesStandard(""));
-        assertFalse(rt2.matchesStandard("/a/b/c/d/e"));
-        assertFalse(rt2.matchesStandard("a/b/c/d"));
-        assertFalse(rt2.matchesStandard("asd"));
-        assertTrue(rt2.matchesStandard("/#"));
-
-
-        // Test Invalid usages
         WildcardTrie rt3 = new WildcardTrie();
-        rt3.add("w/qqq#");
-        assertFalse(rt3.matchesMQTT("w/qqq/e/r"));
-        assertTrue(rt3.matchesMQTT("w/qqq#"));
-
-        assertFalse(rt3.matchesStandard("w/qqq/e/r"));
-        assertTrue(rt3.matchesStandard("w/qqq#"));
-
-        rt3.add("12/#/");
-        assertFalse(rt3.matchesMQTT("12/4/5/6"));
-        assertTrue(rt3.matchesMQTT("12/#/"));
-
-        assertFalse(rt3.matchesStandard("12/4/5/6"));
-        assertTrue(rt3.matchesStandard("12/#/"));
-
-        rt3.add("##");
-        assertFalse(rt3.matchesMQTT("abcd"));
-        assertTrue(rt3.matchesMQTT("##"));
-
-        assertFalse(rt3.matchesStandard("abcd"));
-        assertTrue(rt3.matchesStandard("##"));
-    }
-
-    @Test
-    void testMQTTSinglelevelWildcardMatching() {
-        //test MQTT wildcard usages according to MQTT V5.0 spec (https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html)
-        // Test Valid usages
-        WildcardTrie rt = new WildcardTrie();
-        rt.add("abc/+/123");
-        assertTrue(rt.matchesMQTT("abc/def/123"));
-        assertFalse(rt.matchesMQTT("abc/def/g/123"));
-
-        assertFalse(rt.matchesStandard("abc/def/123"));
-        assertFalse(rt.matchesStandard("abc/def/g/123"));
-        assertTrue(rt.matchesStandard("abc/+/123"));
-
-        rt.add("+/56");
-        assertTrue(rt.matchesMQTT("123/56"));
-        assertFalse(rt.matchesMQTT("89/1/56"));
-
-        assertFalse(rt.matchesStandard("123/56"));
-        assertFalse(rt.matchesStandard("89/1/56"));
-        assertTrue(rt.matchesStandard("+/56"));
-
-        rt.add("xyz/+/abcd/+/1");
-        assertTrue(rt.matchesMQTT("xyz/ghj/abcd//1"));
-
-        assertFalse(rt.matchesStandard("xyz/ghj/abcd//1"));
-
-        rt.add("123/fgh/+");
-        assertTrue(rt.matchesMQTT("123/fgh/ert"));
-        assertFalse(rt.matchesMQTT("123/fgh/12/34"));
-
-        assertFalse(rt.matchesStandard("123/fgh/ert"));
-        assertFalse(rt.matchesStandard("123/fgh/12/34"));
-        assertTrue(rt.matchesStandard("123/fgh/+"));
-
-        rt.add("89/+/+/+/90");
-        assertTrue(rt.matchesMQTT("89/1/2/3/90"));
-        assertTrue(rt.matchesMQTT("89/1/2//90"));
-        assertFalse(rt.matchesMQTT("89/1/2/90"));
-        assertFalse(rt.matchesMQTT("89/1/2/3/4/90"));
-
-        assertFalse(rt.matchesStandard("89/1/2/3/90"));
-        assertFalse(rt.matchesStandard("89/1/2//90"));
-        assertFalse(rt.matchesStandard("89/1/2/90"));
-        assertFalse(rt.matchesStandard("89/1/2/3/4/90"));
-        assertTrue(rt.matchesStandard("89/+/+/+/90"));
-
-        WildcardTrie rt1 = new WildcardTrie();
-        rt1.add("+");
-        assertTrue(rt1.matchesMQTT("abc"));
-        assertFalse(rt1.matchesMQTT("/123"));
-
-        assertFalse(rt1.matchesStandard("abc"));
-        assertTrue(rt1.matchesStandard("+"));
-
-        rt1.add("+/+");
-        assertTrue(rt1.matchesMQTT("/123"));
-        assertFalse(rt1.matchesMQTT("/123/"));
-
-        assertFalse(rt1.matchesStandard("/123"));
-        assertTrue(rt1.matchesStandard("+/+"));
-
-        // Test Invalid usages
-        WildcardTrie rt2 = new WildcardTrie();
-        rt2.add("ax/qwe+/123");
-        assertFalse(rt2.matchesMQTT("ax/qwert/123"));
-        assertTrue(rt2.matchesMQTT("ax/qwe+/123"));
-
-        assertFalse(rt2.matchesStandard("ax/qwert/123"));
-        assertTrue(rt2.matchesStandard("ax/qwe+/123"));
-
-        rt2.add("12/+23");
-        assertFalse(rt2.matchesMQTT("12/x23"));
-
-        assertFalse(rt2.matchesStandard("12/x23"));
-        assertTrue(rt2.matchesStandard("12/+23"));
-
-        rt2.add("/+/++");
-        assertFalse(rt2.matchesMQTT("/33/ty"));
-        assertTrue(rt2.matchesMQTT("/zz/++"));
-
-        assertFalse(rt2.matchesStandard("/33/ty"));
-        assertFalse(rt2.matchesStandard("/zz/++"));
-    }
-
-    @Test
-    void testMultipleWildcardsMatching() {
-        WildcardTrie rt = new WildcardTrie();
-        rt.add("xyz*/+/*room/#");
-        assertTrue(rt.matchesMQTT("xyzzzz/89/bedroom/light/5"));
-        assertFalse(rt.matchesMQTT("xyzzzz/89/fan2/bedroom/light/5"));
-
-        assertFalse(rt.matchesStandard("xyzzzz/89/bedroom/light/5"));
-        assertFalse(rt.matchesStandard("xyzzzz/89/fan2/bedroom/light/5"));
-        assertTrue(rt.matchesStandard("xyzzzz/+/bedroom/#"));
-
-        rt.add("12/*#");
-        assertTrue(rt.matchesMQTT("12/345#"));
-        assertFalse(rt.matchesMQTT("12/45/67"));
-
-        rt.add("x*/+/#");
-        assertTrue(rt.matchesMQTT("xyzzzz/89/fan2/bedroom/light/5"));
-        assertTrue(rt.matchesMQTT("xyzzz34/matchPlus"));
-        assertFalse(rt.matchesMQTT("xyzzz34"));
-
-        assertFalse(rt.matchesStandard("xyzzzz/89/fan2/bedroom/light/5"));
-        assertFalse(rt.matchesStandard("xyzzz34/matchPlus"));
-        assertFalse(rt.matchesStandard("xyzzz34"));
-        assertTrue(rt.matchesStandard("xcv/+/#"));
-
-        rt.add("a/+/+/#/+");
-        assertTrue(rt.matchesMQTT("a/b/c/#/d"));
-        assertFalse(rt.matchesMQTT("a/b/c/d/e"));
-
-        assertTrue(rt.matchesStandard("a/+/+/#/+"));
-
-        // Add everything to see previous resources authorized now
-        rt.add("#");
-        assertTrue(rt.matchesMQTT("xyzzzz/89/fan2/bedroom/light/5"));
-        assertTrue(rt.matchesMQTT("12/45/67"));
-        assertTrue(rt.matchesMQTT("xyzzz34"));
-        assertTrue(rt.matchesMQTT("a/b/c/d/e"));
-
-        assertFalse(rt.matchesStandard("xyzzzz/89/fan2/bedroom/light/5"));
-        assertFalse(rt.matchesStandard("12/45/67"));
-        assertFalse(rt.matchesStandard("xyzzz34"));
-        assertFalse(rt.matchesStandard("a/b/c/d/e"));
-
-        WildcardTrie rt1 = new WildcardTrie();
-        rt1.add("2131/#/#/+/ui/#");
-        assertFalse(rt1.matchesMQTT("2131/x/y/z/ui/1"));
-        assertTrue(rt1.matchesMQTT("2131/#/#/z/ui/1/56"));
-
-        // Add everything to see previous resources authorized now
-        rt1.add("*");
-        assertTrue(rt1.matchesMQTT("2131/x/y/z/ui/1"));
-
-        assertTrue(rt1.matchesStandard("2131/x/y/z/ui/1"));
-
-        WildcardTrie rt2 = new WildcardTrie();
-        rt2.add("abc*/#");
-        assertTrue(rt2.matchesMQTT("abc123"));
-
-        rt2.add("x*/+/#");
-        assertTrue(rt2.matchesMQTT("xcvb/123"));
-        assertTrue(rt2.matchesMQTT("xcvb/123/4/5"));
+        rt3.add("**/abc");
+        assertTrue(rt3.matches("78/abc"));
+        assertTrue(rt3.matches("7/8/abc"));
+        assertTrue(rt3.matches("78/abc"));
     }
 }

--- a/src/test/java/com/aws/greengrass/authorization/WildcardTrieTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/WildcardTrieTest.java
@@ -61,18 +61,27 @@ class WildcardTrieTest {
         rt1.add("*90*");
         assertTrue(rt1.matches("ABC89078"));
 
-        // Only '*' should match all resources
+        // Test that wildcard doesn't stop matching at '/'
         WildcardTrie rt2 = new WildcardTrie();
-        rt2.add("*wer");
-        assertFalse(rt2.matches("123werX"));
-        rt2.add("*");
-        assertTrue(rt2.matches("123werX"));
-        assertTrue(rt2.matches("9999/88"));
+        rt2.add("ab/*/c");
 
+        assertTrue(rt2.matches("ab/12/c"));
+        assertTrue(rt2.matches("ab/1/3/2/c"));
+
+        assertFalse(rt2.matches("ab/1/34/2/c/"));
+
+        // Only '*' should match all resources
         WildcardTrie rt3 = new WildcardTrie();
-        rt3.add("**/abc");
-        assertTrue(rt3.matches("78/abc"));
-        assertTrue(rt3.matches("7/8/abc"));
-        assertTrue(rt3.matches("78/abc"));
+        rt3.add("*wer");
+        assertFalse(rt3.matches("123werX"));
+        rt3.add("*");
+        assertTrue(rt3.matches("123werX"));
+        assertTrue(rt3.matches("9999/88"));
+
+        WildcardTrie rt4 = new WildcardTrie();
+        rt4.add("**/abc");
+        assertTrue(rt4.matches("78/abc"));
+        assertTrue(rt4.matches("7/8/abc"));
+        assertTrue(rt4.matches("78/abc"));
     }
 }

--- a/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
@@ -6,8 +6,7 @@
 package com.aws.greengrass.builtin.services.mqttproxy;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
-import com.aws.greengrass.authorization.AuthorizationHandler.ResourceLookupPolicy;
-import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.mqttclient.SubscribeRequest;
@@ -37,9 +36,14 @@ import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import static com.aws.greengrass.authorization.AuthorizationHandler.ANY_REGEX;
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -58,6 +62,17 @@ class MqttProxyIPCAgentTest {
     private static final String TEST_SERVICE = "TestService";
     private static final String TEST_TOPIC = "TestTopic";
     private static final byte[] TEST_PAYLOAD = "TestPayload".getBytes(StandardCharsets.UTF_8);
+    private static final String TEST_SINGLE_LEVEL_WILDCARD = "topic/with/single/level/+/wildcard";
+    private static final String TEST_MULTI_LEVEL_WILDCARD = "topic/with/multi/level/wildcard/#";
+    private static final List<String> TEST_SINGLE_LEVEL_AUTHORIZED = Arrays.asList(
+            "topic/with/single/level/+/wildcard",
+            "topic/with/single/level/abc/wildcard");
+    private static final List<String> TEST_MULTI_LEVEL_AUTHORIZED = Arrays.asList(
+            "topic/with/multi/level/wildcard/#",
+            "topic/with/multi/level/wildcard/+/abc",
+            "topic/with/multi/level/wildcard/abc/#",
+            "topic/with/multi/level/wildcard/abc",
+            "topic/with/multi/level/wildcard/abc/xyz");
 
     @Mock
     OperationContinuationHandlerContext mockContext;
@@ -93,7 +108,8 @@ class MqttProxyIPCAgentTest {
         CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
         completableFuture.complete(0);
         when(mqttClient.publish(any())).thenReturn(completableFuture);
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
         ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor.forClass(PublishRequest.class);
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler
@@ -102,9 +118,8 @@ class MqttProxyIPCAgentTest {
                     = publishToIoTCoreOperationHandler.handleRequest(publishToIoTCoreRequest);
 
             assertNotNull(publishToIoTCoreResponse);
-            verify(authorizationHandler).isAuthorized(MQTT_PROXY_SERVICE_NAME, Permission.builder().principal(TEST_SERVICE)
-                    .operation(GreengrassCoreIPCService.PUBLISH_TO_IOT_CORE)
-                    .resource(TEST_TOPIC).build(), ResourceLookupPolicy.MQTT_STYLE);
+            verify(authorizationHandler).getAuthorizedResources(MQTT_PROXY_SERVICE_NAME, TEST_SERVICE,
+                    GreengrassCoreIPCService.PUBLISH_TO_IOT_CORE);
 
             verify(mqttClient).publish(publishRequestArgumentCaptor.capture());
             PublishRequest capturedPublishRequest = publishRequestArgumentCaptor.getValue();
@@ -124,7 +139,8 @@ class MqttProxyIPCAgentTest {
         CompletableFuture<Integer> f = new CompletableFuture<>();
         f.completeExceptionally(new SpoolerStoreException("Spool full"));
         when(mqttClient.publish(any())).thenReturn(f);
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getPublishToIoTCoreOperationHandler(mockContext)) {
@@ -140,7 +156,8 @@ class MqttProxyIPCAgentTest {
         subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
         subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
 
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
         ArgumentCaptor<SubscribeRequest> subscribeRequestArgumentCaptor
                 = ArgumentCaptor.forClass(SubscribeRequest.class);
         ArgumentCaptor<UnsubscribeRequest> unsubscribeRequestArgumentCaptor
@@ -153,9 +170,8 @@ class MqttProxyIPCAgentTest {
                     = subscribeToIoTCoreOperationHandler.handleRequest(subscribeToIoTCoreRequest);
 
             assertNotNull(subscribeToIoTCoreResponse);
-            verify(authorizationHandler).isAuthorized(MQTT_PROXY_SERVICE_NAME, Permission.builder().principal(TEST_SERVICE)
-                    .operation(GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE)
-                    .resource(TEST_TOPIC).build(), ResourceLookupPolicy.MQTT_STYLE);
+            verify(authorizationHandler).getAuthorizedResources(MQTT_PROXY_SERVICE_NAME, TEST_SERVICE,
+                    GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE);
 
             verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
             SubscribeRequest capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
@@ -180,13 +196,43 @@ class MqttProxyIPCAgentTest {
     }
 
     @Test
+    void GIVEN_wildcard_resources_WHEN_doAuthorization_THEN_authorized() throws Exception {
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_SINGLE_LEVEL_WILDCARD, TEST_MULTI_LEVEL_WILDCARD)));
+
+        for (String topic : TEST_SINGLE_LEVEL_AUTHORIZED) {
+            mqttProxyIPCAgent.doAuthorization(GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE, TEST_SERVICE, topic);
+        }
+        for (String topic : TEST_MULTI_LEVEL_AUTHORIZED) {
+            mqttProxyIPCAgent.doAuthorization(GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE, TEST_SERVICE, topic);
+        }
+    }
+
+    @Test
+    void GIVEN_wildcard_resources_WHEN_doAuthorization_with_unauthorized_topic_THEN_not_authorized() throws Exception {
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_SINGLE_LEVEL_WILDCARD, TEST_MULTI_LEVEL_WILDCARD)));
+
+        assertThrows(AuthorizationException.class, () -> mqttProxyIPCAgent.doAuthorization(
+                GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE, TEST_SERVICE, TEST_TOPIC));
+    }
+
+    @Test
+    void GIVEN_star_resource_WHEN_doAuthorization_THEN_authorized() throws Exception {
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any())).thenReturn(Collections.singleton(ANY_REGEX));
+
+        mqttProxyIPCAgent.doAuthorization(GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE, TEST_SERVICE, TEST_TOPIC);
+    }
+
+    @Test
     void GIVEN_MqttProxyIPCAgent_WHEN_publish_with_invalid_qos_THEN_error_thrown() throws Exception {
         PublishToIoTCoreRequest publishToIoTCoreRequest = new PublishToIoTCoreRequest();
         publishToIoTCoreRequest.setPayload(TEST_PAYLOAD);
         publishToIoTCoreRequest.setTopicName(TEST_TOPIC);
         publishToIoTCoreRequest.setQos("10");
 
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getPublishToIoTCoreOperationHandler(mockContext)) {
@@ -202,7 +248,8 @@ class MqttProxyIPCAgentTest {
         publishToIoTCoreRequest.setPayload(TEST_PAYLOAD);
         publishToIoTCoreRequest.setTopicName(TEST_TOPIC);
 
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getPublishToIoTCoreOperationHandler(mockContext)) {
@@ -232,7 +279,8 @@ class MqttProxyIPCAgentTest {
         publishToIoTCoreRequest.setTopicName(TEST_TOPIC);
         publishToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
 
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getPublishToIoTCoreOperationHandler(mockContext)) {
@@ -248,7 +296,8 @@ class MqttProxyIPCAgentTest {
         subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
         subscribeToIoTCoreRequest.setQos("10");
 
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
 
         try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
@@ -263,7 +312,8 @@ class MqttProxyIPCAgentTest {
         SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
         subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
 
-        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        when(authorizationHandler.getAuthorizedResources(any(), any(), any()))
+                .thenReturn(Collections.singleton(TEST_TOPIC));
 
         try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.builtin.services.pubsub;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
-import com.aws.greengrass.authorization.AuthorizationHandler.ResourceLookupPolicy;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -101,7 +100,7 @@ class PubSubIPCEventStreamAgentTest {
                     subscribeToTopicHandler.handleRequest(subscribeToTopicRequest);
             assertNotNull(subscribeToTopicResponse);
 
-            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture(), eq(ResourceLookupPolicy.MQTT_STYLE));
+            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture());
             Permission capturedPermission = permissionArgumentCaptor.getValue();
             assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.SUBSCRIBE_TO_TOPIC));
             assertThat(capturedPermission.getPrincipal(), is(TEST_SERVICE));
@@ -134,7 +133,7 @@ class PubSubIPCEventStreamAgentTest {
             PublishToTopicResponse publishToTopicResponse = publishToTopicHandler.handleRequest(publishToTopicRequest);
             assertNotNull(publishToTopicResponse);
 
-            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture(), eq(ResourceLookupPolicy.MQTT_STYLE));
+            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture());
             Permission capturedPermission = permissionArgumentCaptor.getValue();
             assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.PUBLISH_TO_TOPIC));
             assertThat(capturedPermission.getPrincipal(), is(TEST_SERVICE));
@@ -176,7 +175,7 @@ class PubSubIPCEventStreamAgentTest {
             PublishToTopicResponse publishToTopicResponse = publishToTopicHandler.handleRequest(publishToTopicRequest);
             assertNotNull(publishToTopicResponse);
 
-            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture(), eq(ResourceLookupPolicy.MQTT_STYLE));
+            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture());
             Permission capturedPermission = permissionArgumentCaptor.getValue();
             assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.PUBLISH_TO_TOPIC));
             assertThat(capturedPermission.getPrincipal(), is(TEST_SERVICE));
@@ -217,8 +216,7 @@ class PubSubIPCEventStreamAgentTest {
             PublishToTopicResponse publishToTopicResponse = publishToTopicHandler.handleRequest(publishToTopicRequest);
             assertNotNull(publishToTopicResponse);
 
-            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture(),
-                    eq(ResourceLookupPolicy.MQTT_STYLE));
+            verify(authorizationHandler).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture());
             Permission capturedPermission = permissionArgumentCaptor.getValue();
             assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.PUBLISH_TO_TOPIC));
             assertThat(capturedPermission.getPrincipal(), is(TEST_SERVICE));
@@ -266,8 +264,7 @@ class PubSubIPCEventStreamAgentTest {
                 assertNotNull(publishToTopicResponse);
             }
 
-            verify(authorizationHandler, times(10)).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture(),
-                    eq(ResourceLookupPolicy.MQTT_STYLE));
+            verify(authorizationHandler, times(10)).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture());
             Permission capturedPermission = permissionArgumentCaptor.getValue();
             assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.PUBLISH_TO_TOPIC));
             assertThat(capturedPermission.getPrincipal(), is(TEST_SERVICE));
@@ -316,8 +313,7 @@ class PubSubIPCEventStreamAgentTest {
                 assertNotNull(publishToTopicResponse);
             }
 
-            verify(authorizationHandler, times(10)).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture(),
-                    eq(ResourceLookupPolicy.MQTT_STYLE));
+            verify(authorizationHandler, times(10)).isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture());
             Permission capturedPermission = permissionArgumentCaptor.getValue();
             assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.PUBLISH_TO_TOPIC));
             assertThat(capturedPermission.getPrincipal(), is(TEST_SERVICE));
@@ -371,8 +367,7 @@ class PubSubIPCEventStreamAgentTest {
             }
 
             verify(authorizationHandler, times(10))
-                    .isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture(),
-                            eq(ResourceLookupPolicy.MQTT_STYLE));
+                    .isAuthorized(eq(PUB_SUB_SERVICE_NAME), permissionArgumentCaptor.capture());
             Permission capturedPermission = permissionArgumentCaptor.getValue();
             assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.PUBLISH_TO_TOPIC));
             assertThat(capturedPermission.getPrincipal(), is(TEST_SERVICE));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change behavior of wildcard evaluation inside Authorization. This was previously implemented where we evaluated both MQTT wildcards (`+,#`) and glob wildcard (`*`). https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1152

Changes: 
- MQTT wildcards will not be evaluated and will be treated as string literals.
- Glob wildcard will not respect MQTT levels now and match across levels. (eg - `ab/*/c` will match `ab/1/2/c` and `ab/12/c`)

**Why is this change necessary:**
The change was made so that wildcards in different policies are consistent with each other and particularly match IoT Core policy's behavior.

**How was this change tested:**
Unit tests
**Any additional information or context required to review the change:**
Design change Discussion: https://quip-amazon.com/9tvKA4JH4Tag/Authorization-Edge-Workflow-CX-Review

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
