### PR TITLE
perf: get Unix username/group using JNA, lazy initialize platform

### DIFF
--- a/src/main/java/com/aws/greengrass/config/PlatformResolver.java
+++ b/src/main/java/com/aws/greengrass/config/PlatformResolver.java
@@ -53,7 +53,7 @@ public class PlatformResolver {
     private final DeviceConfiguration deviceConfiguration;
 
     private static final AtomicReference<Platform> DETECTED_PLATFORM =
-            new AtomicReference<>(initializePlatform());
+            new AtomicReference<>();
 
     private static Platform initializePlatform() {
         return Platform.builder()
@@ -75,7 +75,7 @@ public class PlatformResolver {
      * @return Platform key-value map
      */
     public Map<String, String> getCurrentPlatform() {
-        Map<String, String> detected = DETECTED_PLATFORM.get();
+        Platform detected = getPlatform();
         if (deviceConfiguration == null) {
             return detected;
         }
@@ -91,6 +91,15 @@ public class PlatformResolver {
             }
         }
         return platform;
+    }
+
+    private synchronized Platform getPlatform() {
+        Platform detected = DETECTED_PLATFORM.get();
+        if (detected == null) {
+            detected = initializePlatform();
+            DETECTED_PLATFORM.set(detected);
+        }
+        return detected;
     }
 
     /**
@@ -135,12 +144,17 @@ public class PlatformResolver {
             return null;
         }
         try {
-            String archDetail = com.aws.greengrass.util.platforms.Platform.getInstance().createNewProcessRunner()
-                    .sh("uname -m").toLowerCase();
-            // TODO: "uname -m" is not sufficient to capture arch details on all platforms.
-            // Currently only return if detected arm, as required by lambda launcher.
-            if ("armv6l".equals(archDetail) || "armv7l".equals(archDetail) || "armv8l".equals(archDetail)) {
-                return archDetail;
+            String arch = getArchInfo();
+            // Since we only can detect the architecture details for arm, only run uname -m when we are running
+            // on arm.
+            if (ARCH_ARM.equals(arch) || ARCH_AARCH64.equals(arch)) {
+                String archDetail = com.aws.greengrass.util.platforms.Platform.getInstance()
+                        .createNewProcessRunner().sh("uname -m").toLowerCase();
+                // TODO: "uname -m" is not sufficient to capture arch details on all platforms.
+                // Currently only return if detected arm, as required by lambda launcher.
+                if ("armv6l".equals(archDetail) || "armv7l".equals(archDetail) || "armv8l".equals(archDetail)) {
+                    return archDetail;
+                }
             }
         } catch (IOException | InterruptedException e) {
             logger.error("Error trying to determine architecture detail - assuming not available", e);

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -16,6 +16,7 @@ import com.aws.greengrass.util.platforms.ShellDecorator;
 import com.aws.greengrass.util.platforms.StubResourceController;
 import com.aws.greengrass.util.platforms.SystemResourceController;
 import com.aws.greengrass.util.platforms.UserDecorator;
+import com.sun.jna.platform.unix.LibC;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.zeroturnaround.process.PidProcess;
@@ -161,20 +162,14 @@ public class UnixPlatform extends Platform {
      */
     private static synchronized UnixUserAttributes loadCurrentUser() throws IOException {
         if (CURRENT_USER == null) {
-            Optional<String> id = id(null, IdOption.User, false);
-            id.orElseThrow(() -> new IOException("Could not lookup current user: " + System.getProperty("user.name")));
-
-            Optional<String> name = id(null, IdOption.User, true);
-
+            int id = LibC.INSTANCE.geteuid();
             UnixUserAttributes.UnixUserAttributesBuilder builder = UnixUserAttributes.builder()
-                    .principalIdentifier(id.get())
-                    .principalName(name.orElse(id.get()));
+                    .principalIdentifier(String.valueOf(id))
+                    .principalName(System.getProperty("user.name"));
 
-            Optional<String> group = id(null, IdOption.Group, false);
-            group.orElseThrow(() -> new IOException("Could not lookup primary group for current user: " + id.get()));
-
-            CURRENT_USER = builder.primaryGid(Long.parseLong(group.get())).build();
-            CURRENT_USER_PRIMARY_GROUP = lookupGroup(group.get());
+            long group = LibC.INSTANCE.getegid();
+            CURRENT_USER = builder.primaryGid(group).build();
+            CURRENT_USER_PRIMARY_GROUP = lookupGroup(String.valueOf(group));
         }
         return CURRENT_USER;
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Decrease startup time ~2 seconds on mac by not using the `id` and `uname` commands on startup. `id` is replaced by JNA `geteuid()/getegid()` and `uname` is not replaced, but is lazy-loaded when it is first needed.

This is where the 2 second gain comes from:
Removes the static block in `UnixExec` which was supposedly a hack to get a good $PATH, but on my mac it just exited 1 so we end up waiting 2 seconds no matter what for no benefit.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
