### PR TITLE
feat: respect --start false when using --setup-system-service true

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -325,7 +325,7 @@ public class GreengrassSetup {
         if (setupSystemService) {
             kernel.getContext().get(KernelLifecycle.class).softShutdown(30);
             boolean ok = kernel.getContext().get(SystemServiceUtilsFactory.class).getInstance()
-                    .setupSystemService(kernel.getContext().get(KernelAlternatives.class));
+                    .setupSystemService(kernel.getContext().get(KernelAlternatives.class), kernelStart);
             if (ok) {
                 outStream.println("Successfully set up Nucleus as a system service");
                 // Nucleus will be launched by OS as a service

--- a/src/main/java/com/aws/greengrass/util/orchestration/InitUtils.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/InitUtils.java
@@ -13,7 +13,7 @@ public class InitUtils implements SystemServiceUtils {
     protected static final Logger logger = LogManager.getLogger(InitUtils.class);
 
     @Override
-    public boolean setupSystemService(KernelAlternatives kernelAlternatives) {
+    public boolean setupSystemService(KernelAlternatives kernelAlternatives, boolean start) {
         logger.atError().log("System service registration is not implemented for this device");
         return false;
     }

--- a/src/main/java/com/aws/greengrass/util/orchestration/ProcdUtils.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/ProcdUtils.java
@@ -30,7 +30,7 @@ public class ProcdUtils implements SystemServiceUtils {
     private static final String PROCD_SERVICE_TEMPLATE = "greengrass.service.procd.template";
 
     @Override
-    public boolean setupSystemService(KernelAlternatives kernelAlternatives) {
+    public boolean setupSystemService(KernelAlternatives kernelAlternatives, boolean start) {
         logger.atInfo(LOG_EVENT_NAME).log("Start procd setup");
         try {
             kernelAlternatives.setupInitLaunchDirIfAbsent();
@@ -56,7 +56,9 @@ public class ProcdUtils implements SystemServiceUtils {
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " reload", false);
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " stop", false);
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " enable", false);
-            SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " start", false);
+            if (start) {
+                SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,SERVICE_CONFIG_FILE_PATH + " start", false);
+            }
 
             logger.atInfo(LOG_EVENT_NAME).log("Successfully set up procd service");
             return true;

--- a/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtils.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtils.java
@@ -17,9 +17,10 @@ public interface SystemServiceUtils {
      * Setup Greengrass as a system service.
      *
      * @param kernelAlternatives KernelAlternatives instance which manages launch directory
+     * @param start Whether or not to start the service right away
      * @return true if setup is successful, false otherwise
      */
-    boolean setupSystemService(KernelAlternatives kernelAlternatives);
+    boolean setupSystemService(KernelAlternatives kernelAlternatives, boolean start);
 
     /**
      * Simply run a command with privileges.

--- a/src/main/java/com/aws/greengrass/util/orchestration/SystemdUtils.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/SystemdUtils.java
@@ -28,7 +28,7 @@ public class SystemdUtils implements SystemServiceUtils {
     private static final String SYSTEMD_SERVICE_TEMPLATE = "greengrass.service.template";
 
     @Override
-    public boolean setupSystemService(KernelAlternatives kernelAlternatives) {
+    public boolean setupSystemService(KernelAlternatives kernelAlternatives, boolean start) {
         logger.atDebug(LOG_EVENT_NAME).log("Start systemd setup");
         try {
             kernelAlternatives.setupInitLaunchDirIfAbsent();
@@ -49,7 +49,9 @@ public class SystemdUtils implements SystemServiceUtils {
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,"systemctl daemon-reload", false);
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,"systemctl unmask greengrass.service", false);
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,"systemctl stop greengrass.service", false);
-            SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,"systemctl start greengrass.service", false);
+            if (start) {
+                SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,"systemctl start greengrass.service", false);
+            }
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME,"systemctl enable greengrass.service", false);
 
             logger.atInfo(LOG_EVENT_NAME).log("Successfully set up systemd service");

--- a/src/main/java/com/aws/greengrass/util/orchestration/WinswUtils.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/WinswUtils.java
@@ -32,7 +32,7 @@ public class WinswUtils implements SystemServiceUtils {
     }
 
     @Override
-    public boolean setupSystemService(KernelAlternatives kernelAlternatives) {
+    public boolean setupSystemService(KernelAlternatives kernelAlternatives, boolean start) {
         logger.atDebug(LOG_EVENT_NAME).log("Start Windows service setup");
         try {
             kernelAlternatives.setupInitLaunchDirIfAbsent();
@@ -55,7 +55,9 @@ public class WinswUtils implements SystemServiceUtils {
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME, ggExe + " uninstall " + serviceConfig, true);
 
             SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME, ggExe + " install " + serviceConfig, false);
-            SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME, ggExe + " start " + serviceConfig, false);
+            if (start) {
+                SystemServiceUtils.runCommand(logger, LOG_EVENT_NAME, ggExe + " start " + serviceConfig, false);
+            }
 
             logger.atInfo(LOG_EVENT_NAME).log("Successfully set up Windows service");
             return true;


### PR DESCRIPTION
**Issue #, if available:**
#1239

**Description of changes:**
This change makes it so that if `--start false` is set with `--setup-system-service true` then the system service is only installed, but not enabled or started.

**Why is this change necessary:**
Current behavior is unintuitive and doesn't really match the help printout for setup which doesn't call out that `--start false` currently doesn't do anything if `--setup-system-service true` is set. I have a usecase where a system reboot happens right after installing greengrass so I want to avoid starting up greengrass until afterwards.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

As far as I can tell there weren't existing tests for easysetup, and I don't really have the expertise for creating those kinds of tests from scratch (esp. for handling other platforms). I did manually test the changes with systemd, but I don't easily have a way of testing the other platforms.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [x] Updated the README if applicable.

These changes should make the behavior more closely match what's already described in the help printout for easysetup.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Not sure if this is considered a breaking change. It does change the behavior of setup when both `--start false` and `--setup-system-service true` are set, but the old behavior doesn't match the documentation.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
