### PR TITLE
feat: add IPC interface to get client device auth token

### DIFF
--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -39,6 +39,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAM
 import static com.aws.greengrass.tes.TokenExchangeService.AUTHZ_TES_OPERATION;
 import static com.aws.greengrass.tes.TokenExchangeService.TOKEN_EXCHANGE_SERVICE_TOPICS;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DELETE_THING_SHADOW;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_CLIENT_DEVICE_AUTH_TOKEN;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_SECRET_VALUE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_THING_SHADOW;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.LIST_NAMED_SHADOWS_FOR_THING;
@@ -111,6 +112,7 @@ public class AuthorizationHandler  {
         componentToOperationsMap.put(CLIENT_DEVICE_AUTH_SERVICE_NAME,
                 new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES,
                         VERIFY_CLIENT_DEVICE_IDENTITY,
+                        GET_CLIENT_DEVICE_AUTH_TOKEN,
                         ANY_REGEX)));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetClientDeviceAuthTokenOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetClientDeviceAuthTokenOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.GetClientDeviceAuthTokenRequest;
+import software.amazon.awssdk.aws.greengrass.model.GetClientDeviceAuthTokenResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractGetClientDeviceAuthTokenOperationHandler extends OperationContinuationHandler<GetClientDeviceAuthTokenRequest, GetClientDeviceAuthTokenResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractGetClientDeviceAuthTokenOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<GetClientDeviceAuthTokenRequest, GetClientDeviceAuthTokenResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getGetClientDeviceAuthTokenModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -42,6 +42,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String GET_COMPONENT_DETAILS = SERVICE_NAMESPACE + "#GetComponentDetails";
 
+  public static final String GET_CLIENT_DEVICE_AUTH_TOKEN = SERVICE_NAMESPACE + "#GetClientDeviceAuthToken";
+
   public static final String PUBLISH_TO_TOPIC = SERVICE_NAMESPACE + "#PublishToTopic";
 
   public static final String SUBSCRIBE_TO_CERTIFICATE_UPDATES = SERVICE_NAMESPACE + "#SubscribeToCertificateUpdates";
@@ -94,6 +96,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(GET_CONFIGURATION);
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_TOPIC);
     SERVICE_OPERATION_SET.add(GET_COMPONENT_DETAILS);
+    SERVICE_OPERATION_SET.add(GET_CLIENT_DEVICE_AUTH_TOKEN);
     SERVICE_OPERATION_SET.add(PUBLISH_TO_TOPIC);
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_CERTIFICATE_UPDATES);
     SERVICE_OPERATION_SET.add(VERIFY_CLIENT_DEVICE_IDENTITY);
@@ -137,7 +140,6 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     operationSupplierMap.put(RESUME_COMPONENT, handler);
   }
 
-
   public void setPublishToIoTCoreHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractPublishToIoTCoreOperationHandler> handler) {
     operationSupplierMap.put(PUBLISH_TO_IOT_CORE, handler);
@@ -147,7 +149,6 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
       Function<OperationContinuationHandlerContext, GeneratedAbstractSubscribeToConfigurationUpdateOperationHandler> handler) {
     operationSupplierMap.put(SUBSCRIBE_TO_CONFIGURATION_UPDATE, handler);
   }
-
 
   public void setDeleteThingShadowHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractDeleteThingShadowOperationHandler> handler) {
@@ -177,6 +178,11 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setGetComponentDetailsHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractGetComponentDetailsOperationHandler> handler) {
     operationSupplierMap.put(GET_COMPONENT_DETAILS, handler);
+  }
+
+  public void setGetClientDeviceAuthTokenHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractGetClientDeviceAuthTokenOperationHandler> handler) {
+    operationSupplierMap.put(GET_CLIENT_DEVICE_AUTH_TOKEN, handler);
   }
 
   public void setPublishToTopicHandler(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add IPC interface to get client device auth token from CDA. Any authorized non-plugin broker (MQTT5 or BYOB) can use this API to the auth token for the client device by presenting a credential. 

**Why is this change necessary:**
Needed to support MQTT5 and BYOB.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
