### PR TITLE
feat: add a new API for getting the cert chain using security service

### DIFF
--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -188,10 +188,8 @@ public final class SecurityService {
             KeyPair keyPair = provider.getKeyPair(privateKeyUri, certificateUri);
             String[] aliases = x509KeyManager.getClientAliases(keyPair.getPublic().getAlgorithm(), null);
             if (aliases == null) {
-                logger.atError().kv(KEY_URI, privateKeyUri).kv(CERT_URI, certificateUri)
-                        .log("Unable to find aliases in the key manager.");
-                throw new CertificateChainLoadingException("Unable to get the certificate chain from the provider "
-                        + "using the key manager");
+                throw new CertificateChainLoadingException("Unable to find aliases in the key manager with the given "
+                        + "private key and certificate URIs");
             }
             for (String alias : aliases) {
                 if (x509KeyManager.getPrivateKey(alias).equals(keyPair.getPrivate())) {
@@ -199,9 +197,7 @@ public final class SecurityService {
                 }
             }
         }
-        logger.atError().kv(KEY_URI, privateKeyUri).kv(CERT_URI, certificateUri)
-                .log("Unable to get the certificate chain using private key and certificate URIs");
-        throw new CertificateChainLoadingException("Unable to get the certificate chain from the provider using the "
+        throw new CertificateChainLoadingException("Unable to get certificate chain from the provider using X509 "
                 + "key manager");
     }
 

--- a/src/main/java/com/aws/greengrass/security/exceptions/CertificateChainLoadingException.java
+++ b/src/main/java/com/aws/greengrass/security/exceptions/CertificateChainLoadingException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.security.exceptions;
+
+public class CertificateChainLoadingException extends Exception {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public CertificateChainLoadingException(String message) {
+        super(message);
+    }
+
+    public CertificateChainLoadingException(String message, Throwable e) {
+        super(message, e);
+    }
+}
+

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -378,7 +378,7 @@ class SecurityServiceTest {
     }
 
     @Test
-    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_multipleKeyManagers_THEN_return_emptyCertChain()
+    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_multipleKeyManagers_THEN_throw_exception()
             throws Exception {
         URI keyUri = new URI("pkcs11:object=key-label");
         URI certificateUri = new URI("file:///path/to/certificate");
@@ -386,12 +386,13 @@ class SecurityServiceTest {
         when(mockKeyProvider.getKeyManagers(keyUri, certificateUri)).thenReturn(mockKeyManagers);
         when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
         service.registerCryptoKeyProvider(mockKeyProvider);
-        X509Certificate[] certs = service.getCertificateChain(keyUri, certificateUri);
-        assertEquals(certs.length,0);
+        assertThrows(Exception.class, ()->{
+            service.getCertificateChain(keyUri, certificateUri);
+        });
     }
 
     @Test
-    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_noMatchingAlias_THEN_return_emptyCertChain()
+    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_noMatchingAlias_THEN_throw_exception()
             throws Exception {
         URI keyUri = new URI("pkcs11:object=key-label");
         URI certificateUri = new URI("file:///path/to/certificate");
@@ -408,12 +409,13 @@ class SecurityServiceTest {
         when(x509KeyManager.getClientAliases(any(), any())).thenReturn(aliases);
 
         service.registerCryptoKeyProvider(mockKeyProvider);
-        X509Certificate[] certs = service.getCertificateChain(keyUri, certificateUri);
-        assertEquals(certs.length, 0);
+        assertThrows(Exception.class, ()->{
+            service.getCertificateChain(keyUri, certificateUri);
+        });
     }
 
     @Test
-    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_noAliases_THEN_return_emptyCertChain()
+    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_noAliases_THEN_throw_exception()
             throws Exception {
         URI keyUri = new URI("pkcs11:object=key-label");
         URI certificateUri = new URI("file:///path/to/certificate");
@@ -425,7 +427,8 @@ class SecurityServiceTest {
         when(mockKeyPair.getPublic()).thenReturn(mock(PublicKey.class));
         when(((X509KeyManager) mockKeyManagers[0]).getClientAliases(any(), any())).thenReturn(null);
         service.registerCryptoKeyProvider(mockKeyProvider);
-        X509Certificate[] certs = service.getCertificateChain(keyUri, certificateUri);
-        assertEquals(certs.length, 0);
+        assertThrows(Exception.class, ()->{
+            service.getCertificateChain(keyUri, certificateUri);
+        });
     }
 }

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -8,10 +8,7 @@ package com.aws.greengrass.security;
 import com.aws.greengrass.config.CaseInsensitiveString;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.deployment.DeviceConfiguration;
-import com.aws.greengrass.security.exceptions.KeyLoadingException;
-import com.aws.greengrass.security.exceptions.MqttConnectionProviderException;
-import com.aws.greengrass.security.exceptions.ServiceProviderConflictException;
-import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
+import com.aws.greengrass.security.exceptions.*;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.EncryptionUtilsTest;
 import org.hamcrest.collection.IsMapContaining;
@@ -386,7 +383,7 @@ class SecurityServiceTest {
         when(mockKeyProvider.getKeyManagers(keyUri, certificateUri)).thenReturn(mockKeyManagers);
         when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
         service.registerCryptoKeyProvider(mockKeyProvider);
-        assertThrows(Exception.class, ()->{
+        assertThrows(CertificateChainLoadingException.class, ()->{
             service.getCertificateChain(keyUri, certificateUri);
         });
     }
@@ -409,7 +406,7 @@ class SecurityServiceTest {
         when(x509KeyManager.getClientAliases(any(), any())).thenReturn(aliases);
 
         service.registerCryptoKeyProvider(mockKeyProvider);
-        assertThrows(Exception.class, ()->{
+        assertThrows(CertificateChainLoadingException.class, ()->{
             service.getCertificateChain(keyUri, certificateUri);
         });
     }
@@ -427,7 +424,7 @@ class SecurityServiceTest {
         when(mockKeyPair.getPublic()).thenReturn(mock(PublicKey.class));
         when(((X509KeyManager) mockKeyManagers[0]).getClientAliases(any(), any())).thenReturn(null);
         service.registerCryptoKeyProvider(mockKeyProvider);
-        assertThrows(Exception.class, ()->{
+        assertThrows(CertificateChainLoadingException.class, ()->{
             service.getCertificateChain(keyUri, certificateUri);
         });
     }

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -29,6 +29,10 @@ import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.X509KeyManager;
 
@@ -37,7 +41,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -344,5 +350,82 @@ class SecurityServiceTest {
                 new URI("file:///path/to/key"), new URI("file:///path/to/cert"))) {
             assertThat(builder, IsNull.notNullValue());
         }
+    }
+
+    @Test
+    void GIVEN_key_and_cert_uri_WHEN_get_cert_chain_THEN_return_cert_chain()
+            throws Exception {
+        URI keyUri = new URI("pkcs11:object=key-label");
+        URI certificateUri = new URI("file:///path/to/certificate");
+        KeyManager[] mockKeyManagers = {mock(X509KeyManager.class)};
+        X509KeyManager x509KeyManager = (X509KeyManager) mockKeyManagers[0];
+        KeyPair mockKeyPair = mock(KeyPair.class);
+        String[] aliases = {"test"};
+        PrivateKey mockPrivateKey = mock(PrivateKey.class);
+        X509Certificate[] x509Certificates = new X509Certificate[1];
+        when(mockKeyProvider.getKeyManagers(keyUri, certificateUri)).thenReturn(mockKeyManagers);
+        when(mockKeyProvider.getKeyPair(keyUri, certificateUri)).thenReturn(mockKeyPair);
+        when(mockKeyPair.getPublic()).thenReturn(mock(PublicKey.class));
+        when(mockKeyPair.getPrivate()).thenReturn(mockPrivateKey);
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
+        when(x509KeyManager.getClientAliases(any(), any())).thenReturn(aliases);
+        when(x509KeyManager.getPrivateKey(aliases[0])).thenReturn(mockPrivateKey);
+        when(x509KeyManager.getCertificateChain("test")).thenReturn(x509Certificates);
+
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        X509Certificate[] certs = service.getCertificateChain(keyUri, certificateUri);
+        assertEquals(certs, x509Certificates);
+    }
+
+    @Test
+    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_multipleKeyManagers_THEN_return_emptyCertChain()
+            throws Exception {
+        URI keyUri = new URI("pkcs11:object=key-label");
+        URI certificateUri = new URI("file:///path/to/certificate");
+        KeyManager[] mockKeyManagers = {mock(X509KeyManager.class), mock(X509KeyManager.class)};
+        when(mockKeyProvider.getKeyManagers(keyUri, certificateUri)).thenReturn(mockKeyManagers);
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        X509Certificate[] certs = service.getCertificateChain(keyUri, certificateUri);
+        assertEquals(certs.length,0);
+    }
+
+    @Test
+    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_noMatchingAlias_THEN_return_emptyCertChain()
+            throws Exception {
+        URI keyUri = new URI("pkcs11:object=key-label");
+        URI certificateUri = new URI("file:///path/to/certificate");
+        KeyManager[] mockKeyManagers = {mock(X509KeyManager.class)};
+        X509KeyManager x509KeyManager = (X509KeyManager) mockKeyManagers[0];
+        KeyPair mockKeyPair = mock(KeyPair.class);
+        String[] aliases = {"test"};
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
+        when(mockKeyProvider.getKeyManagers(keyUri, certificateUri)).thenReturn(mockKeyManagers);
+        when(mockKeyProvider.getKeyPair(keyUri, certificateUri)).thenReturn(mockKeyPair);
+        when(mockKeyPair.getPublic()).thenReturn(mock(PublicKey.class));
+        when(mockKeyPair.getPrivate()).thenReturn(mock(PrivateKey.class));
+        when(x509KeyManager.getPrivateKey(aliases[0])).thenReturn(mock(PrivateKey.class));
+        when(x509KeyManager.getClientAliases(any(), any())).thenReturn(aliases);
+
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        X509Certificate[] certs = service.getCertificateChain(keyUri, certificateUri);
+        assertEquals(certs.length, 0);
+    }
+
+    @Test
+    void GIVEN_key_and_cert_uri_WHEN_getCertificateChain_noAliases_THEN_return_emptyCertChain()
+            throws Exception {
+        URI keyUri = new URI("pkcs11:object=key-label");
+        URI certificateUri = new URI("file:///path/to/certificate");
+        KeyManager[] mockKeyManagers = {mock(X509KeyManager.class)};
+        KeyPair mockKeyPair = mock(KeyPair.class);
+        when(mockKeyProvider.getKeyManagers(keyUri, certificateUri)).thenReturn(mockKeyManagers);
+        when(mockKeyProvider.getKeyPair(keyUri, certificateUri)).thenReturn(mockKeyPair);
+        when(mockKeyProvider.supportedKeyType()).thenReturn("PKCS11");
+        when(mockKeyPair.getPublic()).thenReturn(mock(PublicKey.class));
+        when(((X509KeyManager) mockKeyManagers[0]).getClientAliases(any(), any())).thenReturn(null);
+        service.registerCryptoKeyProvider(mockKeyProvider);
+        X509Certificate[] certs = service.getCertificateChain(keyUri, certificateUri);
+        assertEquals(certs.length, 0);
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- CryptoKey provider interface is updated with the addition of a new API for getting the certificate chain. 
- Adds a new API in SecurityService to get certificate chain using private key and certificate URIs by using the newly updated interface. However, this change is also compatible with older implementations of the providers as certificate chain is obtained by using key manager from the existing APIs. 

**Why is this change necessary:**
- This change is needed for enabling BYOCA feature where customers can provide private key and cert of the CA through file system or HSM. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
