### PR TITLE
feat: track unchanged components across status updates

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/SimpleAppAndCustomerApp.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/SimpleAppAndCustomerApp.json
@@ -1,0 +1,21 @@
+{
+  "deploymentId": "TestDeploymentId3",
+  "configurationArn": "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1",
+  "components": {
+    "SimpleApp": {
+      "version": "1.0.0"
+    },
+    "CustomerApp": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 100,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 120,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 120
+  }
+}

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
@@ -29,6 +29,7 @@ public class DeploymentStatusKeeper {
     public static final String DEPLOYMENT_ID_KEY_NAME = "DeploymentId";
     public static final String CONFIGURATION_ARN_KEY_NAME = "ConfigurationArn";
     public static final String DEPLOYMENT_TYPE_KEY_NAME = "DeploymentType";
+    public static final String DEPLOYMENT_ROOT_PACKAGES_KEY_NAME = "DeploymentRootPackages";
     public static final String DEPLOYMENT_STATUS_KEY_NAME = "DeploymentStatus";
     public static final String DEPLOYMENT_STATUS_DETAILS_KEY_NAME = "DeploymentStatusDetails";
     private static final Logger logger = LogManager.getLogger(DeploymentStatusKeeper.class);
@@ -63,11 +64,12 @@ public class DeploymentStatusKeeper {
      * @param deploymentType   type of deployment.
      * @param status           status of deployment.
      * @param statusDetails    other details of deployment status.
+     * @param rootPackages     root packages in the deployment.
      * @throws IllegalArgumentException for invalid deployment type
      */
     public void persistAndPublishDeploymentStatus(String deploymentId, String configurationArn,
                                                   DeploymentType deploymentType, String status,
-                                                  Map<String, Object> statusDetails) {
+                                                  Map<String, Object> statusDetails, List<String> rootPackages) {
 
         //While this method is being run, another thread could be running the publishPersistedStatusUpdates
         // method which consumes the data in config from the same topics. These two thread needs to be synchronized
@@ -80,6 +82,7 @@ public class DeploymentStatusKeeper {
             deploymentDetails.put(DEPLOYMENT_TYPE_KEY_NAME, deploymentType.toString());
             deploymentDetails.put(DEPLOYMENT_STATUS_KEY_NAME, status);
             deploymentDetails.put(DEPLOYMENT_STATUS_DETAILS_KEY_NAME, statusDetails);
+            deploymentDetails.put(DEPLOYMENT_ROOT_PACKAGES_KEY_NAME, rootPackages);
             //Each status update is uniquely stored
             Topics processedDeployments = getProcessedDeployments();
             Topics thisJob = processedDeployments.createInteriorChild(String.valueOf(System.currentTimeMillis()));

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Synchronized;
 
+import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -49,4 +50,7 @@ public class DeploymentTaskMetadata {
         return this.deployment.getDeploymentDocumentObj();
     }
 
+    public List<String> getRootPackages() {
+        return this.getDeploymentDocument().getRootPackages();
+    }
 }

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -562,6 +562,8 @@ public class FleetStatusService extends GreengrassService {
         // a failed deployment as component's last installation source.
         if (deploymentDetails.containsKey(DEPLOYMENT_ROOT_PACKAGES_KEY_NAME)
                 && JobStatus.SUCCEEDED.toString().equals(deploymentInformation.getStatus())) {
+            // Setting the unchangedRootComponents to be the entire list of root packages, and then later
+            // if a component changed state since last FSS update we will remove it from this list.
             deploymentInformation.setUnchangedRootComponents((List<String>) deploymentDetails
                     .get(DEPLOYMENT_ROOT_PACKAGES_KEY_NAME));
         }

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -63,6 +63,7 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_T
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.CONFIGURATION_ARN_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ROOT_PACKAGES_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_TYPE_KEY_NAME;
@@ -402,6 +403,13 @@ public class FleetStatusService extends GreengrassService {
             });
             removedDependenciesSet.forEach(serviceFssTracksMap::remove);
             removedDependenciesSet.clear();
+
+            // remove any component from unchanged status component list if it's in updatedGreengrassServiceSet
+            if (deploymentInformation != null && deploymentInformation.getUnchangedRootComponents() != null) {
+                deploymentInformation.getUnchangedRootComponents().removeIf(
+                        componentName -> updatedGreengrassServiceSet.stream()
+                                .anyMatch(service -> service.getName().equals(componentName)));
+            }
             uploadFleetStatusServiceData(updatedGreengrassServiceSet, overAllStatus.get(), deploymentInformation,
                     trigger);
         }
@@ -548,6 +556,14 @@ public class FleetStatusService extends GreengrassService {
                     .errorTypes((List<String>) statusDetailsMap.get(DEPLOYMENT_ERROR_TYPES_KEY))
                     .build();
             deploymentInformation.setStatusDetails(statusDetails);
+        }
+        // Use unchangedRootComponents to update lastInstallationSource and lastReportedTimestamp in cloud.
+        // Only update the unchangedRootComponents list if a deployment is successful, because we should not display
+        // a failed deployment as component's last installation source.
+        if (deploymentDetails.containsKey(DEPLOYMENT_ROOT_PACKAGES_KEY_NAME)
+                && JobStatus.SUCCEEDED.toString().equals(deploymentInformation.getStatus())) {
+            deploymentInformation.setUnchangedRootComponents((List<String>) deploymentDetails
+                    .get(DEPLOYMENT_ROOT_PACKAGES_KEY_NAME));
         }
         return deploymentInformation;
     }

--- a/src/main/java/com/aws/greengrass/status/model/DeploymentInformation.java
+++ b/src/main/java/com/aws/greengrass/status/model/DeploymentInformation.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -22,4 +24,7 @@ public class DeploymentInformation {
     private StatusDetails statusDetails;
     private String fleetConfigurationArnForStatus;
     private String deploymentId;
+    // tracking root components in a deployment FSS update without component status detail due to state unchanged
+    // since last update
+    private List<String> unchangedRootComponents;
 }

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -100,7 +100,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     private static final String EXPECTED_GROUP_NAME = "thinggroup/group1";
     private static final String EXPECTED_ROOT_PACKAGE_NAME = "component1";
     private static final String TEST_DEPLOYMENT_ID = "testDeploymentId";
-    private static final List<String > EXPECTED_ROOT_PACKAGE_LIST = Collections.singletonList("component1");
+    private static final List<String> EXPECTED_ROOT_PACKAGE_LIST = Collections.singletonList("component1");
     private static final Duration TEST_DEPLOYMENT_POLLING_FREQUENCY = Duration.ofSeconds(1);
 
     private static final String TEST_CONFIGURATION_ARN =

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -46,6 +46,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,6 +100,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     private static final String EXPECTED_GROUP_NAME = "thinggroup/group1";
     private static final String EXPECTED_ROOT_PACKAGE_NAME = "component1";
     private static final String TEST_DEPLOYMENT_ID = "testDeploymentId";
+    private static final List<String > EXPECTED_ROOT_PACKAGE_LIST = Collections.singletonList("component1");
     private static final Duration TEST_DEPLOYMENT_POLLING_FREQUENCY = Duration.ofSeconds(1);
 
     private static final String TEST_CONFIGURATION_ARN =
@@ -416,17 +418,17 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         doNothing().when(deploymentStatusKeeper)
                 .persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1), eq(expectedConfigArn), eq(type),
