### PR TITLE
fix: avoid NPE in getting v2 data client

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -179,7 +179,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
 
     @Override
     public Optional<String> checkDownloadable() {
-        return Optional.ofNullable(clientFactory.getConfigValidationError());
+        return clientFactory.getConfigValidationError();
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -27,6 +27,8 @@ import javax.inject.Inject;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_CERTIFICATE_FILE_PATH;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_GG_DATA_PLANE_PORT;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_CRED_ENDPOINT;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_DATA_ENDPOINT;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PRIVATE_KEY_PATH;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_ROOT_CA_PATH;
 
@@ -54,7 +56,9 @@ public class GreengrassServiceClientFactory {
             }
             if (validString(node, DEVICE_PARAM_AWS_REGION) || validString(node, DEVICE_PARAM_ROOT_CA_PATH)
                     || validString(node, DEVICE_PARAM_CERTIFICATE_FILE_PATH) || validString(node,
-                    DEVICE_PARAM_PRIVATE_KEY_PATH) || validString(node, DEVICE_PARAM_GG_DATA_PLANE_PORT)) {
+                    DEVICE_PARAM_PRIVATE_KEY_PATH) || validString(node, DEVICE_PARAM_GG_DATA_PLANE_PORT)
+                    || validString(node, DEVICE_PARAM_IOT_CRED_ENDPOINT) || validString(node,
+                    DEVICE_PARAM_IOT_DATA_ENDPOINT)) {
                 validateConfiguration();
                 cleanClient();
             }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Adds subscription to iot data and credential endpoints in `GreengrassServiceClientFactory` so that it re-validates cloud connection when any cloud-related configs change.
2. Validate configs when getting v2 data client or config validation error, instead of whenever a config node change, to  reduce duplicate callbacks.


**Why is this change necessary:**
`GreengrassServiceClientFactory` has incomplete subscription to device configuration on cloud-related configs, so that it may miss the updates from `ProvisioningConfigUpdateHelper::updateNucleusConfiguration` at the end of fleet provisioning and still considers device in an offline state even though it's online.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**


**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
