### PR TITLE
test: adding integ tests for fss triggered by local deployment

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -88,7 +88,7 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
         TestFeatureParameters.internalEnableTestingFeatureParameters(DEFAULT_HANDLER);
 
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
-                IotJobsFleetStatusServiceTest.class.getResource("onlyMain.yaml"));
+                EventFleetStatusServiceTest.class.getResource("onlyMain.yaml"));
         kernel.getContext().put(MqttClient.class, mqttClient);
 
         when(mqttClient.publish(any(PublishRequest.class))).thenAnswer(i -> {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
adding integ tests for fss triggered by local deployment

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [X] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