-                        eq(JobStatus.IN_PROGRESS.toString()), any());
+                        eq(JobStatus.IN_PROGRESS.toString()), any(), any());
 
         startDeploymentServiceInAnotherThread();
         verify(deploymentStatusKeeper, timeout(1000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(expectedConfigArn), eq(type), eq(JobStatus.IN_PROGRESS.toString()), any());
+                eq(expectedConfigArn), eq(type), eq(JobStatus.IN_PROGRESS.toString()), any(), any());
         verify(deploymentStatusKeeper, timeout(10000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any());
+                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any(), any());
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any());
+                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any(), any());
         ArgumentCaptor<Map<String, Object>> mapCaptor = ArgumentCaptor.forClass(Map.class);
         verify(mockComponentsToGroupPackages).replaceAndWait(mapCaptor.capture());
         Map<String, Object> groupToRootPackages = mapCaptor.getValue();
@@ -456,10 +458,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
 
@@ -481,10 +483,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                statusDetails.capture());
+                statusDetails.capture(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         assertEquals("Unable to create deployment directory. mock error", statusDetails.getValue().get(DEPLOYMENT_FAILURE_CAUSE_KEY));
         assertListEquals(Arrays.asList("DEPLOYMENT_FAILURE", "IO_ERROR", "IO_WRITE_ERROR"),
                 (List<String>) statusDetails.getValue().get(DEPLOYMENT_ERROR_STACK_KEY));
@@ -517,10 +519,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
 
         ArgumentCaptor<Map<String, Object>> mapCaptor = ArgumentCaptor.forClass(Map.class);
         verify(deploymentGroupTopics).replaceAndWait(mapCaptor.capture());
@@ -554,10 +556,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     @Test
@@ -575,10 +577,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     @Test
@@ -601,7 +603,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(updateSystemPolicyService, WAIT_FOUR_SECONDS).discardPendingUpdateAction(TEST_DEPLOYMENT_ID);
         verify(mockFuture, WAIT_FOUR_SECONDS).cancel(true);
     }
