### PR TITLE
feat: add IPC interface and agent for publishing component metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.9.2-SNAPSHOT</version>
+            <version>1.9.2-Telemetry-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
@@ -157,7 +157,7 @@ class TelemetryAgentTest extends BaseITCase {
                 try {
                     MetricsPayload mp = new ObjectMapper().readValue(pr.getPayload(), MetricsPayload.class);
                     assertEquals(QualityOfService.AT_LEAST_ONCE, pr.getQos());
-                    assertEquals("2020-07-30", mp.getSchema());
+                    assertEquals("2022-06-30", mp.getSchema());
                     // enough to verify the first message of type MetricsPayload
                     telemetryMessageVerified = true;
                     break;

--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.ipc.modules.ComponentMetricIPCService.PUT_COMPONENT_METRIC_SERVICE_NAME;
 import static com.aws.greengrass.ipc.modules.LifecycleIPCService.LIFECYCLE_SERVICE_NAME;
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
 import static com.aws.greengrass.ipc.modules.PubSubIPCService.PUB_SUB_SERVICE_NAME;
@@ -47,6 +48,7 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.LIS
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PAUSE_COMPONENT;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_IOT_CORE;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUBLISH_TO_TOPIC;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.PUT_COMPONENT_METRIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.RESUME_COMPONENT;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_CERTIFICATE_UPDATES;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE;
@@ -130,6 +132,8 @@ public class AuthorizationHandler  {
                 STOP_COMPONENT, CREATE_LOCAL_DEPLOYMENT,
                 GET_LOCAL_DEPLOYMENT_STATUS, LIST_LOCAL_DEPLOYMENTS,
                 CREATE_DEBUG_PASSWORD, ANY_REGEX)));
+        componentToOperationsMap.put(PUT_COMPONENT_METRIC_SERVICE_NAME,
+                new HashSet<>(Arrays.asList(PUT_COMPONENT_METRIC, ANY_REGEX)));
 
         Map<String, List<AuthorizationPolicy>> componentNameToPolicies = policyParser.parseAllAuthorizationPolicies(
                 kernel);

