### PR TITLE
revert: fix(fss): correct config arn and add deployment id

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -454,7 +454,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         if (cancelDeployment) {
             deployment = new Deployment(DeploymentType.SHADOW, UUID.randomUUID().toString(), true);
         } else {
-            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configuration.getDeploymentId());
+            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configurationArn);
         }
         if (deploymentQueue.offer(deployment)) {
             logger.atInfo().kv("ID", deployment.getId()).log("Added shadow deployment job");


### PR DESCRIPTION
Reverts #1273 

**Issue #, if available:**

**Description of changes:**

Manually reverts #1273 to use the ARN as the deployment ID for shadow deployments. `git revert` caused too many conflicts to undo due to all the recent error code changes.

**Why is this change necessary:**
This revert is necessary because the previous PR changed the format of FSS updates in an incompatible way. The `GetDeployment` cloud API always returned "in progress" instead of "completed" for completed shadow deployments.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
