### PR TITLE
perf: static list of service implementors

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelTest.java
@@ -53,7 +53,7 @@ class KernelTest extends BaseITCase {
                     new ExpectedStdoutPattern(1, "NEWMAIN", "Assignment to 'run' script'")};
 
     private static final Map<Integer, CountDownLatch> COUNT_DOWN_LATCHES = new HashMap<>();
-    public static final int TIMEOUT = 30;
+    public static final int TIMEOUT = 45;
     private Kernel kernel;
 
     @BeforeAll
@@ -230,7 +230,7 @@ class KernelTest extends BaseITCase {
                 serviceRunning.countDown();
             }
         });
-        assertTrue(serviceRunning.await(30, TimeUnit.SECONDS));
+        assertTrue(serviceRunning.await(TIMEOUT, TimeUnit.SECONDS));
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/provisioning/ProvisionFromPluginTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/provisioning/ProvisionFromPluginTest.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.KernelLifecycle;
+import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.Coerce;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.event.Level;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.mqtt.MqttException;
 
@@ -59,8 +61,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(GGExtension.class)
-public class ProvisionFromTestPlugin extends BaseITCase {
+public class ProvisionFromPluginTest extends BaseITCase {
 
+    private static final int TIMEOUT = 20;
     private Kernel kernel;
 
     @TempDir
@@ -203,7 +206,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
             }
         })) {
             kernel.launch();
-            assertTrue(logLatch.await(10, TimeUnit.SECONDS));
+            assertTrue(logLatch.await(TIMEOUT, TimeUnit.SECONDS));
             kernel.getContext().waitForPublishQueueToClear();
             DeviceConfiguration deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
             assertThat(() -> Coerce.toString(deviceConfiguration.getIotDataEndpoint()),
@@ -215,6 +218,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
     @Order(5)
     @Test
     void GIVEN_plugin_jar_added_to_trusted_plugins_dir_AND_plugin_return_immediately_THEN_device_comes_online(ExtensionContext context) throws Throwable {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         ignoreExceptionUltimateCauseOfType(context, MqttException.class);
         ignoreExceptionUltimateCauseOfType(context, CrtRuntimeException.class);
         ignoreExceptionUltimateCauseOfType(context, InvalidKeyException.class);
@@ -230,7 +234,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel, configFilePath.toUri().toURL());
         addProvisioningPlugin("testProvisioningPlugin-tests.jar");
         CountDownLatch logLatch =  new CountDownLatch(3);
-        try ( AutoCloseable listener = TestUtils.createCloseableLogListener((message) -> {
+        try (AutoCloseable listener = TestUtils.createCloseableLogListener((message) -> {
             String messageString = message.getMessage();
             if (KernelLifecycle.UPDATED_PROVISIONING_MESSAGE.equals(messageString)
                     || IotJobsHelper.SUBSCRIBING_TO_TOPICS_MESSAGE.equals(messageString) && logLatch.getCount() < 3
@@ -240,7 +244,7 @@ public class ProvisionFromTestPlugin extends BaseITCase {
             }
         })) {
             kernel.launch();
-            assertTrue(logLatch.await(10, TimeUnit.SECONDS));
+            assertTrue(logLatch.await(TIMEOUT, TimeUnit.SECONDS));
             kernel.getContext().waitForPublishQueueToClear();
             DeviceConfiguration deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
             assertEquals("test.us-east-1.iot.data.endpoint", Coerce.toString(deviceConfiguration.getIotDataEndpoint()));

--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -126,6 +126,12 @@ public class EZPlugins implements Closeable {
         });
     }
 
+    // Only use in tests to scan our own classpath for @ImplementsService
+    public synchronized EZPlugins scanSelfClasspath() {
+        loadPlugins(true, this.getClass().getClassLoader());
+        return this;
+    }
+
     /**
      * Don't call loadCache until after all of the implementing/annotated matchers have been registered.
      *

--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -143,7 +143,6 @@ public class EZPlugins implements Closeable {
                 }
             }
         });
-        loadPlugins(true, this.getClass().getClassLoader());
         if (!trustedFiles.isEmpty()) {
             AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
                 URLClassLoader trusted = new URLClassLoader(trustedFiles.toArray(new URL[0]), root);

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -344,9 +344,9 @@ public class Kernel {
      */
     public void writeConfig(Writer w) {
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put(SERVICES_NAMESPACE_TOPIC, config.findTopics(SERVICES_NAMESPACE_TOPIC).toPOJO());
+        configMap.put(SERVICES_NAMESPACE_TOPIC, config.lookupTopics(SERVICES_NAMESPACE_TOPIC).toPOJO());
         configMap.put(DeviceConfiguration.SYSTEM_NAMESPACE_KEY,
-                config.findTopics(DeviceConfiguration.SYSTEM_NAMESPACE_KEY).toPOJO());
+                config.lookupTopics(DeviceConfiguration.SYSTEM_NAMESPACE_KEY).toPOJO());
         try {
             CONFIG_YAML_WRITER.writeValue(w, configMap);
         } catch (IOException ex) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -90,6 +90,10 @@ public class KernelLifecycle {
     public static final String MULTIPLE_PROVISIONING_PLUGINS_FOUND_EXCEPTION = "Multiple provisioning plugins found "
             + "[%s]. Greengrass expects only one provisioning plugin";
     public static final String UPDATED_PROVISIONING_MESSAGE = "Updated provisioning configuration";
+    private static final List<Class<? extends GreengrassService>> BUILTIN_SERVICES =
+            Arrays.asList(DockerApplicationManagerService.class, UpdateSystemPolicyService.class,
+                    DeploymentService.class, FleetStatusService.class, TelemetryAgent.class,
+                    TokenExchangeService.class);
 
     private final Kernel kernel;
     private final KernelCommandLine kernelCommandLine;
@@ -373,10 +377,7 @@ public class KernelLifecycle {
             logger.atError().log("Error finding built in service plugins", t);
         }
 
-        for (Class<? extends GreengrassService> cl : Arrays
-                .asList(DockerApplicationManagerService.class, UpdateSystemPolicyService.class,
-                        DeploymentService.class, FleetStatusService.class, TelemetryAgent.class,
-                        TokenExchangeService.class)) {
+        for (Class<? extends GreengrassService> cl : BUILTIN_SERVICES) {
             ImplementsService is = cl.getAnnotation(ImplementsService.class);
             if (is.autostart() && !autostart.contains(is.name())) {
                 autostart.add(is.name());

--- a/src/test/java/com/aws/greengrass/dependency/EZPluginsTest.java
+++ b/src/test/java/com/aws/greengrass/dependency/EZPluginsTest.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.util;
+package com.aws.greengrass.dependency;
 
-import com.aws.greengrass.dependency.EZPlugins;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,6 +49,7 @@ class EZPluginsTest {
                 }
             });
             try {
+                pl.scanSelfClasspath();
                 pl.loadCache();
             } catch (IOException ex) {
                 cause(ex).printStackTrace(System.out);

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
@@ -12,9 +12,10 @@ import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.dependency.EZPlugins;
 import com.aws.greengrass.dependency.ImplementsService;
-import com.aws.greengrass.deployment.DeploymentService;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.ipc.IPCEventStreamService;
+import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
 import com.aws.greengrass.provisioning.DeviceIdentityInterface;
@@ -61,6 +62,7 @@ import java.util.function.Consumer;
 
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.Kernel.DEFAULT_CONFIG_YAML_FILE_READ;
+import static com.aws.greengrass.lifecyclemanager.KernelCommandLine.MAIN_SERVICE_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -113,6 +115,8 @@ class KernelLifecycleTest {
     @TempDir
     protected Path tempRootDir;
     private NucleusPaths mockPaths;
+    private GreengrassService mockOthers;
+    private GreengrassService mockMain;
 
     @BeforeAll
     public static void createMockProvisioningPlugin() {
@@ -131,7 +135,7 @@ class KernelLifecycleTest {
     }
 
     @BeforeEach
-    void beforeEach() throws IOException {
+    void beforeEach() throws IOException, ServiceLoadException {
         System.setProperty("root", tempRootDir.toAbsolutePath().toString());
 
         mockKernel = mock(Kernel.class);
@@ -160,6 +164,11 @@ class KernelLifecycleTest {
         kernelLifecycle = new KernelLifecycle(mockKernel, mockKernelCommandLine, mockPaths);
         kernelLifecycle.setProvisioningConfigUpdateHelper(mockProvisioningConfigUpdateHelper);
         kernelLifecycle.setProvisioningPluginFactory(mockProvisioningPluginFactory);
+
+        mockMain = mock(GreengrassService.class);
+        mockOthers = mock(GreengrassService.class);
+        doReturn(mockMain).when(mockKernel).locateIgnoreError(eq(MAIN_SERVICE_NAME));
+        doReturn(mockOthers).when(mockKernel).locate(not(eq(MAIN_SERVICE_NAME)));
     }
 
     @AfterEach
@@ -170,15 +179,17 @@ class KernelLifecycleTest {
         kernelLifecycle.shutdown();
     }
 
+    @ImplementsService(autostart = true, name = "KernelLifecycle")
+    private static class KLF extends GreengrassService {
+        public KLF(Topics topics) {
+            super(topics);
+        }
+    }
+
     @SuppressWarnings("PMD.CloseResource")
     @Test
     void GIVEN_kernel_WHEN_launch_with_autostart_services_THEN_autostarts_added_as_dependencies_of_main()
-            throws Exception {
-        GreengrassService mockMain = mock(GreengrassService.class);
-        GreengrassService mockOthers = mock(GreengrassService.class);
-        doReturn(mockMain).when(mockKernel).locateIgnoreError(eq("main"));
-        doReturn(mockOthers).when(mockKernel).locate(not(eq("main")));
-
+            throws InputValidationException {
         // Mock out EZPlugins so I can return a deterministic set of services to be added as auto-start
         EZPlugins pluginMock = mock(EZPlugins.class);
         kernelLifecycle.setStartables(new ArrayList<>());
@@ -186,42 +197,26 @@ class KernelLifecycleTest {
         doAnswer((i) -> {
             ClassAnnotationMatchProcessor func = i.getArgument(1);
 
-            func.processMatch(UpdateSystemPolicyService.class);
-            func.processMatch(DeploymentService.class);
+            func.processMatch(KLF.class);
 
             return null;
         }).when(pluginMock).annotated(eq(ImplementsService.class), any());
 
         kernelLifecycle.launch();
-        // Expect 2 times because I returned 2 plugins from above: SafeUpdate and Deployment
-        verify(mockMain, times(2)).addOrUpdateDependency(eq(mockOthers), eq(DependencyType.HARD), eq(true));
+        // Expect 5 times because 4 builtins are already set as autostart + KLF
+        verify(mockMain, times(5)).addOrUpdateDependency(eq(mockOthers), eq(DependencyType.HARD), eq(true));
     }
 
     @SuppressWarnings("PMD.CloseResource")
     @Test
     void GIVEN_kernel_WHEN_launch_without_provisioning_plugin_AND_device_not_provisioned_THEN_device_starts_offline()
             throws Exception {
-
-        GreengrassService mockMain = mock(GreengrassService.class);
-        GreengrassService mockOthers = mock(GreengrassService.class);
-        doReturn(mockMain).when(mockKernel).locateIgnoreError(eq("main"));
-        doReturn(mockOthers).when(mockKernel).locate(not(eq("main")));
-
         when(mockDeviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(false);
 
         kernelLifecycle.setStartables(new ArrayList<>());
         EZPlugins pluginMock = mock(EZPlugins.class);
         when(mockContext.get(EZPlugins.class)).thenReturn(pluginMock);
         doAnswer((i) -> null).when(pluginMock).implementing(eq(DeviceIdentityInterface.class), any());
-
-        doAnswer((i) -> {
-            ClassAnnotationMatchProcessor func = i.getArgument(1);
-
-            func.processMatch(UpdateSystemPolicyService.class);
-            func.processMatch(DeploymentService.class);
-
-            return null;
-        }).when(pluginMock).annotated(eq(ImplementsService.class), any());
 
         kernelLifecycle.launch();
         // Expect 2 times because I returned 2 plugins from above: SafeUpdate and Deployment
@@ -231,7 +226,7 @@ class KernelLifecycleTest {
         verify(mockProvisioningConfigUpdateHelper, times(0))
                 .updateSystemConfiguration(any(SystemConfiguration.class)
                         , eq(UpdateBehaviorTree.UpdateBehavior.MERGE));
-        verify(mockMain, times(2)).addOrUpdateDependency(eq(mockOthers),
+        verify(mockMain, times(4)).addOrUpdateDependency(eq(mockOthers),
                 eq(DependencyType.HARD), eq(true));
     }
 
@@ -483,7 +478,7 @@ class KernelLifecycleTest {
     @Test
     void GIVEN_kernel_WHEN_launch_with_config_THEN_effective_config_written() throws Exception {
         GreengrassService mockMain = mock(GreengrassService.class);
-        doReturn(mockMain).when(mockKernel).locateIgnoreError(eq("main"));
+        doReturn(mockMain).when(mockKernel).locateIgnoreError(eq(MAIN_SERVICE_NAME));
 
         kernelLifecycle.initConfigAndTlog();
         verify(mockKernel).writeEffectiveConfig();

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.lifecyclemanager;
 import com.amazon.aws.iot.greengrass.component.common.DependencyType;
 import com.aws.greengrass.config.Configuration;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.EZPlugins;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
 import com.aws.greengrass.deployment.DeploymentQueue;
@@ -273,6 +274,7 @@ class KernelTest {
         GreengrassService main = kernel.locate("1");
         assertEquals("tester", main.getName());
 
+        kernel.getContext().get(EZPlugins.class).scanSelfClasspath();
         GreengrassService service2 = kernel.locate("testImpl");
         assertEquals("testImpl", service2.getName());
     }

--- a/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
+++ b/src/test/java/com/aws/greengrass/util/BatchedSubscriberTest.java
@@ -200,6 +200,11 @@ class BatchedSubscriberTest {
         AtomicInteger numTimesCalled = new AtomicInteger();
         CountDownLatch testComplete = new CountDownLatch(1);
 
+        // Lookup the topic which will be created by the updateMap call below
+        // so that this event has time to propagate and then we have a known number of updates for below
+        topics.lookup("key");
+        topics.context.waitForPublishQueueToClear();
+
         BatchedSubscriber bs = new BatchedSubscriber(topics, (what) -> {
             if (what == WhatHappened.initialized) {
                 numInitializations.incrementAndGet();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Stops scanning the classloader of Nucleus for `@ImplementsService`, rather we have a static list of builtin services. This is useful for performance as scanning the classloader can take a while. It is also useful for static builds (Graal, JamaicaVM) and Android. 

Also falls back to reading the `java.home` system property if we cannot find the Jar path by finding the code location from the classloader. This is to support JamaicaVM.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
