### PR TITLE
fix: reduce timeout when closing mqtt client

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -284,6 +284,13 @@ class AwsIotMqttClient implements Closeable {
                 MqttClient.DEFAULT_MQTT_OPERATION_TIMEOUT, MqttClient.MQTT_OPERATION_TIMEOUT_KEY));
     }
 
+    int getCloseTimeout() {
+        // Use a shorter timeout for disconnection when closing client,
+        // since the socket will close anyway when the process dies
+        return Coerce.toInt(mqttTopics.findOrDefault(
+                MqttClient.DEFAULT_MQTT_CLOSE_TIMEOUT, MqttClient.MQTT_OPERATION_TIMEOUT_KEY));
+    }
+
     /**
      * Run re-subscription task in another thread so that the current thread is not blocked by it. The task will keep
      * retrying until all subscription succeeded or it's canceled by network interruption.
@@ -399,7 +406,7 @@ class AwsIotMqttClient implements Closeable {
             resubscribeFuture.cancel(true);
         }
         try {
-            disconnect().get(getTimeout(), TimeUnit.MILLISECONDS);
+            disconnect().get(getCloseTimeout(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             logger.atError().log("Error while disconnecting the MQTT client", e);
         }

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -88,11 +88,11 @@ public class MqttClient implements Closeable {
     private static final int DEFAULT_MQTT_SOCKET_TIMEOUT = (int) Duration.ofSeconds(3).toMillis();
     static final String MQTT_OPERATION_TIMEOUT_KEY = "operationTimeoutMs";
     static final int DEFAULT_MQTT_OPERATION_TIMEOUT = (int) Duration.ofSeconds(30).toMillis();
+    static final int DEFAULT_MQTT_CLOSE_TIMEOUT = (int) Duration.ofSeconds(2).toMillis();
     static final String MQTT_MAX_IN_FLIGHT_PUBLISHES_KEY = "maxInFlightPublishes";
     static final int DEFAULT_MAX_IN_FLIGHT_PUBLISHES = 5;
     public static final int MAX_SUBSCRIPTIONS_PER_CONNECTION = 50;
     public static final String CLIENT_ID_KEY = "clientId";
-    public static final int EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS = 2;
     static final int IOT_MAX_LIMIT_IN_FLIGHT_OF_QOS1_PUBLISHES = 100;
     static final String MQTT_MAX_OF_MESSAGE_SIZE_IN_BYTES_KEY = "maxMessageSizeInBytes";
     static final String MQTT_MAX_OF_PUBLISH_RETRY_COUNT_KEY = "maxPublishRetry";
@@ -802,15 +802,6 @@ public class MqttClient implements Closeable {
         clientBootstrap.close();
         hostResolver.close();
         eventLoopGroup.close();
-        try {
-            eventLoopGroup.getShutdownCompleteFuture().get(EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (ExecutionException e) {
-            logger.atError().log("Error shutting down event loop", e);
-        } catch (TimeoutException e) {
-            logger.atError().log("Timed out shutting down event loop", e);
-        }
     }
 
     public void addToCallbackEvents(MqttClientConnectionEvents callbacks) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Reduce default `AwsIotMqttClient` disconnection timeout at close from 30 seconds to 2 seconds;
2. Do not wait for event loop group shutdown.

**Why is this change necessary:**
To reduce the shutdown time of Nucleus.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
