### PR TITLE
feat: batched subscriber

### DIFF
--- a/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
+++ b/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
@@ -32,17 +32,14 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
     };
 
     /**
-     * Callback to be performed when
-     * <ul>
-     *     <li>the subscription is initialized</li>
-     *     <li>a batch of changes have fired</li>
-     * </ul>
+     * Callback to perform after a batch of changes fires.
      */
     public interface Callback {
         /**
          * Perform the subscriber action.
          *
-         * @param what {@link WhatHappened#initialized} on subscription initialization, otherwise a pass-through from the subscription.
+         * @param what {@link WhatHappened#initialized} on subscription initialization,
+         *             otherwise a pass-through from the subscription.
          */
         void run(WhatHappened what);
     }
@@ -53,7 +50,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
     private final Callback callback;
 
     /**
-     * Constructs a new BatchedSubscriber
+     * Constructs a new BatchedSubscriber.
      *
      * @param callback action to perform after a batch of changes
      */
@@ -62,7 +59,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
     }
 
     /**
-     * Constructs a new BatchedSubscriber
+     * Constructs a new BatchedSubscriber.
      *
      * @param exclusions exclude changes based on what happened
      * @param callback   action to perform after a batch of changes

--- a/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
+++ b/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
@@ -15,6 +15,14 @@ import com.aws.greengrass.config.WhatHappened;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 
+/**
+ * Utility class that allows a subscription to only fire
+ * on the last change in a batch.
+ *
+ * <p>This is useful in scenarios such as configuration changes
+ * where you may only want to perform expensive work once within
+ * a short span.
+ */
 public final class BatchedSubscriber {
 
     private final Runnable unsubscribe;
@@ -23,16 +31,36 @@ public final class BatchedSubscriber {
         this.unsubscribe = unsubscribe;
     }
 
+    /**
+     * Remove the subscription.
+     */
     public void unsubscribe() {
         if (unsubscribe != null) {
             unsubscribe.run();
         }
     }
 
+    /**
+     * Subscribe to topic changes.
+     *
+     * @param topic      topic
+     * @param afterBatch callback to perform after a batch of changes
+     * @return batched subscriber
+     */
     public static BatchedSubscriber subscribe(Topic topic, Runnable afterBatch) {
         return subscribe(topic, afterBatch, null, null);
     }
 
+    /**
+     * Subscribe to topic changes. Subscriptions will only be called once
+     * for a batch of changes.
+     *
+     * @param topic            topic
+     * @param afterBatch       callback to perform after a batch of changes
+     * @param onInitialization callback to perform after the subscription has been added
+     * @param excludeFilter    custom filter for ignoring changes
+     * @return batched subscriber
+     */
     public static BatchedSubscriber subscribe(Topic topic,
                                               Runnable afterBatch, Runnable onInitialization,
                                               BiPredicate<WhatHappened, Topic> excludeFilter) {
@@ -67,10 +95,28 @@ public final class BatchedSubscriber {
         return new BatchedSubscriber(() -> topic.remove(subscriber));
     }
 
+    /**
+     * Subscribe to topic changes. Subscriptions will only be called once
+     * for a batch of changes.
+     *
+     * @param topics     topics
+     * @param afterBatch callback to perform after a batch of changes
+     * @return batched subscriber
+     */
     public static BatchedSubscriber subscribe(Topics topics, Runnable afterBatch) {
         return subscribe(topics, afterBatch, null, null);
     }
 
+    /**
+     * Subscribe to topic changes. Subscriptions will only be called once
+     * for a batch of changes.
+     *
+     * @param topics           topics
+     * @param afterBatch       callback to perform after a batch of changes
+     * @param onInitialization callback to perform after the subscription has been added
+     * @param excludeFilter    custom filter for ignoring changes
+     * @return batched subscriber
+     */
     public static BatchedSubscriber subscribe(Topics topics,
                                               Runnable afterBatch, Runnable onInitialization,
                                               BiPredicate<WhatHappened, Node> excludeFilter) {

--- a/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
+++ b/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
@@ -84,9 +84,7 @@ public final class BatchedSubscriber {
 
             numRequestedChanges.incrementAndGet();
             topic.context.runOnPublishQueue(() -> {
-                int c = numRequestedChanges.decrementAndGet();
-                System.out.println("numChanges: " + c + ", totalCalls: " + totalCalls.incrementAndGet());
-                if (c == 0) {
+                if (numRequestedChanges.decrementAndGet() == 0) {
                     afterBatch.run();
                 }
             });

--- a/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
+++ b/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
@@ -26,27 +27,20 @@ import java.util.function.BiPredicate;
  */
 public final class BatchedSubscriber implements ChildChanged, Subscriber {
 
-    private static final BiPredicate<WhatHappened, Node> BASE_EXCLUSION = (what, child) ->
-            what == WhatHappened.timestampUpdated || what == WhatHappened.interiorAdded;
+    private static final WhatHappened[] DEFAULT_IGNORED_CHANGES = {
+            WhatHappened.timestampUpdated,
+            WhatHappened.interiorAdded,
+            WhatHappened.initialized
+    };
 
-    private final Node node;
+    private static final BiPredicate<WhatHappened, Node> DEFAULT_EXCLUSIONS = (what, child) ->
+            Arrays.asList(DEFAULT_IGNORED_CHANGES).contains(what);
+
     private final AtomicInteger numRequestedChanges = new AtomicInteger();
 
+    private final Node node;
     private final BiPredicate<WhatHappened, Node> exclusions;
-    private final Callback callback;
-
-    /**
-     * Callback to perform after a batch of changes fires.
-     */
-    public interface Callback {
-        /**
-         * Perform the subscriber action.
-         *
-         * @param what {@link WhatHappened#initialized} on subscription initialization,
-         *             otherwise a pass-through from the subscription.
-         */
-        void run(WhatHappened what);
-    }
+    private final Runnable callback;
 
     /**
      * Constructs a new BatchedSubscriber.
@@ -54,7 +48,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
      * @param topic    topic to subscribe to
      * @param callback action to perform after a batch of changes
      */
-    public BatchedSubscriber(Topic topic, Callback callback) {
+    public BatchedSubscriber(Topic topic, Runnable callback) {
         this(topic, null, callback);
     }
 
@@ -65,7 +59,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
      * @param exclusions predicate for ignoring a subset topic changes
      * @param callback   action to perform after a batch of changes
      */
-    public BatchedSubscriber(Topic topic, BiPredicate<WhatHappened, Node> exclusions, Callback callback) {
+    public BatchedSubscriber(Topic topic, BiPredicate<WhatHappened, Node> exclusions, Runnable callback) {
         this((Node) topic, exclusions, callback);
     }
 
@@ -75,7 +69,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
      * @param topics   topics to subscribe to
      * @param callback action to perform after a batch of changes
      */
-    public BatchedSubscriber(Topics topics, Callback callback) {
+    public BatchedSubscriber(Topics topics, Runnable callback) {
         this(topics, null, callback);
     }
 
@@ -86,7 +80,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
      * @param exclusions predicate for ignoring a subset topics changes
      * @param callback   action to perform after a batch of changes
      */
-    public BatchedSubscriber(Topics topics, BiPredicate<WhatHappened, Node> exclusions, Callback callback) {
+    public BatchedSubscriber(Topics topics, BiPredicate<WhatHappened, Node> exclusions, Runnable callback) {
         this((Node) topics, exclusions, callback);
     }
 
@@ -97,10 +91,10 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
      * @param exclusions predicate for ignoring a subset topic(s) changes
      * @param callback   action to perform after a batch of changes
      */
-    private BatchedSubscriber(Node node, BiPredicate<WhatHappened, Node> exclusions, Callback callback) {
+    private BatchedSubscriber(Node node, BiPredicate<WhatHappened, Node> exclusions, Runnable callback) {
         Objects.requireNonNull(node);
         this.node = node;
-        this.exclusions = exclusions == null ? BASE_EXCLUSION : exclusions;
+        this.exclusions = exclusions == null ? DEFAULT_EXCLUSIONS : exclusions;
         this.callback = callback;
     }
 
@@ -138,17 +132,10 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
             return;
         }
 
-        if (what == WhatHappened.initialized) {
-            if (callback != null) {
-                callback.run(what);
-            }
-            return;
-        }
-
         numRequestedChanges.incrementAndGet();
         child.context.runOnPublishQueue(() -> {
             if (numRequestedChanges.decrementAndGet() == 0) {
-                callback.run(what);
+                callback.run();
             }
         });
     }

--- a/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
+++ b/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import com.aws.greengrass.config.ChildChanged;
+import com.aws.greengrass.config.Node;
+import com.aws.greengrass.config.Subscriber;
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.WhatHappened;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
+
+public final class BatchedSubscriber {
+
+    private final Runnable unsubscribe;
+
+    private BatchedSubscriber(Runnable unsubscribe) {
+        this.unsubscribe = unsubscribe;
+    }
+
+    public void unsubscribe() {
+        if (unsubscribe != null) {
+            unsubscribe.run();
+        }
+    }
+
+    public static BatchedSubscriber subscribe(Topic topic, Runnable afterBatch) {
+        return subscribe(topic, afterBatch, null, null);
+    }
+
+    public static BatchedSubscriber subscribe(Topic topic,
+                                              Runnable afterBatch, Runnable onInitialization,
+                                              BiPredicate<WhatHappened, Topic> excludeFilter) {
+        AtomicInteger numRequestedChanges = new AtomicInteger();
+        AtomicInteger totalCalls = new AtomicInteger();
+        Subscriber subscriber = (what, child) -> {
+            if (what == WhatHappened.initialized) {
+                if (onInitialization != null) {
+                    onInitialization.run();
+                }
+                return;
+            }
+
+            if (what == WhatHappened.timestampUpdated || what == WhatHappened.interiorAdded) {
+                return;
+            }
+
+            if (excludeFilter != null && excludeFilter.test(what, child)) {
+                return;
+            }
+
+            numRequestedChanges.incrementAndGet();
+            topic.context.runOnPublishQueue(() -> {
+                int c = numRequestedChanges.decrementAndGet();
+                System.out.println("numChanges: " + c + ", totalCalls: " + totalCalls.incrementAndGet());
+                if (c == 0) {
+                    afterBatch.run();
+                }
+            });
+        };
+        topic.subscribe(subscriber);
+        return new BatchedSubscriber(() -> topic.remove(subscriber));
+    }
+
+    public static BatchedSubscriber subscribe(Topics topics, Runnable afterBatch) {
+        return subscribe(topics, afterBatch, null, null);
+    }
+
+    public static BatchedSubscriber subscribe(Topics topics,
+                                              Runnable afterBatch, Runnable onInitialization,
+                                              BiPredicate<WhatHappened, Node> excludeFilter) {
+        AtomicInteger numRequestedChanges = new AtomicInteger();
+        ChildChanged subscriber = (what, child) -> {
+            if (what == WhatHappened.initialized) {
+                if (onInitialization != null) {
+                    onInitialization.run();
+                }
+                return;
+            }
+
+            if (what == WhatHappened.timestampUpdated || what == WhatHappened.interiorAdded) {
+                return;
+            }
+
+            if (excludeFilter != null && excludeFilter.test(what, child)) {
+                return;
+            }
+
+            numRequestedChanges.incrementAndGet();
+            topics.context.runOnPublishQueue(() -> {
+                if (numRequestedChanges.decrementAndGet() == 0) {
+                    afterBatch.run();
+                }
+            });
+        };
+        topics.subscribe(subscriber);
+        return new BatchedSubscriber(() -> topics.remove(subscriber));
+    }
+}

--- a/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
+++ b/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
@@ -26,10 +26,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class BatchedSubscriber implements ChildChanged, Subscriber {
 
-    private static final WhatHappened[] BASE_EXCLUSIONS = new WhatHappened[]{
+    private static final WhatHappened[] BASE_EXCLUSIONS = {
             WhatHappened.timestampUpdated,
             WhatHappened.interiorAdded
     };
+
+    private final AtomicInteger numRequestedChanges = new AtomicInteger();
+    private final Set<WhatHappened> exclusions = new HashSet<>();
+
+    private final Callback callback;
 
     /**
      * Callback to perform after a batch of changes fires.
@@ -43,11 +48,6 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
          */
         void run(WhatHappened what);
     }
-
-    private final AtomicInteger numRequestedChanges = new AtomicInteger();
-    private final Set<WhatHappened> exclusions = new HashSet<>();
-
-    private final Callback callback;
 
     /**
      * Constructs a new BatchedSubscriber.

--- a/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
+++ b/src/main/java/com/aws/greengrass/util/BatchedSubscriber.java
@@ -52,7 +52,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
      * @param callback action to perform after a batch of changes
      */
     public BatchedSubscriber(Callback callback) {
-        this((what, node) -> false, callback);
+        this(null, callback);
     }
 
     /**
@@ -62,8 +62,7 @@ public final class BatchedSubscriber implements ChildChanged, Subscriber {
      * @param callback   action to perform after a batch of changes
      */
     public BatchedSubscriber(BiPredicate<WhatHappened, Node> exclusions, Callback callback) {
-        Objects.requireNonNull(exclusions);
-        this.exclusions = (what, node) -> BASE_EXCLUSION.test(what, node) || exclusions.test(what, node);
+        this.exclusions = exclusions == null ? BASE_EXCLUSION : exclusions;
         this.callback = callback;
     }
 

--- a/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
+++ b/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
@@ -37,9 +37,16 @@ class BatchedSubscriberTest {
     void GIVEN_subscribe_to_topic_WHEN_unsubscribe_THEN_subscription_not_invoked() throws Exception {
         Topic topic = Topic.of(new Context(), "topic", null);
 
+        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
 
-        BatchedSubscriber bs = new BatchedSubscriber(topic, numTimesCalled::incrementAndGet);
+        BatchedSubscriber bs = new BatchedSubscriber(topic, (what) -> {
+            if (what == WhatHappened.initialized) {
+                numInitializations.incrementAndGet();
+                return;
+            }
+            numTimesCalled.incrementAndGet();
+        });
         bs.subscribe();
 
         try {
@@ -52,6 +59,7 @@ class BatchedSubscriberTest {
             topic.context.close();
         }
 
+        assertEquals(1, numInitializations.get());
         assertEquals(1, numTimesCalled.get());
     }
 
@@ -62,7 +70,7 @@ class BatchedSubscriberTest {
         BiPredicate<WhatHappened, Node> excludeEverything = (what, child) -> true;
 
         AtomicInteger numTimesCalled = new AtomicInteger();
-        BatchedSubscriber bs = new BatchedSubscriber(topic, excludeEverything, numTimesCalled::incrementAndGet);
+        BatchedSubscriber bs = new BatchedSubscriber(topic, excludeEverything, (what) -> numTimesCalled.incrementAndGet());
         bs.subscribe();
 
         try {
@@ -80,10 +88,16 @@ class BatchedSubscriberTest {
     void GIVEN_subscribe_to_topic_WHEN_burst_of_events_THEN_callback_runs_once() throws Exception {
         Topic topic = Topic.of(new Context(), "topic", null);
 
+        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topic, () -> {
+        BatchedSubscriber bs = new BatchedSubscriber(topic, (what) -> {
+            if (what == WhatHappened.initialized) {
+                numInitializations.incrementAndGet();
+                return;
+            }
+
             numTimesCalled.getAndIncrement();
             testComplete.countDown();
         });
@@ -98,6 +112,7 @@ class BatchedSubscriberTest {
             topic.context.close();
         }
 
+        assertEquals(1, numInitializations.get());
         assertEquals(1, numTimesCalled.get());
     }
 
@@ -107,10 +122,16 @@ class BatchedSubscriberTest {
 
         final int expectedNumChanges = 10;
 
+        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topic, () -> {
+        BatchedSubscriber bs = new BatchedSubscriber(topic, (what) -> {
+            if (what == WhatHappened.initialized) {
+                numInitializations.incrementAndGet();
+                return;
+            }
+
             if (numTimesCalled.incrementAndGet() >= expectedNumChanges) {
                 testComplete.countDown();
             }
@@ -130,6 +151,7 @@ class BatchedSubscriberTest {
             topic.context.close();
         }
 
+        assertEquals(1, numInitializations.get());
         assertEquals(expectedNumChanges, numTimesCalled.get());
     }
 
@@ -138,10 +160,16 @@ class BatchedSubscriberTest {
     void GIVEN_subscribe_to_topics_WHEN_burst_of_events_THEN_callback_runs_once() throws Exception {
         Topics topics = Topics.of(new Context(), "topic", null);
 
+        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topics, () -> {
+        BatchedSubscriber bs = new BatchedSubscriber(topics, (what) -> {
+            if (what == WhatHappened.initialized) {
+                numInitializations.incrementAndGet();
+                return;
+            }
+
             numTimesCalled.getAndIncrement();
             testComplete.countDown();
         });
@@ -158,6 +186,7 @@ class BatchedSubscriberTest {
             topics.context.close();
         }
 
+        assertEquals(1, numInitializations.get());
         assertEquals(1, numTimesCalled.get());
     }
 
@@ -167,10 +196,16 @@ class BatchedSubscriberTest {
 
         final int expectedNumChanges = 10;
 
+        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topics, () -> {
+        BatchedSubscriber bs = new BatchedSubscriber(topics, (what) -> {
+            if (what == WhatHappened.initialized) {
+                numInitializations.incrementAndGet();
+                return;
+            }
+
             if (numTimesCalled.incrementAndGet() >= expectedNumChanges) {
                 testComplete.countDown();
             }
@@ -190,6 +225,7 @@ class BatchedSubscriberTest {
             topics.context.close();
         }
 
+        assertEquals(1, numInitializations.get());
         assertEquals(expectedNumChanges, numTimesCalled.get());
     }
 

--- a/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
+++ b/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
@@ -37,16 +37,9 @@ class BatchedSubscriberTest {
     void GIVEN_subscribe_to_topic_WHEN_unsubscribe_THEN_subscription_not_invoked() throws Exception {
         Topic topic = Topic.of(new Context(), "topic", null);
 
-        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
 
-        BatchedSubscriber bs = new BatchedSubscriber(topic, (what) -> {
-            if (what == WhatHappened.initialized) {
-                numInitializations.incrementAndGet();
-                return;
-            }
-            numTimesCalled.incrementAndGet();
-        });
+        BatchedSubscriber bs = new BatchedSubscriber(topic, numTimesCalled::incrementAndGet);
         bs.subscribe();
 
         try {
@@ -59,7 +52,6 @@ class BatchedSubscriberTest {
             topic.context.close();
         }
 
-        assertEquals(1, numInitializations.get());
         assertEquals(1, numTimesCalled.get());
     }
 
@@ -70,7 +62,7 @@ class BatchedSubscriberTest {
         BiPredicate<WhatHappened, Node> excludeEverything = (what, child) -> true;
 
         AtomicInteger numTimesCalled = new AtomicInteger();
-        BatchedSubscriber bs = new BatchedSubscriber(topic, excludeEverything, (what) -> numTimesCalled.incrementAndGet());
+        BatchedSubscriber bs = new BatchedSubscriber(topic, excludeEverything, numTimesCalled::incrementAndGet);
         bs.subscribe();
 
         try {
@@ -88,16 +80,10 @@ class BatchedSubscriberTest {
     void GIVEN_subscribe_to_topic_WHEN_burst_of_events_THEN_callback_runs_once() throws Exception {
         Topic topic = Topic.of(new Context(), "topic", null);
 
-        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topic, (what) -> {
-            if (what == WhatHappened.initialized) {
-                numInitializations.incrementAndGet();
-                return;
-            }
-
+        BatchedSubscriber bs = new BatchedSubscriber(topic, () -> {
             numTimesCalled.getAndIncrement();
             testComplete.countDown();
         });
@@ -112,7 +98,6 @@ class BatchedSubscriberTest {
             topic.context.close();
         }
 
-        assertEquals(1, numInitializations.get());
         assertEquals(1, numTimesCalled.get());
     }
 
@@ -122,16 +107,10 @@ class BatchedSubscriberTest {
 
         final int expectedNumChanges = 10;
 
-        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topic, (what) -> {
-            if (what == WhatHappened.initialized) {
-                numInitializations.incrementAndGet();
-                return;
-            }
-
+        BatchedSubscriber bs = new BatchedSubscriber(topic, () -> {
             if (numTimesCalled.incrementAndGet() >= expectedNumChanges) {
                 testComplete.countDown();
             }
@@ -151,7 +130,6 @@ class BatchedSubscriberTest {
             topic.context.close();
         }
 
-        assertEquals(1, numInitializations.get());
         assertEquals(expectedNumChanges, numTimesCalled.get());
     }
 
@@ -160,16 +138,10 @@ class BatchedSubscriberTest {
     void GIVEN_subscribe_to_topics_WHEN_burst_of_events_THEN_callback_runs_once() throws Exception {
         Topics topics = Topics.of(new Context(), "topic", null);
 
-        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topics, (what) -> {
-            if (what == WhatHappened.initialized) {
-                numInitializations.incrementAndGet();
-                return;
-            }
-
+        BatchedSubscriber bs = new BatchedSubscriber(topics, () -> {
             numTimesCalled.getAndIncrement();
             testComplete.countDown();
         });
@@ -186,7 +158,6 @@ class BatchedSubscriberTest {
             topics.context.close();
         }
 
-        assertEquals(1, numInitializations.get());
         assertEquals(1, numTimesCalled.get());
     }
 
@@ -196,16 +167,10 @@ class BatchedSubscriberTest {
 
         final int expectedNumChanges = 10;
 
-        AtomicInteger numInitializations = new AtomicInteger();
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
-        BatchedSubscriber bs = new BatchedSubscriber(topics, (what) -> {
-            if (what == WhatHappened.initialized) {
-                numInitializations.incrementAndGet();
-                return;
-            }
-
+        BatchedSubscriber bs = new BatchedSubscriber(topics, () -> {
             if (numTimesCalled.incrementAndGet() >= expectedNumChanges) {
                 testComplete.countDown();
             }
@@ -225,7 +190,6 @@ class BatchedSubscriberTest {
             topics.context.close();
         }
 
-        assertEquals(1, numInitializations.get());
         assertEquals(expectedNumChanges, numTimesCalled.get());
     }
 

--- a/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
+++ b/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.UpdateBehaviorTree;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+@ExtendWith(GGExtension.class)
+class BatchedSubscriberTest {
+
+    private final Supplier<UpdateBehaviorTree> mergeBehavior = () ->
+            new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, System.currentTimeMillis());
+
+    @Test
+    void GIVEN_subscribe_to_topic_WHEN_burst_of_events_THEN_callback_runs_once() throws Exception {
+        Topic topic = Topic.of(new Context(), "topic", null);
+        AtomicInteger numTimesCalled = new AtomicInteger();
+        CountDownLatch testComplete = new CountDownLatch(1);
+
+        BatchedSubscriber s = BatchedSubscriber.subscribe(topic, () -> {
+            numTimesCalled.getAndIncrement();
+            testComplete.countDown();
+        });
+
+        try {
+            // For a consistent happy-path test, we ensure all config changes
+            // are properly queued before batched subscriber does its work.
+            // Otherwise, there's a race condition between how quickly
+            // all changes reach the queue and when the publish queue processes
+            // the first message.
+            CountDownLatch waitForChangesToQueue = new CountDownLatch(1);
+            topic.context.runOnPublishQueue(() -> {
+                try {
+                    waitForChangesToQueue.await();
+                } catch (InterruptedException e) {
+                    fail(e);
+                }
+            });
+
+            IntStream.range(0, 10).forEach(topic::withValue);
+            waitForChangesToQueue.countDown();
+
+            assertTrue(testComplete.await(5L, TimeUnit.SECONDS));
+            topic.context.waitForPublishQueueToClear();
+        } finally {
+            s.unsubscribe();
+            topic.context.close();
+        }
+
+        assertEquals(1, numTimesCalled.get());
+    }
+
+    @Test
+    void GIVEN_subscribe_to_topic_WHEN_separate_events_THEN_callback_runs_every_time() throws Exception {
+        Topic topic = Topic.of(new Context(), "topic", null);
+
+        final int expectedNumChanges = 10;
+
+        AtomicInteger numTimesCalled = new AtomicInteger();
+        CountDownLatch testComplete = new CountDownLatch(1);
+
+        BatchedSubscriber s = BatchedSubscriber.subscribe(topic, () -> {
+            if (numTimesCalled.incrementAndGet() >= expectedNumChanges) {
+                testComplete.countDown();
+            }
+        });
+
+        try {
+            IntStream.range(0, expectedNumChanges).forEach(i -> {
+                topic.withValue(i);
+                topic.context.waitForPublishQueueToClear();
+            });
+
+            assertTrue(testComplete.await(5L, TimeUnit.SECONDS));
+            topic.context.waitForPublishQueueToClear();
+        } finally {
+            s.unsubscribe();
+            topic.context.close();
+        }
+
+        assertEquals(expectedNumChanges, numTimesCalled.get());
+    }
+
+
+    @Test
+    void GIVEN_subscribe_to_topics_WHEN_burst_of_events_THEN_callback_runs_once() throws Exception {
+        Topics topics = Topics.of(new Context(), "topic", null);
+        AtomicInteger numTimesCalled = new AtomicInteger();
+        CountDownLatch testComplete = new CountDownLatch(1);
+
+        BatchedSubscriber s = BatchedSubscriber.subscribe(topics, () -> {
+            numTimesCalled.getAndIncrement();
+            testComplete.countDown();
+        });
+
+        try {
+            // For a consistent happy-path test, we ensure all config changes
+            // are properly queued before batched subscriber does its work.
+            // Otherwise, there's a race condition between how quickly
+            // all changes reach the queue and when the publish queue processes
+            // the first message.
+            CountDownLatch waitForChangesToQueue = new CountDownLatch(1);
+            topics.context.runOnPublishQueue(() -> {
+                try {
+                    waitForChangesToQueue.await();
+                } catch (InterruptedException e) {
+                    fail(e);
+                }
+            });
+
+            IntStream.range(0, 5).forEach(i ->
+                    topics.updateFromMap(Utils.immutableMap("key", i), mergeBehavior.get())
+            );
+            waitForChangesToQueue.countDown();
+
+            assertTrue(testComplete.await(5L, TimeUnit.SECONDS));
+            topics.context.waitForPublishQueueToClear();
+        } finally {
+            s.unsubscribe();
+            topics.context.close();
+        }
+
+        assertEquals(1, numTimesCalled.get());
+    }
+
+    @Test
+    void GIVEN_subscribe_to_topics_WHEN_separate_events_THEN_callback_runs_every_time() throws Exception {
+        Topics topics = Topics.of(new Context(), "topic", null);
+
+        final int expectedNumChanges = 10;
+
+        AtomicInteger numTimesCalled = new AtomicInteger();
+        CountDownLatch testComplete = new CountDownLatch(1);
+
+        BatchedSubscriber s = BatchedSubscriber.subscribe(topics, () -> {
+            if (numTimesCalled.incrementAndGet() >= expectedNumChanges) {
+                testComplete.countDown();
+            }
+        });
+
+        try {
+            IntStream.range(0, expectedNumChanges).forEach(i -> {
+                topics.updateFromMap(Utils.immutableMap("key", i), mergeBehavior.get());
+                topics.context.waitForPublishQueueToClear();
+            });
+
+            assertTrue(testComplete.await(5L, TimeUnit.SECONDS));
+            topics.context.waitForPublishQueueToClear();
+        } finally {
+            s.unsubscribe();
+            topics.context.close();
+        }
+
+        assertEquals(expectedNumChanges, numTimesCalled.get());
+    }
+}

--- a/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
+++ b/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.util;
 
+import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.UpdateBehaviorTree;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -35,9 +37,10 @@ class BatchedSubscriberTest {
     void GIVEN_subscribe_to_topic_WHEN_exclusion_specified_THEN_changes_are_excluded() throws Exception {
         Topic topic = Topic.of(new Context(), "topic", null);
 
+        BiPredicate<WhatHappened, Node> excludeEverything = (what, child) -> true;
 
         AtomicInteger numTimesCalled = new AtomicInteger();
-        BatchedSubscriber bs = new BatchedSubscriber(WhatHappened.values(), (what) -> numTimesCalled.incrementAndGet());
+        BatchedSubscriber bs = new BatchedSubscriber(excludeEverything, (what) -> numTimesCalled.incrementAndGet());
         topic.subscribe(bs);
 
         try {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds a `BatchedSubscriber` utility that allows callers to run a callback *after* a batch of changes have fired, rather than executing potentially expensive work per each change.

Thanks @MikeDombo for suggesting this feature

**Why is this change necessary:**

One use case is in mqtt bridge, where we wish to restart the bridge if a config change is detected. If multiple config changes happen in quick succession, we only want to trigger the restart once.  (development effort is in progress, and this change is intended to be used in mqtt bridge)

**How was this change tested:**
Unit tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
