### PR TITLE
feat: PutComponentMetric access control policy validation

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.ipc.IPCEventStreamService;
 import com.aws.greengrass.ipc.Startable;
 import com.aws.greengrass.ipc.modules.AuthorizationService;
+import com.aws.greengrass.ipc.modules.ComponentMetricIPCService;
 import com.aws.greengrass.ipc.modules.ConfigStoreIPCService;
 import com.aws.greengrass.ipc.modules.LifecycleIPCService;
 import com.aws.greengrass.ipc.modules.MqttProxyIPCService;
@@ -107,7 +108,7 @@ public class KernelLifecycle {
     @Setter(AccessLevel.PACKAGE)
     private List<Class<? extends Startable>> startables = Arrays.asList(IPCEventStreamService.class,
             AuthorizationService.class, ConfigStoreIPCService.class, LifecycleIPCService.class,
-            PubSubIPCService.class, MqttProxyIPCService.class);
+            PubSubIPCService.class, MqttProxyIPCService.class, ComponentMetricIPCService.class);
     @Getter
     private ConfigurationWriter tlog;
     private GreengrassService mainService;

--- a/src/main/java/com/aws/greengrass/telemetry/MetricsAggregator.java
+++ b/src/main/java/com/aws/greengrass/telemetry/MetricsAggregator.java
@@ -72,10 +72,12 @@ public class MetricsAggregator {
             // Read from the Telemetry/namespace*.log file.
             // TODO: [P41214521] Read only those files that are modified after the last aggregation.
             // file.lastModified() behavior is platform dependent.
+            // filter only files with given namespace that end in ".log"
             try (Stream<Path> paths = Files
                     .walk(TelemetryConfig.getTelemetryDirectory())
                     .filter(Files::isRegularFile)
-                    .filter((path) -> Coerce.toString(path.getFileName()).startsWith(namespace))
+                    .filter((path) -> Coerce.toString(path.getFileName()).startsWith(namespace)
+                            && Coerce.toString(path.getFileName()).endsWith(".log"))
             ) {
                 paths.forEach(path -> {
                     try (Stream<String> logs = Files.lines(path)) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add resource validation to authorization checks in PutComponentMetric handler.
Add ComponentMetricIPCService to kernel lifecycle. 

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
