### PR TITLE
feat: add IPC interface to authz client device action

### DIFF
--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -38,6 +38,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.ACCESS_CONTR
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.tes.TokenExchangeService.AUTHZ_TES_OPERATION;
 import static com.aws.greengrass.tes.TokenExchangeService.TOKEN_EXCHANGE_SERVICE_TOPICS;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.AUTHORIZE_CLIENT_DEVICE_ACTION;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DELETE_THING_SHADOW;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_CLIENT_DEVICE_AUTH_TOKEN;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_SECRET_VALUE;
@@ -113,6 +114,7 @@ public class AuthorizationHandler  {
                 new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES,
                         VERIFY_CLIENT_DEVICE_IDENTITY,
                         GET_CLIENT_DEVICE_AUTH_TOKEN,
+                        AUTHORIZE_CLIENT_DEVICE_ACTION,
                         ANY_REGEX)));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractAuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractAuthorizeClientDeviceActionOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.AuthorizeClientDeviceActionRequest;
+import software.amazon.awssdk.aws.greengrass.model.AuthorizeClientDeviceActionResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractAuthorizeClientDeviceActionOperationHandler extends OperationContinuationHandler<AuthorizeClientDeviceActionRequest, AuthorizeClientDeviceActionResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractAuthorizeClientDeviceActionOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<AuthorizeClientDeviceActionRequest, AuthorizeClientDeviceActionResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getAuthorizeClientDeviceActionModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -50,6 +50,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String VERIFY_CLIENT_DEVICE_IDENTITY = SERVICE_NAMESPACE + "#VerifyClientDeviceIdentity";
 
+  public static final String AUTHORIZE_CLIENT_DEVICE_ACTION = SERVICE_NAMESPACE + "#AuthorizeClientDeviceAction";
+
   public static final String LIST_COMPONENTS = SERVICE_NAMESPACE + "#ListComponents";
 
   public static final String CREATE_DEBUG_PASSWORD = SERVICE_NAMESPACE + "#CreateDebugPassword";
@@ -100,6 +102,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(PUBLISH_TO_TOPIC);
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_CERTIFICATE_UPDATES);
     SERVICE_OPERATION_SET.add(VERIFY_CLIENT_DEVICE_IDENTITY);
+    SERVICE_OPERATION_SET.add(AUTHORIZE_CLIENT_DEVICE_ACTION);
     SERVICE_OPERATION_SET.add(LIST_COMPONENTS);
     SERVICE_OPERATION_SET.add(CREATE_DEBUG_PASSWORD);
     SERVICE_OPERATION_SET.add(GET_THING_SHADOW);
@@ -198,6 +201,11 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setVerifyClientDeviceIdentityHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractVerifyClientDeviceIdentityOperationHandler> handler) {
     operationSupplierMap.put(VERIFY_CLIENT_DEVICE_IDENTITY, handler);
+  }
+
+  public void setAuthorizeClientDeviceActionHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractAuthorizeClientDeviceActionOperationHandler> handler) {
+    operationSupplierMap.put(AUTHORIZE_CLIENT_DEVICE_ACTION, handler);
   }
 
   public void setListComponentsHandler(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add IPC interface to authorize client device action using client device auth component.

**Why is this change necessary:**
Needed for integrating MQTT5/BYOB over IPC. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
