### PR TITLE
fix: handle subscription close on purposeful connection interruption

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.integrationtests.e2e.mqttclient;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.integrationtests.e2e.BaseE2ETestCase;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.mqttclient.SubscribeRequest;
@@ -16,14 +17,21 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.aws.greengrass.testcommons.testutilities.TestUtils.createCloseableLogListener;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("PMD.CloseResource")
@@ -82,7 +90,7 @@ class MqttTest extends BaseE2ETestCase {
         //subscribe to 50 topics using first connection.
         int numberOfTopics = 50;
         for (int i = 0; i < numberOfTopics; i++) {
-            client.subscribe(SubscribeRequest.builder().topic("A/"+ i).callback((m) -> {}).build());
+            client.subscribe(SubscribeRequest.builder().topic("A/" + i).callback((m) -> {}).build());
         }
         //close the first connections and create a second connection.
         client.close();
@@ -91,16 +99,65 @@ class MqttTest extends BaseE2ETestCase {
         // Using the second connection to subscribes to another 50 topics, IoT core limits subscriptions to 50 topics per connection.
         // if the session from first connection is not terminated, subscribe operations made by second connection will not succeed.
         for (int i = 0; i < numberOfTopics; i++) {
-            client.subscribe(SubscribeRequest.builder().topic("B/"+ i ).callback((m) -> {
+            client.subscribe(SubscribeRequest.builder().topic("B/" + i).callback((m) -> {
                 cdl.countDown();
                 logger.atInfo().kv("remaining", cdl.getCount()).log("Received 1 message from cloud.");
             }).build());
         }
         for (int i = 0; i < numberOfTopics; i++) {
-            client.publish(PublishRequest.builder().topic("B/"+ i ).payload("What's up".getBytes(StandardCharsets.UTF_8))
+            client.publish(PublishRequest.builder().topic("B/" + i).payload("What's up".getBytes(StandardCharsets.UTF_8))
                     .build()).get(5, TimeUnit.SECONDS);
             logger.atInfo().kv("total", i + 1).log("Added 1 message to spooler.");
         }
         assertTrue(cdl.await(1, TimeUnit.MINUTES), "All messages published and received");
+    }
+
+    @Test
+    void GIVEN_mqttClient_WHEN_subscribe_interrupted_THEN_does_not_close_connection(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, InterruptedException.class);
+        CountDownLatch interruptCdl = new CountDownLatch(1);
+
+        Consumer<GreengrassLogMessage> logListener = m -> {
+            if ("Connection purposefully interrupted".equals(m.getMessage())) {
+                if (m.getContexts().get("clientId").endsWith("#2")) {
+                    interruptCdl.countDown();
+                }
+            }
+        };
+
+        try (AutoCloseable l = createCloseableLogListener(logListener)) {
+            int numberOfTopics = 100;
+            ExecutorService executorService = Executors.newCachedThreadPool();
+            CountDownLatch messagesCdl = new CountDownLatch(numberOfTopics);
+            kernel = new Kernel().parseArgs("-r", tempRootDir.toAbsolutePath().toString());
+            setDefaultRunWithUser(kernel);
+            deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, TEST_REGION.toString(),
+                    TES_ROLE_ALIAS_NAME);
+
+            MqttClient client = kernel.getContext().get(MqttClient.class);
+            Future<?> subscribeFuture = executorService.submit(() -> {
+                for (int i = 0; i < numberOfTopics; i++) {
+                    String topic = "B/" + i;
+                    try {
+                        client.subscribe(SubscribeRequest.builder().topic(topic).callback((m) -> {
+                            messagesCdl.countDown();
+                            logger.atInfo().kv("remaining", messagesCdl.getCount())
+                                    .log("Received 1 message from cloud.");
+                        }).build());
+                    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+                        logger.atError().kv("topic", topic).cause(e).log("Error subscribing");
+                    }
+                }
+            });
+            assertTrue(interruptCdl.await(40, TimeUnit.SECONDS), "Connection should be interrupted for client 2");
+            subscribeFuture.cancel(true);
+            for (int i = 0; i < numberOfTopics; i++) {
+                client.publish(PublishRequest.builder().topic("B/" + i).payload("What's up".getBytes(StandardCharsets.UTF_8))
+                        .build()).get(5, TimeUnit.SECONDS);
+                logger.atInfo().kv("total", i + 1).log("Added 1 message to spooler.");
+            }
+            assertTrue(messagesCdl.await(1, TimeUnit.MINUTES), "All messages published and received");
+        }
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
@@ -158,7 +158,7 @@ class MqttTest extends BaseE2ETestCase {
             }
             assertTrue(messagesCdl.await(1, TimeUnit.MINUTES), "All messages published and received");
         } finally {
-            executorService.shutdown();
+            executorService.shutdownNow();
         }
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/mqttclient/MqttTest.java
@@ -125,10 +125,9 @@ class MqttTest extends BaseE2ETestCase {
                 }
             }
         };
-
+        ExecutorService executorService = Executors.newCachedThreadPool();
         try (AutoCloseable l = createCloseableLogListener(logListener)) {
             int numberOfTopics = 100;
-            ExecutorService executorService = Executors.newCachedThreadPool();
             CountDownLatch messagesCdl = new CountDownLatch(numberOfTopics);
             kernel = new Kernel().parseArgs("-r", tempRootDir.toAbsolutePath().toString());
             setDefaultRunWithUser(kernel);
@@ -158,6 +157,8 @@ class MqttTest extends BaseE2ETestCase {
                 logger.atInfo().kv("total", i + 1).log("Added 1 message to spooler.");
             }
             assertTrue(messagesCdl.await(1, TimeUnit.MINUTES), "All messages published and received");
+        } finally {
+            executorService.shutdown();
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -225,7 +225,7 @@ class AwsIotMqttClient implements Closeable {
         // For the initial connect, client connects with cleanSession=true and disconnects.
         // This deletes any previous session information maintained by IoT Core.
         // For subsequent connects, the client connects with cleanSession=false
-        CompletableFuture<Void> voidCompletableFuture =  CompletableFuture.completedFuture(null);
+        CompletableFuture<Void> voidCompletableFuture = CompletableFuture.completedFuture(null);
         if (initialConnect.get()) {
             voidCompletableFuture = establishConnection(true).thenCompose((session) -> {
                 initialConnect.set(false);
@@ -343,11 +343,9 @@ class AwsIotMqttClient implements Closeable {
         }
     }
 
-    boolean canAddNewSubscription() {
-        synchronized (this) {
-            return (subscriptionTopics.size() + inprogressSubscriptionsCount())
-                    < MqttClient.MAX_SUBSCRIPTIONS_PER_CONNECTION;
-        }
+    synchronized boolean canAddNewSubscription() {
+        return (subscriptionTopics.size() + inprogressSubscriptionsCount())
+                < MqttClient.MAX_SUBSCRIPTIONS_PER_CONNECTION;
     }
 
     int subscriptionCount() {
@@ -358,10 +356,8 @@ class AwsIotMqttClient implements Closeable {
         return inprogressSubscriptions.get();
     }
 
-    boolean isConnectionClosable() {
-        synchronized (this) {
-            return subscriptionTopics.size() + inprogressSubscriptionsCount() == 0;
-        }
+    synchronized boolean isConnectionClosable() {
+        return subscriptionTopics.size() + inprogressSubscriptionsCount() == 0;
     }
 
     synchronized boolean connected() {

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -343,7 +343,10 @@ class AwsIotMqttClient implements Closeable {
     }
 
     boolean canAddNewSubscription() {
-        return subscriptionTopics.size() < MqttClient.MAX_SUBSCRIPTIONS_PER_CONNECTION;
+        synchronized (this) {
+            return (subscriptionTopics.size() + inprogressSubscriptionsCount())
+                    < MqttClient.MAX_SUBSCRIPTIONS_PER_CONNECTION;
+        }
     }
 
     int subscriptionCount() {
@@ -352,6 +355,12 @@ class AwsIotMqttClient implements Closeable {
 
     int inprogressSubscriptionsCount() {
         return inprogressSubscriptions.get();
+    }
+
+    boolean isConnectionClosable() {
+        synchronized (this) {
+            return (subscriptionTopics.size() + inprogressSubscriptionsCount()) == 0;
+        }
     }
 
     synchronized boolean connected() {

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -70,6 +70,7 @@ class AwsIotMqttClient implements Closeable {
     @Getter(AccessLevel.PACKAGE)
     private final Map<String, QualityOfService> subscriptionTopics = new ConcurrentHashMap<>();
     private final Map<String, QualityOfService> droppedSubscriptionTopics = new ConcurrentHashMap<>();
+    @Getter(AccessLevel.PACKAGE)
     private final AtomicInteger inprogressSubscriptions = new AtomicInteger();
     private Future<?> resubscribeFuture;
     @Setter
@@ -359,7 +360,7 @@ class AwsIotMqttClient implements Closeable {
 
     boolean isConnectionClosable() {
         synchronized (this) {
-            return (subscriptionTopics.size() + inprogressSubscriptionsCount()) == 0;
+            return subscriptionTopics.size() + inprogressSubscriptionsCount() == 0;
         }
     }
 

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -701,7 +701,7 @@ public class MqttClient implements Closeable {
                 // subscriptions.
                 Set<AwsIotMqttClient> closableConnections =
                         connections.stream()
-                                .filter((c) -> c.subscriptionCount() == 0 && c.inprogressSubscriptionsCount() == 0)
+                                .filter(AwsIotMqttClient::isConnectionClosable)
                                 .collect(Collectors.toSet());
                 for (AwsIotMqttClient closableConnection : closableConnections) {
                     // Leave the last connection alive to use for publishing

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -497,4 +497,34 @@ class AwsIotMqttClientTest {
         verify(connection, timeout(VERIFY_TIMEOUT_MILLIS).times(5)).subscribe(eq("C"), any());
         verify(connection, timeout(VERIFY_TIMEOUT_MILLIS).times(3)).subscribe(eq("A"), any());
     }
+
+    @Test
+    void GIVEN_mqttClient_has_subscribed_to_any_topic_or_has_inprgoress_subscritpion_WHEN_isConnectionClosable_THEN_returns_false() {
+        AwsIotMqttClient.setSubscriptionRetryMillis(500);
+        AwsIotMqttClient.setWaitTimeJitterMaxMillis(1);
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
+                callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
+
+        client.getSubscriptionTopics().put("A/B", QualityOfService.AT_LEAST_ONCE);
+        assertFalse(client.isConnectionClosable());
+
+        client.getSubscriptionTopics().clear();
+        client.getInprogressSubscriptions().incrementAndGet();
+
+        assertFalse(client.isConnectionClosable());
+
+        client.getInprogressSubscriptions().decrementAndGet();
+        assertTrue(client.isConnectionClosable());
+    }
+
+    @Test
+    void GIVEN_mqttClient_has_no_subscribed_topic_or_any_inprgoress_subscritpion_WHEN_isConnectionClosable_THEN_returns_true() {
+        AwsIotMqttClient.setSubscriptionRetryMillis(500);
+        AwsIotMqttClient.setWaitTimeJitterMaxMillis(1);
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
+                callbackEventManager, executorService, ses);
+        client.disableRateLimiting();
+        assertTrue(client.isConnectionClosable());
+    }
 }

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -327,10 +327,8 @@ class MqttClientTest {
         when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
         when(mockIndividual2.canAddNewSubscription()).thenReturn(true);
         when(mockIndividual3.canAddNewSubscription()).thenReturn(true);
-        when(mockIndividual1.subscriptionCount()).thenReturn(50);
-        when(mockIndividual2.subscriptionCount()).thenReturn(1);
-        when(mockIndividual3.subscriptionCount()).thenReturn(0);
-        when(mockIndividual3.inprogressSubscriptionsCount()).thenReturn(0);
+        when(mockIndividual2.isConnectionClosable()).thenReturn(false);
+        when(mockIndividual3.isConnectionClosable()).thenReturn(true);
 
         client.getConnections().add(mockIndividual1);
         client.getConnections().add(mockIndividual2);
@@ -360,10 +358,7 @@ class MqttClientTest {
         when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
         when(mockIndividual2.canAddNewSubscription()).thenReturn(true);
         when(mockIndividual3.canAddNewSubscription()).thenReturn(true);
-        when(mockIndividual1.subscriptionCount()).thenReturn(50);
-        when(mockIndividual2.subscriptionCount()).thenReturn(1);
-        when(mockIndividual3.subscriptionCount()).thenReturn(0);
-        when(mockIndividual3.inprogressSubscriptionsCount()).thenReturn(1);
+        when(mockIndividual3.isConnectionClosable()).thenReturn(false);
 
         client.getConnections().add(mockIndividual1);
         client.getConnections().add(mockIndividual2);

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -72,6 +72,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -315,6 +316,71 @@ class MqttClientTest {
     }
 
     @Test
+    void GIVEN_3_connections_with_2_able_accept_new_WHEN_subscribe_THEN_closes_connection_with_no_subscribers()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService));
+        assertFalse(client.connected());
+        AwsIotMqttClient mockIndividual1 = mock(AwsIotMqttClient.class);
+        AwsIotMqttClient mockIndividual2 = mock(AwsIotMqttClient.class);
+        AwsIotMqttClient mockIndividual3 = mock(AwsIotMqttClient.class);
+        when(mockIndividual2.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
+        when(mockIndividual2.canAddNewSubscription()).thenReturn(true);
+        when(mockIndividual3.canAddNewSubscription()).thenReturn(true);
+        when(mockIndividual1.subscriptionCount()).thenReturn(50);
+        when(mockIndividual2.subscriptionCount()).thenReturn(1);
+        when(mockIndividual3.subscriptionCount()).thenReturn(0);
+        when(mockIndividual3.inprogressSubscriptionsCount()).thenReturn(0);
+
+        client.getConnections().add(mockIndividual1);
+        client.getConnections().add(mockIndividual2);
+        client.getConnections().add(mockIndividual3);
+
+        Pair<CompletableFuture<Void>, Consumer<MqttMessage>> abc = asyncAssertOnConsumer((m) -> {
+            assertEquals("A/B/C", m.getTopic());
+        }, 1);
+        client.subscribe(SubscribeRequest.builder().topic("A/B/C").callback(abc.getRight()).build());
+
+        assertEquals(2, client.getConnections().size());
+        verify(mockIndividual1, never()).close();
+        verify(mockIndividual2, never()).close();
+        verify(mockIndividual3, atMostOnce()).close();
+        verify(mockIndividual2, atMostOnce()).subscribe(any(), any());
+    }
+
+    @Test
+    void GIVEN_3_connections_with_2_able_accept_new_with_in_progress_WHEN_subscribe_THEN_does_not_close_any_connections()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService));
+        assertFalse(client.connected());
+        AwsIotMqttClient mockIndividual1 = mock(AwsIotMqttClient.class);
+        AwsIotMqttClient mockIndividual2 = mock(AwsIotMqttClient.class);
+        AwsIotMqttClient mockIndividual3 = mock(AwsIotMqttClient.class);
+        when(mockIndividual2.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
+        when(mockIndividual2.canAddNewSubscription()).thenReturn(true);
+        when(mockIndividual3.canAddNewSubscription()).thenReturn(true);
+        when(mockIndividual1.subscriptionCount()).thenReturn(50);
+        when(mockIndividual2.subscriptionCount()).thenReturn(1);
+        when(mockIndividual3.subscriptionCount()).thenReturn(0);
+        when(mockIndividual3.inprogressSubscriptionsCount()).thenReturn(1);
+
+        client.getConnections().add(mockIndividual1);
+        client.getConnections().add(mockIndividual2);
+        client.getConnections().add(mockIndividual3);
+
+        Pair<CompletableFuture<Void>, Consumer<MqttMessage>> abc = asyncAssertOnConsumer((m) -> {
+            assertEquals("A/B/C", m.getTopic());
+        }, 1);
+        client.subscribe(SubscribeRequest.builder().topic("A/B/C").callback(abc.getRight()).build());
+
+        assertEquals(3, client.getConnections().size());
+        verify(mockIndividual1, never()).close();
+        verify(mockIndividual2, never()).close();
+        verify(mockIndividual3, never()).close();
+    }
+
+    @Test
     void GIVEN_incoming_messages_to_2clients_WHEN_received_THEN_subscribers_are_called_without_duplication()
             throws ExecutionException, InterruptedException, TimeoutException {
         MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService));
@@ -326,8 +392,6 @@ class MqttClientTest {
         when(client.getNewMqttClient()).thenReturn(mockIndividual1).thenReturn(mockIndividual2);
         when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
         when(mockIndividual2.canAddNewSubscription()).thenReturn(true);
-        when(mockIndividual1.subscriptionCount()).thenReturn(1);
-        when(mockIndividual2.subscriptionCount()).thenReturn(1);
 
         Pair<CompletableFuture<Void>, Consumer<MqttMessage>> abc = asyncAssertOnConsumer((m) -> {
             assertEquals("A/B/C", m.getTopic());


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-shadow-manager/issues/120

**Description of changes:**
`MqttClient` checks the number of subscriptions on a connection as well as any ongoing subscriptions on that connection before closing it.
`AwsIotMqttClient` does not send a connection interrupted callback if the connection was closed on purpose (like on an initial connect for a new connection).

**Why is this change necessary:**
Whenever a subscribing thread gets interrupted in the middle of a subscription, there is a possibility that a newly created MQTT connection gets closed before the original subscription even finishes. This change makes sure that a subscriber will always get a MQTT connection and the `MqttClient` does not close any open connection which has atleast one subscription or atleast one ongoing subscription.

**How was this change tested:**
Added E2E tests as well as unit tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [X] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
