### PR TITLE
fix: use RFC 4648 compliant Base64 decoders

### DIFF
--- a/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
+++ b/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
@@ -85,22 +85,31 @@ public final class EncryptionUtils {
         if (keyString.contains(PKCS_1_PEM_HEADER)) {
             keyString = keyString.replace(PKCS_1_PEM_HEADER, "");
             keyString = keyString.replace(PKCS_1_PEM_FOOTER, "");
+            keyString = removeAllNewLines(keyString);
             return readPkcs1PrivateKey(Base64.getDecoder().decode(keyString));
         }
 
         if (keyString.contains(PKCS_8_PEM_HEADER)) {
             keyString = keyString.replace(PKCS_8_PEM_HEADER, "");
             keyString = keyString.replace(PKCS_8_PEM_FOOTER, "");
+            keyString = removeAllNewLines(keyString);
             return readPkcs8PrivateKey(Base64.getDecoder().decode(keyString));
         }
 
         if (keyString.contains(PKCS_8_EC_HEADER)) {
             keyString = keyString.replace(PKCS_8_EC_HEADER, "");
             keyString = keyString.replace(PKCS_8_EC_FOOTER, "");
+            keyString = removeAllNewLines(keyString);
             return readPkcs8PrivateKey(Base64.getDecoder().decode(keyString));
         }
 
         return readPkcs8PrivateKey(keyBytes);
+    }
+
+    private static String removeAllNewLines(String keyString) {
+        keyString = keyString.replace("\n", "");
+        keyString = keyString.replace("\r", "");
+        return keyString;
     }
 
     private static KeyPair readPkcs8PrivateKey(byte[] pkcs8Bytes) throws GeneralSecurityException {

--- a/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
+++ b/src/main/java/com/aws/greengrass/util/EncryptionUtils.java
@@ -85,19 +85,19 @@ public final class EncryptionUtils {
         if (keyString.contains(PKCS_1_PEM_HEADER)) {
             keyString = keyString.replace(PKCS_1_PEM_HEADER, "");
             keyString = keyString.replace(PKCS_1_PEM_FOOTER, "");
-            return readPkcs1PrivateKey(Base64.getMimeDecoder().decode(keyString));
+            return readPkcs1PrivateKey(Base64.getDecoder().decode(keyString));
         }
 
         if (keyString.contains(PKCS_8_PEM_HEADER)) {
             keyString = keyString.replace(PKCS_8_PEM_HEADER, "");
             keyString = keyString.replace(PKCS_8_PEM_FOOTER, "");
-            return readPkcs8PrivateKey(Base64.getMimeDecoder().decode(keyString));
+            return readPkcs8PrivateKey(Base64.getDecoder().decode(keyString));
         }
 
         if (keyString.contains(PKCS_8_EC_HEADER)) {
             keyString = keyString.replace(PKCS_8_EC_HEADER, "");
             keyString = keyString.replace(PKCS_8_EC_FOOTER, "");
-            return readPkcs8PrivateKey(Base64.getMimeDecoder().decode(keyString));
+            return readPkcs8PrivateKey(Base64.getDecoder().decode(keyString));
         }
 
         return readPkcs8PrivateKey(keyBytes);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
From RFC 7468 (https://www.rfc-editor.org/rfc/rfc7468)
> Textual encoding begins with a line comprising "-----BEGIN ", a
   label, and "-----", and ends with a line comprising "-----END ", a
   label, and "-----".  Between these lines, or "encapsulation
   boundaries", are base64-encoded data according to Section 4 of
   [RFC4648].

RFC4648 is implemented in Java as the Base64 encoder/decoder, not the Base64 MIME encoder.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
