### PR TITLE
fix: add check in Telemetry agent for timestamp during publish

### DIFF
--- a/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
@@ -246,19 +246,25 @@ public class TelemetryAgent extends GreengrassService {
     /**
      * Helper for metrics uploader. Also used in tests.
      */
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
     void publishPeriodicMetrics() {
-        if (!isConnected.get()) {
-            logger.atDebug().log("Cannot publish the metrics. MQTT connection interrupted.");
-            return;
+        try {
+            if (!isConnected.get()) {
+                logger.atDebug().log("Cannot publish the metrics. MQTT connection interrupted.");
+                return;
+            }
+            long timestamp = Instant.now().toEpochMilli();
+            long lastPublish = Coerce.toLong(getPeriodicPublishTimeTopic());
+            Map<Long, List<AggregatedNamespaceData>> metricsToPublishMap =
+                    metricsAggregator.getMetricsToPublish(lastPublish, timestamp);
+            getPeriodicPublishTimeTopic().withValue(timestamp);
+            if (metricsToPublishMap != null && metricsToPublishMap.containsKey(timestamp)) {
+                publisher.publish(MetricsPayload.builder().build(), metricsToPublishMap.get(timestamp));
+                logger.atInfo().event("telemetry-metrics-published").log("Telemetry metrics update published.");
+            }
+        } catch (Throwable t) {
+            logger.atWarn().log("Error collecting telemetry. Will retry.", t);
         }
-        long timestamp = Instant.now().toEpochMilli();
-        long lastPublish = Coerce.toLong(getPeriodicPublishTimeTopic());
-        Map<Long, List<AggregatedNamespaceData>> metricsToPublishMap =
-                metricsAggregator.getMetricsToPublish(lastPublish, timestamp);
-        getPeriodicPublishTimeTopic().withValue(timestamp);
-        // TODO: [P41214679] Do not publish if the metrics are empty.
-        publisher.publish(MetricsPayload.builder().build(), metricsToPublishMap.get(timestamp));
-        logger.atInfo().event("telemetry-metrics-published").log("Telemetry metrics update published.");
     }
 
     private Topic getPeriodicPublishTimeTopic() {

--- a/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
@@ -264,6 +264,7 @@ public class TelemetryAgent extends GreengrassService {
             }
         } catch (Throwable t) {
             logger.atWarn().log("Error collecting telemetry. Will retry", t);
+            return;
         }
         try {
             getPeriodicPublishTimeTopic().withValue(timestamp);

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,7 @@ import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_LAST_PERIODI
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -247,5 +249,11 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         verify(mockMqttClient, times(0)).publish(publishRequestArgumentCaptor.capture());
         // aggregation is continued irrespective of the mqtt connection
         verify(ma, timeout(timeoutMs).atLeastOnce()).aggregateMetrics(anyLong(), anyLong());
+    }
+
+    @Test
+    void GIVEN_no_metrics_to_publish_WHEN_publish_THEN_finishes_without_exception() {
+        when(ma.getMetricsToPublish(anyLong(), anyLong())).thenReturn(Collections.emptyMap());
+        assertDoesNotThrow(() -> telemetryAgent.publishPeriodicMetrics());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add additional check to see if the aggregated metrics map has the current timestamp or not.

**Why is this change necessary:**
Do not publish telemetry if no metrics exist. 

**How was this change tested:**
- [X] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
