### PR TITLE
fix(deployment): dedupe shadow deployment that resumes after restart

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -160,7 +160,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
         };
 
         try (AutoCloseable l = TestUtils.createCloseableLogListener(listener)) {
-            submitSampleJobDocument(
+            submitSampleCloudDeploymentDocument(
                     DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithNonDisruptableService.json").toURI(),
                     "deployNonDisruptable", DeploymentType.SHADOW);
 
@@ -206,9 +206,9 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                 }));
 
                 assertTrue(cdlDeployNonDisruptable.await(30, TimeUnit.SECONDS));
-                submitSampleJobDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRedSignalService.json")
+                submitSampleCloudDeploymentDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRedSignalService.json")
                         .toURI(), "deployRedSignal", DeploymentType.SHADOW);
-                submitSampleJobDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithNonDisruptableService.json")
+                submitSampleCloudDeploymentDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithNonDisruptableService.json")
                         .toURI(), "redeployNonDisruptable", DeploymentType.SHADOW);
                 assertTrue(cdlRedeployNonDisruptable.await(15, TimeUnit.SECONDS));
                 assertTrue(cdlDeployRedSignal.await(1, TimeUnit.SECONDS));
@@ -230,7 +230,6 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
 
         try (AutoCloseable l = TestUtils.createCloseableLogListener(listener)) {
 
-
             CountDownLatch redSignalServiceLatch = new CountDownLatch(1);
             kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
                 if (service.getName().equals("RedSignal") && newState.equals(State.RUNNING)) {
@@ -239,7 +238,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                 }
             });
 
-            submitSampleJobDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRedSignalService.json")
+            submitSampleCloudDeploymentDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRedSignalService.json")
                     .toURI(), "deployRedSignal", DeploymentType.SHADOW); // DeploymentType.SHADOW is used here and it
             // is same for DeploymentType.IOT_JOBS
             assertTrue(redSignalServiceLatch.await(30, TimeUnit.SECONDS));
@@ -273,7 +272,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
         },"dummy");
 
         try (AutoCloseable l = TestUtils.createCloseableLogListener(listener)) {
-            submitSampleJobDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRequiredCapability.json")
+            submitSampleCloudDeploymentDocument(DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithRequiredCapability.json")
                     .toURI(), "deployRedSignal", DeploymentType.SHADOW);
             assertTrue(cdlDeployRedSignal.await(30, TimeUnit.SECONDS));
             assertTrue(deploymentCDL.await(10,TimeUnit.SECONDS));
@@ -341,7 +340,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                 }
             });
 
-            submitSampleJobDocument(
+            submitSampleCloudDeploymentDocument(
                     DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithResourceLimits.json").toURI(),
                     "deployComponentWithResourceLimits", DeploymentType.SHADOW);
             assertTrue(componentRunning.await(30, TimeUnit.SECONDS));
@@ -482,7 +481,7 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                 + "requiredCapabilityNotPresent.");
     }
 
-    private void submitSampleJobDocument(URI uri, String arn, DeploymentType type) throws Exception {
+    private void submitSampleCloudDeploymentDocument(URI uri, String arn, DeploymentType type) throws Exception {
         Configuration deploymentConfiguration = OBJECT_MAPPER.readValue(new File(uri), Configuration.class);
         deploymentConfiguration.setCreationTimestamp(System.currentTimeMillis());
         deploymentConfiguration.setConfigurationArn(arn);

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -451,7 +451,7 @@ public class DeploymentService extends GreengrassService {
                 IotJobsHelper.getLatestQueuedJobs().addProcessedJob(deployment.getId());
             } else if (DeploymentType.SHADOW.equals(deployment.getDeploymentType())) {
                 // Track this Shadow deployment for de-duplication
-                context.get(ShadowDeploymentListener.class).getLastConfigurationArn().set(deployment.getId());
+                context.get(ShadowDeploymentListener.class).setLastConfigurationArn(deployment.getId());
             }
         }
         if (deploymentTask == null) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -356,7 +356,7 @@ public class DeploymentService extends GreengrassService {
             logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY_NAME, currentDeploymentTaskMetadata.getDeploymentId())
                     .log("Deployment task is cancelled");
         }
-        // Setting this to null to indicate there is not current deployment being processed
+        // Setting this to null to indicate there is no current deployment being processed
         // Did not use optionals over null due to performance
         currentDeploymentTaskMetadata = null;
     }
@@ -449,6 +449,9 @@ public class DeploymentService extends GreengrassService {
             if (DeploymentType.IOT_JOBS.equals(deployment.getDeploymentType())) {
                 // Keep track of IoT jobs for de-duplication
                 IotJobsHelper.getLatestQueuedJobs().addProcessedJob(deployment.getId());
+            } else if (DeploymentType.SHADOW.equals(deployment.getDeploymentType())) {
+                // Track this Shadow deployment for de-duplication
+                context.get(ShadowDeploymentListener.class).getLastConfigurationArn().set(deployment.getId());
             }
         }
         if (deploymentTask == null) {

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -468,9 +468,18 @@ public class ShadowDeploymentListener implements InjectionActions {
         }
     }
 
-
     private MqttClientConnection getMqttClientConnection() {
         return new WrapperMqttClientConnection(mqttClient);
     }
 
+    /**
+     * Threadsafe setter for lastConfigurationArn.
+     *
+     * @param configurationArn  value to set lastConfigurationArn to
+     */
+    public void setLastConfigurationArn(String configurationArn) {
+        synchronized (ShadowDeploymentListener.class) {
+            lastConfigurationArn.set(configurationArn);
+        }
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**
- 

**Description of changes:**
Deduplicate deployments of type SHADOW when it triggers nucleus restart due to bootstrap task/nucleus version update etc, but the deployment resumes after restart when it's put in the deployment queue during launch.

**Why is this change necessary:**
To fix a race condition where deployment finishes and is removed from the queue and the current deployment task tracker and the status has not reached the cloud yet, but the shadow subscriptions are setup and the latest shadow is requested, which does not include the finished status, leading to duplicate deployment workflow execution.

Draft PR waiting for tests. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [x] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
