### PR TITLE
feat: add GG Root CA Path as env variable

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/ShellRunner.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/ShellRunner.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.lifecyclemanager;
 
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.ProxyUtils;
@@ -29,6 +30,7 @@ public interface ShellRunner {
 
     class Default implements ShellRunner {
         public static final String TES_AUTH_HEADER = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+        public static final String GG_ROOT_CA_PATH = "GG_ROOT_CA_PATH";
         private static final String SCRIPT_NAME_KEY = "scriptName";
 
         @Inject
@@ -42,6 +44,10 @@ public interface ShellRunner {
             if (!isEmpty(command) && onBehalfOf != null) {
                 Path cwd = nucleusPaths.workPath(onBehalfOf.getServiceName());
                 Logger logger = getLoggerToUse(onBehalfOf);
+                String rootCaPath = Coerce.toString(deviceConfiguration.getRootCAFilePath());
+                if (rootCaPath == null) {
+                    rootCaPath = "";
+                }
                 Exec exec = Platform.getInstance().createNewProcessRunner()
                         .withShell(command)
                         .withOut(s -> {
@@ -60,6 +66,7 @@ public interface ShellRunner {
                         .setenv(TES_AUTH_HEADER,
                                 String.valueOf(onBehalfOf.getPrivateConfig().findLeafChild(SERVICE_UNIQUE_ID_KEY)
                                         .getOnce()))
+                        .setenv(GG_ROOT_CA_PATH, rootCaPath)
                         .cd(cwd.toFile().getAbsoluteFile())
                         .logger(logger);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add the `rootCaPath` config value as environment variable.
**Why is this change necessary:**
We will need the variable to provide connector components the path to proxy certificate bundle in case customer is running behind a proxy.
**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
