### PR TITLE
test(e2e): ignore newly seen MQTT error in e2e test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
@@ -189,6 +189,8 @@ public class BaseE2ETestCase implements AutoCloseable {
     void beforeEach(ExtensionContext context) {
         // MQTT connection may close quickly in some tests, this is OK and should not be a concern.
         ignoreExceptionUltimateCauseWithMessageSubstring(context, "The connection was closed unexpectedly");
+        ignoreExceptionUltimateCauseWithMessageSubstring(context,
+                "Old requests from the previous session are cancelled");
     }
 
     @BeforeAll


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Ignores: https://github.com/awslabs/aws-c-mqtt/blame/0a70bf814845e487b7e4862af7ad9e4a1199b5f4/source/mqtt.c#L150-L152 which can happen when the MQTT session is restarted as clean (which cancels pending requests).

I have posed a question to the SDK team why we're only seeing this now that we've updated to SDK 1.10.2 though the error code hasn't changed in 2 years.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [x] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Manually ran E2E test suite locally and verified no failures.

```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
