### PR TITLE
fix: do not wait for mqtt client disconnect on context shutdown

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -792,7 +792,7 @@ public class MqttClient implements Closeable {
             spoolingFuture.get().cancel(true);
         }
 
-        connections.forEach(AwsIotMqttClient::close);
+        connections.forEach(AwsIotMqttClient::closeOnShutdown);
         if (proxyTlsOptions != null) {
             proxyTlsOptions.close();
         }

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -232,7 +232,7 @@ class MqttClientTest {
         }
 
         client.close();
-        verify(iClient1).close();
+        verify(iClient1).closeOnShutdown();
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
During context shutdown and Mqtt client closing, do not wait for `AwsIotMqttClient::disconnect`.

**Why is this change necessary:**
Since SDK v1.9.2, once the SDK/CRT has been told to shutdown, we cannot guarantee that the SDK/CRT code will complete as expected because of our JVM access being taken away. However, since the program is shutting down, there should not be a need to wait on the code to finish since it will be terminated and all processes stopped. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
