### PR TITLE
fix: flaky integ tests for Telemetry

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
@@ -25,6 +25,7 @@ import com.aws.greengrass.util.exceptions.TLSAuthException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.ArgumentCaptor;
@@ -35,7 +36,10 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -48,13 +52,15 @@ import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_LAST_PERIODI
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.atLeast;
@@ -77,12 +83,12 @@ class TelemetryAgentTest extends BaseITCase {
     @BeforeEach
     void before() {
         kernel = new Kernel();
-        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any()))
-                .thenReturn(aggregateInterval);
-        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC), any()))
-                .thenReturn(publishInterval);
-        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC), any()))
-                .thenReturn(DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC);
+        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC),
+                any())).thenReturn(aggregateInterval);
+        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_PUBLISH_INTERVAL_SEC),
+                any())).thenReturn(publishInterval);
+        when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC),
+                any())).thenReturn(DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC);
         // Unable to reproduce on my dev machine, when run as github workflow, ScheduledExecutor throws
         // RejectedExecutionException. TestFeatureParameters seems to be having some old handlers. Clearing previous
         // handlers here
@@ -99,9 +105,10 @@ class TelemetryAgentTest extends BaseITCase {
     }
 
     // TODO: enable this once the test is not flaky.
-    //@Test
+    @Test
     void GIVEN_kernel_running_with_telemetry_config_WHEN_launch_THEN_metrics_are_published(ExtensionContext context)
             throws InterruptedException, IOException, DeviceConfigurationException {
+        CountDownLatch metricsPublished = new CountDownLatch(1);
         // Ignore exceptions caused by mock device configs
         ignoreExceptionOfType(context, SdkClientException.class);
         ignoreExceptionOfType(context, TLSAuthException.class);
@@ -109,8 +116,8 @@ class TelemetryAgentTest extends BaseITCase {
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel, this.getClass().getResource("config.yaml"));
         kernel.getContext().put(MqttClient.class, mqttClient);
         kernel.getContext().put(DeviceConfiguration.class,
-                new DeviceConfiguration(kernel, MOCK_THING_NAME, "us-east-1", "us-east-1", "mock", "mock", "mock", "us-east-1",
-                        "mock"));
+                new DeviceConfiguration(kernel, MOCK_THING_NAME, "us-east-1", "us-east-1", "mock", "mock", "mock",
+                        "us-east-1", "mock"));
         //WHEN
         CountDownLatch telemetryRunning = new CountDownLatch(1);
         kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
@@ -125,32 +132,40 @@ class TelemetryAgentTest extends BaseITCase {
         assertTrue(telemetryRunning.await(10, TimeUnit.SECONDS), "TelemetryAgent is not in RUNNING state.");
         Topics telTopics = kernel.findServiceTopic(TELEMETRY_AGENT_SERVICE_TOPICS);
         assertNotNull(telTopics);
-        long lastAgg = Coerce.toLong(telTopics.find(RUNTIME_STORE_NAMESPACE_TOPIC,
-                TELEMETRY_LAST_PERIODIC_AGGREGATION_TIME_TOPIC));
+        long lastAgg = Coerce.toLong(
+                telTopics.find(RUNTIME_STORE_NAMESPACE_TOPIC, TELEMETRY_LAST_PERIODIC_AGGREGATION_TIME_TOPIC));
 
         //wait till the first publish
-        TimeUnit.SECONDS.sleep(publishInterval + 1);
-        assertTrue(Coerce.toLong(telTopics.find(RUNTIME_STORE_NAMESPACE_TOPIC,
-                TELEMETRY_LAST_PERIODIC_AGGREGATION_TIME_TOPIC)) > lastAgg);
+        assertThat(() -> Coerce.toLong(
+                telTopics.find(RUNTIME_STORE_NAMESPACE_TOPIC, TELEMETRY_LAST_PERIODIC_AGGREGATION_TIME_TOPIC))
+                > lastAgg, eventuallyEval(is(true), Duration.ofSeconds(publishInterval + 1)));
+
         assertNotNull(ta.getPeriodicPublishMetricsFuture(), "periodic publish future is not scheduled.");
         long delay = ta.getPeriodicPublishMetricsFuture().getDelay(TimeUnit.SECONDS);
         assertTrue(delay <= publishInterval);
         // telemetry logs are always written to ~root/telemetry
-        assertEquals(kernel.getNucleusPaths().rootPath().resolve("telemetry"),
-                TelemetryConfig.getTelemetryDirectory());
+        assertEquals(kernel.getNucleusPaths().rootPath().resolve("telemetry"), TelemetryConfig.getTelemetryDirectory());
         // THEN
         boolean telemetryMessageVerified = false;
-        if(delay < aggregateInterval) {
+        if (delay < aggregateInterval) {
             verify(mqttClient, atLeast(0)).publish(captor.capture());
         } else {
-            verify(mqttClient, atLeastOnce()).publish(captor.capture());
-            List<PublishRequest> prs = captor.getAllValues();
-            String telemetryPublishTopic = DEFAULT_TELEMETRY_METRICS_PUBLISH_TOPIC.replace("{thingName}", MOCK_THING_NAME);
-            for (PublishRequest pr : prs) {
+            String telemetryPublishTopic =
+                    DEFAULT_TELEMETRY_METRICS_PUBLISH_TOPIC.replace("{thingName}", MOCK_THING_NAME);
+            List<PublishRequest> prs = new ArrayList<>();
+            when(mqttClient.publish(any(PublishRequest.class))).thenAnswer(i -> {
+                Object argument = i.getArgument(0);
+                PublishRequest publishRequest = (PublishRequest) argument;
                 // filter for telemetry topic because messages published to irrelevant topics can be captured here
-                if (!telemetryPublishTopic.equals(pr.getTopic())) {
-                    continue;
+                if (telemetryPublishTopic.equals(publishRequest.getTopic())) {
+                    prs.add(publishRequest);
+                    metricsPublished.countDown();
                 }
+                return CompletableFuture.completedFuture(0);
+            });
+            assertTrue(metricsPublished.await(10, TimeUnit.SECONDS), "Metrics not published ");
+
+            for (PublishRequest pr : prs) {
                 try {
                     MetricsPayload mp = new ObjectMapper().readValue(pr.getPayload(), MetricsPayload.class);
                     assertEquals(QualityOfService.AT_LEAST_ONCE, pr.getQos());
@@ -164,7 +179,5 @@ class TelemetryAgentTest extends BaseITCase {
             }
             assertTrue(telemetryMessageVerified, "Did not see message published to telemetry metrics topic");
         }
-
     }
 }
-


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Newer fixes in Telemetry Agent cause integ tests to be flaky. Fixed TelemetryAgentTest and IPCComponentMetricsTest. 

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
