### PR TITLE
chore: use defusedxml in github scripts

### DIFF
--- a/.github/scripts/binaryCompatibility.py
+++ b/.github/scripts/binaryCompatibility.py
@@ -4,7 +4,7 @@
 import argparse
 import json
 import os
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from agithub.GitHub import GitHub
 

--- a/.github/scripts/cover2cover.py
+++ b/.github/scripts/cover2cover.py
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 import sys
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import re
 import os.path
 

--- a/.github/scripts/flake.py
+++ b/.github/scripts/flake.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import os
 import subprocess
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from collections import defaultdict
 
 from agithub.GitHub import GitHub


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
