### PR TITLE
feat(loader): use customer-provided java path (if any)

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -30,14 +30,19 @@ launch_kernel() {
 
   JVM_OPTIONS="$JVM_OPTIONS -Droot=$GG_ROOT"
   OPTIONS="--setup-system-service false"
-  if [ ! -z ${CONFIG_FILE} ]; then
+  if [ ! -z "${CONFIG_FILE}" ]; then
     OPTIONS="$OPTIONS --config $CONFIG_FILE"
   fi
+  JAVA_EXE="java"
+  if [ ! -z "${GG_JAVA_EXE}" ]; then
+    JAVA_EXE="$GG_JAVA_EXE"
+  fi
+  echo "Java executable: "${JAVA_EXE}
   echo "JVM options: "${JVM_OPTIONS}
   echo "Nucleus options: "${OPTIONS}
   child_pid=""
   trap 'echo Received SIGTERM; sigterm_received=1; kill -TERM ${child_pid}; wait ${child_pid}; echo Killed child PID' TERM
-  java -Dlog.store=FILE ${JVM_OPTIONS} -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS} &
+  ${JAVA_EXE} -Dlog.store=FILE ${JVM_OPTIONS} -jar "$LAUNCH_DIR/distro/lib/Greengrass.jar" ${OPTIONS} &
   child_pid="$!"
   wait "${child_pid}"
   kernel_exit_code=$?

--- a/scripts/loader.cmd
+++ b/scripts/loader.cmd
@@ -64,12 +64,22 @@ IF EXIST %LAUNCH_DIR%\launch.params (
 SET JVM_OPTIONS=%JVM_OPTIONS% -Droot="%GG_ROOT%"
 SET OPTIONS=--setup-system-service false
 
+REM enable extensions so we can use "IF DEFINED"
+SETLOCAL ENABLEEXTENSIONS
+
+IF DEFINED GG_JAVA_EXE (
+    SET JAVA_EXE=%GG_JAVA_EXE%
+) ELSE (
+    SET JAVA_EXE=java
+)
+
+ECHO Java executable: %JAVA_EXE%
 ECHO JVM options: %JVM_OPTIONS%
 ECHO Nucleus options: %OPTIONS%
 SET /A MAX_RETRIES=3
 @REM Attempt to start the nucleus 3 times
 FOR /L %%i IN (1,1,%MAX_RETRIES%) DO (
-    java -Dlog.store=FILE %JVM_OPTIONS% -jar "%LAUNCH_DIR%\distro\lib\Greengrass.jar" %OPTIONS%
+    %JAVA_EXE% -Dlog.store=FILE %JVM_OPTIONS% -jar "%LAUNCH_DIR%\distro\lib\Greengrass.jar" %OPTIONS%
     SET KERNEL_EXIT_CODE=!ERRORLEVEL!
 
     IF !KERNEL_EXIT_CODE! EQU 0 (
@@ -118,7 +128,7 @@ EXIT /B !KERNEL_EXIT_CODE!
 
 @REM Checks if directory is a symlink by checking its attributes
 @REM @param1 directory to test
-@REM @param2 out varialbe (pass by reference)
+@REM @param2 out variable (pass by reference)
 @REM    1 = @param1 is a symlinked directory
 @REM    0 = @param1 is NOT a symlink
 :directory_is_symlink


### PR DESCRIPTION
**Issue #, if available:**
Resolves #1279 

**Description of changes:**
Loader scripts for Unix and Windows now read $GG_JAVA_EXE (if provided) and will use this as the path for the java executable file. If it is not provided, then it falls back to the existing behavior to try calling "java" which will use the PATH resolution to find java.

**Why is this change necessary:**
This change allows customers to more easily set which Java will be used to run Greengrass itself, without needing to modify $PATH.

**How was this change tested:**
Manually tested on Windows and Unix that both defaults (no GG_JAVA_EXE) and custom paths (including with spaces in the exe path for Windows) do work as expected.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