--- a/src/main/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgent.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.builtin.services.telemetry;
+
+import com.aws.greengrass.authorization.AuthorizationHandler;
+import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.telemetry.impl.Metric;
+import com.aws.greengrass.telemetry.impl.MetricFactory;
+import com.aws.greengrass.telemetry.models.TelemetryAggregation;
+import com.aws.greengrass.telemetry.models.TelemetryUnit;
+import com.aws.greengrass.util.Utils;
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.commons.lang3.EnumUtils;
+import software.amazon.awssdk.aws.greengrass.GeneratedAbstractPutComponentMetricOperationHandler;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.PutComponentMetricRequest;
+import software.amazon.awssdk.aws.greengrass.model.PutComponentMetricResponse;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+
+import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static com.aws.greengrass.ipc.modules.ComponentMetricIPCService.PUT_COMPONENT_METRIC_SERVICE_NAME;
+
+public class ComponentMetricIPCEventStreamAgent {
+    private static final Logger logger = LogManager.getLogger(ComponentMetricIPCEventStreamAgent.class);
+    private static final Pattern SERVICE_NAME_REGEX = Pattern.compile("^aws\\.");
+    private static final String NON_ALPHANUMERIC_REGEX = "[^A-Za-z0-9]";
+    private static final String SERVICE_NAME = "ServiceName";
+
+    @Getter(AccessLevel.PACKAGE)
+    private final Map<String, MetricFactory> metricFactoryMap = new HashMap<>();
+    private final AuthorizationHandler authorizationHandler;
+
+    @Inject
+    ComponentMetricIPCEventStreamAgent(AuthorizationHandler authorizationHandler) {
+        this.authorizationHandler = authorizationHandler;
+    }
+
+    public PutComponentMetricOperationHandler getPutComponentMetricHandler(
+            OperationContinuationHandlerContext context) {
+        return new PutComponentMetricOperationHandler(context);
+    }
+
+    class PutComponentMetricOperationHandler extends GeneratedAbstractPutComponentMetricOperationHandler {
+        private final String serviceName;
+
+        protected PutComponentMetricOperationHandler(OperationContinuationHandlerContext context) {
+            super(context);
+            serviceName = context.getAuthenticationData().getIdentityLabel();
+        }
+
+        @Override
+        protected void onStreamClosed() {
+            // NA
+        }
+
+        @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.AvoidCatchingGenericException"})
+        @Override
+        public PutComponentMetricResponse handleRequest(PutComponentMetricRequest componentMetricRequest) {
+            return translateExceptions(() -> {
+                logger.atDebug().kv(SERVICE_NAME, serviceName)
+                        .log("Received putComponentMetricRequest from component " + serviceName);
+
+                // Authorize request for given operation
+                try {
+                    doAuthorization(this.getOperationModelContext().getOperationName(), serviceName);
+                } catch (AuthorizationException e) {
+                    logger.atError().kv(SERVICE_NAME, serviceName)
+                            .log("{} is not authorized to perform operation", serviceName);
+                    throw new UnauthorizedError(e.getMessage());
+                }
+
+                //validate - metric name length, value is non negative etc etc
+                List<software.amazon.awssdk.aws.greengrass.model.Metric> metricList =
+                        componentMetricRequest.getMetrics();
+                try {
+                    validateComponentMetricRequest(metricList);
+                } catch (IllegalArgumentException e) {
+                    logger.atError().kv(SERVICE_NAME, serviceName)
+                            .log("invalid component metric request from %s", serviceName);
+                    throw new InvalidArgumentsError(e.getMessage());
+                }
+
+                // Perform translations on metrics List
+                try {
+                    final String metricNamespace = serviceName;
+                    translateAndEmit(metricList, metricNamespace);
+                } catch (IllegalArgumentException e) {
+                    logger.atError().kv(SERVICE_NAME, serviceName)
+                            .log("invalid component metric request from %s", serviceName);
+                    throw new InvalidArgumentsError(e.getMessage());
+                } catch (Exception ex) {
+                    logger.atError().kv(SERVICE_NAME, serviceName)
+                            .log("error while emitting metrics from %s", serviceName);
+                    throw new ServiceError(ex.getMessage());
+                }
+
+                return new PutComponentMetricResponse();
+            });
+        }
+
+        @Override
+        public void handleStreamEvent(EventStreamJsonMessage streamRequestEvent) {
+            // NA
+        }
+
+        // Translate request metrics to telemetry metrics and emit them
+        private void translateAndEmit(List<software.amazon.awssdk.aws.greengrass.model.Metric> componentMetrics,
+                                      String metricNamespace) {
+            final MetricFactory metricFactory =
+                    metricFactoryMap.computeIfAbsent(metricNamespace, k -> new MetricFactory(metricNamespace));
+
+            componentMetrics.forEach(metric -> {
+                logger.atDebug().kv(SERVICE_NAME, serviceName)
+                        .log("Translating component metric to Telemetry metric" + metric.getName());
+                Metric telemetryMetric = getTelemetryMetric(metric, metricNamespace);
+                logger.atDebug().kv(SERVICE_NAME, serviceName)
+                        .log("Publish Telemetry metric" + telemetryMetric.getName());
+                metricFactory.putMetricData(telemetryMetric);
+            });
+        }
+    }
+
+
+    // Creates telemetry metric object for given request metric
+    private Metric getTelemetryMetric(software.amazon.awssdk.aws.greengrass.model.Metric metric,
+                                      String metricNamespace) {
+        return Metric.builder()
+                .namespace(metricNamespace)
+                .name(metric.getName())
+                .unit(valueOfIgnoreCase(metric.getUnitAsString()))
+                .aggregation(TelemetryAggregation.Sum)
+                .value(metric.getValue())
+                .timestamp(Instant.now().toEpochMilli())
+                .build();
+    }
+
+    // Translate unit from metric request to telemetry unit
+    private TelemetryUnit valueOfIgnoreCase(String unitAsString) {
+        if (unitAsString == null || unitAsString.isEmpty()) {
+            throw new IllegalArgumentException("Invalid telemetry unit: Found null or empty value");
+        }
+
+        final String replacedString = String.join("", unitAsString.split(NON_ALPHANUMERIC_REGEX));
+        TelemetryUnit telemetryEnum = EnumUtils.getEnumIgnoreCase(TelemetryUnit.class, replacedString);
+
+        if (telemetryEnum == null || telemetryEnum.toString().isEmpty()) {
+            throw new IllegalArgumentException("Invalid telemetry unit: No matching TelemetryUnit type found");
+        }
+        return telemetryEnum;
+    }
+
+    // Validate metric request
+    // Check name, unit and value arguments
+    private void validateComponentMetricRequest(List<software.amazon.awssdk.aws.greengrass.model.Metric> metrics) {
+        if (Utils.isEmpty(metrics)) {
+            throw new IllegalArgumentException(
+                    String.format("Null or Empty list of metrics found in PutComponentMetricRequest"));
+        }
+        for (software.amazon.awssdk.aws.greengrass.model.Metric metric : metrics) {
+            if (Utils.isEmpty(metric.getName()) || metric.getName().getBytes(StandardCharsets.UTF_8).length > 32
+                    || Utils.isEmpty(metric.getUnitAsString())  || metric.getValue() < 0) {
+                throw new IllegalArgumentException(
+                        String.format("Invalid argument found in PutComponentMetricRequest"));
+            }
+        }
+    }
+
+    // Validate if request is authorized for given operation
+    // Also validate if serviceName is of format "aws.*"
+    private void doAuthorization(String opName, String serviceName) throws AuthorizationException {
+        if (authorizationHandler.isAuthorized(PUT_COMPONENT_METRIC_SERVICE_NAME,
+                Permission.builder().operation(opName).principal(serviceName).resource("*").build())
+                && SERVICE_NAME_REGEX.matcher(serviceName).find()) {
+            return;
+        }
+        throw new AuthorizationException(String.format("Principal %s is not authorized to perform %s:%s ", serviceName,
+                PUT_COMPONENT_METRIC_SERVICE_NAME, opName));
+    }
+}

