### PR TITLE
fix(deps): fix race condition in reacting to state changes for dependencies

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
@@ -6,9 +6,7 @@
 package com.aws.greengrass.integrationtests.deployment;
 
 import com.aws.greengrass.config.PlatformResolver;
-import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeploymentConfigMerger;
 import com.aws.greengrass.deployment.model.ComponentUpdatePolicy;
@@ -31,7 +29,6 @@ import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
-import com.aws.greengrass.util.Coerce;
 import org.apache.commons.lang3.SystemUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -451,8 +448,8 @@ class DeploymentConfigMergingTest extends BaseITCase {
         kernel.launch();
 
         CountDownLatch mainRunningLatch = new CountDownLatch(1);
-        kernel.getMain().addStateSubscriber((WhatHappened what, Topic t) -> {
-            if (Coerce.toEnum(State.class, t).isRunning()) {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (kernel.getMain().equals(service) && newState.isRunning()) {
                 mainRunningLatch.countDown();
             }
         });
@@ -515,8 +512,8 @@ class DeploymentConfigMergingTest extends BaseITCase {
         kernel.launch();
 
         CountDownLatch mainFinished = new CountDownLatch(1);
-        kernel.getMain().addStateSubscriber((WhatHappened what, Topic t) -> {
-            if (Coerce.toEnum(State.class, t).equals(State.FINISHED)) {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (kernel.getMain().equals(service) && State.FINISHED.equals(newState)) {
                 mainFinished.countDown();
             }
         });

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -16,7 +16,6 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
 import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
-import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.platforms.unix.linux.Cgroup;
 import com.aws.greengrass.util.platforms.unix.linux.LinuxSystemResourceController;
 import org.apache.commons.lang3.SystemUtils;
@@ -596,8 +595,8 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         kernel.launch();
 
         CountDownLatch mainRunningLatch = new CountDownLatch(1);
-        kernel.getMain().addStateSubscriber((WhatHappened what, Topic t) -> {
-            if (Coerce.toEnum(State.class, t).isRunning()) {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (kernel.getMain().equals(service) && newState.isRunning()) {
                 mainRunningLatch.countDown();
             }
         });

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelShutdownTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelShutdownTest.java
@@ -5,13 +5,9 @@
 
 package com.aws.greengrass.integrationtests.lifecyclemanager;
 
-import com.aws.greengrass.config.Topic;
-import com.aws.greengrass.config.WhatHappened;
-import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.Kernel;
-import com.aws.greengrass.util.Coerce;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,8 +55,8 @@ class KernelShutdownTest extends BaseITCase {
         });
 
         CountDownLatch mainRunningLatch = new CountDownLatch(1);
-        kernel.getMain().addStateSubscriber((WhatHappened what, Topic t) -> {
-            if (Coerce.toEnum(State.class, t).isRunning()) {
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (kernel.getMain().equals(service) && newState.isRunning()) {
                 mainRunningLatch.countDown();
             }
         });

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/SetupDependencyTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/SetupDependencyTest.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.lifecyclemanager;
 
 import com.amazon.aws.iot.greengrass.component.common.DependencyType;
-import com.aws.greengrass.config.Subscriber;
 import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
@@ -57,7 +56,7 @@ class SetupDependencyTest extends GGServiceTestUtil {
         GreengrassService dep1 = mock(GreengrassService.class);
 
         greengrassService.addOrUpdateDependency(dep1, DependencyType.SOFT, false);
-        verify(dep1).addStateSubscriber(any(Subscriber.class));
+        verify(context).addGlobalStateChangeListener(any(GlobalStateChangeListener.class));
 
         Map<GreengrassService, DependencyType> dependencies = greengrassService.getDependencies();
         assertEquals(1, dependencies.size());
@@ -71,7 +70,7 @@ class SetupDependencyTest extends GGServiceTestUtil {
         assertEquals(1, dependencies.size());
         assertEquals(DependencyType.HARD, dependencies.get(dep1));
         // Remove the previous subscriber.
-        verify(dep1).removeStateSubscriber(any(Subscriber.class));
+        verify(context).removeGlobalStateChangeListener(any(GlobalStateChangeListener.class));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
Handle race condition in reacting to state changes of dependencies

**Why is this change necessary:**
Leads to dependent components sometimes not restarting when hard dependencies restart, or not waiting for hard dependencies to finish required state transition before proceeding with their own state transition.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
