### PR TITLE
fix: remove duplicate fss messages at nucleus launch

### DIFF
--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -327,6 +327,7 @@ public class FleetStatusService extends GreengrassService {
     public void updateFleetStatusUpdateForAllComponents(Boolean isConfigurationUpdate) {
         if (isConfigurationUpdate) {
             updateFleetStatusUpdateForAllComponents(Trigger.NETWORK_RECONFIGURE);
+            return;
         }
         updateFleetStatusUpdateForAllComponents(Trigger.NUCLEUS_LAUNCH);
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removing  duplicate fss messages at nucleus launch

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
