### PR TITLE
fix: better command line boolean parsing

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -426,15 +426,15 @@ public class GreengrassSetup {
                     break;
                 case PROVISION_THING_ARG:
                 case PROVISION_THING_ARG_SHORT:
-                    this.needProvisioning = Coerce.toBoolean(getArg());
+                    this.needProvisioning = parseBooleanArg();
                     break;
                 case SETUP_SYSTEM_SERVICE_ARG:
                 case SETUP_SYSTEM_SERVICE_ARG_SHORT:
-                    this.setupSystemService = Coerce.toBoolean(getArg());
+                    this.setupSystemService = parseBooleanArg();
                     break;
                 case KERNEL_START_ARG:
                 case KERNEL_START_ARG_SHORT:
-                    this.kernelStart = Coerce.toBoolean(getArg());
+                    this.kernelStart = parseBooleanArg();
                     break;
                 case DEFAULT_USER_ARG:
                 case DEFAULT_USER_ARG_SHORT:
@@ -448,7 +448,7 @@ public class GreengrassSetup {
                     break;
                 case DEPLOY_DEV_TOOLS_ARG:
                 case DEPLOY_DEV_TOOLS_ARG_SHORT:
-                    this.deployDevTools = Coerce.toBoolean(getArg());
+                    this.deployDevTools = parseBooleanArg();
                     break;
                 case TRUSTED_PLUGIN_ARG:
                 case TRUSTED_PLUGIN_ARG_SHORT:
@@ -468,6 +468,16 @@ public class GreengrassSetup {
         }
     }
 
+    private boolean parseBooleanArg() {
+        String peeked = peekArg();
+        if (peeked == null || peeked.startsWith("-")) {
+            // default is true when an option is supplied with nothing after. ex: --deploy-dev-tools
+            // default is true when an option is supplied with another option after. ex: --deploy-dev-tools --provision
+            return true;
+        }
+        return Coerce.toBoolean(getArg());
+    }
+
     private void validatePluginJarPath(String pluginJarPath) {
         String nm = Utils.namePart(pluginJarPath);
         if (!nm.endsWith(EZPlugins.JAR_FILE_EXTENSION)) {
@@ -481,9 +491,15 @@ public class GreengrassSetup {
         // which will be thrown as RuntimeException when copying the plugin jar.
     }
 
-    @SuppressWarnings("PMD.NullAssignment")
     private String getArg() {
-        return arg = setupArgs == null || argpos >= setupArgs.length ? null : setupArgs[argpos++];
+        String peek = peekArg();
+        argpos++;
+        return peek;
+    }
+
+    @SuppressWarnings("PMD.NullAssignment")
+    private String peekArg() {
+        return arg = setupArgs == null || argpos >= setupArgs.length ? null : setupArgs[argpos];
     }
 
     void provision(Kernel kernel) throws IOException, DeviceConfigurationException {

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -98,7 +98,7 @@ class GreengrassSetupTest {
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name",
                         "--thing-group-name", "mock_thing_group_name", "--thing-policy-name", "mock_thing_policy_name",
                         "--tes-role-name", "mock_tes_role_name", "--tes-role-alias-name", "mock_tes_role_alias_name",
-                        "--provision", "y", "--aws-region","us-east-1", "-ss", "false");
+                        "--provision", "--aws-region","us-east-1", "-ss", "false");
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);


### PR DESCRIPTION
**Issue #, if available:**
Closes #1181

**Description of changes:**

- Option is true when an option is supplied with nothing after. ex: --deploy-dev-tools.
- Option is true when an option is supplied with another option after. ex: --deploy-dev-tools --provision

**Why is this change necessary:**

**How was this change tested:**
Updated existing test to use the new scheme where a boolean argument is missing.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
