### PR TITLE
fix: reduce shutdown time by omitting mqtt unsubscribe

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -273,10 +273,6 @@ public class DeploymentService extends GreengrassService {
     @Override
     protected void shutdown() {
         receivedShutdown.set(true);
-        IotJobsHelper iotJobsHelper = context.get(IotJobsHelper.class);
-        if (iotJobsHelper != null) {
-            iotJobsHelper.unsubscribeFromIotJobsTopics();
-        }
     }
 
     @SuppressWarnings("PMD.NullAssignment")

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -154,7 +154,6 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @AfterEach
     void afterEach() {
         deploymentService.shutdown();
-        verify(iotJobsHelper).unsubscribeFromIotJobsTopics();
         if (deploymentServiceThread != null && deploymentServiceThread.isAlive()) {
             deploymentServiceThread.interrupt();
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Reduce shutdown time by omitting MQTT unsubscribe in DeploymentService.shutdown().
Update unit testing accordingly.

**Why is this change necessary:**

There appears to be an issue in the most recent version of aws-iot-device-sdk (observed after upgrading from 1.8.5 -> 1.9.2), which causes our MQTT unsubscribe to block for the full DEFAULT_MQTT_OPERATION_TIMEOUT=30 seconds under certain conditions.

To work around this issue, this PR removes the MQTT unsubscribe step during service shutdown.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
