### PR TITLE
test: fix FSS periodic integration test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -101,8 +101,10 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
                 FleetStatusDetails publishedFleetStatusDetails = OBJECT_MAPPER.readValue(publishRequest.getPayload(),
                         FleetStatusDetails.class);
                 // Skip FSS message triggered at kernel launch
-                if (publishedFleetStatusDetails.getTrigger() != Trigger.NUCLEUS_LAUNCH
-                        && publishedFleetStatusDetails.getTrigger() != Trigger.NETWORK_RECONFIGURE) {
+                if (mainServiceFinished.get() && kernel.orderedDependencies().size() == publishedFleetStatusDetails
+                        .getComponentStatusDetails().size() && publishedFleetStatusDetails
+                        .getTrigger() != Trigger.NUCLEUS_LAUNCH && publishedFleetStatusDetails
+                        .getTrigger() != Trigger.NETWORK_RECONFIGURE) {
                     fleetStatusDetails.set(publishedFleetStatusDetails);
                     allComponentsInFssPeriodicUpdate.countDown();
                 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
FSS periodic integration test checks if all `GreengrassService` is in the periodic update message. Test is failing intermittently because sometimes an update is triggered and asserted before all services are started. Skipping periodic updates when main is not finished.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
