### PR TITLE
fix: add nullcheck when discarding action in UpdateSystemPolicyService

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/UpdateSystemPolicyService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/UpdateSystemPolicyService.java
@@ -119,7 +119,7 @@ public class UpdateSystemPolicyService extends GreengrassService {
         if (pendingUpdateAction != null) {
             // Signal components that they can resume their work since the update is not going to happen
             lifecycleIPCAgent.sendPostComponentUpdateEvent(
-                    new PostComponentUpdateEvent().withDeploymentId(pendingActions.get(tag).getDeploymentId()));
+                    new PostComponentUpdateEvent().withDeploymentId(pendingUpdateAction.getDeploymentId()));
             pendingActions.remove(tag);
         }
         return true;

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/UpdateSystemPolicyService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/UpdateSystemPolicyService.java
@@ -115,10 +115,13 @@ public class UpdateSystemPolicyService extends GreengrassService {
         if (tag.equals(actionInProgress.get())) {
             return false;
         }
-        // Signal components that they can resume their work since the update is not going to happen
-        lifecycleIPCAgent.sendPostComponentUpdateEvent(
-                new PostComponentUpdateEvent().withDeploymentId(pendingActions.get(tag).getDeploymentId()));
-        pendingActions.remove(tag);
+        final UpdateAction pendingUpdateAction = pendingActions.get(tag);
+        if (pendingUpdateAction != null) {
+            // Signal components that they can resume their work since the update is not going to happen
+            lifecycleIPCAgent.sendPostComponentUpdateEvent(
+                    new PostComponentUpdateEvent().withDeploymentId(pendingActions.get(tag).getDeploymentId()));
+            pendingActions.remove(tag);
+        }
         return true;
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Add nullcheck in UpdateSystemPolicyService.discardPendingUpdateAction(...) when using the result of pendingActions.get(...).

**Why is this change necessary:**

Without this change, cancellation deployments can fail, in certain scenarios, due to an internal NullPointerException.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
