### PR TITLE
feat: do not send accumulated telemetry metrics for everything except GreengrassComponents

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelMetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelMetricsEmitter.java
@@ -24,7 +24,7 @@ import javax.inject.Inject;
 
 public class KernelMetricsEmitter extends PeriodicMetricsEmitter {
     public static final Logger logger = LogManager.getLogger(KernelMetricsEmitter.class);
-    private static final String NAMESPACE = "GreengrassComponents";
+    public static final String NAMESPACE = "GreengrassComponents";
     private final Kernel kernel;
     private final MetricFactory mf = new MetricFactory(NAMESPACE);
 

--- a/src/main/java/com/aws/greengrass/telemetry/AggregatedMetric.java
+++ b/src/main/java/com/aws/greengrass/telemetry/AggregatedMetric.java
@@ -24,6 +24,9 @@ import java.util.Map;
 public class AggregatedMetric {
     @JsonProperty("N")
     private String name;
+    // TODO: We do not need this to be a map. This map assumes that a metric can have multiple aggregation types and
+    //  values, which is incorrect. This can just be replaced by a String (for aggregation type)
+    //  and an Object (for value).
     private Map<String, Object> value = new HashMap<>();
     @JsonProperty("U")
     private TelemetryUnit unit;

--- a/src/main/java/com/aws/greengrass/telemetry/README.md
+++ b/src/main/java/com/aws/greengrass/telemetry/README.md
@@ -113,5 +113,5 @@ Publishing the aggregated metrics is performed based on the interval configured 
 - Read `AggregateMetrics.log` present in the Telemetry directory.
 - Publish only those metrics that are aggregated after the last publish and before the current time. This is essentially list of the above aggregated metrics.
 - There will be mn entries in this list where n is the number of namespaces and m is the number of times the aggregation is performed. Ideally, there will be 24n entries as metrics are aggregated 24 times in a day before the publish.
-- There is an additional point for each namespace which is the accumulation of these aggregated points. So, there will be 24n + n points at the time of publishing data once a day. 
-- The n metrics collected as the accumulation of the aggregated points have the same timestamp as publishing timestamp.
+- Only for `GreengrassComponents` namespace: There is an additional point for each namespace which is the accumulation of these aggregated points. So, there will be 24n + n points at the time of publishing data once a day.
+  - The n metrics collected as the accumulation of the aggregated points have the same timestamp as publishing timestamp.

--- a/src/test/java/com/aws/greengrass/telemetry/MetricsAggregatorTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/MetricsAggregatorTest.java
@@ -16,6 +16,7 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,10 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class MetricsAggregatorTest {
     private static final ObjectMapper mapper = new ObjectMapper();
-    private static final String gc = "GreengrassComponents";
-    private final MetricFactory mf = new MetricFactory(gc);
-    private final MetricFactory metricFactory = new MetricFactory(AGGREGATE_METRICS_FILE);
-    private final MetricsAggregator ma = new MetricsAggregator();
+    private static final String GREENGRASS_COMPONENTS_NS = "GreengrassComponents";
+    private static final String STREAM_MANAGER_NS = "aws.greengrass.StreamManager";
+    private final MetricFactory greengrassComponentsMetricsFactory = new MetricFactory(GREENGRASS_COMPONENTS_NS);
+    private final MetricFactory streamManagerMetricsFactory = new MetricFactory(STREAM_MANAGER_NS);
+    private final MetricFactory aggregatedMetricFactory = new MetricFactory(AGGREGATE_METRICS_FILE);
+    private final MetricsAggregator metricsAggregator = new MetricsAggregator();
     @TempDir
     protected Path tempRootDir;
 
@@ -59,41 +62,48 @@ class MetricsAggregatorTest {
     }
 
     @Test
-    void GIVEN_system_metrics_WHEN_aggregate_THEN_aggregate_only_the_latest_values()
+    void GIVEN_kernel_metrics_WHEN_aggregate_THEN_aggregate_only_the_latest_values()
             throws InterruptedException, IOException {
         //Create a sample file with system metrics so we can test the freshness of the file and logs
         //with respect to the current timestamp
         long lastAgg = Instant.now().toEpochMilli();
-        Metric m1 = new Metric(gc, "A", TelemetryUnit.Percent, TelemetryAggregation.Sum);
-        Metric m2 = new Metric(gc, "B", TelemetryUnit.Megabytes, TelemetryAggregation.Average);
-        Metric m3 = new Metric(gc, "C", TelemetryUnit.Count, TelemetryAggregation.Maximum);
-        mf.putMetricData(m1, 10);
-        mf.putMetricData(m2, 2000);
-        mf.putMetricData(m3, 4000);
-        mf.putMetricData(m1, 20);
-        mf.putMetricData(m2, 3000);
-        mf.putMetricData(m3, 5000);
-        mf.putMetricData(m1, 30);
-        mf.putMetricData(m2, 4000);
-        mf.putMetricData(m3, 6000);
+        Metric m1 = new Metric(GREENGRASS_COMPONENTS_NS, "A", TelemetryUnit.Percent, TelemetryAggregation.Sum);
+        Metric m2 = new Metric(GREENGRASS_COMPONENTS_NS, "B", TelemetryUnit.Megabytes, TelemetryAggregation.Average);
+        Metric m3 = new Metric(GREENGRASS_COMPONENTS_NS, "C", TelemetryUnit.Count, TelemetryAggregation.Maximum);
+        greengrassComponentsMetricsFactory.putMetricData(m1, 10);
+        greengrassComponentsMetricsFactory.putMetricData(m2, 2000);
+        greengrassComponentsMetricsFactory.putMetricData(m3, 4000);
+        greengrassComponentsMetricsFactory.putMetricData(m1, 20);
+        greengrassComponentsMetricsFactory.putMetricData(m2, 3000);
+        greengrassComponentsMetricsFactory.putMetricData(m3, 5000);
+        greengrassComponentsMetricsFactory.putMetricData(m1, 30);
+        greengrassComponentsMetricsFactory.putMetricData(m2, 4000);
+        greengrassComponentsMetricsFactory.putMetricData(m3, 6000);
         TimeUnit.MILLISECONDS.sleep(100);
         long currTimestamp = Instant.now().toEpochMilli();
-        ma.aggregateMetrics(lastAgg, currTimestamp);
+        metricsAggregator.aggregateMetrics(lastAgg, currTimestamp);
         Path path = TelemetryConfig.getTelemetryDirectory().resolve("AggregateMetrics.log");
-        List<String> list = Files.readAllLines(path);
-        assertEquals(1, list.size()); // Metrics are aggregated based on the namespace.
-        for (String s : list) {
-            AggregatedNamespaceData am = mapper.readValue(mapper.readTree(s).get("message").asText(),
+        List<String> aggregatedMetricLogs = Files.readAllLines(path);
+        assertEquals(1, aggregatedMetricLogs.size()); // Metrics are aggregated based on the namespace.
+        for (String aggregatedMetricLog : aggregatedMetricLogs) {
+            AggregatedNamespaceData am = mapper.readValue(mapper.readTree(aggregatedMetricLog).get("message").asText(),
                     AggregatedNamespaceData.class);
-            if (am.getNamespace().equals(gc)) {
+            if (am.getNamespace().equals(GREENGRASS_COMPONENTS_NS)) {
                 assertEquals(3, am.getMetrics().size()); // Three system metrics
                 for (AggregatedMetric metrics : am.getMetrics()) {
-                    if (metrics.getName().equals("A")) {
-                        assertEquals((double) 60, metrics.getValue().get("Sum"));
-                    } else if (metrics.getName().equals("B")) {
-                        assertEquals((double) 3000, metrics.getValue().get("Average"));
-                    } else if (metrics.getName().equals("C")) {
-                        assertEquals((double) 6000, metrics.getValue().get("Maximum"));
+                    switch (metrics.getName()) {
+                        case "A":
+                            assertEquals((double) 60, metrics.getValue().get("Sum"));
+                            break;
+                        case "B":
+                            assertEquals((double) 3000, metrics.getValue().get("Average"));
+                            break;
+                        case "C":
+                            assertEquals((double) 6000, metrics.getValue().get("Maximum"));
+                            break;
+                        default:
+                            Assertions.fail("Should not get any other metric name");
+                            break;
                     }
                 }
             }
@@ -102,14 +112,14 @@ class MetricsAggregatorTest {
         TimeUnit.SECONDS.sleep(1);
         currTimestamp = Instant.now().toEpochMilli();
         // Aggregate values within 1 second interval at this timestamp with 1
-        ma.aggregateMetrics(lastAgg, currTimestamp);
-        list = Files.readAllLines(path);
-        assertEquals(1, list.size()); // AggregateMetrics.log is appended
+        metricsAggregator.aggregateMetrics(lastAgg, currTimestamp);
+        aggregatedMetricLogs = Files.readAllLines(path);
+        assertEquals(1, aggregatedMetricLogs.size()); // AggregateMetrics.log is appended
         //with the latest aggregations.
-        for (String s : list) {
-            GreengrassLogMessage egLog = mapper.readValue(s, GreengrassLogMessage.class);
+        for (String aggregatedMetricLog : aggregatedMetricLogs) {
+            GreengrassLogMessage egLog = mapper.readValue(aggregatedMetricLog, GreengrassLogMessage.class);
             AggregatedNamespaceData am = mapper.readValue(egLog.getMessage(), AggregatedNamespaceData.class);
-            if (am.getTimestamp() == currTimestamp && am.getNamespace().equals(gc)) {
+            if (am.getTimestamp() == currTimestamp && am.getNamespace().equals(GREENGRASS_COMPONENTS_NS)) {
                 assertEquals(0, am.getMetrics().size()); // There is no aggregation as there are no latest values
             }
         }
@@ -122,26 +132,26 @@ class MetricsAggregatorTest {
         // with respect to the current timestamp
         ignoreExceptionOfType(exContext, MismatchedInputException.class);
         long lastAgg = Instant.now().toEpochMilli();
-        Metric m1 = new Metric(gc, "A", TelemetryUnit.Percent, TelemetryAggregation.Sum);
-        Metric m2 = new Metric(gc, "B", TelemetryUnit.Megabytes, TelemetryAggregation.Average);
+        Metric m1 = new Metric(GREENGRASS_COMPONENTS_NS, "A", TelemetryUnit.Percent, TelemetryAggregation.Sum);
+        Metric m2 = new Metric(GREENGRASS_COMPONENTS_NS, "B", TelemetryUnit.Megabytes, TelemetryAggregation.Average);
         // Put null data
-        mf.putMetricData(m1, null);
+        greengrassComponentsMetricsFactory.putMetricData(m1, null);
 
         // Put invalid data for average aggregation
-        mf.putMetricData(m2, "banana");
-        mf.putMetricData(m2, 2000);
+        greengrassComponentsMetricsFactory.putMetricData(m2, "banana");
+        greengrassComponentsMetricsFactory.putMetricData(m2, 2000);
         //put invalid metric
-        mf.logMetrics(new TelemetryLoggerMessage("alfredo"));
+        greengrassComponentsMetricsFactory.logMetrics(new TelemetryLoggerMessage("alfredo"));
         TimeUnit.MILLISECONDS.sleep(100);
         // Aggregate values within 1 second interval at this timestamp with 1
-        ma.aggregateMetrics(lastAgg, Instant.now().toEpochMilli());
+        metricsAggregator.aggregateMetrics(lastAgg, Instant.now().toEpochMilli());
         Path path = TelemetryConfig.getTelemetryDirectory().resolve("AggregateMetrics.log");
-        List<String> list = Files.readAllLines(path);
-        assertEquals(1, list.size()); // Metrics are aggregated based on the namespace.
-        for (String s : list) {
-            GreengrassLogMessage egLog = mapper.readValue(s, GreengrassLogMessage.class);
+        List<String> aggregatedMetricLogs = Files.readAllLines(path);
+        assertEquals(1, aggregatedMetricLogs.size()); // Metrics are aggregated based on the namespace.
+        for (String aggregatedMetricLog : aggregatedMetricLogs) {
+            GreengrassLogMessage egLog = mapper.readValue(aggregatedMetricLog, GreengrassLogMessage.class);
             AggregatedNamespaceData am = mapper.readValue(egLog.getMessage(), AggregatedNamespaceData.class);
-            if (am.getNamespace().equals(gc)) {
+            if (am.getNamespace().equals(GREENGRASS_COMPONENTS_NS)) {
                 assertEquals(2, am.getMetrics().size()); // Two system metrics, one of them is null
                 for (AggregatedMetric metrics : am.getMetrics()) {
                     if (metrics.getName().equals("A")) {
@@ -168,40 +178,40 @@ class MetricsAggregatorTest {
         metricList.add(new AggregatedMetric("A", map, TelemetryUnit.Percent));
         map.put("Average", 9000);
         metricList.add(new AggregatedMetric("B", map, TelemetryUnit.Megabytes));
-        AggregatedNamespaceData aggregatedMetric = new AggregatedNamespaceData(currentTimestamp, gc, metricList);
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        AggregatedNamespaceData aggregatedMetric = new AggregatedNamespaceData(currentTimestamp, GREENGRASS_COMPONENTS_NS, metricList);
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
         TimeUnit.MILLISECONDS.sleep(100);
         // Create an instance of the metrics uploader to get the aggregated metrics
-        Map<Long, List<AggregatedNamespaceData>> list = ma.getMetricsToPublish(lastPublish, currentTimestamp);
+        Map<Long, List<AggregatedNamespaceData>> aggregatedNamespaceDataMap = metricsAggregator.getMetricsToPublish(lastPublish, currentTimestamp);
 
         //We perform aggregation on the aggregated data points at the time of publish and get n additional metrics with
         // the current timestamp where n = no of namespaces. But here, we have empty aggregations. so they are not added
-        assertEquals(0, list.get(currentTimestamp).size());
+        assertEquals(0, aggregatedNamespaceDataMap.size());
         currentTimestamp = Instant.now().toEpochMilli();
-        list = ma.getMetricsToPublish(lastPublish, currentTimestamp);
+        aggregatedNamespaceDataMap = metricsAggregator.getMetricsToPublish(lastPublish, currentTimestamp);
         lastPublish = currentTimestamp;
         // we only have one list of the metrics collected
-        assertEquals(1, list.size());
+        assertEquals(1, aggregatedNamespaceDataMap.size());
 
         //we have 3 entries of the aggregated metrics before this latest TS + one metric for each namespace
-        assertEquals(3 + 1, list.get(currentTimestamp).size());
+        assertEquals(3 + 1, aggregatedNamespaceDataMap.get(currentTimestamp).size());
 
         TimeUnit.SECONDS.sleep(1);
         currentTimestamp = Instant.now().toEpochMilli();
-        aggregatedMetric = new AggregatedNamespaceData(currentTimestamp, gc, metricList);
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetric = new AggregatedNamespaceData(currentTimestamp, GREENGRASS_COMPONENTS_NS, metricList);
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
         TimeUnit.MILLISECONDS.sleep(100);
         currentTimestamp = Instant.now().toEpochMilli();
-        list = ma.getMetricsToPublish(lastPublish, currentTimestamp);
+        aggregatedNamespaceDataMap = metricsAggregator.getMetricsToPublish(lastPublish, currentTimestamp);
 
         // we only have one list of the metrics collected
-        assertEquals(1, list.size());
+        assertEquals(1, aggregatedNamespaceDataMap.size());
 
         // Will not collect the first 3 entries as they are stale. Latest 2 + n accumulated data point
-        assertEquals(2 + 1, list.get(currentTimestamp).size());
+        assertEquals(2 + 1, aggregatedNamespaceDataMap.get(currentTimestamp).size());
     }
 
     @Test
@@ -224,17 +234,17 @@ class MetricsAggregatorTest {
         map3.put("Average", 9000);
         am = new AggregatedMetric("B", map3, TelemetryUnit.Megabytes);
         metricList.add(am);
-        AggregatedNamespaceData aggregatedMetric = new AggregatedNamespaceData(currentTimestamp, gc, metricList);
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        AggregatedNamespaceData aggregatedMetric = new AggregatedNamespaceData(currentTimestamp, GREENGRASS_COMPONENTS_NS, metricList);
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
 
-        metricFactory.logMetrics(new TelemetryLoggerMessage("buffaloWildWings")); // will be ignored
-        metricFactory.logMetrics(new TelemetryLoggerMessage(null)); // will be ignored
-        metricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage("buffaloWildWings")); // will be ignored
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(null)); // will be ignored
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
         TimeUnit.MILLISECONDS.sleep(100);
         currentTimestamp = Instant.now().toEpochMilli();
-        Map<Long, List<AggregatedNamespaceData>> metricsMap = ma.getMetricsToPublish(lastPublish, currentTimestamp);
+        Map<Long, List<AggregatedNamespaceData>> metricsMap = metricsAggregator.getMetricsToPublish(lastPublish, currentTimestamp);
 
         // The published metrics will not contain the null aggregated metric
         assertFalse(metricsMap.get(currentTimestamp).contains(null));
@@ -247,10 +257,115 @@ class MetricsAggregatorTest {
         assertEquals(currentTimestamp, metricsMap.get(currentTimestamp)
                 .get(metricsMap.get(currentTimestamp).size()-1).getTimestamp());
         for (AggregatedNamespaceData amet : metricsMap.get(currentTimestamp)) {
-            if (amet.getNamespace().equals(gc)) {
+            if (amet.getNamespace().equals(GREENGRASS_COMPONENTS_NS)) {
                 // There are 3 metrics in GreengrassComponents namespace.
                 assertEquals(3, amet.getMetrics().size());
             }
         }
+    }
+
+    @Test
+    void GIVEN_stream_manager_metrics_WHEN_aggregate_THEN_aggregate_only_the_latest_values()
+            throws InterruptedException, IOException {
+        //Create a sample file with stream manager metrics so we can test the freshness of the file and logs
+        //with respect to the current timestamp
+        long lastAgg = Instant.now().toEpochMilli();
+        Metric m1 = new Metric(STREAM_MANAGER_NS, "BytesUploadedToS3", TelemetryUnit.Count, TelemetryAggregation.Sum);
+        Metric m2 = new Metric(STREAM_MANAGER_NS, "BytesUploadedToKinesis", TelemetryUnit.Count, TelemetryAggregation.Sum);
+        Metric m3 = new Metric(STREAM_MANAGER_NS, "BytesUploadedToIotAnalytics", TelemetryUnit.Count, TelemetryAggregation.Sum);
+        streamManagerMetricsFactory.putMetricData(m1, 10);
+        streamManagerMetricsFactory.putMetricData(m2, 2000);
+        streamManagerMetricsFactory.putMetricData(m3, 4000);
+        streamManagerMetricsFactory.putMetricData(m1, 20);
+        streamManagerMetricsFactory.putMetricData(m2, 3000);
+        streamManagerMetricsFactory.putMetricData(m3, 5000);
+        streamManagerMetricsFactory.putMetricData(m1, 30);
+        streamManagerMetricsFactory.putMetricData(m2, 4000);
+        streamManagerMetricsFactory.putMetricData(m3, 6000);
+        TimeUnit.MILLISECONDS.sleep(100);
+        long currTimestamp = Instant.now().toEpochMilli();
+
+        // Need to delete these files since during the unit tests, these get created. It does not happen when the component calls the API.
+        // This is a bug in the greengrass logger where it creates additional loggers on every dot (.)
+        Files.delete(TelemetryConfig.getTelemetryDirectory().resolve("aws.log"));
+        Files.delete(TelemetryConfig.getTelemetryDirectory().resolve("aws.greengrass.log"));
+        metricsAggregator.aggregateMetrics(lastAgg, currTimestamp);
+        Path path = TelemetryConfig.getTelemetryDirectory().resolve("AggregateMetrics.log");
+        List<String> aggregatedMetricLogs = Files.readAllLines(path);
+        assertEquals(1, aggregatedMetricLogs.size()); // Metrics are aggregated based on the namespace.
+        for (String aggregatedMetricLog : aggregatedMetricLogs) {
+            AggregatedNamespaceData am = mapper.readValue(mapper.readTree(aggregatedMetricLog).get("message").asText(),
+                                                          AggregatedNamespaceData.class);
+            if (am.getNamespace().equals(STREAM_MANAGER_NS)) {
+                assertEquals(3, am.getMetrics().size());
+                for (AggregatedMetric metrics : am.getMetrics()) {
+                    switch (metrics.getName()) {
+                        case "BytesUploadedToS3":
+                            assertEquals((double) 60, metrics.getValue().get("Sum"));
+                            break;
+                        case "BytesUploadedToKinesis":
+                            assertEquals((double) 9000, metrics.getValue().get("Sum"));
+                            break;
+                        case "BytesUploadedToIotAnalytics":
+                            assertEquals((double) 15000, metrics.getValue().get("Sum"));
+                            break;
+                        default:
+                            Assertions.fail("Should not get any other metric name");
+                            break;
+                    }
+                }
+            }
+        }
+        lastAgg = currTimestamp;
+        TimeUnit.SECONDS.sleep(1);
+        currTimestamp = Instant.now().toEpochMilli();
+        // Aggregate values within 1 second interval at this timestamp with 1
+        metricsAggregator.aggregateMetrics(lastAgg, currTimestamp);
+        aggregatedMetricLogs = Files.readAllLines(path);
+        assertEquals(1, aggregatedMetricLogs.size()); // AggregateMetrics.log is appended
+        //with the latest aggregations.
+        for (String aggregatedMetricLog : aggregatedMetricLogs) {
+            GreengrassLogMessage egLog = mapper.readValue(aggregatedMetricLog, GreengrassLogMessage.class);
+            AggregatedNamespaceData am = mapper.readValue(egLog.getMessage(), AggregatedNamespaceData.class);
+            if (am.getTimestamp() == currTimestamp && am.getNamespace().equals(STREAM_MANAGER_NS)) {
+                assertEquals(0, am.getMetrics().size()); // There is no aggregation as there are no latest values
+            }
+        }
+    }
+
+
+    @Test
+    void GIVEN_aggregated_metrics_for_stream_manager_WHEN_publish_THEN_does_not_send_accumulated_metric() throws InterruptedException {
+        //Create a sample file with aggregated metrics so we can test the freshness of the file and logs
+        // with respect to the current timestamp
+        long lastPublish = Instant.now().toEpochMilli();
+        long currentTimestamp = Instant.now().toEpochMilli();
+        List<AggregatedMetric> metricList = new ArrayList<>();
+        Map<String, Object> map = new HashMap<>();
+        map.put("Sum", 4000);
+        metricList.add(new AggregatedMetric("BytesUploadedToS3", map, TelemetryUnit.Count));
+        map.put("Sum", 15);
+        metricList.add(new AggregatedMetric("BytesUploadedToKinesis", map, TelemetryUnit.Count));
+        map.put("Sum", 9000);
+        metricList.add(new AggregatedMetric("BytesUploadedToIotAnalytics", map, TelemetryUnit.Count));
+        AggregatedNamespaceData aggregatedMetric = new AggregatedNamespaceData(currentTimestamp, STREAM_MANAGER_NS, metricList);
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        aggregatedMetricFactory.logMetrics(new TelemetryLoggerMessage(aggregatedMetric));
+        TimeUnit.MILLISECONDS.sleep(100);
+        // Create an instance of the metrics uploader to get the aggregated metrics
+        Map<Long, List<AggregatedNamespaceData>> aggregatedNamespaceDataMap = metricsAggregator.getMetricsToPublish(lastPublish, currentTimestamp);
+
+        //We perform aggregation on the aggregated data points at the time of publish and get n additional metrics with
+        // the current timestamp where n = no of namespaces. But here, we have empty aggregations. so they are not added
+        assertEquals(0, aggregatedNamespaceDataMap.size());
+        currentTimestamp = Instant.now().toEpochMilli();
+        aggregatedNamespaceDataMap = metricsAggregator.getMetricsToPublish(lastPublish, currentTimestamp);
+        lastPublish = currentTimestamp;
+        // we only have one list of the metrics collected
+        assertEquals(1, aggregatedNamespaceDataMap.size());
+
+        //we have 3 entries of the aggregated metrics before this latest TS
+        assertEquals(3, aggregatedNamespaceDataMap.get(currentTimestamp).size());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Currently, we send all aggregated telemetry data points for an entire day to the cloud along with an accumulated data point for the entire day for every namespace (except the `SystemMetrics` namespace).  We only have one other namespace being emitted from the nucleus which is `GreengrassComponents`. With this change, we will only send the accumulated data point for the `GreengrassComponents`.

**Why is this change necessary:**

There is no reason to send an accumulated data point for other namespaces which will be integrating with the `PutComponentMetric` IPC API. We should just send the 24 aggregated data points.

**How was this change tested:**
- [X] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [X] Updated the README if applicable.

**Compatibility Checklist:**
- [X] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
