### PR TITLE
fix: bubble up chain of error messages from deployment workflow

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -265,7 +265,8 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                     status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("FAILED")) {
                 deploymentCDL.countDown();
                 assertThat(((Map) status.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)).get(DEPLOYMENT_FAILURE_CAUSE_KEY),
-                        equalTo("The current nucleus version doesn't support one or more capabilities that are required by "
+                        equalTo("MissingRequiredCapabilitiesException: The current nucleus version doesn't support one"
+                                + " or more capabilities that are required by "
                     + "this deployment: ANOTHER_CAPABILITY"));
             }
             return true;
@@ -460,7 +461,8 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                     status.get(DEPLOYMENT_STATUS_KEY_NAME).equals("FAILED")) {
                 deploymentCDL.countDown();
                 assertThat(((Map)status.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)).get(DEPLOYMENT_FAILURE_CAUSE_KEY),
-                        equalTo("The current nucleus version doesn't support one or more capabilities that are "
+                        equalTo("MissingRequiredCapabilitiesException: The current nucleus version doesn't support one"
+                                + " or more capabilities that are "
                         + "required by this deployment: NOT_SUPPORTED_1, NOT_SUPPORTED_2"));
             }
 

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -312,7 +312,8 @@ public class DeploymentService extends GreengrassService {
                     deploymentDirectoryManager.persistLastSuccessfulDeployment();
                 } else {
                     if (result.getFailureCause() != null) {
-                        statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, result.getFailureCause().getMessage());
+                        Throwable failureCause = result.getFailureCause();
+                        statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, Utils.generateFailureMessage(failureCause));
                     }
                     if (FAILED_ROLLBACK_NOT_REQUESTED.equals(result.getDeploymentStatus())) {
                         // Update the groupToRootComponents mapping in config for the case where there is no rollback
@@ -344,7 +345,7 @@ public class DeploymentService extends GreengrassService {
                 logger.atError().kv(DEPLOYMENT_ID_LOG_KEY_NAME, currentDeploymentTaskMetadata.getDeploymentId())
                         .setCause(t).log("Deployment task throws unknown exception");
                 HashMap<String, String> statusDetails = new HashMap<>();
-                statusDetails.put("error", t.getMessage());
+                statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, Utils.generateFailureMessage(t));
                 deploymentStatusKeeper
                         .persistAndPublishDeploymentStatus(currentDeploymentTaskMetadata.getDeploymentId(),
                                 currentDeploymentTaskMetadata.getDeploymentType(), JobStatus.FAILED.toString(),
@@ -655,7 +656,7 @@ public class DeploymentService extends GreengrassService {
                     .kv("DeploymentType", deployment.getDeploymentType().toString())
                     .log("Invalid document for deployment");
             HashMap<String, String> statusDetails = new HashMap<>();
-            statusDetails.put("error", e.getMessage());
+            statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, Utils.generateFailureMessage(e));
             deploymentStatusKeeper
                     .persistAndPublishDeploymentStatus(deployment.getId(), deployment.getDeploymentType(),
                             JobStatus.FAILED.toString(), statusDetails);

--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -187,6 +187,22 @@ public final class Utils {
     }
 
     /**
+     * Get the chain of exceptions and messages from the chain of causes.
+     *
+     * @param t throwable.
+     * @return String chain of exceptions and messages.
+     */
+    public static String generateFailureMessage(Throwable t) {
+        StringBuilder failureMessage =
+                new StringBuilder(t.getClass().getSimpleName()).append(": ").append(t.getMessage());
+        while (t.getCause() != null) {
+            t = t.getCause();
+            failureMessage.append(" -> ").append(t.getClass().getSimpleName()).append(": ").append(t.getMessage());
+        }
+        return failureMessage.toString();
+    }
+
+    /**
      * Generate a secure random string of a given length.
      *
      * @param desiredLength length of the output string

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -481,7 +481,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
                 eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), statusDetails.capture());
-        assertEquals("java.io.IOException: mock error", statusDetails.getValue().get("error"));
+        assertEquals("DeploymentTaskFailureException: java.io.IOException: mock error -> IOException: mock error", statusDetails.getValue().get("deployment-failure-cause"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We currently only send last error message from deployment workflow to FSS. This does not give customers enough meaningful information. This change will enable customers to see the chain of error messages instead.

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
