### PR TITLE
fix: bubble up more complete error messages from deployment workflow

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -312,7 +312,8 @@ public class DeploymentService extends GreengrassService {
                     deploymentDirectoryManager.persistLastSuccessfulDeployment();
                 } else {
                     if (result.getFailureCause() != null) {
-                        statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, result.getFailureCause().getMessage());
+                        Throwable failureCause = result.getFailureCause();
+                        statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, Utils.generateFailureMessage(failureCause));
                     }
                     if (FAILED_ROLLBACK_NOT_REQUESTED.equals(result.getDeploymentStatus())) {
                         // Update the groupToRootComponents mapping in config for the case where there is no rollback
@@ -344,7 +345,7 @@ public class DeploymentService extends GreengrassService {
                 logger.atError().kv(DEPLOYMENT_ID_LOG_KEY_NAME, currentDeploymentTaskMetadata.getDeploymentId())
                         .setCause(t).log("Deployment task throws unknown exception");
                 HashMap<String, String> statusDetails = new HashMap<>();
-                statusDetails.put("error", t.getMessage());
+                statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, t.getMessage());
                 deploymentStatusKeeper
                         .persistAndPublishDeploymentStatus(currentDeploymentTaskMetadata.getDeploymentId(),
                                 currentDeploymentTaskMetadata.getDeploymentType(), JobStatus.FAILED.toString(),
@@ -655,7 +656,7 @@ public class DeploymentService extends GreengrassService {
                     .kv("DeploymentType", deployment.getDeploymentType().toString())
                     .log("Invalid document for deployment");
             HashMap<String, String> statusDetails = new HashMap<>();
-            statusDetails.put("error", e.getMessage());
+            statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, e.getMessage());
             deploymentStatusKeeper
                     .persistAndPublishDeploymentStatus(deployment.getId(), deployment.getDeploymentType(),
                             JobStatus.FAILED.toString(), statusDetails);

--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -187,6 +187,22 @@ public final class Utils {
     }
 
     /**
+     * Get the chain of exceptions and messages from the chain of causes.
+     *
+     * @param t throwable.
+     * @return String chain of exceptinos and messages.
+     */
+    public static String generateFailureMessage(Throwable t) {
+        StringBuilder failureMessage =
+                new StringBuilder(t.getClass().toString()).append(": ").append(t.getMessage());
+        while (t.getCause() != null) {
+            t = t.getCause();
+            failureMessage.append(" -> ").append(t.getClass().toString()).append(": ").append(t.getMessage());
+        }
+        return failureMessage.toString();
+    }
+
+    /**
      * Generate a secure random string of a given length.
      *
      * @param desiredLength length of the output string


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We currently only send last error message from deployment workfkow to FSS. This does not give customers enough meaningful information. This change will enable customers to see the chain of error messages instead.


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
