### PR TITLE
feat: allow Greengrass data endpoint to be configured

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
@@ -55,17 +55,22 @@ public final class ClientConfigurationUtils {
             logger.atError().setCause(e).log("Caught exception while parsing Nucleus args");
             throw new RuntimeException(e);
         }
+
         // Use customer configured GG endpoint if it is set
         String endpoint = Coerce.toString(deviceConfiguration.getGGDataEndpoint());
-        if (Utils.isEmpty(endpoint)) {
-            // Use customer configured IoT data endpoint if it is set
-            endpoint = Coerce.toString(deviceConfiguration.getIotDataEndpoint());
-        }
         int port = Coerce.toInt(deviceConfiguration.getGreengrassDataPlanePort());
         if (Utils.isEmpty(endpoint)) {
-            // Fallback to global endpoint if nothing was set before
+            // Fallback to global endpoint if no GG endpoint was specified
             return RegionUtils.getGreengrassDataPlaneEndpoint(Coerce.toString(deviceConfiguration.getAWSRegion()),
                     stage, port);
+        }
+
+        // If customer specifies "iotdata" then use the iotdata endpoint, rather than needing them to specify the same
+        // endpoint twice in the config.
+        String iotData = Coerce.toString(deviceConfiguration.getIotDataEndpoint());
+        if (endpoint.toLowerCase().contains("iotdata") && Utils.isNotEmpty(iotData)) {
+            // Use customer configured IoT data endpoint if it is set
+            endpoint = iotData;
         }
 
         // This method returns a URI, not just an endpoint

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -94,6 +94,7 @@ public class DeviceConfiguration {
     public static final String DEVICE_PARAM_THING_NAME = "thingName";
     public static final String DEVICE_PARAM_JVM_OPTIONS = "jvmOptions";
     public static final String JVM_OPTION_ROOT_PATH = "-Droot=";
+    public static final String DEVICE_PARAM_GG_DATA_ENDPOINT = "greengrassDataPlaneEndpoint";
     public static final String DEVICE_PARAM_IOT_DATA_ENDPOINT = "iotDataEndpoint";
     public static final String DEVICE_PARAM_IOT_CRED_ENDPOINT = "iotCredEndpoint";
     public static final String DEVICE_PARAM_PRIVATE_KEY_PATH = "privateKeyPath";
@@ -588,6 +589,10 @@ public class DeviceConfiguration {
 
     public Topic getInterpolateComponentConfiguration() {
         return getTopic(DEVICE_PARAM_INTERPOLATE_COMPONENT_CONFIGURATION).dflt(false);
+    }
+
+    public Topic getGGDataEndpoint() {
+        return getTopic(DEVICE_PARAM_GG_DATA_ENDPOINT).dflt("");
     }
 
     public Topic getIotDataEndpoint() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
