### PR TITLE
fix: allow dependency update with default timestamp

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -174,7 +174,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
         NoOpPathOwnershipHandler.register(kernel);
 
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
-                DeploymentTaskIntegrationTest.class.getResource("onlyMain.yaml"));
+                DeploymentTaskIntegrationTest.class.getResource("noMain.yaml"));
 
         kernel.launch();
         // get required instances from context
@@ -266,6 +266,31 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     @AfterEach
     void afterEach() {
         executorService.shutdownNow();
+    }
+
+    /**
+     * Start with a fresh kernel. Deploy a component with broken install script. Deployment should fail and rollback
+     * successfully. This test needs to happen before all other test cases since it requires a fresh kernel.
+     */
+    @Test
+    @Order(0)
+    void GIVEN_kernel_with_no_deployment_history_WHEN_new_service_install_breaks_THEN_services_are_rolled_back(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionUltimateCauseOfType(context, ServiceUpdateException.class);
+
+        Future<DeploymentResult> resultFuture = submitSampleJobDocument(
+                DeploymentTaskIntegrationTest.class.getResource("Failure3RollbackDeployment.json").toURI(),
+                System.currentTimeMillis());
+        DeploymentResult result = resultFuture.get(DEPLOYMENT_TIMEOUT, TimeUnit.SECONDS);
+        List<String> services = kernel.orderedDependencies().stream()
+                .filter(greengrassService -> greengrassService instanceof GenericExternalService)
+                .map(GreengrassService::getName).collect(Collectors.toList());
+
+        // should only contain main, Nucleus
+        assertEquals(2, services.size());
+        assertThat(services, containsInAnyOrder("main", DEFAULT_NUCLEUS_COMPONENT_NAME));
+        assertThrows(ServiceLoadException.class, () -> kernel.locate("ComponentWithBrokenInstall"));
+        assertEquals(DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_COMPLETE, result.getDeploymentStatus());
     }
 
     /**

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
@@ -75,6 +75,7 @@ import static com.aws.greengrass.dependency.EZPlugins.JAR_FILE_EXTENSION;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
@@ -268,6 +269,9 @@ class PluginComponentTest extends BaseITCase {
     void GIVEN_kernel_WHEN_deploy_new_plugin_broken_THEN_rollback_succeeds(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, ServiceLoadException.class);
         ignoreExceptionOfType(context, ServiceUpdateException.class);
+        // The class loader is holding on to the jar file. This creates an error when deployment tries to delete the
+        // jar file. This code is a temporary workaround. In long term we should be able to handle unloading plugin.
+        ignoreExceptionWithMessage(context,  "Failed to delete package brokenPlugin-v1.0.0");
 
         // launch Nucleus
         kernel.parseArgs();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -115,7 +115,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         // Verify have 1 publish request for each of IoTJobs, ShadowDeploymentService, and FSS
         ArgumentCaptor<PublishRequest> publishRequestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
-        verify(mqttClient, timeout(5000).times(3)).publish(publishRequestCaptor.capture());
+        verify(mqttClient, timeout(5000).atLeast(3)).publish(publishRequestCaptor.capture());
         List<PublishRequest> publishRequests = publishRequestCaptor.getAllValues();
 
         String IoTJobsTopic = "$aws/things/ThingName/shadow/name/AWSManagedGreengrassV2Deployment/get";

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/Failure3RollbackDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/Failure3RollbackDeployment.json
@@ -1,0 +1,16 @@
+{
+  "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
+  "Packages": [
+    {
+      "Name": "ComponentWithBrokenInstall",
+      "ResolvedVersion": "1.0.0",
+      "RootComponent": true
+    }
+  ],
+  "Timestamp": 1592574829000,
+  "FailureHandlingPolicy": "ROLLBACK",
+  "ComponentUpdatePolicy": {
+    "Timeout": 60,
+    "ComponentUpdatePolicyAction": "NOTIFY_COMPONENTS"
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentWithBrokenInstall-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentWithBrokenInstall-1.0.0.yaml
@@ -1,0 +1,18 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: ComponentWithBrokenInstall
+ComponentDescription: A service that just can't run
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      install: |-
+        powershell -command "& { echo \"Broken install.\"; exit 1 }"
+  - Platform:
+      os: all
+    Lifecycle:
+      install: |-
+        echo "Broken install."
+        exit 1

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/noMain.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/noMain.yaml
@@ -1,0 +1,8 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
@@ -161,7 +161,7 @@ public class GreengrassService implements InjectionActions {
 
     private synchronized void initDependenciesTopic() {
         externalDependenciesTopic.subscribe((what, node) -> {
-            if (!WhatHappened.changed.equals(what) || node.getModtime() <= 1) {
+            if (!WhatHappened.changed.equals(what)) {
                 return;
             }
             Collection<String> depList = (Collection<String>) node.getOnce();

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
@@ -165,11 +165,17 @@ public class GreengrassService implements InjectionActions {
                 return;
             }
             Collection<String> depList = (Collection<String>) node.getOnce();
+            if (node.getModtime() <= 1) {
+                logger.atError().log("Previous dependencies: {}", dependencies.toString());
+            }
             logger.atDebug().log("Setting up dependencies again {}", String.join(",", depList));
             try {
                 setupDependencies(depList);
             } catch (ServiceLoadException | InputValidationException e) {
                 logger.atError().log("Error while setting up dependencies from subscription", e);
+            }
+            if (node.getModtime() <= 1) {
+                logger.atError().log("Updated dependencies: {}", dependencies.toString());
             }
         });
 

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.OrderedExecutorService;
 import org.hamcrest.collection.IsMapContaining;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -80,8 +82,9 @@ class PubSubIPCEventStreamAgentTest {
     @Captor
     ArgumentCaptor<Permission> permissionArgumentCaptor;
 
+    final ExecutorService pool = Executors.newCachedThreadPool();
     private final OrderedExecutorService orderedExecutorService =
-            new OrderedExecutorService(Executors.newCachedThreadPool());
+            new OrderedExecutorService(pool);
     private PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent;
 
     @BeforeEach
@@ -90,6 +93,11 @@ class PubSubIPCEventStreamAgentTest {
         lenient().when(mockContext.getAuthenticationData()).thenReturn(mockAuthenticationData);
         lenient().when(mockAuthenticationData.getIdentityLabel()).thenReturn(TEST_SERVICE);
         pubSubIPCEventStreamAgent = new PubSubIPCEventStreamAgent(authorizationHandler, orderedExecutorService);
+    }
+
+    @AfterEach
+    void afterEach() {
+        pool.shutdownNow();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/GreengrassServiceTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/GreengrassServiceTest.java
@@ -69,7 +69,6 @@ class GreengrassServiceTest {
         when(kernel.locateIgnoreError("D")).thenReturn(dService);
         lenient().when(kernel.locateIgnoreError("E")).thenReturn(eService);
         aService = spy(new GreengrassService(root.findTopics(SERVICES_NAMESPACE_TOPIC, "A")));
-
     }
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -199,8 +199,8 @@ class KernelTest {
         service1.postInject();
 
         // Introduce a dependency cycle
-        service1.addOrUpdateDependency(mockMain, DependencyType.HARD, false);
-        mockMain.addOrUpdateDependency(service1, DependencyType.HARD, false);
+        service1.addOrUpdateDependency(mockMain, DependencyType.HARD, true);
+        mockMain.addOrUpdateDependency(service1, DependencyType.HARD, true);
 
         // Nucleus component is always present as an additional dependency of main
         List<GreengrassService> od = new ArrayList<>(kernel.orderedDependencies());

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -487,7 +487,7 @@ class LifecycleTest {
         Topics dependencyServiceTopics = serviceRoot.createInteriorChild("dependencyService");
         TestService dependencyService = new TestService(dependencyServiceTopics);
 
-        testService.addOrUpdateDependency(dependencyService, DependencyType.HARD, false);
+        testService.addOrUpdateDependency(dependencyService, DependencyType.HARD, true);
 
         assertTrue(testService.getDependencies().containsKey(dependencyService));
         CountDownLatch serviceStarted = new CountDownLatch(1);

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -536,7 +536,7 @@ class LifecycleTest {
         dependencyService.reportState(State.ERRORED);
 
         // THEN
-        assertTrue(serviceRestarted.await(500, TimeUnit.MILLISECONDS));
+        assertTrue(serviceRestarted.await(2, TimeUnit.SECONDS));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -489,6 +489,7 @@ class LifecycleTest {
 
         testService.addOrUpdateDependency(dependencyService, DependencyType.HARD, false);
 
+        assertTrue(testService.getDependencies().containsKey(dependencyService));
         CountDownLatch serviceStarted = new CountDownLatch(1);
         testService.setStartupRunnable(
             () -> {
@@ -514,6 +515,7 @@ class LifecycleTest {
         assertTrue(serviceStarted.await(1500, TimeUnit.MILLISECONDS));
         assertEquals(State.STARTING, testService.getState());
 
+        assertTrue(testService.getDependencies().containsKey(dependencyService));
         CountDownLatch serviceRestarted = new CountDownLatch(2);
         context.addGlobalStateChangeListener((service, oldState, newState) -> {
             if (!"testService".equals(service.getName())) {
@@ -534,6 +536,7 @@ class LifecycleTest {
 
         // WHEN dependency errored
         dependencyService.reportState(State.ERRORED);
+        assertTrue(testService.getDependencies().containsKey(dependencyService));
 
         // THEN
         assertTrue(serviceRestarted.await(2, TimeUnit.SECONDS));

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/ThreadProtector.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/ThreadProtector.java
@@ -6,17 +6,22 @@
 package com.aws.greengrass.testcommons.testutilities;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("PMD.SystemPrintln")
-public class ThreadProtector implements AfterAllCallback {
+public class ThreadProtector implements AfterAllCallback, BeforeAllCallback {
     private static final Set<String> ALLOWED_THREAD_NAMES = new HashSet<>(Arrays.asList(
             "main",
             "Monitor Ctrl-Break",
@@ -24,6 +29,7 @@ public class ThreadProtector implements AfterAllCallback {
             "junit-jupiter-timeout-watcher",
             "idle-connection-reaper",
             "java-sdk-http-connection-reaper"));
+    private Thread t;
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
@@ -36,6 +42,9 @@ public class ThreadProtector implements AfterAllCallback {
                 System.err.println("Threads are still running: " + liveThreads);
 //                fail("Threads are still running: " + liveThreads);
             }
+        }
+        if (t != null) {
+            t.interrupt();
         }
     }
 
@@ -50,5 +59,52 @@ public class ThreadProtector implements AfterAllCallback {
                 // that's why we will ignore it here
                 .filter(t -> !t.getName().contains("globalEventExecutor"))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        t = new Thread(() -> {
+            // Initial sleep time is 5 minutes (default test timeout). After the first 5 minutes, we then
+            // dump threads every 1 minute.
+            long sleepTime = 5L;
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    TimeUnit.MINUTES.sleep(sleepTime);
+                    sleepTime = 1L;
+                } catch (InterruptedException e) {
+                    break;
+                }
+
+                System.err.println("Checking for blocked threads");
+                System.err.flush();
+                long[] deadLocked = threadBean.findDeadlockedThreads();
+                long[] deadLockedMon = threadBean.findMonitorDeadlockedThreads();
+                if (deadLocked != null && deadLocked.length > 0) {
+                    for (ThreadInfo ti : threadBean.getThreadInfo(deadLocked, true, true)) {
+                        System.err.println(ti);
+                        System.err.flush();
+                    }
+                }
+
+                if (deadLockedMon != null && deadLockedMon.length > 0) {
+                    for (ThreadInfo ti : threadBean.getThreadInfo(deadLockedMon, true, true)) {
+                        System.err.println(ti);
+                        System.err.flush();
+                    }
+                }
+
+                if ((deadLocked == null || deadLocked.length == 0) &&
+                        (deadLockedMon == null || deadLockedMon.length == 0)) {
+                    System.err.println("No blocked threads found? Dumping all threads");
+                    System.err.flush();
+                    for (ThreadInfo ti : threadBean.dumpAllThreads(true, true)) {
+                        System.err.println(ti);
+                        System.err.flush();
+                    }
+                }
+            }
+        });
+        t.start();
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1168

**Description of changes:**

1. Fixes a bug in which deployment of component with broken install script stuck indefinitely, if the device has no deployment history. Rollback's truncate tlog could not update main's dependency because its modtime was default 1; main was still waiting for the broken component to be ready, and yet the broken component was waiting for main to exit, so rollback was stuck.

2. Fixes a deadlock between `GreengrassService::setupDependencies` & `UpdateSystemPolicyService::runUpdateActions` during deployment. Specific conditions as below. It was not discovered earlier because with `node.getModtime() <= 1` the dependency subscription returns instantly.

>`Nucleus running -> UpdateSystemPolicyService running -> deployment -> mergeInNewConfig -> run update action for deployment -> lock UpdateSystemPolicyService -> deployment activates -> updateConfiguration -> add task to publish thread and wait publish thread to finish -> UpdateSystemPolicyService's dependencies subscription triggered by updateConfiguration ->  (publisher thread) setupDependencies -> wait for the lock -> deadlock`

3. Add mechanisms to `ThreadProtector` to detect deadlock and thread dump in github workflow.

**Why is this change necessary:**
Bug fixes.

**How was this change tested:**
Added integ test. The test fails before the change and passes after the change.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
