### PR TITLE
fix: pull out cause of CompletionException in OperationContinuationHandler

### DIFF
--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandler.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public abstract class OperationContinuationHandler<RequestType extends EventStreamJsonMessage,
         ResponseType extends EventStreamJsonMessage,
@@ -325,6 +326,10 @@ public abstract class OperationContinuationHandler<RequestType extends EventStre
     }
 
     private void handleAndSendError(Throwable throwable) {
+        // Pull out the underlying error from the "handle" method of a CompletableFuture
+        if (throwable instanceof CompletionException) {
+            throwable = throwable.getCause();
+        }
         if (throwable instanceof EventStreamOperationError) {
             //We do not check if the specific exception thrown is a part of the core service?
             sendModeledError((EventStreamOperationError) throwable);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Required and tested by https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/68.

This change pulls out the cause from `CompletionException` in our error handler. `CompletionException` is what is returned by `CompletableFuture.handle` or .`exceptionally` rather than the actual cause.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
