### PR TITLE
feat: implement receive mode in pubsub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.7.0-SNAPSHOT</version>
+            <version>1.7.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCPubSubTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCPubSubTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.event.Level;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.model.ReceiveMode;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToTopicRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToTopicResponse;
 import software.amazon.awssdk.aws.greengrass.model.SubscriptionResponseMessage;
@@ -62,6 +63,7 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -263,7 +265,8 @@ class IPCPubSubTest extends BaseITCase {
                                 }
                             })).getResponse();
             try {
-                fut.get(3, TimeUnit.SECONDS);
+                SubscribeToTopicResponse res = fut.get(3, TimeUnit.SECONDS);
+                assertNull(res.getTopicName());
             } catch (Exception e) {
                 logger.atError().setCause(e).log("Error when subscribing to component updates");
                 fail("Caught exception when subscribing to component updates");
@@ -277,11 +280,12 @@ class IPCPubSubTest extends BaseITCase {
 
     @Test
     @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
-    void GIVEN_PubSubEventStreamClient_WHEN_subscribe_to_wildcard_THEN_publishes_to_subtopic_only_once() throws Exception {
+    void GIVEN_PubSubEventStreamClient_WHEN_subscribe_to_wildcard_with_receive_all_mode_THEN_publishes_to_subtopic_only_once() throws Exception {
         LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         String topicName = "/topic/1/+";
         SubscribeToTopicRequest subscribeToTopicRequest = new SubscribeToTopicRequest();
         subscribeToTopicRequest.setTopic(topicName);
+        subscribeToTopicRequest.setReceiveMode(ReceiveMode.RECEIVE_ALL_MESSAGES);
         CountDownLatch cdl = new CountDownLatch(1);
         AtomicInteger atomicInteger = new AtomicInteger();
 
@@ -331,6 +335,66 @@ class IPCPubSubTest extends BaseITCase {
 
             publishToTopicOverIpcAsBinaryMessage(greengrassCoreIPCClient, "/topic/1/2", "ABCDEFG");
             assertTrue(cdl.await(20, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
+    void GIVEN_PubSubEventStreamClient_WHEN_subscribe_to_wildcard_with_no_receive_mode_THEN_not_publishes_to_subtopic_to_same_component() throws Exception {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
+        String topicName = "/topic/1/+";
+        SubscribeToTopicRequest subscribeToTopicRequest = new SubscribeToTopicRequest();
+        subscribeToTopicRequest.setTopic(topicName);
+        // Default receive mode is RECEIVE_MESSAGE_FROM_OTHERS for wildcards
+        CountDownLatch cdl = new CountDownLatch(1);
+        AtomicInteger atomicInteger = new AtomicInteger();
+
+        CountDownLatch subscriptionLatch = new CountDownLatch(1);
+
+        // Allowed resource /to*/#
+        String authToken = IPCTestUtils.getAuthTokeForService(kernel, "SubscribeAndPublishWildcard");
+        SocketOptions socketOptions = TestUtils.getSocketOptionsForIPC();
+        try (EventStreamRPCConnection clientConnection =
+                     IPCTestUtils.connectToGGCOverEventStreamIPC(socketOptions, authToken, kernel);
+             AutoCloseable l = TestUtils.createCloseableLogListener(m -> {
+                 if (m.getMessage().contains("Subscribed to topic")) {
+                     subscriptionLatch.countDown();
+                 }
+             })){
+            GreengrassCoreIPCClient greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
+            CompletableFuture<SubscribeToTopicResponse> fut =
+                    greengrassCoreIPCClient.subscribeToTopic(subscribeToTopicRequest,
+                            Optional.of(new StreamResponseHandler<SubscriptionResponseMessage>() {
+                                @Override
+                                public void onStreamEvent(SubscriptionResponseMessage message) {
+                                    assertNotNull(message.getBinaryMessage());
+                                    assertNull(message.getJsonMessage());
+                                    assertEquals("ABCDEFG", new String(message.getBinaryMessage().getMessage()));
+                                    atomicInteger.incrementAndGet();
+                                    cdl.countDown();
+                                }
+
+                                @Override
+                                public boolean onStreamError(Throwable error) {
+                                    logger.atError().log("Received a stream error", error);
+                                    return false;
+                                }
+
+                                @Override
+                                public void onStreamClosed() {
+
+                                }
+                            })).getResponse();
+            try {
+                fut.get(3, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                logger.atError().setCause(e).log("Error when subscribing to component updates");
+                fail("Caught exception when subscribing to component updates");
+            }
+            assertTrue(subscriptionLatch.await(10, TimeUnit.SECONDS));
+
+            publishToTopicOverIpcAsBinaryMessage(greengrassCoreIPCClient, "/topic/1/2", "ABCDEFG");
+            assertFalse(cdl.await(20, TimeUnit.SECONDS));
         }
     }
 

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgent.java
@@ -21,8 +21,10 @@ import software.amazon.awssdk.aws.greengrass.GeneratedAbstractSubscribeToTopicOp
 import software.amazon.awssdk.aws.greengrass.model.BinaryMessage;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 import software.amazon.awssdk.aws.greengrass.model.JsonMessage;
+import software.amazon.awssdk.aws.greengrass.model.MessageContext;
 import software.amazon.awssdk.aws.greengrass.model.PublishToTopicRequest;
 import software.amazon.awssdk.aws.greengrass.model.PublishToTopicResponse;
+import software.amazon.awssdk.aws.greengrass.model.ReceiveMode;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToTopicRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToTopicResponse;
 import software.amazon.awssdk.aws.greengrass.model.SubscriptionResponseMessage;
@@ -31,6 +33,7 @@ import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext
 import software.amazon.awssdk.eventstreamrpc.StreamEventPublisher;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -76,7 +79,19 @@ public class PubSubIPCEventStreamAgent {
      * @param serviceName name of the service subscribing.
      */
     public void subscribe(String topic, Consumer<PublishEvent> cb, String serviceName) {
-        handleSubscribeToTopicRequest(topic, serviceName, cb);
+        subscribe(topic, cb, serviceName, null);
+    }
+
+    /**
+     * Handle the subscription request from internal plugin services with given receive mode.
+     *
+     * @param topic       topic name.
+     * @param cb          callback to be called for each published message
+     * @param serviceName name of the service subscribing.
+     * @param receiveMode the mode of messages sending back to the originating component.
+     */
+    public void subscribe(String topic, Consumer<PublishEvent> cb, String serviceName, ReceiveMode receiveMode) {
+        handleSubscribeToTopicRequest(topic, serviceName, receiveMode, cb);
     }
 
     /**
@@ -87,9 +102,19 @@ public class PubSubIPCEventStreamAgent {
      * @param serviceName name of the service unsubscribing.
      */
     public void unsubscribe(String topic, Consumer<PublishEvent> cb, String serviceName) {
-        if (listeners.remove(topic, cb)) {
-            log.atDebug().kv(COMPONENT_NAME, serviceName).log("Unsubscribed from topic {}", topic);
-        }
+        unsubscribe(topic, cb, serviceName, null);
+    }
+
+    /**
+     * Unsubscribe from a topic for internal plugin services with given receive mode.
+     *
+     * @param topic       topic name.
+     * @param cb          callback to remove from subscription
+     * @param serviceName name of the service unsubscribing.
+     * @param receiveMode the mode of messages sending back to the originating component.
+     */
+    public void unsubscribe(String topic, Consumer<PublishEvent> cb, String serviceName, ReceiveMode receiveMode) {
+        handleUnsubscribeToTopicRequest(topic, serviceName,receiveMode, cb);
     }
 
     /**
@@ -115,18 +140,31 @@ public class PubSubIPCEventStreamAgent {
                 || topic.contains(GLOB_WILDCARD)) {
             throw new InvalidArgumentsError("Publish topic must not contain a wildcard.");
         }
-        Set<Object> contexts = listeners.get(topic);
+        Set<SubscriptionCallback> contexts = listeners.get(topic);
         if (contexts == null || contexts.isEmpty()) {
             log.atDebug().kv(COMPONENT_NAME, serviceName).log("No one subscribed to topic {}. Returning.", topic);
             // Still technically successful, just no one was subscribed
             return new PublishToTopicResponse();
         }
+        Set<Object> cbs = new HashSet<>();
+        contexts.forEach(context -> {
+            // With RECEIVE_MESSAGES_FROM_OTHERS mode, message will not be sent back to its source component.
+            if (serviceName.equals(context.getSourceComponent()) && ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS
+                    .equals(context.getReceiveMode())) {
+                log.atDebug().kv(COMPONENT_NAME, serviceName)
+                        .log("Message will not be sent back on topic {} in {} mode", topic,
+                                context.getReceiveMode().getValue());
+            } else {
+                cbs.add(context.getCallback());
+            }
+        });
         SubscriptionResponseMessage message = new SubscriptionResponseMessage();
         PublishEvent publishedEvent = PublishEvent.builder().topic(topic).build();
+        MessageContext messageContext = new MessageContext().withTopic(topic);
         if (jsonMessage.isPresent()) {
             JsonMessage message1 = new JsonMessage();
             message1.setMessage(jsonMessage.get());
-            message1.setEventTopic(topic);
+            message1.setContext(messageContext);
             message.setJsonMessage(message1);
             try {
                 publishedEvent.setPayload(SERIALIZER.writeValueAsBytes(jsonMessage.get()));
@@ -138,12 +176,12 @@ public class PubSubIPCEventStreamAgent {
         if (binaryMessage.isPresent()) {
             BinaryMessage binaryMessage1 = new BinaryMessage();
             binaryMessage1.setMessage(binaryMessage.get());
-            binaryMessage1.setEventTopic(topic);
+            binaryMessage1.setContext(messageContext);
             message.setBinaryMessage(binaryMessage1);
             publishedEvent.setPayload(binaryMessage.get());
         }
 
-        contexts.forEach(context -> {
+        cbs.forEach(context -> {
             log.atDebug().kv(COMPONENT_NAME, serviceName).log("Sending publish event for topic {}", topic);
             if (context instanceof StreamEventPublisher) {
                 StreamEventPublisher<SubscriptionResponseMessage> publisher =
@@ -157,14 +195,23 @@ public class PubSubIPCEventStreamAgent {
         return new PublishToTopicResponse();
     }
 
-    private void handleSubscribeToTopicRequest(String topic, String serviceName, Object handler) {
+    private void handleSubscribeToTopicRequest(String topic, String serviceName, ReceiveMode receiveMode,
+                                               Object handler) {
         // TODO: [P32540011]: All IPC service requests need input validation
         validateSubTopic(topic);
-        if (listeners.add(topic, handler)) {
+        SubscriptionCallback subscriptionConfig = convertToSubscriptionConfig(topic, serviceName, receiveMode, handler);
+        if (listeners.add(topic, subscriptionConfig)) {
             log.atDebug().kv(COMPONENT_NAME, serviceName).log("Subscribed to topic {}", topic);
         }
     }
 
+    private void handleUnsubscribeToTopicRequest(String topic, String serviceName, ReceiveMode receiveMode,
+                                                 Object handler) {
+        SubscriptionCallback subscriptionConfig = convertToSubscriptionConfig(topic, serviceName, receiveMode, handler);
+        if (listeners.remove(topic, subscriptionConfig)) {
+            log.atDebug().kv(COMPONENT_NAME, serviceName).log("Unsubscribed from topic {}", topic);
+        }
+    }
 
     class PublishToTopicOperationHandler extends GeneratedAbstractPublishToTopicOperationHandler {
         private final String serviceName;
@@ -213,6 +260,7 @@ public class PubSubIPCEventStreamAgent {
         @Getter
         private final String serviceName;
         private String subscribeTopic;
+        private ReceiveMode receiveMode;
 
         protected SubscribeToTopicOperationHandler(OperationContinuationHandlerContext context) {
             super(context);
@@ -222,7 +270,7 @@ public class PubSubIPCEventStreamAgent {
         @Override
         protected void onStreamClosed() {
             if (Utils.isNotEmpty(subscribeTopic)) {
-                listeners.remove(subscribeTopic, this);
+                handleUnsubscribeToTopicRequest(subscribeTopic, serviceName, receiveMode, this);
             }
         }
 
@@ -236,8 +284,10 @@ public class PubSubIPCEventStreamAgent {
                 } catch (AuthorizationException e) {
                     throw new UnauthorizedError(e.getMessage());
                 }
-                handleSubscribeToTopicRequest(subscribeRequest.getTopic(), serviceName, this);
+                handleSubscribeToTopicRequest(subscribeRequest.getTopic(), serviceName,
+                        subscribeRequest.getReceiveMode(), this);
                 subscribeTopic = subscribeRequest.getTopic();
+                receiveMode = subscribeRequest.getReceiveMode();
                 return new SubscribeToTopicResponse();
             });
         }
@@ -252,6 +302,25 @@ public class PubSubIPCEventStreamAgent {
         if (Utils.isEmpty(topic)) {
             throw new InvalidArgumentsError("Subscribe topic must not be empty");
         }
+    }
+
+    private ReceiveMode validateReceiveMode(String topic, ReceiveMode receiveMode) {
+        if (receiveMode != null) {
+            return receiveMode;
+        }
+        // If no receiveMode is set and the topic contains wildcard, use RECEIVE_MESSAGES_FROM_OTHERS
+        // Otherwise, default is RECEIVE_ALL_MESSAGES
+        if (SubscriptionTrie.isWildcard(topic)) {
+            return ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS;
+        } else {
+            return ReceiveMode.RECEIVE_ALL_MESSAGES;
+        }
+    }
+
+    private SubscriptionCallback convertToSubscriptionConfig(String topic, String serviceName,
+                                                             ReceiveMode receiveMode, Object handler) {
+        ReceiveMode validatedReceiveMode = validateReceiveMode(topic, receiveMode);
+        return new SubscriptionCallback(serviceName, validatedReceiveMode, handler);
     }
 
     private void doAuthorization(String opName, String serviceName, String topic) throws AuthorizationException {

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscribeRequest.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscribeRequest.java
@@ -9,10 +9,11 @@ import lombok.Builder;
 import lombok.Value;
 import software.amazon.awssdk.aws.greengrass.model.ReceiveMode;
 
-@Value
 @Builder
-public class SubscriptionCallback {
-    String sourceComponent;
-    ReceiveMode receiveMode;
+@Value
+public class SubscribeRequest {
+    String topic;
     Object callback;
+    String serviceName;
+    ReceiveMode receiveMode;
 }

--- a/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionCallback.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionCallback.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.builtin.services.pubsub;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.aws.greengrass.model.ReceiveMode;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubscriptionCallback {
+    String sourceComponent;
+    ReceiveMode receiveMode;
+    Object callback;
+}

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -495,7 +495,10 @@ class PubSubIPCEventStreamAgentTest {
             throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<PublishEvent> consumer = getConsumer(countDownLatch);
-        pubSubIPCEventStreamAgent.subscribe(TEST_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS);
+        SubscribeRequest request =
+                SubscribeRequest.builder().topic(TEST_TOPIC).callback(consumer).serviceName(TEST_SERVICE)
+                        .receiveMode(ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS).build();
+        pubSubIPCEventStreamAgent.subscribe(request);
 
         assertEquals(1, pubSubIPCEventStreamAgent.getListeners().size());
         assertTrue(pubSubIPCEventStreamAgent.getListeners().containsKey(TEST_TOPIC));
@@ -504,7 +507,7 @@ class PubSubIPCEventStreamAgentTest {
         pubSubIPCEventStreamAgent.publish(TEST_TOPIC, "ABCDEF".getBytes(), TEST_SERVICE);
         assertFalse(countDownLatch.await(10, TimeUnit.SECONDS));
 
-        pubSubIPCEventStreamAgent.unsubscribe(TEST_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS);
+        pubSubIPCEventStreamAgent.unsubscribe(request);
         assertEquals(0, pubSubIPCEventStreamAgent.getListeners().size());
     }
 
@@ -513,8 +516,10 @@ class PubSubIPCEventStreamAgentTest {
             throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<PublishEvent> consumer = getConsumer(countDownLatch);
-        pubSubIPCEventStreamAgent.subscribe(TEST_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_ALL_MESSAGES);
-
+        SubscribeRequest request =
+                SubscribeRequest.builder().topic(TEST_TOPIC).callback(consumer).serviceName(TEST_SERVICE)
+                        .receiveMode(ReceiveMode.RECEIVE_ALL_MESSAGES).build();
+        pubSubIPCEventStreamAgent.subscribe(request);
         assertEquals(1, pubSubIPCEventStreamAgent.getListeners().size());
         assertTrue(pubSubIPCEventStreamAgent.getListeners().containsKey(TEST_TOPIC));
         assertEquals(1, pubSubIPCEventStreamAgent.getListeners().get(TEST_TOPIC).size());
@@ -522,7 +527,7 @@ class PubSubIPCEventStreamAgentTest {
         pubSubIPCEventStreamAgent.publish(TEST_TOPIC, "ABCDEF".getBytes(), TEST_SERVICE);
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
 
-        pubSubIPCEventStreamAgent.unsubscribe(TEST_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_ALL_MESSAGES);
+        pubSubIPCEventStreamAgent.unsubscribe(request);
         assertEquals(0, pubSubIPCEventStreamAgent.getListeners().size());
     }
 
@@ -559,8 +564,10 @@ class PubSubIPCEventStreamAgentTest {
             throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<PublishEvent> consumer = getConsumer(countDownLatch);
-        pubSubIPCEventStreamAgent.subscribe(TEST_WILDCARD_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_ALL_MESSAGES);
-
+        SubscribeRequest request =
+                SubscribeRequest.builder().topic(TEST_WILDCARD_TOPIC).callback(consumer).serviceName(TEST_SERVICE)
+                        .receiveMode(ReceiveMode.RECEIVE_ALL_MESSAGES).build();
+        pubSubIPCEventStreamAgent.subscribe(request);
         assertEquals(1, pubSubIPCEventStreamAgent.getListeners().size());
         assertTrue(pubSubIPCEventStreamAgent.getListeners().containsKey(TEST_WILDCARD_TOPIC));
         assertEquals(1, pubSubIPCEventStreamAgent.getListeners().get(TEST_WILDCARD_TOPIC).size());
@@ -568,7 +575,7 @@ class PubSubIPCEventStreamAgentTest {
         pubSubIPCEventStreamAgent.publish("Test/A/Topic/B/C", "ABCDEF".getBytes(), TEST_SERVICE);
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
 
-        pubSubIPCEventStreamAgent.unsubscribe(TEST_WILDCARD_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_ALL_MESSAGES);
+        pubSubIPCEventStreamAgent.unsubscribe(request);
         assertEquals(0, pubSubIPCEventStreamAgent.getListeners().size());
     }
 
@@ -577,7 +584,10 @@ class PubSubIPCEventStreamAgentTest {
             throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<PublishEvent> consumer = getConsumer(countDownLatch);
-        pubSubIPCEventStreamAgent.subscribe(TEST_WILDCARD_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS);
+        SubscribeRequest request =
+                SubscribeRequest.builder().topic(TEST_WILDCARD_TOPIC).callback(consumer).serviceName(TEST_SERVICE)
+                        .receiveMode(ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS).build();
+        pubSubIPCEventStreamAgent.subscribe(request);
 
         assertEquals(1, pubSubIPCEventStreamAgent.getListeners().size());
         assertTrue(pubSubIPCEventStreamAgent.getListeners().containsKey(TEST_WILDCARD_TOPIC));
@@ -586,7 +596,7 @@ class PubSubIPCEventStreamAgentTest {
         pubSubIPCEventStreamAgent.publish("Test/A/Topic/B/C", "ABCDEF".getBytes(), TEST_SERVICE);
         assertFalse(countDownLatch.await(10, TimeUnit.SECONDS));
 
-        pubSubIPCEventStreamAgent.unsubscribe(TEST_WILDCARD_TOPIC, consumer, TEST_SERVICE, ReceiveMode.RECEIVE_MESSAGES_FROM_OTHERS);
+        pubSubIPCEventStreamAgent.unsubscribe(request);
         assertEquals(0, pubSubIPCEventStreamAgent.getListeners().size());
     }
 

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
@@ -33,11 +33,11 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 @ExtendWith({GGExtension.class})
 public class SubscriptionTrieTest {
 
-    SubscriptionTrie trie;
+    SubscriptionTrie<SubscriptionCallback> trie;
 
     @BeforeEach
     void setup() {
-        trie = new SubscriptionTrie();
+        trie = new SubscriptionTrie<>();
     }
 
     @ParameterizedTest

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/SubscriptionTrieTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.aws.greengrass.model.ReceiveMode;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -25,6 +26,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -41,8 +43,8 @@ public class SubscriptionTrieTest {
     @ParameterizedTest
     @MethodSource("subscriptionMatch")
     public void GIVEN_subscription_THEN_match(String subscription, List<String> topics) {
-        Object cb1 = new Object();
-        Object cb2 = new Object();
+        SubscriptionCallback cb1 = generateSubscriptionCallback();
+        SubscriptionCallback cb2 = generateSubscriptionCallback();
         trie.add(subscription, cb1);
         trie.add(subscription, cb2);
         for (String topic : topics) {
@@ -67,8 +69,8 @@ public class SubscriptionTrieTest {
     @ParameterizedTest
     @MethodSource("subscriptionNotMatch")
     public void GIVEN_subscription_THEN_do_not_match(String subscription, List<String> topics) {
-        Object cb1 = new Object();
-        Object cb2 = new Object();
+        SubscriptionCallback cb1 = generateSubscriptionCallback();
+        SubscriptionCallback cb2 = generateSubscriptionCallback();
         trie.add(subscription, cb1);
         trie.add(subscription, cb2);
 
@@ -92,8 +94,8 @@ public class SubscriptionTrieTest {
     @Test
     public void GIVEN_subscription_WHEN_remove_topic_THEN_no_matches() {
         assertEquals(0, trie.size());
-        Object cb1 = new Object();
-        Object cb2 = new Object();
+        SubscriptionCallback cb1 = generateSubscriptionCallback();
+        SubscriptionCallback cb2 = generateSubscriptionCallback();
         String topic = "foo";
         trie.add(topic, cb1);
         trie.add(topic, cb2);
@@ -112,9 +114,9 @@ public class SubscriptionTrieTest {
     @Test
     public void GIVEN_subscription_wildcard_WHEN_remove_topic_THEN_no_matches() {
         assertEquals(0, trie.size());
-        Object cb1 = new Object();
-        Object cb2 = new Object();
-        Object cb3 = new Object();
+        SubscriptionCallback cb1 = generateSubscriptionCallback();
+        SubscriptionCallback cb2 = generateSubscriptionCallback();
+        SubscriptionCallback cb3 = generateSubscriptionCallback();
         String topic = "foo/+/bar/#";
         trie.add(topic, cb1);
         trie.add(topic, cb2);
@@ -133,5 +135,27 @@ public class SubscriptionTrieTest {
         assertThat("remove topic", trie.remove(topic, cb2), is(true));
         assertThat(trie.get(topic), is(empty()));
         assertEquals(0, trie.size());
+    }
+
+    @Test
+    void GIVEN_topics_WHEN_isWildcard_THEN_returns_whether_it_uses_wildcard() {
+        assertTrue(SubscriptionTrie.isWildcard("+"));
+        assertTrue(SubscriptionTrie.isWildcard("#"));
+        assertTrue(SubscriptionTrie.isWildcard("/+/"));
+        assertTrue(SubscriptionTrie.isWildcard("/#"));
+        assertTrue(SubscriptionTrie.isWildcard("foo/+"));
+        assertTrue(SubscriptionTrie.isWildcard("foo/ba+/#"));
+        assertTrue(SubscriptionTrie.isWildcard("foo/+/bar/#"));
+        assertTrue(SubscriptionTrie.isWildcard("$aws/things/+/shadow/#"));
+
+        assertFalse(SubscriptionTrie.isWildcard("/"));
+        assertFalse(SubscriptionTrie.isWildcard("foo"));
+        assertFalse(SubscriptionTrie.isWildcard("#/foo"));
+        assertFalse(SubscriptionTrie.isWildcard("foo/+bar"));
+        assertFalse(SubscriptionTrie.isWildcard("foo/+#"));
+    }
+
+    private SubscriptionCallback generateSubscriptionCallback() {
+        return new SubscriptionCallback("TEST_COMPONENT", ReceiveMode.RECEIVE_ALL_MESSAGES, new Object());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Implement the new `ReceiveMode` flag for `SubscribeToTopicRequest` in PubSub agent. 
- Refactor SubscriptionTrie to store the new SubscriptionCallback. 
- Update device SDK snapshot. (which also removes eventTopic from `JsonMessage/BinaryMessage` and adds `MessageContext`)

`ReceiveMode` currently has two modes: 
- `RECEIVE_ALL_MESSAGES`: current behavior, all messages will be received by any subscriber.
- `RECEIVE_MESSAGES_FROM_OTHERS`: messaged will not be sent back to the same component that publishes it.

If ReceiveMode is NOT specified, RECEIVE_MESSAGES_FROM_OTHERS will be used if the subscription topic uses wildcard, and RECEIVE_ALL_MESSAGES will be used otherwise.

**Why is this change necessary:**
The new RECEIVE_MESSAGES_FROM_OTHERS mode can prevent unwanted circular routes.

**How was this change tested:**
mvn -U -ntp verify

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
