### PR TITLE
feat: FSS update triggered by local deployments

### DIFF
--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -781,7 +781,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
 
         mqttClientConnectionEventsArgumentCaptor.getValue().onConnectionResumed(false);
 
-        TimeUnit.SECONDS.sleep(1);
+        TimeUnit.SECONDS.sleep(5);
 
         // Verify that an MQTT message with the components' status is uploaded.
         verify(mockMqttClient, atLeast(1)).publish(publishRequestArgumentCaptor.capture());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
adding FSS trigger for local deployments and deployments with no component state changes

**Why is this change necessary:**
With this change, local deployments will be reflected in the cloud. 
Cloud team is planning subsequent changes to make local deployment information available to customers through their APIs.
These changes are part of our ongoing improvements to FSS and device health notifications.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

UATs will be added separately

Tested locally by temporarily adding logs and confirming that FSS updates were published for local deployments and deployments with no component state changes

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [X ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
