### PR TITLE
fix(fss): correct config arn and add deployment id

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/ShadowDeploymentForMosquitto.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/ShadowDeploymentForMosquitto.json
@@ -1,0 +1,18 @@
+{
+  "deploymentId": "TestDeploymentId4",
+  "configurationArn": "arn:aws:greengrass:us-east-1:12345678910:configuration:thing/ThingName:1",
+  "components": {
+    "Mosquitto": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 100,
+  "failureHandlingPolicy": "DO_NOTHING",
+  "componentUpdatePolicy": {
+    "timeout": 120,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 120
+  }
+}

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
@@ -27,6 +27,7 @@ public class DeploymentStatusKeeper {
 
     public static final String PROCESSED_DEPLOYMENTS_TOPICS = "ProcessedDeployments";
     public static final String DEPLOYMENT_ID_KEY_NAME = "DeploymentId";
+    public static final String CONFIGURATION_ARN_KEY_NAME = "ConfigurationArn";
     public static final String DEPLOYMENT_TYPE_KEY_NAME = "DeploymentType";
     public static final String DEPLOYMENT_STATUS_KEY_NAME = "DeploymentStatus";
     public static final String DEPLOYMENT_STATUS_DETAILS_KEY_NAME = "DeploymentStatusDetails";
@@ -57,13 +58,15 @@ public class DeploymentStatusKeeper {
     /**
      * Persist deployment status in kernel config.
      *
-     * @param deploymentId   id for the deployment.
-     * @param deploymentType type of deployment.
-     * @param status         status of deployment.
-     * @param statusDetails  other details of deployment status.
+     * @param deploymentId     id for the deployment.
+     * @param configurationArn arn for deployment target configuration.
+     * @param deploymentType   type of deployment.
+     * @param status           status of deployment.
+     * @param statusDetails    other details of deployment status.
      * @throws IllegalArgumentException for invalid deployment type
      */
-    public void persistAndPublishDeploymentStatus(String deploymentId, DeploymentType deploymentType, String status,
+    public void persistAndPublishDeploymentStatus(String deploymentId,
+                                                  String configurationArn, DeploymentType deploymentType, String status,
                                                   Map<String, String> statusDetails) {
 
         //While this method is being run, another thread could be running the publishPersistedStatusUpdates
@@ -73,6 +76,7 @@ public class DeploymentStatusKeeper {
                     .log("Storing deployment status");
             Map<String, Object> deploymentDetails = new HashMap<>();
             deploymentDetails.put(DEPLOYMENT_ID_KEY_NAME, deploymentId);
+            deploymentDetails.put(CONFIGURATION_ARN_KEY_NAME, configurationArn);
             deploymentDetails.put(DEPLOYMENT_TYPE_KEY_NAME, deploymentType.toString());
             deploymentDetails.put(DEPLOYMENT_STATUS_KEY_NAME, status);
             deploymentDetails.put(DEPLOYMENT_STATUS_DETAILS_KEY_NAME, statusDetails);

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -448,7 +448,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         if (cancelDeployment) {
             deployment = new Deployment(DeploymentType.SHADOW, UUID.randomUUID().toString(), true);
         } else {
-            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configurationArn);
+            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configuration.getDeploymentId());
         }
         if (deploymentQueue.offer(deployment)) {
             logger.atInfo().kv("ID", deployment.getId()).log("Added shadow deployment job");

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -59,6 +59,7 @@ import javax.inject.Inject;
 import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.CONFIGURATION_ARN_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
@@ -534,7 +535,8 @@ public class FleetStatusService extends GreengrassService {
     private DeploymentInformation getDeploymentInformation(Map<String, Object> deploymentDetails) {
         DeploymentInformation deploymentInformation = DeploymentInformation.builder()
                 .status((String) deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME))
-                .fleetConfigurationArnForStatus((String) deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME)).build();
+                .deploymentId((String) deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME))
+                .fleetConfigurationArnForStatus((String) deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME)).build();
         if (deploymentDetails.containsKey(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)) {
             Map<String, String> statusDetailsMap =
                     (Map<String, String>) deploymentDetails.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);

--- a/src/main/java/com/aws/greengrass/status/model/DeploymentInformation.java
+++ b/src/main/java/com/aws/greengrass/status/model/DeploymentInformation.java
@@ -21,4 +21,5 @@ public class DeploymentInformation {
     private String status;
     private StatusDetails statusDetails;
     private String fleetConfigurationArnForStatus;
+    private String deploymentId;
 }

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -89,6 +89,7 @@ import static org.mockito.Mockito.when;
 class DeploymentServiceTest extends GGServiceTestUtil {
 
     private static final String TEST_JOB_ID_1 = "TEST_JOB_1";
+    private static final String CONFIG_ARN_PLACEHOLDER = "TARGET_CONFIGURATION_ARN";
     private static final String EXPECTED_GROUP_NAME = "thinggroup/group1";
     private static final String EXPECTED_ROOT_PACKAGE_NAME = "component1";
     private static final String TEST_DEPLOYMENT_ID = "testDeploymentId";
@@ -363,14 +364,13 @@ class DeploymentServiceTest extends GGServiceTestUtil {
             Deployment.DeploymentType type)
             throws Exception {
         String expectedGroupName = EXPECTED_GROUP_NAME;
+        String expectedConfigArn = null;
         if (type.equals(Deployment.DeploymentType.LOCAL)) {
             expectedGroupName = LOCAL_DEPLOYMENT_GROUP_NAME;
+        } else {
+            expectedConfigArn = TEST_CONFIGURATION_ARN;
         }
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument, type, TEST_JOB_ID_1));
         Topics allGroupTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
@@ -405,19 +405,19 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         mockFuture.complete(new DeploymentResult(DeploymentStatus.SUCCESSFUL, null));
         when(mockExecutorService.submit(any(DefaultDeploymentTask.class))).thenReturn(mockFuture);
 
-        doNothing().when(deploymentStatusKeeper).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(type), eq(JobStatus.IN_PROGRESS.toString()), any());
+        doNothing().when(deploymentStatusKeeper)
+                .persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1), eq(expectedConfigArn), eq(type),
+                        eq(JobStatus.IN_PROGRESS.toString()), any());
 
         startDeploymentServiceInAnotherThread();
         verify(deploymentStatusKeeper, timeout(1000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(type), eq(JobStatus.IN_PROGRESS.toString()), any());
-        verify(deploymentStatusKeeper, timeout(10000))
-                .persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                        eq(type), eq(JobStatus.SUCCEEDED.toString()), any());
+                eq(expectedConfigArn), eq(type), eq(JobStatus.IN_PROGRESS.toString()), any());
+        verify(deploymentStatusKeeper, timeout(10000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any());
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(type), eq(JobStatus.SUCCEEDED.toString()), any());
+                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any());
         ArgumentCaptor<Map<String, Object>> mapCaptor = ArgumentCaptor.forClass(Map.class);
         verify(mockComponentsToGroupPackages).replaceAndWait(mapCaptor.capture());
         Map<String, Object> groupToRootPackages = mapCaptor.getValue();
