### PR TITLE
fix: do not recreate bootstrap manager on root path changes

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
@@ -145,6 +145,8 @@ public class KernelCommandLine {
 
         kernel.getConfig().lookup("system", "rootpath").dflt(rootAbsolutePath)
                 .subscribe((whatHappened, topic) -> initPaths(Coerce.toString(topic)));
+        bootstrapManager = new BootstrapManager(kernel);
+        kernel.getContext().put(BootstrapManager.class, bootstrapManager);
     }
 
     void updateDeviceConfiguration(DeviceConfiguration deviceConfiguration) {
@@ -196,9 +198,6 @@ public class KernelCommandLine {
         // GG_NEEDS_REVIEW (Hui): TODO: Add current kernel to local component store, if not exits.
         // Add symlinks for current Kernel alt, if not exits
         // Register Kernel Loader as system service (platform-specific), if not exits
-
-        bootstrapManager = new BootstrapManager(kernel);
-        kernel.getContext().put(BootstrapManager.class, bootstrapManager);
         kernel.getContext().get(KernelAlternatives.class);
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Do not recreate bootstrap manager on root path changes since it does not interact with root path.

**Why is this change necessary:**
If the loader script is running on a different root path from target config, bootstrap manager is created once when kernel parses arguments, and another time when kernel initializes config from target config that changes the root path. On the second time, bootstrap manager does not load from disk and the list of `BootstrapTaskStatus` is lost; kernel would consider all bootstrap steps finished, request restart, and stuck in an infinite restart loop.

Hence deployment with multiple bootstrap steps to a nucleus that runs loader script on a different path than desired root path would result in infinite restart loop.


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
Deployment to nucleus on Snap would run into this issue because loader script runs on a different directory.

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
