### PR TITLE
feat: add message type and timestamp in FleetStatusDetails

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -27,6 +27,7 @@ import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.status.FleetStatusDetails;
 import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.status.MessageType;
 import com.aws.greengrass.status.OverallStatus;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
@@ -206,6 +207,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
 
             FleetStatusDetails fleetStatusDetails = OBJECT_MAPPER.readValue(pr.getPayload(), FleetStatusDetails.class);
             assertEquals("ThingName", fleetStatusDetails.getThing());
+            assertEquals(MessageType.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getMessageType());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             assertEquals(componentNamesToCheck.size(), fleetStatusDetails.getComponentStatusDetails().size());
@@ -363,6 +365,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
             FleetStatusDetails fleetStatusDetails = OBJECT_MAPPER.readValue(pr.getPayload(), FleetStatusDetails.class);
             assertEquals("ThingName", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+            assertEquals(MessageType.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getMessageType());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             // Last deployment had only 1 component + "main" in fss update ComponentStatusDetails
             assertEquals(2, fleetStatusDetails.getComponentStatusDetails().size());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -263,6 +263,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
             FleetStatusDetails fleetStatusDetails = OBJECT_MAPPER.readValue(pr.getPayload(), FleetStatusDetails.class);
             assertEquals("ThingName", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+            assertEquals(MessageType.LOCAL_DEPLOYMENT, fleetStatusDetails.getMessageType());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             assertEquals(componentNamesToCheck.size(), fleetStatusDetails.getComponentStatusDetails().size());
             fleetStatusDetails.getComponentStatusDetails().forEach(componentStatusDetails -> {
@@ -316,6 +317,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
 
             assertEquals("ThingName", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+            assertEquals(MessageType.LOCAL_DEPLOYMENT, fleetStatusDetails.getMessageType());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             assertEquals(0, fleetStatusDetails.getComponentStatusDetails().size());
             Slf4jLogAdapter.removeGlobalListener(logListener);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.status.ComponentStatusDetails;
 import com.aws.greengrass.status.FleetStatusDetails;
 import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.status.MessageType;
 import com.aws.greengrass.status.OverallStatus;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testing.TestFeatureParameterInterface;
@@ -148,6 +149,7 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
         assertNotNull(fleetStatusDetails);
         assertNotNull(fleetStatusDetails.get());
         assertEquals("ThingName", fleetStatusDetails.get().getThing());
+        assertEquals(MessageType.CADENCE, fleetStatusDetails.get().getMessageType());
         assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.get().getOverallStatus());
         assertNotNull(fleetStatusDetails.get().getComponentStatusDetails());
         Set<String> allComponents =

--- a/src/main/java/com/aws/greengrass/status/FleetStatusDetails.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusDetails.java
@@ -33,6 +33,10 @@ public class FleetStatusDetails implements Chunkable<ComponentStatusDetails> {
 
     private long sequenceNumber;
 
+    private long timestamp;
+
+    private MessageType messageType;
+
     @JsonProperty("components")
     private List<ComponentStatusDetails> componentStatusDetails;
 

--- a/src/main/java/com/aws/greengrass/status/MessageType.java
+++ b/src/main/java/com/aws/greengrass/status/MessageType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.status;
+
+import com.aws.greengrass.deployment.model.Deployment.DeploymentType;
+
+public enum MessageType {
+    LOCAL_DEPLOYMENT,
+    THING_DEPLOYMENT,
+    THING_GROUP_DEPLOYMENT,
+    BROKEN_COMPONENT,
+    RECONNECT,
+    CADENCE;
+
+    /**
+     * Get MessageTypeEnum from DeploymentType.
+     *
+     * @param deploymentType deploymentType
+     * @return deployment message type
+     * @throws IllegalArgumentException invalid deployment type
+     */
+    public static MessageType fromDeploymentType(DeploymentType deploymentType) {
+        switch (deploymentType) {
+            case LOCAL:
+                return LOCAL_DEPLOYMENT;
+            case SHADOW:
+                return THING_DEPLOYMENT;
+            case IOT_JOBS:
+                return THING_GROUP_DEPLOYMENT;
+            default:
+                throw new IllegalArgumentException("Invalid deployment type: " + deploymentType);
+        }
+    }
+}

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -366,6 +366,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         // Update the job status for an ongoing deployment to IN_PROGRESS.
         map.put(DEPLOYMENT_STATUS_KEY_NAME, JobStatus.IN_PROGRESS.toString());
         map.put(DEPLOYMENT_ID_KEY_NAME, "testJob");
+        map.put(DEPLOYMENT_TYPE_KEY_NAME, "IOT_JOBS");
         consumerArgumentCaptor.getValue().apply(map);
 
         mqttClientConnectionEventsArgumentCaptor.getValue().onConnectionInterrupted(500);
@@ -694,6 +695,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         Map<String, Object> map = new HashMap<>();
         map.put(DEPLOYMENT_STATUS_KEY_NAME, JobStatus.IN_PROGRESS.toString());
         map.put(DEPLOYMENT_ID_KEY_NAME, "testJob");
+        map.put(DEPLOYMENT_TYPE_KEY_NAME, "IOT_JOBS");
         consumerArgumentCaptor.getValue().apply(map);
 
         mqttClientConnectionEventsArgumentCaptor.getValue().onConnectionInterrupted(500);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Added `MessageType` enum to represent the trigger of FSS update.
2. Added `messageType` and `timestamps` in `FleetStatusDetails`.
3. Updated relevant tests.

**Why is this change necessary:**
To help service gain better visibility of events on device.
These changes are part of our ongoing improvements to FSS and device health notifications.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