@@ -432,11 +432,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     void GIVEN_deployment_job_WHEN_deployment_completes_with_non_retryable_error_THEN_report_failed_job_status(
             ExtensionContext context)
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -450,9 +446,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                any());
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
+                any());
     }
 
 
@@ -460,11 +458,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     void GIVEN_deployment_job_WHEN_deployment_metadata_setup_fails_THEN_report_failed_job_status(
             ExtensionContext context)
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -477,20 +471,18 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         ArgumentCaptor<Map<String, String>> statusDetails = ArgumentCaptor.forClass(Map.class);
 
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                any());
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), statusDetails.capture());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
+                statusDetails.capture());
         assertEquals("DeploymentTaskFailureException: java.io.IOException: mock error -> IOException: mock error", statusDetails.getValue().get("deployment-failure-cause"));
     }
 
     @Test
     void GIVEN_deployment_job_with_auto_rollback_not_requested_WHEN_deployment_process_fails_THEN_report_failed_job_status()
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -511,9 +503,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                any());
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
+                any());
 
         ArgumentCaptor<Map<String, Object>> mapCaptor = ArgumentCaptor.forClass(Map.class);
         verify(deploymentGroupTopics).replaceAndWait(mapCaptor.capture());
@@ -534,11 +528,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_deployment_job_with_auto_rollback_requested_WHEN_deployment_fails_and_rollback_succeeds_THEN_report_failed_job_status()
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
+
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -549,20 +540,17 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
                 any());
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
+                any());
     }
 
     @Test
     void GIVEN_deployment_job_with_auto_rollback_requested_WHEN_deployment_fails_and_rollback_fails_THEN_report_failed_job_status()
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -573,20 +561,17 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
                 any());
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
+                any());
     }
 
     @Test
     void GIVEN_deployment_job_cancelled_WHEN_waiting_for_safe_time_THEN_then_cancel_deployment()
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -601,7 +586,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         // Expecting three invocations, once for each retry attempt
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                any());
         verify(updateSystemPolicyService, WAIT_FOUR_SECONDS).discardPendingUpdateAction(TEST_DEPLOYMENT_ID);
         verify(mockFuture, WAIT_FOUR_SECONDS).cancel(true);
     }
