### PR TITLE
fix: handle null ggv2dataclient

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/IotJobsFleetStatusServiceTest.java
@@ -141,7 +141,7 @@ class IotJobsFleetStatusServiceTest extends BaseITCase {
         GreengrassV2DataClient mcf = mock(GreengrassV2DataClient.class);
         lenient().when(mcf.resolveComponentCandidates(any(ResolveComponentCandidatesRequest.class)))
                 .thenThrow(ResourceNotFoundException.class);
-        lenient().when(mgscf.getGreengrassV2DataClient()).thenReturn(mcf);
+        lenient().when(mgscf.fetchGreengrassV2DataClient()).thenReturn(mcf);
         kernel.getContext().put(GreengrassServiceClientFactory.class, mgscf);
 
         componentNamesToCheck.clear();

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
@@ -81,8 +81,8 @@ public class ComponentServiceHelper {
         try (GreengrassV2DataClient greengrasV2DataClient = RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
             GreengrassV2DataClient client = clientFactory.getGreengrassV2DataClient();
             if (client == null) {
-                String errorMessage = clientFactory.getConfigValidationError().isPresent()
-                        ? clientFactory.getConfigValidationError().get() : "Could not get GreengrassV2DataClient";
+                String errorMessage = clientFactory.getConfigValidationError().orElse("Could not get "
+                        + "GreengrassV2DataClient");
                 throw new DeviceConfigurationException(errorMessage);
             }
             return client;

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentServiceHelper.java
@@ -79,13 +79,7 @@ public class ComponentServiceHelper {
                         .retryableExceptions(Arrays.asList(DeviceConfigurationException.class)).build();
 
         try (GreengrassV2DataClient greengrasV2DataClient = RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
-            GreengrassV2DataClient client = clientFactory.getGreengrassV2DataClient();
-            if (client == null) {
-                String errorMessage = clientFactory.getConfigValidationError().orElse("Could not get "
-                        + "GreengrassV2DataClient");
-                throw new DeviceConfigurationException(errorMessage);
-            }
-            return client;
+            return clientFactory.fetchGreengrassV2DataClient();
         }, "get-greengrass-v2-data-client", logger)) {
 
             result = greengrasV2DataClient.resolveComponentCandidates(request);

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -23,7 +23,6 @@ import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpResponse;
-import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.GetComponentVersionArtifactRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.GetComponentVersionArtifactResponse;
 
@@ -198,16 +197,11 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
 
         try {
             return RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
-                GreengrassV2DataClient client = clientFactory.getGreengrassV2DataClient();
-                if (client == null) {
-                    String errorMessage =  clientFactory.getConfigValidationError().orElse("Could not get "
-                            + "GreengrassV2DataClient");
-                    throw new DeviceConfigurationException(errorMessage);
-                }
                 GetComponentVersionArtifactRequest getComponentArtifactRequest =
                         GetComponentVersionArtifactRequest.builder().artifactName(artifactName).arn(arn).build();
                 GetComponentVersionArtifactResponse getComponentArtifactResult =
-                        client.getComponentVersionArtifact(getComponentArtifactRequest);
+                        clientFactory.fetchGreengrassV2DataClient()
+                                .getComponentVersionArtifact(getComponentArtifactRequest);
                 return getComponentArtifactResult.preSignedUrl();
             }, "get-artifact-size", logger);
         } catch (InterruptedException e) {

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -200,8 +200,8 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
             return RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
                 GreengrassV2DataClient client = clientFactory.getGreengrassV2DataClient();
                 if (client == null) {
-                    String errorMessage =  clientFactory.getConfigValidationError().isPresent()
-                            ? clientFactory.getConfigValidationError().get() : "Could not get GreengrassV2DataClient";
+                    String errorMessage =  clientFactory.getConfigValidationError().orElse("Could not get "
+                            + "GreengrassV2DataClient");
                     throw new DeviceConfigurationException(errorMessage);
                 }
                 GetComponentVersionArtifactRequest getComponentArtifactRequest =

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -167,9 +167,8 @@ public class DeploymentDocumentDownloader {
                     .log("Calling Greengrass cloud to get full deployment configuration.");
 
             if (client == null) {
-                String errorMessage =  greengrassServiceClientFactory.getConfigValidationError().isPresent()
-                        ? greengrassServiceClientFactory.getConfigValidationError().get()
-                        : "Could not get GreengrassV2DataClient";
+                String errorMessage =  greengrassServiceClientFactory.getConfigValidationError().orElse("Could not "
+                        + "get GreengrassV2DataClient");
                 throw new DeviceConfigurationException(errorMessage);
             }
 

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -28,7 +28,6 @@ import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.GetDeploymentConfigurationRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.GetDeploymentConfigurationResponse;
 import software.amazon.awssdk.utils.IoUtils;
@@ -162,17 +161,12 @@ public class DeploymentDocumentDownloader {
 
         GetDeploymentConfigurationResponse deploymentConfiguration;
 
-        try (GreengrassV2DataClient client = greengrassServiceClientFactory.getGreengrassV2DataClient()) {
+        try {
             logger.atInfo().kv("DeploymentId", deploymentId).kv("ThingName", thingName)
                     .log("Calling Greengrass cloud to get full deployment configuration.");
 
-            if (client == null) {
-                String errorMessage =  greengrassServiceClientFactory.getConfigValidationError().orElse("Could not "
-                        + "get GreengrassV2DataClient");
-                throw new DeviceConfigurationException(errorMessage);
-            }
-
-            deploymentConfiguration = client.getDeploymentConfiguration(getDeploymentConfigurationRequest);
+            deploymentConfiguration = greengrassServiceClientFactory.fetchGreengrassV2DataClient()
+                    .getDeploymentConfiguration(getDeploymentConfigurationRequest);
         } catch (AwsServiceException e) {
             throw new RetryableDeploymentDocumentDownloadException(
                     "Greengrass Cloud Service returned an error when getting full deployment configuration.", e);

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -162,12 +162,10 @@ public class DeploymentDocumentDownloader {
 
         GetDeploymentConfigurationResponse deploymentConfiguration;
 
-        try {
+        try (GreengrassV2DataClient client = greengrassServiceClientFactory.getGreengrassV2DataClient()) {
             logger.atInfo().kv("DeploymentId", deploymentId).kv("ThingName", thingName)
                     .log("Calling Greengrass cloud to get full deployment configuration.");
 
-
-            GreengrassV2DataClient client = greengrassServiceClientFactory.getGreengrassV2DataClient();
             if (client == null) {
                 String errorMessage =  greengrassServiceClientFactory.getConfigValidationError().isPresent()
                         ? greengrassServiceClientFactory.getConfigValidationError().get()
@@ -176,7 +174,6 @@ public class DeploymentDocumentDownloader {
             }
 
             deploymentConfiguration = client.getDeploymentConfiguration(getDeploymentConfigurationRequest);
-            client.close();
         } catch (AwsServiceException e) {
             throw new RetryableDeploymentDocumentDownloadException(
                     "Greengrass Cloud Service returned an error when getting full deployment configuration.", e);

--- a/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.RetryUtils;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.ListThingGroupsForCoreDeviceRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.ListThingGroupsForCoreDeviceResponse;
 
@@ -75,18 +74,12 @@ public class ThingGroupHelper {
 
         return RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
             do {
-                GreengrassV2DataClient client = clientFactory.getGreengrassV2DataClient();
-                if (client == null) {
-                    String errorMessage = clientFactory.getConfigValidationError().orElse("Could not get "
-                            + "GreengrassV2DataClient");
-                    throw new DeviceConfigurationException(errorMessage);
-                }
-
                 ListThingGroupsForCoreDeviceRequest request = ListThingGroupsForCoreDeviceRequest.builder()
                         .coreDeviceThingName(Coerce.toString(deviceConfiguration.getThingName()))
                         .nextToken(nextToken.get()).build();
 
-                ListThingGroupsForCoreDeviceResponse response = client.listThingGroupsForCoreDevice(request);
+                ListThingGroupsForCoreDeviceResponse response =
+                        clientFactory.fetchGreengrassV2DataClient().listThingGroupsForCoreDevice(request);
                 response.thingGroups().forEach(thingGroup -> {
                     //adding direct thing groups
                     thingGroupNames.add(THING_GROUP_RESOURCE_TYPE_PREFIX + thingGroup.thingGroupName());

--- a/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
@@ -77,8 +77,8 @@ public class ThingGroupHelper {
             do {
                 GreengrassV2DataClient client = clientFactory.getGreengrassV2DataClient();
                 if (client == null) {
-                    String errorMessage =  clientFactory.getConfigValidationError().isPresent()
-                            ? clientFactory.getConfigValidationError().get() : "Could not get GreengrassV2DataClient";
+                    String errorMessage = clientFactory.getConfigValidationError().orElse("Could not get "
+                            + "GreengrassV2DataClient");
                     throw new DeviceConfigurationException(errorMessage);
                 }
 

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -111,11 +111,31 @@ public class GreengrassServiceClientFactory {
     /**
      * Initializes and returns GreengrassV2DataClient.
      * Note that this method can return null if there is a config validation error.
+     * @deprecated use fetchGreengrassV2DataClient instead.
      */
+    @Deprecated
     public synchronized GreengrassV2DataClient getGreengrassV2DataClient() {
         if (getConfigValidationError().isPresent()) {
             logger.atWarn().log("Failed to validate config for Greengrass v2 data client: {}", configValidationError);
             return null;
+        }
+
+        if (greengrassV2DataClient == null) {
+            configureClient(deviceConfiguration);
+        }
+        return greengrassV2DataClient;
+    }
+
+    /**
+     * Initializes and returns GreengrassV2DataClient.
+     * @throws DeviceConfigurationException when fails to validate configs.
+     */
+    public synchronized GreengrassV2DataClient fetchGreengrassV2DataClient() throws DeviceConfigurationException {
+        if (getConfigValidationError().isPresent()) {
+            logger.atWarn().log("Failed to validate config for Greengrass v2 data client: {}",
+                    configValidationError);
+            throw new DeviceConfigurationException("Failed to validate config for Greengrass v2 data client: "
+                    + configValidationError);
         }
 
         if (greengrassV2DataClient == null) {

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.RecipeMetadata;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.RetryUtils;
@@ -77,8 +78,8 @@ class GreengrassRepositoryDownloaderTest {
     private ComponentStore componentStore;
 
     @BeforeEach
-    void beforeEach() {
-        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+    void beforeEach() throws DeviceConfigurationException {
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
 import com.aws.greengrass.deployment.exceptions.DeploymentTaskFailureException;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.deployment.exceptions.RetryableDeploymentDocumentDownloadException;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.network.HttpClientProvider;
@@ -86,8 +87,8 @@ class DeploymentDocumentDownloaderTest {
     private DeploymentDocumentDownloader downloader;
 
     @BeforeEach
-    void beforeEach() {
-        when(greengrassServiceClientFactory.getGreengrassV2DataClient()).thenReturn(greengrassV2DataClient);
+    void beforeEach() throws DeviceConfigurationException {
+        when(greengrassServiceClientFactory.fetchGreengrassV2DataClient()).thenReturn(greengrassV2DataClient);
         lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
         when(deviceConfiguration.getThingName()).thenReturn(thingNameTopic);
         downloader = new DeploymentDocumentDownloader(greengrassServiceClientFactory, deviceConfiguration,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updating users of GreengrassV2DataClient getGreengrassV2DataClient() to handle a null response.

**Why is this change necessary:**
We've seen NPEs when the client is not retrieved.

**How was this change tested:**
- [X] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [X ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
