### PR TITLE
test: scan our own classpath for plugins during integration tests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/BaseITCase.java
@@ -52,6 +52,7 @@ public class BaseITCase {
 
     @BeforeEach
     void setRootDir() {
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         tempRootDir = Paths.get(System.getProperty("root"));
         LogConfig.getRootLogConfig().reset();
     }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -392,6 +392,10 @@ public class KernelLifecycle {
     private void loadPlugins() {
         EZPlugins pim = kernel.getContext().get(EZPlugins.class);
         try {
+            // For integration testing of plugins, scan our own classpath to find the @ImplementsService
+            if ("true".equals(System.getProperty("aws.greengrass.scanSelfClasspath"))) {
+                pim.scanSelfClasspath();
+            }
             pim.loadCache();
             if (!serviceImplementors.isEmpty()) {
                 kernel.getContext().put(Kernel.CONTEXT_SERVICE_IMPLEMENTERS, serviceImplementors);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add an option to scan our own classpath which was removed by an earlier PR (#1187). This is needed for integration testing of plugins which are in tested from the same classpath as Nucleus.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
