### PR TITLE
  feat: add IPC interface for verifying client device identity 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.8.3-SNAPSHOT</version>
+            <version>1.8.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -50,6 +50,7 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUB
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_TOPIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_THING_SHADOW;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.VERIFY_CLIENT_DEVICE_IDENTITY;
 
 /**
  * Main module which is responsible for handling AuthZ for Greengrass. This only manages
@@ -108,7 +109,9 @@ public class AuthorizationHandler  {
         componentToOperationsMap.put(LIFECYCLE_SERVICE_NAME, new HashSet<>(Arrays.asList(PAUSE_COMPONENT,
                 RESUME_COMPONENT, ANY_REGEX)));
         componentToOperationsMap.put(CLIENT_DEVICE_AUTH_SERVICE_NAME,
-                new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES, ANY_REGEX)));
+                new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES,
+                        VERIFY_CLIENT_DEVICE_IDENTITY,
+                        ANY_REGEX)));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(
                 kernel);

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractVerifyClientDeviceIdentityOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractVerifyClientDeviceIdentityOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRequest;
+import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractVerifyClientDeviceIdentityOperationHandler extends OperationContinuationHandler<VerifyClientDeviceIdentityRequest, VerifyClientDeviceIdentityResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractVerifyClientDeviceIdentityOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<VerifyClientDeviceIdentityRequest, VerifyClientDeviceIdentityResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getVerifyClientDeviceIdentityModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -44,6 +44,10 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String PUBLISH_TO_TOPIC = SERVICE_NAMESPACE + "#PublishToTopic";
 
+  public static final String SUBSCRIBE_TO_CERTIFICATE_UPDATES = SERVICE_NAMESPACE + "#SubscribeToCertificateUpdates";
+
+  public static final String VERIFY_CLIENT_DEVICE_IDENTITY = SERVICE_NAMESPACE + "#VerifyClientDeviceIdentity";
+
   public static final String LIST_COMPONENTS = SERVICE_NAMESPACE + "#ListComponents";
 
   public static final String CREATE_DEBUG_PASSWORD = SERVICE_NAMESPACE + "#CreateDebugPassword";
@@ -77,7 +81,6 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public static final String PAUSE_COMPONENT = SERVICE_NAMESPACE + "#PauseComponent";
 
   public static final String CREATE_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CreateLocalDeployment";
-  public static final String SUBSCRIBE_TO_CERTIFICATE_UPDATES = SERVICE_NAMESPACE + "#SubscribeToCertificateUpdates";
 
   static {
     SERVICE_OPERATION_SET = new HashSet();
@@ -92,6 +95,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_TOPIC);
     SERVICE_OPERATION_SET.add(GET_COMPONENT_DETAILS);
     SERVICE_OPERATION_SET.add(PUBLISH_TO_TOPIC);
+    SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_CERTIFICATE_UPDATES);
+    SERVICE_OPERATION_SET.add(VERIFY_CLIENT_DEVICE_IDENTITY);
     SERVICE_OPERATION_SET.add(LIST_COMPONENTS);
     SERVICE_OPERATION_SET.add(CREATE_DEBUG_PASSWORD);
     SERVICE_OPERATION_SET.add(GET_THING_SHADOW);
@@ -109,7 +114,6 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(STOP_COMPONENT);
     SERVICE_OPERATION_SET.add(PAUSE_COMPONENT);
     SERVICE_OPERATION_SET.add(CREATE_LOCAL_DEPLOYMENT);
-    SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_CERTIFICATE_UPDATES);
   }
 
   private final Map<String, Function<OperationContinuationHandlerContext, ? extends ServerConnectionContinuationHandler>> operationSupplierMap;
@@ -144,10 +148,6 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     operationSupplierMap.put(SUBSCRIBE_TO_CONFIGURATION_UPDATE, handler);
   }
 
-  public void setSubscribeToCertificateUpdatesHandler(
-          Function<OperationContinuationHandlerContext, GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler> handler) {
-    operationSupplierMap.put(SUBSCRIBE_TO_CERTIFICATE_UPDATES, handler);
-  }
 
   public void setDeleteThingShadowHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractDeleteThingShadowOperationHandler> handler) {
@@ -182,6 +182,16 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setPublishToTopicHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractPublishToTopicOperationHandler> handler) {
     operationSupplierMap.put(PUBLISH_TO_TOPIC, handler);
+  }
+
+  public void setSubscribeToCertificateUpdatesHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler> handler) {
+    operationSupplierMap.put(SUBSCRIBE_TO_CERTIFICATE_UPDATES, handler);
+  }
+
+  public void setVerifyClientDeviceIdentityHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractVerifyClientDeviceIdentityOperationHandler> handler) {
+    operationSupplierMap.put(VERIFY_CLIENT_DEVICE_IDENTITY, handler);
   }
 
   public void setListComponentsHandler(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add IPC operation handlers for client device auth calls. 

**Why is this change necessary:**
Needed for mqtt5/BYOB integration. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