--- a/src/main/java/com/aws/greengrass/ipc/modules/ComponentMetricIPCService.java
+++ b/src/main/java/com/aws/greengrass/ipc/modules/ComponentMetricIPCService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.ipc.modules;
+
+import com.aws.greengrass.authorization.AuthorizationHandler;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.builtin.services.telemetry.ComponentMetricIPCEventStreamAgent;
+import com.aws.greengrass.dependency.InjectionActions;
+import com.aws.greengrass.ipc.Startable;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import javax.inject.Inject;
+
+public class ComponentMetricIPCService implements Startable, InjectionActions {
+    public static final String PUT_COMPONENT_METRIC_SERVICE_NAME = "aws.greengrass.ipc.componentmetric";
+    private static final Logger logger = LogManager.getLogger(ComponentMetricIPCService.class);
+    @Inject
+    private AuthorizationHandler authorizationHandler;
+
+    @Inject
+    private ComponentMetricIPCEventStreamAgent eventStreamAgent;
+
+    @Inject
+    private GreengrassCoreIPCService greengrassCoreIPCService;
+
+    @Override
+    public void postInject() {
+        List<String> opCodes = new ArrayList<>();
+        opCodes.add(GreengrassCoreIPCService.PUT_COMPONENT_METRIC);
+        try {
+            authorizationHandler.registerComponent(PUT_COMPONENT_METRIC_SERVICE_NAME, new HashSet<>(opCodes));
+        } catch (AuthorizationException e) {
+            logger.atError("initialize-put-component-metric-authorization-error", e)
+                    .log("Failed to initialize the Component Metric service with the Authorization module.");
+        }
+    }
+
+    @Override
+    public void startup() {
+        greengrassCoreIPCService.setPutComponentMetricHandler(
+                context -> eventStreamAgent.getPutComponentMetricHandler(context));
+    }
+}

