### PR TITLE
fix: save deployment queue during nucleus shutdown; re-implement DeploymentQueue to handle de-duplication

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -150,7 +150,9 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                 if (m.getMessage().contains("Current deployment finished") && m.getContexts().get("DeploymentId").equals("deployNonDisruptable")) {
                     cdlDeployNonDisruptable.countDown();
                 }
-                if (m.getMessage().contains("Discarding device deployment") && m.getContexts().get("DEPLOYMENT_ID").equals("deployRedSignal")) {
+                if (m.getMessage().contains("New deployment replacing enqueued deployment")
+                        && m.getContexts().get("DeploymentId").equals("redeployNonDisruptable")
+                        && m.getContexts().get("DiscardedDeploymentId").equals("deployRedSignal")) {
                     cdlDeployRedSignal.countDown();
                 }
                 if (m.getMessage().contains("Current deployment finished") && m.getContexts().get("DeploymentId").equals("redeployNonDisruptable")) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 
 /**
@@ -93,11 +94,10 @@ public class DeploymentQueue {
         }
 
         // is the internal queue id already in use?
-        final String enqueuedDeploymentId = deploymentIdQueue.stream()
+        final Optional<String> enqueuedDeploymentId = deploymentIdQueue.stream()
                 .filter(enqueuedId -> enqueuedId.equals(offeredDeploymentInternalId))
-                .findAny()
-                .orElse(null);
-        if (enqueuedDeploymentId != null) {
+                .findAny();
+        if (enqueuedDeploymentId.isPresent()) {
             // internal queue id is already in use
             final Deployment enqueuedDeployment = deploymentMap.get(enqueuedDeploymentId);
             if (enqueuedDeployment == null) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
@@ -6,76 +6,162 @@
 package com.aws.greengrass.deployment;
 
 import com.aws.greengrass.deployment.model.Deployment;
-import com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 
-import java.util.Iterator;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 
+/**
+ * <p>DeploymentQueue is a thread-safe deployment queue that automatically de-duplicates by deployment id, and
+ * also de-duplicates shadow deployments, i.e. there can be at-most-one shadow deployment enqueued.</p>
+ *
+ * <p>DeploymentQueue is implemented internally as a deployment id queue, along with a map of id -> deployment.</p>
+ *
+ * <p>When an offered deployment has a unique deployment id, it is enqueued normally.</p>
+ *
+ * <p>When an offered deployment has the same deployment id as an already-enqueued element:
+ *     - if the offered deployment meets replacement criteria, then the enqueued element is replaced by the offered
+ *       element, preserving queue order.
+ *     - otherwise, the offered deployment is ignored.</p>
+ *
+ * <p>Replacement criteria are as follows:
+ *     - offered.getDeploymentStage().getPriority() > enqueued.getDeploymentStage().getPriority(), OR
+ *     - offered.isCancelled() == true, OR
+ *     - offered.getDeploymentType().equals(SHADOW)</p>
+ *
+ * <p>When an offered deployment is a shadow deployment:
+ *     - if there is already a shadow deployment in the queue, then replace it and preserve queue order.
+ *     - otherwise, enqueue normally.</p>
+ */
 public class DeploymentQueue {
 
+    /**
+     * For the internal queue, shadow deployments use a special queue id. Effectively, this means there can be at most
+     * one shadow deployment in the queue.
+     */
+    private static final String SHADOW_DEPLOYMENT_QUEUE_ID = Deployment.DeploymentType.SHADOW.name();
+
+    private static final String DEPLOYMENT_ID_LOG_KEY = "DeploymentId";
+    private static final String DISCARDED_DEPLOYMENT_ID_LOG_KEY = "DiscardedDeploymentId";
     private static final Logger logger = LogManager.getLogger(DeploymentQueue.class);
-    private final ConcurrentLinkedQueue<Deployment> deploymentsQueue = new ConcurrentLinkedQueue();
 
     /**
-     * Add a deployment to the queue.
-     *
-     * @param deployment deployment
+     * Internal queue of deployment id's. For shadow deployments, the internal queue id is not the same as the
+     * actual deployment id.
      */
-    public synchronized boolean offer(Deployment deployment) {
-        //For shadow deployment when desired state is reverted, it can result in scheduling a deployment which is
-        // same as
-        if (!DeploymentType.SHADOW.equals(deployment.getDeploymentType()) && deploymentsQueue.contains(deployment)) {
+    private final Queue<String> deploymentIdQueue = new LinkedList<>();
+
+    /**
+     * Map of internal queue id -> deployment instance.
+     */
+    private final Map<String, Deployment> deploymentMap = new HashMap<>();
+
+    /**
+     * <p>If the offered deployment id is unique, then insert the offered deployment at the tail of the queue.</p>
+     *
+     * <p>When an offered deployment has the same deployment id as an already-enqueued element:
+     *     - if the offered deployment meets replacement criteria, then the enqueued element is replaced by the offered
+     *       element, preserving queue order.
+     *     - otherwise, the offered deployment is ignored.</p>
+     *
+     * <p>Replacement criteria are as follows:
+     *     - offered.getDeploymentStage().getPriority() > enqueued.getDeploymentStage().getPriority(), OR
+     *     - offered.isCancelled() == true, OR
+     *     - offered.getDeploymentType().equals(SHADOW)</p>
+     *
+     * <p>When an offered deployment is a shadow deployment:
+     *     - if there is already a shadow deployment in the queue, then replace it and preserve queue order.
+     *     - otherwise, enqueue normally.</p>
+     *
+     * @param offeredDeployment the offered deployment instance.
+     * @return true if the queue was modified, otherwise false.
+     */
+    public synchronized boolean offer(Deployment offeredDeployment) {
+        if (offeredDeployment == null) {
             return false;
         }
-        return deploymentsQueue.offer(deployment);
-    }
-
-    /**
-     * Get the next deployment to be deployed.
-     *
-     * @return deployment
-     */
-    public synchronized Deployment peek() {
-        Deployment deployment = deploymentsQueue.peek();
-        // Discarding is not done at schedule time because the DeploymentService does not remove the deployments
-        // atomically DeploymentService first peeks and determine if the next deployment is actionable.
-        while (deployment != null && canDeploymentBeDiscarded(deployment)) {
-            logger.atInfo().kv("DEPLOYMENT_ID", deployment.getId())
-                    .kv("DEPLOYMENT_TYPE", deployment.getDeploymentType())
-                    .log("Discarding device deployment");
-            deploymentsQueue.remove();
-            deployment = deploymentsQueue.peek();
+        final String offeredDeploymentInternalId; // the id to employ in the internal queue
+        if (Deployment.DeploymentType.SHADOW.equals(offeredDeployment.getDeploymentType())) {
+            offeredDeploymentInternalId = SHADOW_DEPLOYMENT_QUEUE_ID;
+        } else {
+            offeredDeploymentInternalId = offeredDeployment.getId();
         }
-        return deployment;
-    }
 
-    /**
-     * Removed the deployment from the head of the queue.
-     */
-    public synchronized void remove() {
-        deploymentsQueue.remove();
-    }
-
-    public boolean isEmpty() {
-        return deploymentsQueue.isEmpty();
-    }
-
-    private boolean canDeploymentBeDiscarded(Deployment selectedDeployment) {
-        // If the selected deployment is of type shadow and there is another deployment in the queue
-        // the selected deployment can be discarded. ShadowDeploymentListener ensures that shadow deployments are
-        // queued based on the order in which they are created in the cloud.
-        if (DeploymentType.SHADOW.equals(selectedDeployment.getDeploymentType())) {
-            Iterator<Deployment> iterator = deploymentsQueue.iterator();
-            while (iterator.hasNext()) {
-                Deployment nextDeployment = iterator.next();
-                if (!selectedDeployment.equals(nextDeployment)
-                        && nextDeployment.getDeploymentType().equals(DeploymentType.SHADOW)) {
-                    return true;
-                }
+        // is the internal queue id already in use?
+        final String enqueuedDeploymentId = deploymentIdQueue.stream()
+                .filter(enqueuedId -> enqueuedId.equals(offeredDeploymentInternalId))
+                .findAny()
+                .orElse(null);
+        if (enqueuedDeploymentId != null) {
+            // internal queue id is already in use
+            final Deployment enqueuedDeployment = deploymentMap.get(enqueuedDeploymentId);
+            if (enqueuedDeployment == null) {
+                logger.atError().kv(DEPLOYMENT_ID_LOG_KEY, offeredDeployment.getId())
+                        .kv("InternalQueueId", offeredDeploymentInternalId)
+                        .log("Logic error: internal queue contains id with no corresponding deployment in map");
+                return false;
             }
+            // check the replacement criteria
+            if (Deployment.DeploymentType.SHADOW.equals(offeredDeployment.getDeploymentType())
+                    || offeredDeployment.isCancelled()
+                    || offeredDeployment.getDeploymentStage().getPriority()
+                    > enqueuedDeployment.getDeploymentStage().getPriority()) {
+                logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, offeredDeployment.getId())
+                        .kv(DISCARDED_DEPLOYMENT_ID_LOG_KEY,
+                                deploymentMap.get(enqueuedDeploymentId) == null ? null
+                                : deploymentMap.get(enqueuedDeploymentId).getId())
+                        .log("New deployment replacing enqueued deployment");
+                deploymentMap.put(enqueuedDeploymentId, offeredDeployment);
+                return true;
+            }
+            logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, offeredDeployment.getId())
+                    .log("New deployment ignored as duplicate");
+            return false;
         }
-        return false;
+
+        // internal queue id is not in use; enqueue deployment normally
+        deploymentIdQueue.add(offeredDeploymentInternalId);
+        deploymentMap.put(offeredDeploymentInternalId, offeredDeployment);
+        return true;
+    }
+
+    /**
+     * Retrieve and remove the deployment at the head of the queue, or return null if the queue is empty.
+     *
+     * @return the deployment retrieved from the head of the queue, or null if the queue is empty.
+     */
+    public synchronized Deployment poll() {
+        final String id = deploymentIdQueue.poll();
+        if (id == null) {
+            return null; // queue is empty
+        }
+        return deploymentMap.remove(id);
+    }
+
+    /**
+     * Return true if the queue contains no elements.
+     *
+     * @return true if the queue contains no elements, otherwise false.
+     */
+    public synchronized boolean isEmpty() {
+        return deploymentIdQueue.isEmpty();
+    }
+
+    /**
+     * Return the contents of the queue as a list of deployments.
+     *
+     * @return the contents of the queue as a list of deployments.
+     */
+    public synchronized List<Deployment> toArray() {
+        final List<Deployment> result = new ArrayList<>();
+        deploymentIdQueue.forEach(id -> {
+            result.add(deploymentMap.get(id));
+        });
+        return result;
     }
 }

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,11 +118,11 @@ public class DeploymentQueue {
      * @return the deployment retrieved from the head of the queue, or null if the queue is empty.
      */
     public synchronized Deployment poll() {
-        final String id = deploymentMap.keySet().iterator().next();
-        if (id == null) {
-            return null; // queue is empty
+        final Iterator<String> deploymentMapIterator = deploymentMap.keySet().iterator();
+        if (deploymentMapIterator.hasNext()) {
+            return deploymentMap.remove(deploymentMapIterator.next());
         }
-        return deploymentMap.remove(id);
+        return null; // queue is empty
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.deployment.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -22,7 +21,6 @@ import lombok.ToString;
 public class Deployment {
     @Setter
     private DeploymentDocument deploymentDocumentObj;
-    @JsonIgnore
     private String deploymentDocument;
     @EqualsAndHashCode.Include
     private DeploymentType deploymentType;
@@ -87,23 +85,38 @@ public class Deployment {
         /**
          * Deployment workflow is non-intrusive, i.e. not impacting kernel runtime
          */
-        DEFAULT,
+        DEFAULT(0),
 
         /**
          * Deployment goes over component bootstrap steps, which can be intrusive to kernel.
          */
-        BOOTSTRAP,
+        BOOTSTRAP(1),
 
         /**
          * Deployment has finished bootstrap steps and is in the middle of applying all changes to Kernel.
          */
-        KERNEL_ACTIVATION,
+        KERNEL_ACTIVATION(2),
 
         /**
          * Deployment tries to rollback to Kernel with previous configuration, after BOOTSTRAP or
          * KERNEL_ACTIVATION fails.
          */
-        KERNEL_ROLLBACK
+        KERNEL_ROLLBACK(3);
+
+        private int priority;
+
+        DeploymentStage(int priority) {
+            this.priority = priority;
+        }
+
+        /**
+         * Get the priority value associated with this deployment stage.
+         *
+         * @return the integer priority value associated with this deployment stage.
+         */
+        public int getPriority() {
+            return priority;
+        }
     }
 
 }

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
@@ -17,17 +17,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class DeploymentTaskMetadata {
     // TODO: [P41179644] clean up duplicate information
     @NonNull @Getter
+    private Deployment deployment;
+    @NonNull @Getter
     private DeploymentTask deploymentTask;
     @NonNull
     private Future<DeploymentResult> deploymentResultFuture;
     @NonNull @Getter
-    private String deploymentId;
-    @NonNull @Getter
-    private Deployment.DeploymentType deploymentType;
-    @NonNull @Getter
     private AtomicInteger deploymentAttemptCount;
-    @NonNull @Getter
-    private DeploymentDocument deploymentDocument;
     @NonNull @Getter
     private boolean cancellable;
 
@@ -39,6 +35,18 @@ public class DeploymentTaskMetadata {
     @Synchronized
     public Future<DeploymentResult> getDeploymentResultFuture() {
         return deploymentResultFuture;
+    }
+
+    public String getDeploymentId() {
+        return this.deployment.getId();
+    }
+
+    public Deployment.DeploymentType getDeploymentType() {
+        return this.deployment.getDeploymentType();
+    }
+
+    public DeploymentDocument getDeploymentDocument() {
+        return this.deployment.getDeploymentDocumentObj();
     }
 
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -463,9 +463,9 @@ public class KernelLifecycle {
      * @param timeoutSeconds Timeout in seconds
      */
     public void softShutdown(int timeoutSeconds) {
+        kernel.getContext().waitForPublishQueueToClear();
         logger.atDebug(SYSTEM_SHUTDOWN_EVENT).log("Start soft shutdown");
         stopAllServices(timeoutSeconds);
-        kernel.getContext().waitForPublishQueueToClear();
         logger.atDebug(SYSTEM_SHUTDOWN_EVENT).log("Closing transaction log");
         close(tlog);
         // Update effective config with our last known state

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class DeploymentQueueTest {
+    private static final DeploymentDocument TEST_DEPLOYMENT_DOCUMENT = new DeploymentDocument();
+    private static final String TEST_DEPLOYMENT_ID_1 = "deployment-1";
+    private static final String TEST_DEPLOYMENT_ID_2 = "deployment-2";
+    private static final String TEST_DEPLOYMENT_ID_3 = "deployment-3";
+
+    /**
+     * Default deployment with id=1
+     */
+    private final Deployment TEST_DEPLOYMENT_1 = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_1,
+            Deployment.DeploymentStage.DEFAULT);
+
+    /**
+     * Default deployment with id=2
+     */
+    private final Deployment TEST_DEPLOYMENT_2 = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_2,
+            Deployment.DeploymentStage.DEFAULT);
+
+    /**
+     * Default deployment with id=3
+     */
+    private final Deployment TEST_DEPLOYMENT_3 = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_3,
+            Deployment.DeploymentStage.DEFAULT);
+
+    /**
+     * Bootstrap deployment with id=1
+     */
+    private final Deployment TEST_DEPLOYMENT_1_BOOTSTRAP = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_1,
+            Deployment.DeploymentStage.BOOTSTRAP);
+
+    /**
+     * Bootstrap deployment with id=2
+     */
+    private final Deployment TEST_DEPLOYMENT_2_BOOTSTRAP = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_2,
+            Deployment.DeploymentStage.BOOTSTRAP);
+
+    /**
+     * Bootstrap deployment with id=3
+     */
+    private final Deployment TEST_DEPLOYMENT_3_BOOTSTRAP = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_3,
+            Deployment.DeploymentStage.BOOTSTRAP);
+
+    /**
+     * Cancelled deployment with id=1
+     */
+    private final Deployment TEST_DEPLOYMENT_1_CANCELLED = new Deployment(
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_1,
+            true);
+
+    /**
+     * Cancelled deployment with id=2
+     */
+    private final Deployment TEST_DEPLOYMENT_2_CANCELLED = new Deployment(
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_2,
+            true);
+
+    /**
+     * Cancelled deployment with id=3
+     */
+    private final Deployment TEST_DEPLOYMENT_3_CANCELLED = new Deployment(
+            Deployment.DeploymentType.LOCAL,
+            TEST_DEPLOYMENT_ID_3,
+            true);
+
+    /**
+     * Shadow deployment with id=1
+     */
+    private final Deployment TEST_DEPLOYMENT_1_SHADOW = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.SHADOW,
+            TEST_DEPLOYMENT_ID_1,
+            Deployment.DeploymentStage.DEFAULT);
+
+    /**
+     * Shadow deployment with id=2
+     */
+    private final Deployment TEST_DEPLOYMENT_2_SHADOW = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.SHADOW,
+            TEST_DEPLOYMENT_ID_2,
+            Deployment.DeploymentStage.DEFAULT);
+
+    /**
+     * Shadow deployment with id=3
+     */
+    private final Deployment TEST_DEPLOYMENT_3_SHADOW = new Deployment(
+            TEST_DEPLOYMENT_DOCUMENT,
+            Deployment.DeploymentType.SHADOW,
+            TEST_DEPLOYMENT_ID_3,
+            Deployment.DeploymentStage.DEFAULT);
+
+    private DeploymentQueue deploymentQueue;
+    private boolean result;
+    private Deployment pollResult;
+
+    @BeforeEach
+    void setup() {
+        deploymentQueue = new DeploymentQueue();
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_offer_deployments_THEN_queue_contains_deployments_in_fifo_order() {
+        assertThat(deploymentQueue.isEmpty(), is(true));
+        assertThat(deploymentQueue.toArray(), empty());
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_1);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.isEmpty(), is(false));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_1));
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_2);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.isEmpty(), is(false));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2));
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_3);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.isEmpty(), is(false));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_3));
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_remove_deployments_THEN_elements_removed_in_fifo_order() {
+        deploymentQueue.offer(TEST_DEPLOYMENT_1);
+        deploymentQueue.offer(TEST_DEPLOYMENT_2);
+        deploymentQueue.offer(TEST_DEPLOYMENT_3);
+        pollResult = deploymentQueue.poll();
+        assertThat(pollResult, is(TEST_DEPLOYMENT_1));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_3));
+        pollResult = deploymentQueue.poll();
+        assertThat(pollResult, is(TEST_DEPLOYMENT_2));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_3));
+        pollResult = deploymentQueue.poll();
+        assertThat(pollResult, is(TEST_DEPLOYMENT_3));
+        assertThat(deploymentQueue.isEmpty(), is(true));
+        assertThat(deploymentQueue.toArray(), empty());
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_offer_null_deployment_THEN_queue_is_not_modified() {
+        result = deploymentQueue.offer(null);
+        assertThat(result, is(false));
+        assertThat(deploymentQueue.toArray(), empty());
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_offer_duplicate_deployments_THEN_queue_is_not_modified() {
+        deploymentQueue.offer(TEST_DEPLOYMENT_1);
+        deploymentQueue.offer(TEST_DEPLOYMENT_2);
+        deploymentQueue.offer(TEST_DEPLOYMENT_3);
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_1);
+        assertThat(result, is(false));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_2);
+        assertThat(result, is(false));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_3);
+        assertThat(result, is(false));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_3));
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_offer_bootstrap_deployments_THEN_queue_replaces_default_deployments() {
+        deploymentQueue.offer(TEST_DEPLOYMENT_1);
+        deploymentQueue.offer(TEST_DEPLOYMENT_2);
+        deploymentQueue.offer(TEST_DEPLOYMENT_3);
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_1_BOOTSTRAP);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1_BOOTSTRAP, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_2_BOOTSTRAP);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1_BOOTSTRAP, TEST_DEPLOYMENT_2_BOOTSTRAP, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_3_BOOTSTRAP);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1_BOOTSTRAP, TEST_DEPLOYMENT_2_BOOTSTRAP, TEST_DEPLOYMENT_3_BOOTSTRAP));
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_offer_cancelled_deployments_THEN_queue_replaces_existing_deployments() {
+        deploymentQueue.offer(TEST_DEPLOYMENT_1);
+        deploymentQueue.offer(TEST_DEPLOYMENT_2_BOOTSTRAP);
+        deploymentQueue.offer(TEST_DEPLOYMENT_3);
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_1_CANCELLED);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_BOOTSTRAP, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_2_CANCELLED);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_CANCELLED, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_3_CANCELLED);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_CANCELLED, TEST_DEPLOYMENT_3_CANCELLED));
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_offer_shadow_deployments_THEN_at_most_one_shadow_deployment_enqueued() {
+        deploymentQueue.offer(TEST_DEPLOYMENT_1);
+        deploymentQueue.offer(TEST_DEPLOYMENT_2);
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_1_SHADOW);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_1_SHADOW));
+        deploymentQueue.offer(TEST_DEPLOYMENT_3);
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_1_SHADOW, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_1_SHADOW);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_1_SHADOW, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_2_SHADOW);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_2_SHADOW, TEST_DEPLOYMENT_3));
+
+        result = deploymentQueue.offer(TEST_DEPLOYMENT_3_SHADOW);
+        assertThat(result, is(true));
+        assertThat(deploymentQueue.toArray(),
+                contains(TEST_DEPLOYMENT_1, TEST_DEPLOYMENT_2, TEST_DEPLOYMENT_3_SHADOW, TEST_DEPLOYMENT_3));
+
+        deploymentQueue.poll();
+        deploymentQueue.poll();
+        pollResult = deploymentQueue.poll();
+        assertThat(pollResult, is(TEST_DEPLOYMENT_3_SHADOW));
+        assertThat(deploymentQueue.toArray(), contains(TEST_DEPLOYMENT_3));
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_modify_queue_concurrently_from_two_threads_THEN_queue_is_consistent()
+            throws InterruptedException {
+
+        // Offer 2000 unique elements concurrently with 2 threads
+        Consumer offerOneThousandDeployments = (threadName) -> {
+            for (int i = 0; i < 1000; i++) {
+                deploymentQueue.offer(new Deployment(
+                        TEST_DEPLOYMENT_DOCUMENT,
+                        Deployment.DeploymentType.LOCAL,
+                        "deployment-" + threadName + i,
+                        Deployment.DeploymentStage.DEFAULT));
+            }
+        };
+        Thread thread1 = new Thread(() -> {
+            offerOneThousandDeployments.accept("thread1");
+        });
+        Thread thread2 = new Thread(() -> {
+            offerOneThousandDeployments.accept("thread2");
+        });
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+        assertThat(deploymentQueue.toArray(), hasSize(2000));
+
+        // Remove 1998 elements concurrently with 2 threads
+        Runnable removeNineHundredNinetyNineDeployments = () -> {
+            for (int i = 0; i < 999; i++) {
+                deploymentQueue.poll();
+            }
+        };
+        thread1 = new Thread(removeNineHundredNinetyNineDeployments);
+        thread2 = new Thread(removeNineHundredNinetyNineDeployments);
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+        assertThat(deploymentQueue.toArray(), hasSize(2));
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class DeploymentQueueTest {
@@ -178,10 +179,10 @@ public class DeploymentQueueTest {
     }
 
     @Test
-    void GIVEN_deployment_queue_WHEN_offer_null_deployment_THEN_queue_is_not_modified() {
-        result = deploymentQueue.offer(null);
-        assertThat(result, is(false));
-        assertThat(deploymentQueue.toArray(), empty());
+    void GIVEN_deployment_queue_WHEN_offer_null_deployment_THEN_throw_exception() {
+        assertThrows(NullPointerException.class, () -> {
+            deploymentQueue.offer(null);
+        });
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
@@ -183,6 +184,14 @@ public class DeploymentQueueTest {
         assertThrows(NullPointerException.class, () -> {
             deploymentQueue.offer(null);
         });
+    }
+
+    @Test
+    void GIVEN_deployment_queue_WHEN_poll_empty_queue_THEN_get_null() {
+        assertThat(deploymentQueue.isEmpty(), is(true));
+        assertThat(deploymentQueue.toArray(), empty());
+        assertNull(deploymentQueue.poll());
+        assertNull(deploymentQueue.poll());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -56,6 +56,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_QUEUE_TOPIC;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_SERVICE_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
@@ -92,6 +93,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     private static final String EXPECTED_GROUP_NAME = "thinggroup/group1";
     private static final String EXPECTED_ROOT_PACKAGE_NAME = "component1";
     private static final String TEST_DEPLOYMENT_ID = "testDeploymentId";
+    private static final Duration TEST_DEPLOYMENT_POLLING_FREQUENCY = Duration.ofSeconds(1);
 
     private static final String TEST_CONFIGURATION_ARN =
             "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1";
@@ -138,8 +140,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         initializeMockedConfig();
 
         lenient().when(stateTopic.getOnce()).thenReturn(State.INSTALLED);
-        Topic pollingFrequency = Topic.of(context, DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS, 1L);
+        Topic pollingFrequency = Topic.of(context, DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS,
+                TEST_DEPLOYMENT_POLLING_FREQUENCY.getSeconds());
         when(deviceConfiguration.getDeploymentPollingFrequencySeconds()).thenReturn(pollingFrequency);
+        lenient().when(config.lookup(DEPLOYMENT_QUEUE_TOPIC)).thenReturn(Topic.of(context, DEPLOYMENT_QUEUE_TOPIC, null));
         when(context.get(IotJobsHelper.class)).thenReturn(iotJobsHelper);
         // Creating the class to be tested
         deploymentService = new DeploymentService(config, mockExecutorService, dependencyResolver, componentManager,
@@ -596,6 +600,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         startDeploymentServiceInAnotherThread();
 
         // Simulate a cancellation deployment
+        Thread.sleep(TEST_DEPLOYMENT_POLLING_FREQUENCY.toMillis()); // wait for previous deployment to be polled
         deploymentQueue.offer(new Deployment(Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1, true));
 
         // Expecting three invocations, once for each retry attempt
@@ -623,6 +628,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         startDeploymentServiceInAnotherThread();
 
         // Simulate a cancellation deployment
+        Thread.sleep(TEST_DEPLOYMENT_POLLING_FREQUENCY.toMillis()); // wait for previous deployment to be polled
         deploymentQueue.offer(new Deployment(Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1, true));
 
         // Expecting three invocations, once for each retry attempt

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -58,7 +58,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -352,10 +351,7 @@ class KernelTest {
         }
 
         DeploymentQueue deployments = kernel.getContext().get(DeploymentQueue.class);
-        assertNotNull(deployments.peek());
-        deployments.remove();
-        assertTrue(deployments.isEmpty());
-
+        assertThat(deployments.toArray(), hasSize(1));
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
@@ -388,7 +384,7 @@ class KernelTest {
         }
 
         DeploymentQueue deployments = kernel.getContext().get(DeploymentQueue.class);
-        assertNull(deployments.peek());
+        assertNull(deployments.poll());
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This PR does three things, primarily:

1) modify shutdown logic in KernelLifecycle so the config transaction log is not closed until after service shutdown

2) since the config transaction log is now available during shutdown, update DeploymentService so that the deployment queue is saved to the config during shutdown, and then loaded from the config during startup.

3) re-implement DeploymentService so it handles de-duplication of deployments in the queue.

**Why is this change necessary:**

Without 1 & 2, it is possible to "lose" deployments in the queue because of a kernel shutdown (queued local deployments, in general; or, queued cloud deployments that were received while online, but where the kernel restarts in an offline state).

3 avoids duplication of queued deployments which might be introduced by 2 in certain scenarios.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
