### PR TITLE
perf: use BatchedSubscriber for authZ changes

### DIFF
--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -155,7 +155,8 @@ public class AuthorizationHandler  {
             reloadedPolicies.putAll(getDefaultPolicies());
 
             try (LockScope scope = LockScope.lock(rwLock.writeLock())) {
-                for (Map.Entry<String, List<AuthorizationPolicy>> primaryPolicyList : componentToAuthZConfig.entrySet()) {
+                for (Map.Entry<String, List<AuthorizationPolicy>> primaryPolicyList
+                        : componentToAuthZConfig.entrySet()) {
                     String policyType = primaryPolicyList.getKey();
                     if (!reloadedPolicies.containsKey(policyType)) {
                         //If the policyType already exists and was not reparsed correctly and/or removed from
@@ -170,7 +171,7 @@ public class AuthorizationHandler  {
                     this.loadAuthorizationPolicies(acl.getKey(), acl.getValue(), true);
                 }
             }
-        });
+        }).subscribe();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.BatchedSubscriber;
 import com.aws.greengrass.util.LockScope;
 import com.aws.greengrass.util.Utils;
 import lombok.NonNull;
@@ -94,7 +95,8 @@ public class AuthorizationHandler  {
         this.kernel = kernel;
         this.authModule = authModule;
         // Adding TES component and operation before it's default policies are fetched
-        componentToOperationsMap.put(TOKEN_EXCHANGE_SERVICE_TOPICS, new HashSet<>(Arrays.asList(AUTHZ_TES_OPERATION)));
+        componentToOperationsMap.put(TOKEN_EXCHANGE_SERVICE_TOPICS, new HashSet<>(
+                Collections.singletonList(AUTHZ_TES_OPERATION)));
         componentToOperationsMap.put(PUB_SUB_SERVICE_NAME, new HashSet<>(Arrays.asList(PUBLISH_TO_TOPIC,
                 SUBSCRIBE_TO_TOPIC, ANY_REGEX)));
         componentToOperationsMap.put(MQTT_PROXY_SERVICE_NAME, new HashSet<>(Arrays.asList(PUBLISH_TO_IOT_CORE,
@@ -118,57 +120,57 @@ public class AuthorizationHandler  {
         }
 
         // Subscribe to future auth config updates
-        this.kernel.getConfig().lookupTopics(SERVICES_NAMESPACE_TOPIC).subscribe(
-                (why, newv) -> {
-                    if (newv == null) {
-                        return;
+        new BatchedSubscriber(this.kernel.getConfig().lookupTopics(SERVICES_NAMESPACE_TOPIC), (why, newv) -> {
+            if (WhatHappened.interiorAdded.equals(why) || WhatHappened.timestampUpdated.equals(why)) {
+                return true;
+            }
+            if (newv == null) {
+                return false;
+            }
+
+            //If there is a childChanged event, it has to be the 'accessControl' Topic that has bubbled up
+            //If there is a childRemoved event, it could be the component is removed, or either the
+            //'accessControl' Topic or/the 'parameters' Topics that has bubbled up, so we need to handle and
+            //filter out all other WhatHappeneds
+            if (WhatHappened.childRemoved.equals(why) || WhatHappened.removed.equals(why)) {
+                // Either a service or a parameter block or acl subkey
+                if (!newv.parent.getName().equals(SERVICES_NAMESPACE_TOPIC) && !newv.getName()
+                        .equals(CONFIGURATION_CONFIG_KEY) && !newv.getName().equals(ACCESS_CONTROL_NAMESPACE_TOPIC)
+                        && !newv.childOf(ACCESS_CONTROL_NAMESPACE_TOPIC)) {
+                    return true;
+                }
+            } else if (!newv.childOf(ACCESS_CONTROL_NAMESPACE_TOPIC) && !newv.getName()
+                    .equals(ACCESS_CONTROL_NAMESPACE_TOPIC)) {
+                // for all other WhatHappened cases we only care about access control change
+                return true;
+            }
+            return false;
+        }, (why) -> {
+            // TODO: [V243584397]: Partial policy reload
+            // For now, reload all policies
+            Map<String, List<AuthorizationPolicy>> reloadedPolicies =
+                    policyParser.parseAllAuthorizationPolicies(kernel);
+
+            // Load default policies
+            reloadedPolicies.putAll(getDefaultPolicies());
+
+            try (LockScope scope = LockScope.lock(rwLock.writeLock())) {
+                for (Map.Entry<String, List<AuthorizationPolicy>> primaryPolicyList : componentToAuthZConfig.entrySet()) {
+                    String policyType = primaryPolicyList.getKey();
+                    if (!reloadedPolicies.containsKey(policyType)) {
+                        //If the policyType already exists and was not reparsed correctly and/or removed from
+                        //the newly parsed list, delete it from our store since it is now an unwanted relic
+                        componentToAuthZConfig.remove(policyType);
+                        authModule.deletePermissionsWithDestination(policyType);
                     }
+                }
 
-                    //If there is a childChanged event, it has to be the 'accessControl' Topic that has bubbled up
-                    //If there is a childRemoved event, it could be the component is removed, or either the
-                    //'accessControl' Topic or/the 'parameters' Topics that has bubbled up, so we need to handle and
-                    //filter out all other WhatHappeneds
-                    if (WhatHappened.childRemoved.equals(why) || WhatHappened.removed.equals(why)) {
-                        // Either a service or a parameter block or acl subkey
-                        if (!newv.parent.getName().equals(SERVICES_NAMESPACE_TOPIC)
-                                && !newv.getName().equals(CONFIGURATION_CONFIG_KEY)
-                                && !newv.getName().equals(ACCESS_CONTROL_NAMESPACE_TOPIC)
-                                && !newv.childOf(ACCESS_CONTROL_NAMESPACE_TOPIC)) {
-                            return;
-                        }
-                    } else if (!newv.childOf(ACCESS_CONTROL_NAMESPACE_TOPIC)
-                            && !newv.getName().equals(ACCESS_CONTROL_NAMESPACE_TOPIC)) {
-                        // for all other WhatHappened cases we only care about access control change
-                        return;
-                    }
-
-                    // TODO: [V243584397]: Partial policy reload
-                    // For now, reload all policies
-                    Map<String, List<AuthorizationPolicy>> reloadedPolicies = policyParser
-                            .parseAllAuthorizationPolicies(kernel);
-
-                    // Load default policies
-                    reloadedPolicies.putAll(getDefaultPolicies());
-
-                    try (LockScope scope = LockScope.lock(rwLock.writeLock())) {
-
-                        for (Map.Entry<String, List<AuthorizationPolicy>> primaryPolicyList :
-                                componentToAuthZConfig.entrySet()) {
-                            String policyType = primaryPolicyList.getKey();
-                            if (!reloadedPolicies.containsKey(policyType)) {
-                                //If the policyType already exists and was not reparsed correctly and/or removed from
-                                //the newly parsed list, delete it from our store since it is now an unwanted relic
-                                componentToAuthZConfig.remove(policyType);
-                                authModule.deletePermissionsWithDestination(policyType);
-                            }
-                        }
-
-                        //Now we reload the policies that reflect the current state of the Nucleus config
-                        for (Map.Entry<String, List<AuthorizationPolicy>> acl : reloadedPolicies.entrySet()) {
-                            this.loadAuthorizationPolicies(acl.getKey(), acl.getValue(), true);
-                        }
-                    }
-                });
+                //Now we reload the policies that reflect the current state of the Nucleus config
+                for (Map.Entry<String, List<AuthorizationPolicy>> acl : reloadedPolicies.entrySet()) {
+                    this.loadAuthorizationPolicies(acl.getKey(), acl.getValue(), true);
+                }
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Switches to using BatchedSubscriber for authorization policy changes to deduplicate effort when multiple changes occur. Saves method references and lambdas as fields of the class to prevent duplicate subscriptions. There are many cases where I did not change to using a field because the subscription is only added once, in a constructor or in postInject.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
