### PR TITLE
test: use prod for e2e tests instead of unreliable gamma

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
@@ -51,7 +51,7 @@ class MqttTest extends BaseE2ETestCase {
             throws IOException, ExecutionException, InterruptedException, TimeoutException, DeviceConfigurationException {
         kernel = new Kernel().parseArgs("-r", tempRootDir.toAbsolutePath().toString());
         setDefaultRunWithUser(kernel);
-        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, GAMMA_REGION.toString(),
+        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, TEST_REGION.toString(),
                 TES_ROLE_ALIAS_NAME);
 
         MqttClient client = kernel.getContext().get(MqttClient.class);
@@ -74,7 +74,7 @@ class MqttTest extends BaseE2ETestCase {
             throws Throwable {
         kernel = new Kernel().parseArgs("-r", tempRootDir.toAbsolutePath().toString());
         setDefaultRunWithUser(kernel);
-        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, GAMMA_REGION.toString(),
+        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, TEST_REGION.toString(),
                 TES_ROLE_ALIAS_NAME);
 
         MqttClient client = kernel.getContext().get(MqttClient.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/tes/TESTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/tes/TESTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.easysetup.DeviceProvisioningHelper.ThingInfo;
+import static com.aws.greengrass.integrationtests.e2e.BaseE2ETestCase.E2ETEST_ENV_STAGE;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.greengrass.deployment.DeviceConfiguration.IOT_ROLE_ALIAS_TOPIC;
@@ -80,7 +81,6 @@ class TESTest extends BaseITCase {
     private static final String AWS_CREDENTIALS_PATTERN =
             "\\{\"AccessKeyId\":\".+\",\"SecretAccessKey\":\".+\"," + "\"Expiration\":\".+\",\"Token\":\".+\"\\}";
     private static final Logger logger = LogManager.getLogger(TESTest.class);
-    private static final IotSdkClientFactory.EnvironmentStage envStage = IotSdkClientFactory.EnvironmentStage.GAMMA;
     @TempDir
     static Path tempDir;
 
@@ -89,10 +89,10 @@ class TESTest extends BaseITCase {
         System.setProperty("root", tempDir.toAbsolutePath().toString());
         kernel = new Kernel();
         kernel.parseArgs("-i", TESTest.class.getResource("tesExample.yaml").toString(), "-ar", AWS_REGION, "-es",
-                envStage.toString());
+                E2ETEST_ENV_STAGE.toString());
         BaseE2ETestCase.setDefaultRunWithUser(kernel);
         deviceProvisioningHelper = new DeviceProvisioningHelper(AWS_REGION,
-                envStage.toString(), System.out);
+                E2ETEST_ENV_STAGE.toString(), System.out);
         roleId = UUID.randomUUID().toString();
         roleName = TES_ROLE_NAME + roleId;
         roleAliasName = TES_ROLE_ALIAS_NAME + roleId;
@@ -121,12 +121,12 @@ class TESTest extends BaseITCase {
             kernel.shutdown();
         } finally {
             deviceProvisioningHelper.cleanThing(
-                    IotSdkClientFactory.getIotClient(AWS_REGION, envStage,
+                    IotSdkClientFactory.getIotClient(AWS_REGION, E2ETEST_ENV_STAGE,
                             Collections.singleton(InvalidRequestException.class)),
                     thingInfo, false);
-            IotJobsUtils.cleanUpIotRoleForTest(IotSdkClientFactory.getIotClient(AWS_REGION, envStage),
+            IotJobsUtils.cleanUpIotRoleForTest(IotSdkClientFactory.getIotClient(AWS_REGION, E2ETEST_ENV_STAGE),
                     IamSdkClientFactory.getIamClient(AWS_REGION), roleName, roleAliasName, thingInfo.getCertificateArn());
-            IotJobsUtils.cleanUpIotRoleForTest(IotSdkClientFactory.getIotClient(AWS_REGION, envStage),
+            IotJobsUtils.cleanUpIotRoleForTest(IotSdkClientFactory.getIotClient(AWS_REGION, E2ETEST_ENV_STAGE),
                     IamSdkClientFactory.getIamClient(AWS_REGION), roleName, newRoleAliasName, thingInfo.getCertificateArn());
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
