### PR TITLE
feat: spool fss publish requests triggered by cloud deployment

### DIFF
--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -368,12 +368,12 @@ public class FleetStatusService extends GreengrassService {
                                                      Trigger trigger) {
         if (!isConnected.get()) {
             // spool deployment updates even if mqtt connection interrupted
-            if (Trigger.isDeploymentTrigger(trigger)) {
-                logger.atDebug().log("Attempting to publish and spool deployment FSS updates even though MQTT "
+            if (Trigger.isCloudDeploymentTrigger(trigger)) {
+                logger.atDebug().log("Attempting to publish and spool cloud deployment FSS updates even though MQTT "
                         + "connection is interrupted");
             } else {
-                logger.atDebug().log("Not updating FSS data on non-deployment events since MQTT connection "
-                        + "is interrupted");
+                logger.atDebug().log("Not updating FSS data on local deployment and component events since MQTT "
+                        + "connection is interrupted");
                 return;
             }
         }
@@ -409,7 +409,7 @@ public class FleetStatusService extends GreengrassService {
                                               OverallStatus overAllStatus,
                                               DeploymentInformation deploymentInformation,
                                               Trigger trigger) {
-        if (!isConnected.get() && !Trigger.isDeploymentTrigger(trigger)) {
+        if (!isConnected.get() && !Trigger.isCloudDeploymentTrigger(trigger)) {
             logger.atDebug().log("Not updating fleet status data since MQTT connection is interrupted");
             return;
         }

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -98,7 +98,6 @@ public class FleetStatusService extends GreengrassService {
     //For testing
     @Getter
     private final AtomicBoolean isConnected = new AtomicBoolean(true);
-    private final AtomicBoolean isEventTriggeredUpdateInProgress = new AtomicBoolean(false);
     private final AtomicBoolean isFSSSetupComplete = new AtomicBoolean(false);
     private final Set<GreengrassService> updatedGreengrassServiceSet =
             Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -298,8 +297,10 @@ public class FleetStatusService extends GreengrassService {
 
         // if there is no ongoing deployment and we encounter a BROKEN component, update the fleet status as UNHEALTHY.
         if (!isDeploymentInProgress.get() && newState.equals(State.BROKEN)) {
-            uploadFleetStatusServiceData(updatedGreengrassServiceSet, OverallStatus.UNHEALTHY, null,
-                    Trigger.BROKEN_COMPONENT);
+            synchronized (updatedGreengrassServiceSet) {
+                uploadFleetStatusServiceData(updatedGreengrassServiceSet, OverallStatus.UNHEALTHY,
+                        null, Trigger.BROKEN_COMPONENT);
+            }
         }
     }
 
@@ -369,129 +370,130 @@ public class FleetStatusService extends GreengrassService {
     private void updateEventTriggeredFleetStatusData(DeploymentInformation deploymentInformation,
                                                      Trigger trigger) {
         if (!isConnected.get()) {
-            logger.atDebug().log("Not updating FSS data on event triggered since MQTT connection is interrupted");
-            return;
-        }
-
-        // Return if we are already in the process of updating FSS data triggered by an event.
-        if (!isEventTriggeredUpdateInProgress.compareAndSet(false, true)) {
-            return;
+            // spool deployment updates even if mqtt connection interrupted
+            if (Trigger.isDeploymentTrigger(trigger)) {
+                logger.atDebug().log("Attempting to publish and spool deployment FSS updates even though MQTT "
+                        + "connection is interrupted");
+            } else {
+                logger.atDebug().log("Not updating FSS data on non-deployment events since MQTT connection "
+                        + "is interrupted");
+                return;
+            }
         }
 
         Instant now = Instant.now();
         AtomicReference<OverallStatus> overAllStatus = new AtomicReference<>();
 
-        // Check if the removed dependency is still running (Probably as a dependant service to another service).
-        // If so, then remove it from the removedDependencies collection.
-        this.kernel.orderedDependencies().forEach(greengrassService -> {
-            serviceFssTracksMap.put(greengrassService, now);
-            overAllStatus.set(getOverallStatusBasedOnServiceState(overAllStatus.get(), greengrassService));
-        });
-        Set<GreengrassService> removedDependenciesSet = new HashSet<>();
+        // if last event-triggered update is still ongoing, wait for it to finish
+        synchronized (updatedGreengrassServiceSet) {
+            // Check if the removed dependency is still running (Probably as a dependant service to another service).
+            // If so, then remove it from the removedDependencies collection.
+            this.kernel.orderedDependencies().forEach(greengrassService -> {
+                serviceFssTracksMap.put(greengrassService, now);
+                overAllStatus.set(getOverallStatusBasedOnServiceState(overAllStatus.get(), greengrassService));
+            });
+            Set<GreengrassService> removedDependenciesSet = new HashSet<>();
 
-        // Add all the removed dependencies to the collection of services to update.
-        serviceFssTracksMap.forEach((greengrassService, instant) -> {
-            if (!instant.equals(now)) {
-                updatedGreengrassServiceSet.add(greengrassService);
-                removedDependenciesSet.add(greengrassService);
-            }
-        });
-        removedDependenciesSet.forEach(serviceFssTracksMap::remove);
-        removedDependenciesSet.clear();
-        uploadFleetStatusServiceData(updatedGreengrassServiceSet, overAllStatus.get(), deploymentInformation, trigger);
-        isEventTriggeredUpdateInProgress.set(false);
+            // Add all the removed dependencies to the collection of services to update.
+            serviceFssTracksMap.forEach((greengrassService, instant) -> {
+                if (!instant.equals(now)) {
+                    updatedGreengrassServiceSet.add(greengrassService);
+                    removedDependenciesSet.add(greengrassService);
+                }
+            });
+            removedDependenciesSet.forEach(serviceFssTracksMap::remove);
+            removedDependenciesSet.clear();
+            uploadFleetStatusServiceData(updatedGreengrassServiceSet, overAllStatus.get(), deploymentInformation,
+                    trigger);
+        }
     }
 
     private void uploadFleetStatusServiceData(Set<GreengrassService> greengrassServiceSet,
                                               OverallStatus overAllStatus,
                                               DeploymentInformation deploymentInformation,
                                               Trigger trigger) {
-        if (!isConnected.get()) {
+        if (!isConnected.get() && !Trigger.isDeploymentTrigger(trigger)) {
             logger.atDebug().log("Not updating fleet status data since MQTT connection is interrupted");
             return;
         }
         List<ComponentStatusDetails> components = new ArrayList<>();
-        long sequenceNumber;
 
-        synchronized (greengrassServiceSet) {
-
-            //When a component version is bumped up, FSS may have pointers to both old and new service instances
-            //Filtering out the old version and only sending the update for the new version
-            Set<GreengrassService> filteredServices = new HashSet<>();
-            greengrassServiceSet.forEach(service -> {
-                try {
-                    GreengrassService runningService = kernel.locate(service.getName());
-                    filteredServices.add(runningService);
-                } catch (ServiceLoadException e) {
-                    //not able to find service, service might be removed.
-                    filteredServices.add(service);
-                }
-            });
-
-            Topics componentsToGroupsTopics = null;
-            HashSet<String> allGroups = new HashSet<>();
-            DeploymentService deploymentService = null;
+        //When a component version is bumped up, FSS may have pointers to both old and new service instances
+        //Filtering out the old version and only sending the update for the new version
+        Set<GreengrassService> filteredServices = new HashSet<>();
+        greengrassServiceSet.forEach(service -> {
             try {
-                GreengrassService deploymentServiceLocateResult = this.kernel
-                        .locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS);
-                if (deploymentServiceLocateResult instanceof DeploymentService) {
-                    deploymentService = (DeploymentService) deploymentServiceLocateResult;
-                    componentsToGroupsTopics = deploymentService.getConfig().lookupTopics(COMPONENTS_TO_GROUPS_TOPICS);
-                }
+                GreengrassService runningService = kernel.locate(service.getName());
+                filteredServices.add(runningService);
             } catch (ServiceLoadException e) {
-                logger.atError().cause(e).log("Unable to locate {} service while uploading FSS data",
-                        DeploymentService.DEPLOYMENT_SERVICE_TOPICS);
+                //not able to find service, service might be removed.
+                filteredServices.add(service);
             }
+        });
 
-            Topics finalComponentsToGroupsTopics = componentsToGroupsTopics;
-
-            DeploymentService finalDeploymentService = deploymentService;
-            filteredServices.forEach(service -> {
-                if (isSystemLevelService(service)) {
-                    return;
-                }
-                List<String> componentGroups = new ArrayList<>();
-                if (finalComponentsToGroupsTopics != null) {
-                    Topics groupsTopics = finalComponentsToGroupsTopics.findTopics(service.getName());
-                    if (groupsTopics != null) {
-                        groupsTopics.children.values().stream().map(n -> (Topic) n).map(Topic::getName)
-                                .forEach(groupName -> {
-                                    componentGroups.add(groupName);
-                                    // Get all the group names from the user components.
-                                    allGroups.add(groupName);
-                                });
-                    }
-                }
-                Topic versionTopic = service.getServiceConfig().findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY);
-                ComponentStatusDetails componentStatusDetails = ComponentStatusDetails.builder()
-                        .componentName(service.getName())
-                        .state(service.getState())
-                        .version(Coerce.toString(versionTopic))
-                        .fleetConfigArns(componentGroups)
-                        .isRoot(finalDeploymentService.isComponentRoot(service.getName()))
-                        .build();
-                components.add(componentStatusDetails);
-            });
-
-            filteredServices.forEach(service -> {
-                if (!isSystemLevelService(service)) {
-                    return;
-                }
-                Topic versionTopic = service.getServiceConfig().findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY);
-                ComponentStatusDetails componentStatusDetails = ComponentStatusDetails.builder()
-                        .componentName(service.getName())
-                        .state(service.getState())
-                        .version(Coerce.toString(versionTopic))
-                        .fleetConfigArns(new ArrayList<>(allGroups))
-                        .isRoot(false) // Set false for all system level services.
-                        .build();
-                components.add(componentStatusDetails);
-            });
-            greengrassServiceSet.clear();
-            Topic sequenceNumberTopic = getSequenceNumberTopic();
-            sequenceNumber = Coerce.toLong(sequenceNumberTopic);
-            sequenceNumberTopic.withValue(sequenceNumber + 1);
+        Topics componentsToGroupsTopics = null;
+        HashSet<String> allGroups = new HashSet<>();
+        DeploymentService deploymentService = null;
+        try {
+            GreengrassService deploymentServiceLocateResult = this.kernel
+                    .locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS);
+            if (deploymentServiceLocateResult instanceof DeploymentService) {
+                deploymentService = (DeploymentService) deploymentServiceLocateResult;
+                componentsToGroupsTopics = deploymentService.getConfig().lookupTopics(COMPONENTS_TO_GROUPS_TOPICS);
+            }
+        } catch (ServiceLoadException e) {
+            logger.atError().cause(e).log("Unable to locate {} service while uploading FSS data",
+                    DeploymentService.DEPLOYMENT_SERVICE_TOPICS);
         }
+
+        Topics finalComponentsToGroupsTopics = componentsToGroupsTopics;
+
+        DeploymentService finalDeploymentService = deploymentService;
+        filteredServices.forEach(service -> {
+            if (isSystemLevelService(service)) {
+                return;
+            }
+            List<String> componentGroups = new ArrayList<>();
+            if (finalComponentsToGroupsTopics != null) {
+                Topics groupsTopics = finalComponentsToGroupsTopics.findTopics(service.getName());
+                if (groupsTopics != null) {
+                    groupsTopics.children.values().stream().map(n -> (Topic) n).map(Topic::getName)
+                            .forEach(groupName -> {
+                                componentGroups.add(groupName);
+                                // Get all the group names from the user components.
+                                allGroups.add(groupName);
+                            });
+                }
+            }
+            Topic versionTopic = service.getServiceConfig().findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY);
+            ComponentStatusDetails componentStatusDetails = ComponentStatusDetails.builder()
+                    .componentName(service.getName())
+                    .state(service.getState())
+                    .version(Coerce.toString(versionTopic))
+                    .fleetConfigArns(componentGroups)
+                    .isRoot(finalDeploymentService.isComponentRoot(service.getName()))
+                    .build();
+            components.add(componentStatusDetails);
+        });
+
+        filteredServices.forEach(service -> {
+            if (!isSystemLevelService(service)) {
+                return;
+            }
+            Topic versionTopic = service.getServiceConfig().findLeafChild(KernelConfigResolver.VERSION_CONFIG_KEY);
+            ComponentStatusDetails componentStatusDetails = ComponentStatusDetails.builder()
+                    .componentName(service.getName())
+                    .state(service.getState())
+                    .version(Coerce.toString(versionTopic))
+                    .fleetConfigArns(new ArrayList<>(allGroups))
+                    .isRoot(false) // Set false for all system level services.
+                    .build();
+            components.add(componentStatusDetails);
+        });
+        greengrassServiceSet.clear();
+        Topic sequenceNumberTopic = getSequenceNumberTopic();
+        long sequenceNumber = Coerce.toLong(sequenceNumberTopic);
+        sequenceNumberTopic.withValue(sequenceNumber + 1);
 
         FleetStatusDetails fleetStatusDetails = FleetStatusDetails.builder()
                 .overallStatus(overAllStatus)

--- a/src/main/java/com/aws/greengrass/status/model/Trigger.java
+++ b/src/main/java/com/aws/greengrass/status/model/Trigger.java
@@ -40,4 +40,14 @@ public enum Trigger {
                 throw new IllegalArgumentException("Invalid deployment type: " + deploymentType);
         }
     }
+
+    /**
+     * Check if a FSS update is deployment triggered.
+     *
+     * @param trigger trigger to check
+     * @return true if it's a deployment
+     */
+    public static boolean isDeploymentTrigger(Trigger trigger) {
+        return trigger == LOCAL_DEPLOYMENT || trigger == THING_DEPLOYMENT || trigger == THING_GROUP_DEPLOYMENT;
+    }
 }

--- a/src/main/java/com/aws/greengrass/status/model/Trigger.java
+++ b/src/main/java/com/aws/greengrass/status/model/Trigger.java
@@ -42,12 +42,12 @@ public enum Trigger {
     }
 
     /**
-     * Check if a FSS update is deployment triggered.
+     * Check if a FSS update is cloud deployment triggered.
      *
      * @param trigger trigger to check
      * @return true if it's a deployment
      */
-    public static boolean isDeploymentTrigger(Trigger trigger) {
-        return trigger == LOCAL_DEPLOYMENT || trigger == THING_DEPLOYMENT || trigger == THING_GROUP_DEPLOYMENT;
+    public static boolean isCloudDeploymentTrigger(Trigger trigger) {
+        return trigger == THING_DEPLOYMENT || trigger == THING_GROUP_DEPLOYMENT;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

1. Attempt to publish fss data triggered by cloud deployment when MQTT connection is interrupted, hence spooling the message.
2. Synchronize all event-triggered FSS update on `updatedServiceSet` so that the tracking set is not modified while an update is ongoing.

Note that a lot of line changes are just indentations, so split view is recommended when reviewing the changes.

**Why is this change necessary:**
To provide better accurate information of deployment result via FSS and improve customer experience of deployment notification on cloud.


**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
