### PR TITLE
fix: accept only exactly iotdata rather than something containing

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
@@ -68,7 +68,7 @@ public final class ClientConfigurationUtils {
         // If customer specifies "iotdata" then use the iotdata endpoint, rather than needing them to specify the same
         // endpoint twice in the config.
         String iotData = Coerce.toString(deviceConfiguration.getIotDataEndpoint());
-        if (endpoint.toLowerCase().contains("iotdata") && Utils.isNotEmpty(iotData)) {
+        if (endpoint.equalsIgnoreCase("iotdata") && Utils.isNotEmpty(iotData)) {
             // Use customer configured IoT data endpoint if it is set
             endpoint = iotData;
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