--- a/src/main/java/com/aws/greengrass/telemetry/MetricsPayload.java
+++ b/src/main/java/com/aws/greengrass/telemetry/MetricsPayload.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class MetricsPayload implements Chunkable<AggregatedNamespaceData> {
     @JsonProperty("Schema")
     @Builder.Default
-    private String schema = "2020-07-30";
+    private String schema = "2022-06-30";
     @JsonProperty("ADP")
     private List<AggregatedNamespaceData> aggregatedNamespaceData;
 

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPutComponentMetricOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPutComponentMetricOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.PutComponentMetricRequest;
+import software.amazon.awssdk.aws.greengrass.model.PutComponentMetricResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractPutComponentMetricOperationHandler extends OperationContinuationHandler<PutComponentMetricRequest, PutComponentMetricResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractPutComponentMetricOperationHandler(
+          OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<PutComponentMetricRequest, PutComponentMetricResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+  ) {
+    return GreengrassCoreIPCServiceModel.getPutComponentMetricModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -32,6 +32,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String DELETE_THING_SHADOW = SERVICE_NAMESPACE + "#DeleteThingShadow";
 
+  public static final String PUT_COMPONENT_METRIC = SERVICE_NAMESPACE + "#PutComponentMetric";
+
   public static final String DEFER_COMPONENT_UPDATE = SERVICE_NAMESPACE + "#DeferComponentUpdate";
 
   public static final String SUBSCRIBE_TO_VALIDATE_CONFIGURATION_UPDATES = SERVICE_NAMESPACE + "#SubscribeToValidateConfigurationUpdates";
@@ -93,6 +95,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(PUBLISH_TO_IOT_CORE);
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_CONFIGURATION_UPDATE);
     SERVICE_OPERATION_SET.add(DELETE_THING_SHADOW);
+    SERVICE_OPERATION_SET.add(PUT_COMPONENT_METRIC);
     SERVICE_OPERATION_SET.add(DEFER_COMPONENT_UPDATE);
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_VALIDATE_CONFIGURATION_UPDATES);
     SERVICE_OPERATION_SET.add(GET_CONFIGURATION);
