### PR TITLE
feat: add chunk info and reformat message type in FleetStatusDetails

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/MultipleGroupsDeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/MultipleGroupsDeploymentE2ETest.java
@@ -51,7 +51,7 @@ import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMP
 import static com.aws.greengrass.deployment.ShadowDeploymentListener.DEPLOYMENT_SHADOW_NAME;
 import static com.aws.greengrass.deployment.ThingGroupHelper.THING_GROUP_RESOURCE_TYPE_PREFIX;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
-import static com.aws.greengrass.status.DeploymentInformation.STATUS_KEY;
+import static com.aws.greengrass.status.model.DeploymentInformation.STATUS_KEY;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/ShadowDeploymentE2ETest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/ShadowDeploymentE2ETest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static com.aws.greengrass.deployment.ShadowDeploymentListener.DEPLOYMENT_SHADOW_NAME;
-import static com.aws.greengrass.status.DeploymentInformation.STATUS_KEY;
+import static com.aws.greengrass.status.model.DeploymentInformation.STATUS_KEY;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -25,10 +25,11 @@ import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.logging.impl.Slf4jLogAdapter;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
-import com.aws.greengrass.status.FleetStatusDetails;
 import com.aws.greengrass.status.FleetStatusService;
-import com.aws.greengrass.status.MessageType;
-import com.aws.greengrass.status.OverallStatus;
+import com.aws.greengrass.status.model.FleetStatusDetails;
+import com.aws.greengrass.status.model.MessageType;
+import com.aws.greengrass.status.model.Trigger;
+import com.aws.greengrass.status.model.OverallStatus;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
@@ -77,6 +78,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -207,7 +209,9 @@ class EventFleetStatusServiceTest extends BaseITCase {
 
             FleetStatusDetails fleetStatusDetails = OBJECT_MAPPER.readValue(pr.getPayload(), FleetStatusDetails.class);
             assertEquals("ThingName", fleetStatusDetails.getThing());
-            assertEquals(MessageType.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getMessageType());
+            assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+            assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
+            assertNull(fleetStatusDetails.getChunkInfo());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             assertEquals(componentNamesToCheck.size(), fleetStatusDetails.getComponentStatusDetails().size());
@@ -263,7 +267,9 @@ class EventFleetStatusServiceTest extends BaseITCase {
             FleetStatusDetails fleetStatusDetails = OBJECT_MAPPER.readValue(pr.getPayload(), FleetStatusDetails.class);
             assertEquals("ThingName", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
-            assertEquals(MessageType.LOCAL_DEPLOYMENT, fleetStatusDetails.getMessageType());
+            assertEquals(Trigger.LOCAL_DEPLOYMENT, fleetStatusDetails.getTrigger());
+            assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+            assertNull(fleetStatusDetails.getChunkInfo());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             assertEquals(componentNamesToCheck.size(), fleetStatusDetails.getComponentStatusDetails().size());
             fleetStatusDetails.getComponentStatusDetails().forEach(componentStatusDetails -> {
@@ -317,7 +323,9 @@ class EventFleetStatusServiceTest extends BaseITCase {
 
             assertEquals("ThingName", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
-            assertEquals(MessageType.LOCAL_DEPLOYMENT, fleetStatusDetails.getMessageType());
+            assertEquals(Trigger.LOCAL_DEPLOYMENT, fleetStatusDetails.getTrigger());
+            assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+            assertNull(fleetStatusDetails.getChunkInfo());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             assertEquals(0, fleetStatusDetails.getComponentStatusDetails().size());
             Slf4jLogAdapter.removeGlobalListener(logListener);
@@ -367,7 +375,9 @@ class EventFleetStatusServiceTest extends BaseITCase {
             FleetStatusDetails fleetStatusDetails = OBJECT_MAPPER.readValue(pr.getPayload(), FleetStatusDetails.class);
             assertEquals("ThingName", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
-            assertEquals(MessageType.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getMessageType());
+            assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
+            assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+            assertNull(fleetStatusDetails.getChunkInfo());
             assertNotNull(fleetStatusDetails.getComponentStatusDetails());
             // Last deployment had only 1 component + "main" in fss update ComponentStatusDetails
             assertEquals(2, fleetStatusDetails.getComponentStatusDetails().size());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -12,8 +12,10 @@ import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
-import com.aws.greengrass.status.FleetStatusDetails;
 import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.status.model.FleetStatusDetails;
+import com.aws.greengrass.status.model.MessageType;
+import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Coerce;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -88,7 +90,9 @@ class FleetStatusServiceSetupTest extends BaseITCase {
         assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState, eventuallyEval(is(State.RUNNING)));
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
         assertThat(()-> fleetStatusDetails.get(), eventuallyEval(notNullValue(), Duration.ofSeconds(30)));
-        assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
+        assertEquals("ThingName", fleetStatusDetails.get().getThing());
+        assertEquals(MessageType.COMPLETE, fleetStatusDetails.get().getMessageType());
+        assertEquals(Trigger.NUCLEUS_LAUNCH, fleetStatusDetails.get().getTrigger());
     }
 
     @Test
@@ -109,7 +113,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
         assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
-
+        assertEquals(Trigger.NETWORK_RECONFIGURE, fleetStatusDetails.get().getTrigger());
         deviceConfiguration.getIotDataEndpoint().withValue("new-ats.iot.us-east-1.amazonaws.com");
         assertEquals("new-ats.iot.us-east-1.amazonaws.com", Coerce.toString(deviceConfiguration.getIotDataEndpoint()));
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -15,7 +15,6 @@ import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.status.model.FleetStatusDetails;
 import com.aws.greengrass.status.model.MessageType;
-import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Coerce;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -78,7 +77,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
     }
 
     @Test
-    void GIVEN_kernel_deployment_WHEN_device_provisioning_completes_before_kernel_launches_and_is_changed_afterTHEN_thing_details_uploaded_to_cloud_exactly_once()
+    void GIVEN_kernel_deployment_WHEN_device_provisioning_completes_before_kernel_launches_and_is_changed_after_THEN_thing_details_uploaded_to_cloud_exactly_once()
             throws Exception {
 
         deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
@@ -92,7 +91,6 @@ class FleetStatusServiceSetupTest extends BaseITCase {
         assertThat(()-> fleetStatusDetails.get(), eventuallyEval(notNullValue(), Duration.ofSeconds(30)));
         assertEquals("ThingName", fleetStatusDetails.get().getThing());
         assertEquals(MessageType.COMPLETE, fleetStatusDetails.get().getMessageType());
-        assertEquals(Trigger.NUCLEUS_LAUNCH, fleetStatusDetails.get().getTrigger());
     }
 
     @Test
@@ -113,7 +111,6 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
         assertThat(() -> fleetStatusDetails.get().getThing(), eventuallyEval(is("ThingName"), Duration.ofSeconds(30)));
-        assertEquals(Trigger.NETWORK_RECONFIGURE, fleetStatusDetails.get().getTrigger());
         deviceConfiguration.getIotDataEndpoint().withValue("new-ats.iot.us-east-1.amazonaws.com");
         assertEquals("new-ats.iot.us-east-1.amazonaws.com", Coerce.toString(deviceConfiguration.getIotDataEndpoint()));
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -15,11 +15,12 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.KernelCommandLine;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
-import com.aws.greengrass.status.ComponentStatusDetails;
-import com.aws.greengrass.status.FleetStatusDetails;
 import com.aws.greengrass.status.FleetStatusService;
-import com.aws.greengrass.status.MessageType;
-import com.aws.greengrass.status.OverallStatus;
+import com.aws.greengrass.status.model.ComponentStatusDetails;
+import com.aws.greengrass.status.model.FleetStatusDetails;
+import com.aws.greengrass.status.model.MessageType;
+import com.aws.greengrass.status.model.Trigger;
+import com.aws.greengrass.status.model.OverallStatus;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testing.TestFeatureParameterInterface;
 import com.aws.greengrass.testing.TestFeatureParameters;
@@ -51,6 +52,7 @@ import static com.aws.greengrass.telemetry.TelemetryAgent.DEFAULT_PERIODIC_PUBLI
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -149,8 +151,10 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
         assertNotNull(fleetStatusDetails);
         assertNotNull(fleetStatusDetails.get());
         assertEquals("ThingName", fleetStatusDetails.get().getThing());
-        assertEquals(MessageType.CADENCE, fleetStatusDetails.get().getMessageType());
+        assertEquals(Trigger.CADENCE, fleetStatusDetails.get().getTrigger());
+        assertEquals(MessageType.COMPLETE, fleetStatusDetails.get().getMessageType());
         assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.get().getOverallStatus());
+        assertNull(fleetStatusDetails.get().getChunkInfo());
         assertNotNull(fleetStatusDetails.get().getComponentStatusDetails());
         Set<String> allComponents =
                 kernel.orderedDependencies().stream().map(GreengrassService::getName).collect(Collectors.toSet());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -98,11 +98,12 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
             Object argument = i.getArgument(0);
             PublishRequest publishRequest = (PublishRequest) argument;
             try {
-                fleetStatusDetails.set(OBJECT_MAPPER.readValue(publishRequest.getPayload(),
-                        FleetStatusDetails.class));
-                if (mainServiceFinished.get() && kernel.orderedDependencies().size() == fleetStatusDetails.get()
-                        .getComponentStatusDetails().size() && fleetStatusDetails.get()
-                        .getTrigger() != Trigger.NUCLEUS_LAUNCH) {
+                FleetStatusDetails publishedFleetStatusDetails = OBJECT_MAPPER.readValue(publishRequest.getPayload(),
+                        FleetStatusDetails.class);
+                // Skip FSS message triggered at kernel launch
+                if (publishedFleetStatusDetails.getTrigger() != Trigger.NUCLEUS_LAUNCH
+                        && publishedFleetStatusDetails.getTrigger() != Trigger.NETWORK_RECONFIGURE) {
+                    fleetStatusDetails.set(publishedFleetStatusDetails);
                     allComponentsInFssPeriodicUpdate.countDown();
                 }
             } catch (JsonMappingException ignored) { }

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -286,7 +286,7 @@ public class IotJobsHelper implements InjectionActions {
             if (node != null && WhatHappened.childChanged.equals(what)
                     && deviceConfiguration.provisionInfoNodeChanged(node, this.isSubscribedToIotJobsTopics.get())) {
                 try {
-                    connectToIotJobs(deviceConfiguration);
+                    connectToIotJobs(deviceConfiguration, true);
                 } catch (DeviceConfigurationException e) {
                     logger.atWarn().kv("errorMessage", e.getMessage()).log(DEVICE_OFFLINE_MESSAGE);
                     return;
@@ -295,22 +295,22 @@ public class IotJobsHelper implements InjectionActions {
         });
 
         try {
-            connectToIotJobs(deviceConfiguration);
+            connectToIotJobs(deviceConfiguration, false);
         } catch (DeviceConfigurationException e) {
             logger.atWarn().kv("errorMessage", e.getMessage()).log(DEVICE_OFFLINE_MESSAGE);
             return;
         }
     }
 
-    private void connectToIotJobs(DeviceConfiguration deviceConfiguration)
+    private void connectToIotJobs(DeviceConfiguration deviceConfiguration, Boolean isConfigurationUpdate)
             throws DeviceConfigurationException {
 
         // Not using isDeviceConfiguredToTalkToCloud() in order to provide the detailed error message to user
         deviceConfiguration.validate();
-        setupCommWithIotJobs();
+        setupCommWithIotJobs(isConfigurationUpdate);
     }
 
-    private void setupCommWithIotJobs() {
+    private void setupCommWithIotJobs(Boolean isConfigurationUpdate) {
 
         if (subscriptionFuture != null && !subscriptionFuture.isDone()) {
             subscriptionFuture.cancel(true);
@@ -343,7 +343,7 @@ public class IotJobsHelper implements InjectionActions {
                 }
                 this.isSubscribedToIotJobsTopics.set(true);
                 deploymentStatusKeeper.publishPersistedStatusUpdates(DeploymentType.IOT_JOBS);
-                this.fleetStatusService.updateFleetStatusUpdateForAllComponents();
+                this.fleetStatusService.updateFleetStatusUpdateForAllComponents(isConfigurationUpdate);
             });
         }
     }

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -59,11 +59,11 @@ import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
-import static com.aws.greengrass.status.DeploymentInformation.ARN_FOR_STATUS_KEY;
-import static com.aws.greengrass.status.DeploymentInformation.STATUS_DETAILS_KEY;
-import static com.aws.greengrass.status.DeploymentInformation.STATUS_KEY;
-import static com.aws.greengrass.status.StatusDetails.DETAILED_STATUS_KEY;
-import static com.aws.greengrass.status.StatusDetails.FAILURE_CAUSE_KEY;
+import static com.aws.greengrass.status.model.DeploymentInformation.ARN_FOR_STATUS_KEY;
+import static com.aws.greengrass.status.model.DeploymentInformation.STATUS_DETAILS_KEY;
+import static com.aws.greengrass.status.model.DeploymentInformation.STATUS_KEY;
+import static com.aws.greengrass.status.model.StatusDetails.DETAILED_STATUS_KEY;
+import static com.aws.greengrass.status.model.StatusDetails.FAILURE_CAUSE_KEY;
 
 @NoArgsConstructor
 public class ShadowDeploymentListener implements InjectionActions {

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -505,7 +505,8 @@ public class FleetStatusService extends GreengrassService {
                 .build();
 
         publisher.publish(fleetStatusDetails, components);
-        logger.atInfo().event("fss-status-update-published").log("Status update published to FSS");
+        logger.atInfo().event("fss-status-update-published").kv("trigger", trigger)
+                .log("Status update published to FSS");
     }
 
     private Topic getSequenceNumberTopic() {

--- a/src/main/java/com/aws/greengrass/status/model/ChunkInfo.java
+++ b/src/main/java/com/aws/greengrass/status/model/ChunkInfo.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.status.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChunkInfo {
+    private int chunkId;
+    private int totalChunks;
+}

--- a/src/main/java/com/aws/greengrass/status/model/ComponentStatusDetails.java
+++ b/src/main/java/com/aws/greengrass/status/model/ComponentStatusDetails.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.status;
+package com.aws.greengrass.status.model;
 
 import com.aws.greengrass.dependency.State;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/aws/greengrass/status/model/DeploymentInformation.java
+++ b/src/main/java/com/aws/greengrass/status/model/DeploymentInformation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.status;
+package com.aws.greengrass.status.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/aws/greengrass/status/model/FleetStatusDetails.java
+++ b/src/main/java/com/aws/greengrass/status/model/FleetStatusDetails.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.status;
+package com.aws.greengrass.status.model;
 
 import com.aws.greengrass.util.Chunkable;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -37,6 +37,11 @@ public class FleetStatusDetails implements Chunkable<ComponentStatusDetails> {
 
     private MessageType messageType;
 
+    private Trigger trigger;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private ChunkInfo chunkInfo;
+
     @JsonProperty("components")
     private List<ComponentStatusDetails> componentStatusDetails;
 
@@ -46,5 +51,13 @@ public class FleetStatusDetails implements Chunkable<ComponentStatusDetails> {
     @Override
     public void setVariablePayload(List<ComponentStatusDetails> variablePayload) {
         this.setComponentStatusDetails(variablePayload);
+    }
+
+    @Override
+    public void setChunkInfo(int chunkId, int totalChunks) {
+        if (this.messageType == MessageType.COMPLETE && totalChunks > 1) {
+            // set chunk info only if it's a complete update and the message splits into multiple chunks
+            chunkInfo = new ChunkInfo(chunkId, totalChunks);
+        }
     }
 }

--- a/src/main/java/com/aws/greengrass/status/model/MessageType.java
+++ b/src/main/java/com/aws/greengrass/status/model/MessageType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.status.model;
+
+
+public enum MessageType {
+    COMPLETE,
+    PARTIAL;
+
+    /**
+     * Get MessageStatus from MessageType.
+     *
+     * @param trigger Trigger of FSS update
+     * @return whether it's a complete or partial FSS update
+     * @throws IllegalArgumentException invalid trigger
+     */
+    public static MessageType fromTrigger(Trigger trigger) {
+        switch (trigger) {
+            case LOCAL_DEPLOYMENT:
+            case THING_DEPLOYMENT:
+            case THING_GROUP_DEPLOYMENT:
+            case BROKEN_COMPONENT:
+            case RECONNECT:
+                return PARTIAL;
+            case CADENCE:
+            case NUCLEUS_LAUNCH:
+            case NETWORK_RECONFIGURE:
+                return COMPLETE;
+            default:
+                throw new IllegalArgumentException("Invalid trigger: " + trigger);
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/status/model/OverallStatus.java
+++ b/src/main/java/com/aws/greengrass/status/model/OverallStatus.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.status;
+package com.aws.greengrass.status.model;
 
 public enum OverallStatus {
     HEALTHY,

--- a/src/main/java/com/aws/greengrass/status/model/StatusDetails.java
+++ b/src/main/java/com/aws/greengrass/status/model/StatusDetails.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.status;
+package com.aws.greengrass.status.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/aws/greengrass/status/model/Trigger.java
+++ b/src/main/java/com/aws/greengrass/status/model/Trigger.java
@@ -3,26 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.status;
+package com.aws.greengrass.status.model;
 
 import com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 
-public enum MessageType {
+public enum Trigger {
     LOCAL_DEPLOYMENT,
     THING_DEPLOYMENT,
     THING_GROUP_DEPLOYMENT,
     BROKEN_COMPONENT,
+    // when mqtt connection resumes
     RECONNECT,
+    // when nucleus initially connects IoT Core, a complete FSS update is sent
+    NUCLEUS_LAUNCH,
+    // when nucleus device configs change, connection to IoT Core is reset and a complete FSS update is sent
+    NETWORK_RECONFIGURE,
+    // periodic FSS complete update
     CADENCE;
 
     /**
-     * Get MessageTypeEnum from DeploymentType.
+     * Get Trigger from DeploymentType.
      *
      * @param deploymentType deploymentType
-     * @return deployment message type
+     * @return deployment trigger
      * @throws IllegalArgumentException invalid deployment type
      */
-    public static MessageType fromDeploymentType(DeploymentType deploymentType) {
+    public static Trigger fromDeploymentType(DeploymentType deploymentType) {
         switch (deploymentType) {
             case LOCAL:
                 return LOCAL_DEPLOYMENT;

--- a/src/main/java/com/aws/greengrass/telemetry/MetricsPayload.java
+++ b/src/main/java/com/aws/greengrass/telemetry/MetricsPayload.java
@@ -29,4 +29,9 @@ public class MetricsPayload implements Chunkable<AggregatedNamespaceData> {
     public void setVariablePayload(List<AggregatedNamespaceData> variablePayload) {
         this.setAggregatedNamespaceData(variablePayload);
     }
+
+    @Override
+    public void setChunkInfo(int id, int totalChunks) {
+        //no-op
+    }
 }

--- a/src/main/java/com/aws/greengrass/util/Chunkable.java
+++ b/src/main/java/com/aws/greengrass/util/Chunkable.java
@@ -9,4 +9,7 @@ import java.util.List;
 
 public interface Chunkable<T> {
     void setVariablePayload(List<T> variablePayload);
+
+    void setChunkInfo(int id, int totalChunks);
+
 }

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -155,7 +155,7 @@ class IotJobsHelperTest {
         verify(mockIotJobsClientWrapper).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(mockIotJobsClientWrapper).SubscribeToDescribeJobExecutionAccepted(any(), any(), any());
         verify(mockIotJobsClientWrapper).SubscribeToDescribeJobExecutionRejected(any(), any(), any());
-        verify(mockFleetStatusService).updateFleetStatusUpdateForAllComponents();
+        verify(mockFleetStatusService).updateFleetStatusUpdateForAllComponents(false);
     }
 
     @Test
@@ -166,7 +166,7 @@ class IotJobsHelperTest {
         verify(mockIotJobsClientWrapper, times(0)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(0)).SubscribeToDescribeJobExecutionAccepted(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(0)).SubscribeToDescribeJobExecutionRejected(any(), any(), any());
-        verify(mockFleetStatusService, times(0)).updateFleetStatusUpdateForAllComponents();
+        verify(mockFleetStatusService, times(0)).updateFleetStatusUpdateForAllComponents(false);
     }
 
     @Test
@@ -182,7 +182,7 @@ class IotJobsHelperTest {
         verify(mockIotJobsClientWrapper, times(1)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(1)).SubscribeToDescribeJobExecutionAccepted(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(1)).SubscribeToDescribeJobExecutionRejected(any(), any(), any());
-        verify(mockFleetStatusService, times(1)).updateFleetStatusUpdateForAllComponents();
+        verify(mockFleetStatusService, times(1)).updateFleetStatusUpdateForAllComponents(true);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -20,6 +20,11 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
+import com.aws.greengrass.status.model.ComponentStatusDetails;
+import com.aws.greengrass.status.model.FleetStatusDetails;
+import com.aws.greengrass.status.model.MessageType;
+import com.aws.greengrass.status.model.OverallStatus;
+import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -219,6 +224,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(VERSION, fleetStatusDetails.getGgcVersion());
         assertEquals("testThing", fleetStatusDetails.getThing());
         assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+        assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
+        assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(JobStatus.SUCCEEDED.toString(), fleetStatusDetails.getDeploymentInformation().getStatus());
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL.toString(),
                 fleetStatusDetails.getDeploymentInformation().getStatusDetails().getDetailedStatus());
@@ -303,6 +311,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(VERSION, fleetStatusDetails.getGgcVersion());
         assertEquals("testThing", fleetStatusDetails.getThing());
         assertEquals(OverallStatus.UNHEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+        assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
+        assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(JobStatus.FAILED.toString(), fleetStatusDetails.getDeploymentInformation().getStatus());
         assertEquals(DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED.toString(),
                 fleetStatusDetails.getDeploymentInformation().getStatusDetails().getDetailedStatus());
@@ -429,6 +440,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(VERSION, fleetStatusDetails.getGgcVersion());
         assertEquals("testThing", fleetStatusDetails.getThing());
         assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(MessageType.COMPLETE, fleetStatusDetails.getMessageType());
+        assertEquals(Trigger.CADENCE, fleetStatusDetails.getTrigger());
+        assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(1, fleetStatusDetails.getComponentStatusDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentStatusDetails().get(0).getComponentName());
         assertNull(fleetStatusDetails.getComponentStatusDetails().get(0).getStatusDetails());
@@ -553,6 +567,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(VERSION, fleetStatusDetails.getGgcVersion());
         assertEquals("testThing", fleetStatusDetails.getThing());
         assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+        assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
+        assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(JobStatus.SUCCEEDED.toString(), fleetStatusDetails.getDeploymentInformation().getStatus());
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL.toString(),
                 fleetStatusDetails.getDeploymentInformation().getStatusDetails().getDetailedStatus());
@@ -615,6 +632,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(VERSION, fleetStatusDetails.getGgcVersion());
         assertEquals("testThing", fleetStatusDetails.getThing());
         assertEquals(OverallStatus.UNHEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+        assertEquals(Trigger.BROKEN_COMPONENT, fleetStatusDetails.getTrigger());
+        assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(1, fleetStatusDetails.getComponentStatusDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentStatusDetails().get(0).getComponentName());
         assertNull(fleetStatusDetails.getComponentStatusDetails().get(0).getStatusDetails());
@@ -731,6 +751,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             assertEquals("testThing", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
             assertEquals(2, fleetStatusDetails.getComponentStatusDetails().size());
+            assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+            assertEquals(Trigger.RECONNECT, fleetStatusDetails.getTrigger());
+            assertNull(fleetStatusDetails.getChunkInfo());
             for (ComponentStatusDetails componentStatusDetails : fleetStatusDetails.getComponentStatusDetails()) {
                 serviceNamesToCheck.remove(componentStatusDetails.getComponentName());
                 assertNull(componentStatusDetails.getStatusDetails());
@@ -796,6 +819,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(VERSION, fleetStatusDetails.getGgcVersion());
         assertEquals("testThing", fleetStatusDetails.getThing());
         assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(MessageType.COMPLETE, fleetStatusDetails.getMessageType());
+        assertEquals(Trigger.CADENCE, fleetStatusDetails.getTrigger());
+        assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(1, fleetStatusDetails.getComponentStatusDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentStatusDetails().get(0).getComponentName());
         assertNull(fleetStatusDetails.getComponentStatusDetails().get(0).getStatusDetails());
@@ -873,6 +899,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             assertEquals("testThing", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
             assertEquals(500, fleetStatusDetails.getComponentStatusDetails().size());
+            assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
+            assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
+            assertNull(fleetStatusDetails.getChunkInfo());
             for (ComponentStatusDetails componentStatusDetails : fleetStatusDetails.getComponentStatusDetails()) {
                 serviceNamesToCheck.remove(componentStatusDetails.getComponentName());
                 assertNull(componentStatusDetails.getStatusDetails());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Moved all model definitions in FSS to `com.aws.greengrass.status.model`
2. Added chunk info to `FleetStatusDetails`, which is non-null if and only if a FSS complete update message exceeds 128KB size limit 
3. Refactored previous enum `MessageType` into `Trigger` and replaced it with `COMPLETE` or `PARTIAL`
4. Updated tests.

**Why is this change necessary:**
To help service gain better visibility of events on device.
These changes are part of our ongoing improvements to FSS and device health notifications.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
Some tests in `EventFleetStatusServiceTest` were flaky because there were also cadence-based updates going on and tests misread periodic FSS messages as event-triggered FSS messages.

To fix them I added additional filtering of messages.

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
