### PR TITLE
feat: add IPC operation for subscribing to cert updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.7.1-SNAPSHOT</version>
+            <version>1.8.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -45,6 +45,7 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PAU
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_TOPIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.RESUME_COMPONENT;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_CERTIFICATE_UPDATES;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_TOPIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_THING_SHADOW;
@@ -64,6 +65,7 @@ public class AuthorizationHandler  {
     public static final String ANY_REGEX = "*";
     public static final String SECRETS_MANAGER_SERVICE_NAME = "aws.greengrass.SecretManager";
     public static final String SHADOW_MANAGER_SERVICE_NAME = "aws.greengrass.ShadowManager";
+    public static final String CLIENT_DEVICE_AUTH_SERVICE_NAME = "aws.greengrass.clientdevices.Auth";
 
     public enum ResourceLookupPolicy {
         STANDARD,
@@ -103,6 +105,8 @@ public class AuthorizationHandler  {
                 UPDATE_THING_SHADOW, DELETE_THING_SHADOW, LIST_NAMED_SHADOWS_FOR_THING, ANY_REGEX)));
         componentToOperationsMap.put(LIFECYCLE_SERVICE_NAME, new HashSet<>(Arrays.asList(PAUSE_COMPONENT,
                 RESUME_COMPONENT, ANY_REGEX)));
+        componentToOperationsMap.put(CLIENT_DEVICE_AUTH_SERVICE_NAME,
+                new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES, ANY_REGEX)));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(
                 kernel);

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.CertificateUpdateEvent;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToCertificateUpdatesRequest;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToCertificateUpdatesResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler extends OperationContinuationHandler<SubscribeToCertificateUpdatesRequest, SubscribeToCertificateUpdatesResponse, EventStreamJsonMessage, CertificateUpdateEvent> {
+    protected GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler(
+            OperationContinuationHandlerContext context) {
+        super(context);
+    }
+
+    @Override
+    public OperationModelContext<SubscribeToCertificateUpdatesRequest, SubscribeToCertificateUpdatesResponse, EventStreamJsonMessage, CertificateUpdateEvent> getOperationModelContext(
+    ) {
+        return GreengrassCoreIPCServiceModel.getSubscribeToCertificateUpdatesModelContext();
+    }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -77,6 +77,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public static final String PAUSE_COMPONENT = SERVICE_NAMESPACE + "#PauseComponent";
 
   public static final String CREATE_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CreateLocalDeployment";
+  public static final String SUBSCRIBE_TO_CERTIFICATE_UPDATES = SERVICE_NAMESPACE + "#SubscribeToCertificateUpdates";
 
   static {
     SERVICE_OPERATION_SET = new HashSet();
@@ -108,6 +109,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(STOP_COMPONENT);
     SERVICE_OPERATION_SET.add(PAUSE_COMPONENT);
     SERVICE_OPERATION_SET.add(CREATE_LOCAL_DEPLOYMENT);
+    SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_CERTIFICATE_UPDATES);
   }
 
   private final Map<String, Function<OperationContinuationHandlerContext, ? extends ServerConnectionContinuationHandler>> operationSupplierMap;
@@ -131,6 +133,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     operationSupplierMap.put(RESUME_COMPONENT, handler);
   }
 
+
   public void setPublishToIoTCoreHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractPublishToIoTCoreOperationHandler> handler) {
     operationSupplierMap.put(PUBLISH_TO_IOT_CORE, handler);
@@ -139,6 +142,11 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setSubscribeToConfigurationUpdateHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractSubscribeToConfigurationUpdateOperationHandler> handler) {
     operationSupplierMap.put(SUBSCRIBE_TO_CONFIGURATION_UPDATE, handler);
+  }
+
+  public void setSubscribeToCertificateUpdatesHandler(
+          Function<OperationContinuationHandlerContext, GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler> handler) {
+    operationSupplierMap.put(SUBSCRIBE_TO_CERTIFICATE_UPDATES, handler);
   }
 
   public void setDeleteThingShadowHandler(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds initial implementation of CDA integration with IPC. This change authorizes and register CDA component with IPC and  adds handlers to `SubscribeToCertificateUpdates` operation. 

**Why is this change necessary:**
This change exposes a new API over IPC for the server (any mqtt broker) to subscribe to its certificate updates such as generation and rotation from the Greengrass V2 CDA component (aws.greengrass.clientdevices.Auth).

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