@@ -628,7 +630,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockFuture, times(0)).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     @Test
@@ -665,7 +667,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockFuture, times(0)).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any());
+                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     String getTestDeploymentDocument() {

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.aws.greengrass.model.DeploymentStatus;
 import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -94,11 +95,11 @@ class DeploymentStatusKeeperTest {
         }, DUMMY_SERVICE_NAME);
 
         deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
-                JobStatus.SUCCEEDED.toString(), new HashMap<>());
+                JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", null, LOCAL,
-                DeploymentStatus.SUCCEEDED.toString(), new HashMap<>());
-        assertEquals(5, updateOfTypeJobs.size());
-        assertEquals(5, updateOfTypeLocal.size());
+                DeploymentStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
+        assertEquals(6, updateOfTypeJobs.size());
+        assertEquals(6, updateOfTypeLocal.size());
         assertEquals("iot_deployment", updateOfTypeJobs.get(DEPLOYMENT_ID_KEY_NAME));
         assertEquals(JobStatus.SUCCEEDED, Coerce.toEnum(JobStatus.class,
                 updateOfTypeJobs.get(DEPLOYMENT_STATUS_KEY_NAME)));
@@ -118,7 +119,7 @@ class DeploymentStatusKeeperTest {
     void GIVEN_deployment_status_update_WHEN_consumer_return_true_THEN_update_is_removed_from_config() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(IOT_JOBS, (details) -> true, DUMMY_SERVICE_NAME);
         deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
-                JobStatus.SUCCEEDED.toString(), new HashMap<>());
+                JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         context.waitForPublishQueueToClear();
         assertEquals(0, processedDeployments.children.size());
     }
@@ -127,7 +128,7 @@ class DeploymentStatusKeeperTest {
     void GIVEN_local_deployment_status_update_WHEN_consumer_return_true_THEN_update_is_removed_from_config() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(LOCAL, (details) -> true, DUMMY_SERVICE_NAME);
         deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", null, LOCAL,
-                DeploymentStatus.SUCCEEDED.toString(), new HashMap<>());
+                DeploymentStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         context.waitForPublishQueueToClear();
         assertEquals(0, processedDeployments.children.size());
     }
@@ -136,7 +137,7 @@ class DeploymentStatusKeeperTest {
     void GIVEN_deployment_status_update_WHEN_consumer_return_false_THEN_update_is_not_removed() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(IOT_JOBS, (details) -> false, DUMMY_SERVICE_NAME);
         deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
-                JobStatus.SUCCEEDED.toString(), new HashMap<>());
+                JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         assertEquals(1, processedDeployments.children.size());
     }
 