@@ -609,11 +595,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_deployment_job_cancelled_WHEN_already_executing_update_THEN_then_finish_deployment()
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -630,17 +612,14 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(updateSystemPolicyService, WAIT_FOUR_SECONDS).discardPendingUpdateAction(TEST_DEPLOYMENT_ID);
         verify(mockFuture, times(0)).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                any());
     }
 
     @Test
     void GIVEN_deployment_job_cancelled_WHEN_already_finished_deployment_task_THEN_then_do_nothing()
             throws Exception {
-        String deploymentDocument
-                = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -670,6 +649,14 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(updateSystemPolicyService, times(0)).discardPendingUpdateAction(any());
         verify(mockFuture, times(0)).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()), any());
+                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
+                any());
+    }
+
+    String getTestDeploymentDocument() {
+        return new BufferedReader(new InputStreamReader(
+                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
+                .lines()
+                .collect(Collectors.joining("\n")).replace(CONFIG_ARN_PLACEHOLDER, TEST_CONFIGURATION_ARN);
     }
 }

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
@@ -93,11 +93,12 @@ class DeploymentStatusKeeperTest {
             return true;
         }, DUMMY_SERVICE_NAME);
 
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", IOT_JOBS, JobStatus.SUCCEEDED.toString(), new HashMap<>());
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", LOCAL, DeploymentStatus.SUCCEEDED.toString(),
-                new HashMap<>());
-        assertEquals(4, updateOfTypeJobs.size());
-        assertEquals(4, updateOfTypeLocal.size());
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+                JobStatus.SUCCEEDED.toString(), new HashMap<>());
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", null, LOCAL,
+                DeploymentStatus.SUCCEEDED.toString(), new HashMap<>());
+        assertEquals(5, updateOfTypeJobs.size());
+        assertEquals(5, updateOfTypeLocal.size());
         assertEquals("iot_deployment", updateOfTypeJobs.get(DEPLOYMENT_ID_KEY_NAME));
         assertEquals(JobStatus.SUCCEEDED, Coerce.toEnum(JobStatus.class,
                 updateOfTypeJobs.get(DEPLOYMENT_STATUS_KEY_NAME)));
@@ -116,7 +117,8 @@ class DeploymentStatusKeeperTest {
     @Test
     void GIVEN_deployment_status_update_WHEN_consumer_return_true_THEN_update_is_removed_from_config() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(IOT_JOBS, (details) -> true, DUMMY_SERVICE_NAME);
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", IOT_JOBS, JobStatus.SUCCEEDED.toString(), new HashMap<>());
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+                JobStatus.SUCCEEDED.toString(), new HashMap<>());
         context.waitForPublishQueueToClear();
         assertEquals(0, processedDeployments.children.size());
     }
@@ -124,7 +126,7 @@ class DeploymentStatusKeeperTest {
     @Test
     void GIVEN_local_deployment_status_update_WHEN_consumer_return_true_THEN_update_is_removed_from_config() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(LOCAL, (details) -> true, DUMMY_SERVICE_NAME);
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", LOCAL,
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", null, LOCAL,
                 DeploymentStatus.SUCCEEDED.toString(), new HashMap<>());
         context.waitForPublishQueueToClear();
         assertEquals(0, processedDeployments.children.size());
@@ -133,7 +135,8 @@ class DeploymentStatusKeeperTest {
     @Test
     void GIVEN_deployment_status_update_WHEN_consumer_return_false_THEN_update_is_not_removed() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(IOT_JOBS, (details) -> false, DUMMY_SERVICE_NAME);
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", IOT_JOBS, JobStatus.SUCCEEDED.toString(), new HashMap<>());
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+                JobStatus.SUCCEEDED.toString(), new HashMap<>());
         assertEquals(1, processedDeployments.children.size());
     }
 
@@ -147,7 +150,8 @@ class DeploymentStatusKeeperTest {
             return consumerReturnValue.get();
         }, DUMMY_SERVICE_NAME);
         // DeploymentStatusKeeper will retain update as consumer returns false
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", IOT_JOBS, JobStatus.SUCCEEDED.toString(), new HashMap<>());
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+                JobStatus.SUCCEEDED.toString(), new HashMap<>());
         assertEquals(1, consumerInvokeCount.get());
 
         // updating the consumer return value to true


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
Deployment information in FSS gets inconsistent values for `fleetConfigurationArnForStatus` - deployment(job) id for IoT Jobs and config arn for Shadow deployments. We have both deployment id and config arn available for either type of deployments. This change adds a new key for deployment id and correctly sets id and arn in respective fields.

**Why is this change necessary:**
To make FSS messages more accurate 

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
