### PR TITLE
fix: correct mqtt chunking publisher algorithm

### DIFF
--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -79,8 +79,6 @@ public class FleetStatusService extends GreengrassService {
     static final String FLEET_STATUS_SEQUENCE_NUMBER_TOPIC = "sequenceNumber";
     static final String FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC = "lastPeriodicUpdateTime";
     private static final int MAX_PAYLOAD_LENGTH_BYTES = 128_000;
-    // Size of chunk info in bytes when chunk id and total chunks are INT_MAX
-    private static final int MAX_CHUNK_INFO_BYTES = 48;
     public static final String DEVICE_OFFLINE_MESSAGE = "Device not configured to talk to AWS IoT cloud. "
             + "FleetStatusService is offline";
     private final DeviceConfiguration deviceConfiguration;
@@ -178,7 +176,6 @@ public class FleetStatusService extends GreengrassService {
         this.periodicPublishIntervalSec = TestFeatureParameters.retrieveWithDefault(Double.class,
                 FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC, periodicPublishIntervalSec).intValue();
         this.publisher.setMaxPayloadLengthBytes(MAX_PAYLOAD_LENGTH_BYTES);
-        this.publisher.setReservedChunkInfoSize(MAX_CHUNK_INFO_BYTES);
         this.platform = platformResolver.getCurrentPlatform()
                 .getOrDefault(PlatformResolver.OS_KEY, PlatformResolver.UNKNOWN_KEYWORD);
 

--- a/src/main/java/com/aws/greengrass/status/model/ChunkInfo.java
+++ b/src/main/java/com/aws/greengrass/status/model/ChunkInfo.java
@@ -7,9 +7,11 @@ package com.aws.greengrass.status.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class ChunkInfo {
     private int chunkId;
     private int totalChunks;

--- a/src/main/java/com/aws/greengrass/status/model/FleetStatusDetails.java
+++ b/src/main/java/com/aws/greengrass/status/model/FleetStatusDetails.java
@@ -54,10 +54,14 @@ public class FleetStatusDetails implements Chunkable<ComponentStatusDetails> {
     }
 
     @Override
+    @SuppressWarnings("PMD.NullAssignment")
     public void setChunkInfo(int chunkId, int totalChunks) {
         if (this.messageType == MessageType.COMPLETE && totalChunks > 1) {
             // set chunk info only if it's a complete update and the message splits into multiple chunks
             chunkInfo = new ChunkInfo(chunkId, totalChunks);
+        } else {
+            // reset chunk info to null to exclude from upload
+            chunkInfo = null;
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/status/model/FleetStatusDetails.java
+++ b/src/main/java/com/aws/greengrass/status/model/FleetStatusDetails.java
@@ -56,12 +56,8 @@ public class FleetStatusDetails implements Chunkable<ComponentStatusDetails> {
     @Override
     @SuppressWarnings("PMD.NullAssignment")
     public void setChunkInfo(int chunkId, int totalChunks) {
-        if (this.messageType == MessageType.COMPLETE && totalChunks > 1) {
-            // set chunk info only if it's a complete update and the message splits into multiple chunks
-            chunkInfo = new ChunkInfo(chunkId, totalChunks);
-        } else {
-            // reset chunk info to null to exclude from upload
-            chunkInfo = null;
-        }
+        // set chunk info only if the message splits into multiple chunks
+        // otherwise, reset chunk info to null to exclude from publish
+        chunkInfo = totalChunks > 1 ? new ChunkInfo(chunkId, totalChunks) : null;
     }
 }

--- a/src/main/java/com/aws/greengrass/util/MqttChunkedPayloadPublisher.java
+++ b/src/main/java/com/aws/greengrass/util/MqttChunkedPayloadPublisher.java
@@ -46,7 +46,7 @@ public class MqttChunkedPayloadPublisher<T> {
             payloadCommonInformationSize = SERIALIZER.writeValueAsBytes(chunkablePayload).length;
         } catch (JsonProcessingException e) {
             logger.atError().cause(e).kv(topicKey, updateTopic)
-                    .log("Unable to write common payload as bytes. Dropping " + "the message");
+                    .log("Unable to write common payload as bytes. Dropping the message");
             return;
         }
 

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -898,7 +898,6 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             assertEquals(VERSION, fleetStatusDetails.getGgcVersion());
             assertEquals("testThing", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
-            assertEquals(500, fleetStatusDetails.getComponentStatusDetails().size());
             assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
             assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
             assertNull(fleetStatusDetails.getChunkInfo());

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -891,7 +891,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         verify(mockMqttClient, times(3)).publish(publishRequestArgumentCaptor.capture());
         List<PublishRequest> publishRequests = publishRequestArgumentCaptor.getAllValues();
         ObjectMapper mapper = new ObjectMapper();
-        for (PublishRequest publishRequest : publishRequests) {
+        for (int i = 0; i < publishRequests.size(); i++) {
+            PublishRequest publishRequest = publishRequests.get(i);
             assertEquals(QualityOfService.AT_LEAST_ONCE, publishRequest.getQos());
             assertEquals("$aws/things/testThing/greengrassv2/health/json", publishRequest.getTopic());
             FleetStatusDetails fleetStatusDetails = mapper.readValue(publishRequest.getPayload(), FleetStatusDetails.class);
@@ -900,7 +901,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
             assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
             assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
-            assertNull(fleetStatusDetails.getChunkInfo());
+            assertEquals(i + 1, fleetStatusDetails.getChunkInfo().getChunkId());
+            assertEquals(publishRequests.size(), fleetStatusDetails.getChunkInfo().getTotalChunks());
             for (ComponentStatusDetails componentStatusDetails : fleetStatusDetails.getComponentStatusDetails()) {
                 serviceNamesToCheck.remove(componentStatusDetails.getComponentName());
                 assertNull(componentStatusDetails.getStatusDetails());

--- a/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
+++ b/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
@@ -50,9 +50,6 @@ class MqttChunkedPayloadPublisherTest {
         publisher.setUpdateTopic("topic");
     }
 
-    // happy case 1
-    // happy case: a long 1 and a short 1
-
     @Test
     void GIVEN_variable_payloads_WHEN_size_limit_not_breach_THEN_send_in_one_chunk() throws IOException {
         ChunkableTestMessage message = new ChunkableTestMessage("commonPayload");

--- a/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
+++ b/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.PublishRequest;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class MqttChunkedPayloadPublisherTest {
+    static final ObjectMapper MAPPER = new ObjectMapper();
+    MqttChunkedPayloadPublisher<String> publisher;
+    @Mock
+    private MqttClient mqttClient;
+    @Captor
+    private ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(mqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
+        publisher = new MqttChunkedPayloadPublisher<>(mqttClient);
+        publisher.setUpdateTopic("topic");
+    }
+
+    // happy case 1
+    // happy case: a long 1 and a short 1
+
+    @Test
+    void GIVEN_variable_payloads_WHEN_size_limit_not_breach_THEN_send_in_one_chunk() throws IOException {
+        ChunkableTestMessage message = new ChunkableTestMessage("commonPayload");
+
+        String payload1 = RandomStringUtils.randomAlphanumeric(20);
+        String payload2 = RandomStringUtils.randomAlphanumeric(20);
+        String payload3 = RandomStringUtils.randomAlphanumeric(20);
+
+        // compute max size
+        message.setVariablePayload(Collections.singletonList(payload1));
+        publisher.setMaxPayloadLengthBytes(Integer.MAX_VALUE);
+
+        // publish
+        message.setVariablePayload(Collections.emptyList());
+        publisher.publish(message, Arrays.asList(payload1, payload2, payload3));
+        verify(mqttClient, times(1)).publish(publishRequestArgumentCaptor.capture());
+        List<PublishRequest> publishRequests = publishRequestArgumentCaptor.getAllValues();
+
+        //check results
+        ChunkableTestMessage message1 =
+                MAPPER.readValue(publishRequests.get(0).getPayload(), ChunkableTestMessage.class);
+        assertEquals("commonPayload", message1.getCommonPayload());
+        assertEquals(3, message1.getVariablePayload().size());
+        assertEquals(message1.getVariablePayload().get(0), payload1);
+        assertEquals(message1.getVariablePayload().get(1), payload2);
+        assertEquals(message1.getVariablePayload().get(2), payload3);
+
+        assertEquals(message1.getId(), 1);
+        assertEquals(message1.getTotalChunks(), 1);
+    }
+
+
+    @Test
+    void GIVEN_two_variable_payloads_WHEN_reach_size_limit_THEN_break_into_two_chunks() throws IOException {
+        ChunkableTestMessage message = new ChunkableTestMessage("commonPayload");
+        message.setChunkInfo(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+        String payload1 = RandomStringUtils.randomAlphanumeric(20);
+        String payload2 = RandomStringUtils.randomAlphanumeric(20);
+
+        // compute max size
+        message.setVariablePayload(Collections.singletonList(payload1));
+        publisher.setMaxPayloadLengthBytes(MAPPER.writeValueAsBytes(message).length + 1);
+
+        // publish
+        message.setVariablePayload(Collections.emptyList());
+        publisher.publish(message, Arrays.asList(payload1, payload2));
+        verify(mqttClient, times(2)).publish(publishRequestArgumentCaptor.capture());
+        List<PublishRequest> publishRequests = publishRequestArgumentCaptor.getAllValues();
+
+        //check results
+        ChunkableTestMessage message1 =
+                MAPPER.readValue(publishRequests.get(0).getPayload(), ChunkableTestMessage.class);
+        assertEquals("commonPayload", message1.getCommonPayload());
+        assertEquals(1, message1.getVariablePayload().size());
+        assertEquals(message1.getVariablePayload().get(0), payload1);
+        assertEquals(message1.getId(), 1);
+        assertEquals(message1.getTotalChunks(), 2);
+
+
+        ChunkableTestMessage message2 =
+                MAPPER.readValue(publishRequests.get(1).getPayload(), ChunkableTestMessage.class);
+        assertEquals("commonPayload", message2.getCommonPayload());
+        assertEquals(1, message2.getVariablePayload().size());
+        assertEquals(message2.getVariablePayload().get(0), payload2);
+        assertEquals(message2.getId(), 2);
+        assertEquals(message2.getTotalChunks(), 2);
+    }
+
+    @Test
+    void GIVEN_3_variable_payloads_WHEN_payload2_requests_a_new_chunk_THEN_payload3_can_still_place_in_first_chunk()
+            throws IOException {
+        ChunkableTestMessage message = new ChunkableTestMessage("commonPayload");
+        message.setChunkInfo(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+        String payload1 = RandomStringUtils.randomAlphanumeric(20);
+        String payload2 = RandomStringUtils.randomAlphanumeric(100);
+        String payload3 = RandomStringUtils.randomAlphanumeric(20);
+
+        // compute max size
+        message.setVariablePayload(Collections.singletonList(payload2));
+        publisher.setMaxPayloadLengthBytes(MAPPER.writeValueAsBytes(message).length + 1);
+
+        // publish
+        message.setVariablePayload(Collections.emptyList());
+        publisher.publish(message, Arrays.asList(payload1, payload2, payload3));
+        verify(mqttClient, times(2)).publish(publishRequestArgumentCaptor.capture());
+        List<PublishRequest> publishRequests = publishRequestArgumentCaptor.getAllValues();
+
+        //check results
+        ChunkableTestMessage message1 =
+                MAPPER.readValue(publishRequests.get(0).getPayload(), ChunkableTestMessage.class);
+        assertEquals("commonPayload", message1.getCommonPayload());
+        assertEquals(2, message1.getVariablePayload().size());
+        assertEquals(message1.getVariablePayload().get(0), payload1);
+        assertEquals(message1.getVariablePayload().get(1), payload3);
+        assertEquals(message1.getId(), 1);
+        assertEquals(message1.getTotalChunks(), 2);
+
+
+        ChunkableTestMessage message2 =
+                MAPPER.readValue(publishRequests.get(1).getPayload(), ChunkableTestMessage.class);
+        assertEquals("commonPayload", message2.getCommonPayload());
+        assertEquals(1, message2.getVariablePayload().size());
+        assertEquals(message2.getVariablePayload().get(0), payload2);
+        assertEquals(message2.getId(), 2);
+        assertEquals(message2.getTotalChunks(), 2);
+    }
+
+    @Test
+    void GIVEN_variable_payloads_too_large_WHEN_publish_THEN_drop_message() throws IOException {
+        ChunkableTestMessage message = new ChunkableTestMessage("commonPayload");
+        message.setChunkInfo(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+        String payload1 = RandomStringUtils.randomAlphanumeric(20);
+        String payload2 = RandomStringUtils.randomAlphanumeric(100);
+        String payload3 = RandomStringUtils.randomAlphanumeric(20);
+
+        // compute max size
+        message.setVariablePayload(Collections.singletonList(payload1));
+        publisher.setMaxPayloadLengthBytes(MAPPER.writeValueAsBytes(message).length + 1);
+
+        // publish
+        message.setVariablePayload(Collections.emptyList());
+        publisher.publish(message, Arrays.asList(payload1, payload2, payload3));
+        verify(mqttClient, times(2)).publish(publishRequestArgumentCaptor.capture());
+        List<PublishRequest> publishRequests = publishRequestArgumentCaptor.getAllValues();
+
+        //check results
+        ChunkableTestMessage message1 =
+                MAPPER.readValue(publishRequests.get(0).getPayload(), ChunkableTestMessage.class);
+        assertEquals("commonPayload", message1.getCommonPayload());
+        assertEquals(1, message1.getVariablePayload().size());
+        assertEquals(message1.getVariablePayload().get(0), payload1);
+        assertEquals(message1.getId(), 1);
+        assertEquals(message1.getTotalChunks(), 2);
+
+
+        ChunkableTestMessage message2 =
+                MAPPER.readValue(publishRequests.get(1).getPayload(), ChunkableTestMessage.class);
+        assertEquals("commonPayload", message2.getCommonPayload());
+        assertEquals(1, message2.getVariablePayload().size());
+        assertEquals(message2.getVariablePayload().get(0), payload3);
+        assertEquals(message2.getId(), 2);
+        assertEquals(message2.getTotalChunks(), 2);
+    }
+
+    @Test
+    void GIVEN_common_payload_too_large_WHEN_publish_THEN_drop_message() throws IOException {
+        ChunkableTestMessage message = new ChunkableTestMessage(RandomStringUtils.randomAlphanumeric(200));
+        message.setChunkInfo(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+        String payload1 = RandomStringUtils.randomAlphanumeric(10);
+        String payload2 = RandomStringUtils.randomAlphanumeric(10);
+
+        publisher.setMaxPayloadLengthBytes(MAPPER.writeValueAsBytes(message).length - 20);
+
+        // publish
+        message.setVariablePayload(Collections.emptyList());
+        publisher.publish(message, Arrays.asList(payload1, payload2));
+        verify(mqttClient, times(0)).publish(publishRequestArgumentCaptor.capture());
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    private static class ChunkableTestMessage implements Chunkable<String> {
+        String commonPayload;
+        List<String> variablePayload;
+        int id;
+        int totalChunks;
+
+        public ChunkableTestMessage(String commonPayload) {
+            this.commonPayload = commonPayload;
+        }
+
+        @Override
+        public void setVariablePayload(List<String> variablePayload) {
+            this.variablePayload = variablePayload;
+        }
+
+        @Override
+        public void setChunkInfo(int id, int totalChunks) {
+            this.id = id;
+            this.totalChunks = totalChunks;
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Fixes chunking algorithm in `MqttChunkedPayloadPublisher`. 
2. Adds unit tests.


**Why is this change necessary:**
Previously the chunking algorithm was functionally incorrect because it just distributed payloads evenly into chunks. If there were a single very long payload, the publish request would breach the size limit.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