@@ -151,7 +152,7 @@ class DeploymentStatusKeeperTest {
         }, DUMMY_SERVICE_NAME);
         // DeploymentStatusKeeper will retain update as consumer returns false
         deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
-                JobStatus.SUCCEEDED.toString(), new HashMap<>());
+                JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         assertEquals(1, consumerInvokeCount.get());
 
         // updating the consumer return value to true

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -231,6 +231,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL.toString(),
                 fleetStatusDetails.getDeploymentInformation().getStatusDetails().getDetailedStatus());
         assertNull(fleetStatusDetails.getDeploymentInformation().getStatusDetails().getFailureCause());
+        assertNull(fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
         assertEquals(2, fleetStatusDetails.getComponentStatusDetails().size());
         assertServiceIsRootOrNot(fleetStatusDetails.getComponentStatusDetails().get(0));
         serviceNamesToCheck.remove(fleetStatusDetails.getComponentStatusDetails().get(0).getComponentName());
@@ -319,6 +320,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
                 fleetStatusDetails.getDeploymentInformation().getStatusDetails().getDetailedStatus());
         assertEquals(failureCauseMessage,
                 fleetStatusDetails.getDeploymentInformation().getStatusDetails().getFailureCause());
+        assertNull(fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
         assertEquals(1, fleetStatusDetails.getComponentStatusDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentStatusDetails().get(0).getComponentName());
         assertNull(fleetStatusDetails.getComponentStatusDetails().get(0).getStatusDetails());
@@ -564,6 +566,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL.toString(),
                 fleetStatusDetails.getDeploymentInformation().getStatusDetails().getDetailedStatus());
         assertNull(fleetStatusDetails.getDeploymentInformation().getStatusDetails().getFailureCause());
+        assertNull(fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
 
         fleetStatusDetails.getComponentStatusDetails().forEach(System.out::println);
         assertEquals(1, fleetStatusDetails.getComponentStatusDetails().size());
@@ -747,6 +750,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
                 assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
                 assertEquals("MockService", componentStatusDetails.getComponentName());
                 assertEquals("testJob", fleetStatusDetails.getDeploymentInformation().getDeploymentId());
+                assertNull(fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
                 assertNull(componentStatusDetails.getStatusDetails());
                 assertEquals(State.RUNNING, componentStatusDetails.getState());
                 assertEquals(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"),


### PR DESCRIPTION
**Description of changes:**
1. Persist root components of a deployment in kernel config via `DeploymentStatusKeeper`
2. Add a new list `unchangedRootComponents` in deployment FSS update to track root components without state change since last update in the deployment FSS update:
    * If a deployment fails, then `unchangedRootComponents` is null;
    * if a deployment succeeds, 
        * if all root components observed state changes during the deployment, and no component errors during deployment, then `unchangedRootComponents` is an empty list;
        * if any root component version is already installed prior to the deployment and in running/finished state, then adds its  name to `unchangedRootComponents`
        * if component observes transient errors during a deployment, while another root components are already running/finished, then add the other component's name to `unchangedRootComponents`
3. Update relevant unit tests and integ tests.

**Why is this change necessary:**
To help service gain better visibility of component installation source and timestamp on device.
These changes are part of our ongoing improvements to FSS and device health notifications.


**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
Currently, event-triggered FSS updates only include the component status details of those who changed states since last update. Therefore, in a deployment status update, if a component did not change state, it would not be included and its installation source would not be updated in the cloud.

Additionally, if a component error status update already includes another component in deployment, the other component would not be included in the final deployment status update, and the installation source would not be updated.

For example, for deployment of component A and B, if the sequence of events were `deployment -> A running and B errors -> A running, B running, and deployment successful`, then the component errored update would contain `[A, B]`, and the deployment update would only contain `[B]`, because A has not changed state since B errored.

In these two scenarios, the service would rely on `unchangedRootComponents` to know these root components also installed by the deployment and update the console.

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