@@ -156,6 +159,11 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setDeleteThingShadowHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractDeleteThingShadowOperationHandler> handler) {
     operationSupplierMap.put(DELETE_THING_SHADOW, handler);
+  }
+
+  public void setPutComponentMetricHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractPutComponentMetricOperationHandler> handler) {
+    operationSupplierMap.put(PUT_COMPONENT_METRIC, handler);
   }
 
   public void setDeferComponentUpdateHandler(

--- a/src/test/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgentTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package com.aws.greengrass.builtin.services.telemetry;
+
+import com.aws.greengrass.authorization.AuthorizationHandler;
+import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.Metric;
+import software.amazon.awssdk.aws.greengrass.model.PutComponentMetricRequest;
+import software.amazon.awssdk.aws.greengrass.model.PutComponentMetricResponse;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
+import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+import static com.aws.greengrass.ipc.modules.ComponentMetricIPCService.PUT_COMPONENT_METRIC_SERVICE_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class ComponentMetricIPCEventStreamAgentTest {
+    private static final String VALID_TEST_COMPONENT = "aws.greengrass.testcomponent";
+    private static final String INVALID_TEST_COMPONENT = "testcomponent";
+    private static final Random RANDOM = new Random();
+
+    @Mock
+    OperationContinuationHandlerContext mockContext;
+    @Mock
+    AuthenticationData mockAuthenticationData;
+    @Mock
+    AuthorizationHandler authorizationHandler;
+    @Captor
+    ArgumentCaptor<Permission> permissionArgumentCaptor;
+
+    final ExecutorService pool = Executors.newCachedThreadPool();
+    private ComponentMetricIPCEventStreamAgent componentMetricIPCEventStreamAgent;
+    private PutComponentMetricRequest validComponentMetricRequest;
+
+    @BeforeEach
+    public void setup() {
+        validComponentMetricRequest = generateComponentRequest("BytesPerSecond");
+        lenient().when(mockContext.getContinuation()).thenReturn(mock(ServerConnectionContinuation.class));
+        lenient().when(mockContext.getAuthenticationData()).thenReturn(mockAuthenticationData);
+        componentMetricIPCEventStreamAgent = new ComponentMetricIPCEventStreamAgent(authorizationHandler);
+    }
+
+    @AfterEach
+    void afterEach() {
+        pool.shutdownNow();
+    }
+
+
+    @Test
+    void GIVEN_put_component_metric_request_with_valid_service_WHEN_handle_request_called_THEN_telemetry_metrics_published()
+            throws AuthorizationException {
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+        lenient().when(mockAuthenticationData.getIdentityLabel()).thenReturn(VALID_TEST_COMPONENT);
+
+        try (ComponentMetricIPCEventStreamAgent.PutComponentMetricOperationHandler putComponentMetricOperationHandler =
+                     componentMetricIPCEventStreamAgent.getPutComponentMetricHandler(
+                mockContext)) {
+            PutComponentMetricResponse putComponentMetricResponse =
+                    putComponentMetricOperationHandler.handleRequest(validComponentMetricRequest);
+            assertNotNull(putComponentMetricResponse);
+
+            verify(authorizationHandler).isAuthorized(eq(PUT_COMPONENT_METRIC_SERVICE_NAME),
+                    permissionArgumentCaptor.capture());
+            Permission capturedPermission = permissionArgumentCaptor.getValue();
+            assertThat(capturedPermission.getOperation(), is(GreengrassCoreIPCService.PUT_COMPONENT_METRIC));
+            assertThat(capturedPermission.getPrincipal(), is(VALID_TEST_COMPONENT));
+            assertThat(capturedPermission.getResource(), is("*"));
+        }
+    }
+
+    @Test
+    void GIVEN_put_component_metric_request_with_invalid_service_name_WHEN_handle_request_called_THEN_throw_exception()
+            throws Exception {
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+        lenient().when(mockAuthenticationData.getIdentityLabel()).thenReturn(INVALID_TEST_COMPONENT);
+        try (ComponentMetricIPCEventStreamAgent.PutComponentMetricOperationHandler putComponentMetricOperationHandler =
+                     componentMetricIPCEventStreamAgent.getPutComponentMetricHandler(
+                mockContext)) {
+            assertThrows(UnauthorizedError.class, () -> {
+                putComponentMetricOperationHandler.handleRequest(validComponentMetricRequest);
+            });
+        }
+    }
+
+    @Test
+    void GIVEN_put_component_metric_request_with_invalid_metric_unit_WHEN_handle_request_called_THEN_throw_exception()
+            throws Exception {
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+        lenient().when(mockAuthenticationData.getIdentityLabel()).thenReturn(VALID_TEST_COMPONENT);
+        PutComponentMetricRequest componentMetricRequest = generateComponentRequest("invalid-unit");
+        try (ComponentMetricIPCEventStreamAgent.PutComponentMetricOperationHandler putComponentMetricOperationHandler =
+                     componentMetricIPCEventStreamAgent.getPutComponentMetricHandler(
+                mockContext)) {
+            assertThrows(InvalidArgumentsError.class, () -> {
+                putComponentMetricOperationHandler.handleRequest(componentMetricRequest);
+            });
+        }
+    }
+
+    @Test
+    void GIVEN_put_component_metric_request_with_null_metric_unit_WHEN_handle_request_called_THEN_throw_exception()
+            throws Exception {
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+        lenient().when(mockAuthenticationData.getIdentityLabel()).thenReturn(VALID_TEST_COMPONENT);
+        PutComponentMetricRequest componentMetricRequest = generateComponentRequest("");
+        try (ComponentMetricIPCEventStreamAgent.PutComponentMetricOperationHandler putComponentMetricOperationHandler =
+                     componentMetricIPCEventStreamAgent.getPutComponentMetricHandler(
+                mockContext)) {
+            assertThrows(InvalidArgumentsError.class, () -> {
+                putComponentMetricOperationHandler.handleRequest(componentMetricRequest);
+            });
+        }
+    }
+
+    @Test
+    void GIVEN_put_component_metric_request_with_no_metrics_WHEN_handle_request_called_THEN_throw_exception()
+            throws Exception {
+        when(authorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+        lenient().when(mockAuthenticationData.getIdentityLabel()).thenReturn(VALID_TEST_COMPONENT);
+        PutComponentMetricRequest componentMetricRequest = new PutComponentMetricRequest();
+        try (ComponentMetricIPCEventStreamAgent.PutComponentMetricOperationHandler putComponentMetricOperationHandler =
+                     componentMetricIPCEventStreamAgent.getPutComponentMetricHandler(
+                mockContext)) {
+            assertThrows(InvalidArgumentsError.class, () -> {
+                putComponentMetricOperationHandler.handleRequest(componentMetricRequest);
+            });
+        }
+    }
+
+
+    private PutComponentMetricRequest generateComponentRequest(String unitType) {
+        PutComponentMetricRequest componentMetricRequest = new PutComponentMetricRequest();
+        List<Metric> metrics = new ArrayList<>();
+        IntStream.range(0, 4).forEach(i -> {
+            Metric metric = new Metric();
+            metric.setName("ExampleName");
+            metric.setUnit(unitType);
+            metric.setValue((double) RANDOM.nextInt(50));
+
+            metrics.add(metric);
+        });
+        componentMetricRequest.setMetrics(metrics);
+
+        return componentMetricRequest;
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add IPC operation handlers for publishing component metrics 
Edit Telemetry metrics payload schema

**Why is this change necessary:**
To allow 1P component to publish metrics

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
