### PR TITLE
fix: change return type of getConfigValidationError back to original

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -181,7 +181,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
 
     @Override
     public Optional<String> checkDownloadable() {
-        return clientFactory.getConfigValidationError();
+        return Optional.ofNullable(clientFactory.getConfigValidationError());
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -22,7 +22,6 @@ import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClientBuilder;
 
 import java.net.URI;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
 
@@ -101,11 +100,11 @@ public class GreengrassServiceClientFactory {
      * Validate again if the device config has changed.
      *
      */
-    public Optional<String> getConfigValidationError() {
+    public String getConfigValidationError() {
         if (deviceConfigChanged.compareAndSet(true, false)) {
             validateConfiguration();
         }
-        return Optional.ofNullable(configValidationError);
+        return configValidationError;
     }
 
     /**
@@ -115,7 +114,7 @@ public class GreengrassServiceClientFactory {
      */
     @Deprecated
     public synchronized GreengrassV2DataClient getGreengrassV2DataClient() {
-        if (getConfigValidationError().isPresent()) {
+        if (getConfigValidationError() != null) {
             logger.atWarn().log("Failed to validate config for Greengrass v2 data client: {}", configValidationError);
             return null;
         }
@@ -131,7 +130,7 @@ public class GreengrassServiceClientFactory {
      * @throws DeviceConfigurationException when fails to validate configs.
      */
     public synchronized GreengrassV2DataClient fetchGreengrassV2DataClient() throws DeviceConfigurationException {
-        if (getConfigValidationError().isPresent()) {
+        if (getConfigValidationError() != null) {
             logger.atWarn().log("Failed to validate config for Greengrass v2 data client: {}",
                     configValidationError);
             throw new DeviceConfigurationException("Failed to validate config for Greengrass v2 data client: "


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change return type of getConfigValidationError back to String

**Why is this change necessary:**
Return type of getConfigValidationError was recently changed from String to Optional<String>.  This was a regression and means that outside callers need to expect a different return type based on which version of Nucleus is being used. We want to avoid this when possible. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
