### PR TITLE
fix(config): race condition when subscribing to changing configuration

### DIFF
--- a/src/test/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgentTest.java
@@ -73,6 +73,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
+@SuppressWarnings("PMD.CloseResource")
 class ConfigStoreIPCEventStreamAgentTest {
     private static final String TEST_COMPONENT_A = "Component_A";
     private static final String TEST_COMPONENT_B = "Component_B";
@@ -396,7 +397,10 @@ class ConfigStoreIPCEventStreamAgentTest {
                 .thenReturn(new CompletableFuture<>());
         SubscribeToConfigurationUpdateRequest subscribe = new SubscribeToConfigurationUpdateRequest();
         subscribe.setComponentName(TEST_COMPONENT_A);
-        SubscribeToConfigurationUpdateResponse response = agent.getConfigurationUpdateHandler(mockContext).handleRequest(subscribe);
+        ConfigStoreIPCEventStreamAgent.ConfigurationUpdateOperationHandler handler =
+                agent.getConfigurationUpdateHandler(mockContext);
+        SubscribeToConfigurationUpdateResponse response = handler.handleRequest(subscribe);
+        handler.afterHandleRequest();
         assertNotNull(response);
 
         configuration.getRoot()
@@ -427,7 +431,10 @@ class ConfigStoreIPCEventStreamAgentTest {
         SubscribeToConfigurationUpdateRequest subscribe = new SubscribeToConfigurationUpdateRequest();
         subscribe.setComponentName(TEST_COMPONENT_A);
         subscribe.setKeyPath(Collections.singletonList(TEST_CONFIG_KEY_1));
-        SubscribeToConfigurationUpdateResponse response = agent.getConfigurationUpdateHandler(mockContext).handleRequest(subscribe);
+        ConfigStoreIPCEventStreamAgent.ConfigurationUpdateOperationHandler handler =
+                agent.getConfigurationUpdateHandler(mockContext);
+        SubscribeToConfigurationUpdateResponse response = handler.handleRequest(subscribe);
+        handler.afterHandleRequest();
         assertNotNull(response);
 
         configuration.getRoot()
@@ -461,7 +468,10 @@ class ConfigStoreIPCEventStreamAgentTest {
         SubscribeToConfigurationUpdateRequest subscribe = new SubscribeToConfigurationUpdateRequest();
         subscribe.setComponentName(TEST_COMPONENT_A);
         subscribe.setKeyPath(Arrays.asList("SomeContainerNode", "SomeLeafNode"));
-        SubscribeToConfigurationUpdateResponse response = agent.getConfigurationUpdateHandler(mockContext).handleRequest(subscribe);
+        ConfigStoreIPCEventStreamAgent.ConfigurationUpdateOperationHandler handler =
+                agent.getConfigurationUpdateHandler(mockContext);
+        SubscribeToConfigurationUpdateResponse response = handler.handleRequest(subscribe);
+        handler.afterHandleRequest();
         assertNotNull(response);
 
         configuration.getRoot()
@@ -497,7 +507,10 @@ class ConfigStoreIPCEventStreamAgentTest {
         SubscribeToConfigurationUpdateRequest subscribe = new SubscribeToConfigurationUpdateRequest();
         subscribe.setComponentName(TEST_COMPONENT_A);
         subscribe.setKeyPath(Arrays.asList("Level1ContainerNode", "Level2ContainerNode"));
-        SubscribeToConfigurationUpdateResponse response = agent.getConfigurationUpdateHandler(mockContext).handleRequest(subscribe);
+        ConfigStoreIPCEventStreamAgent.ConfigurationUpdateOperationHandler handler =
+                agent.getConfigurationUpdateHandler(mockContext);
+        SubscribeToConfigurationUpdateResponse response = handler.handleRequest(subscribe);
+        handler.afterHandleRequest();
         assertNotNull(response);
 
         configuration.getRoot()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes a race condition which causes this failure: https://github.com/aws-greengrass/aws-greengrass-nucleus/runs/8234655490?check_suite_focus=true.

```
software.amazon.awssdk.eventstreamrpc.UnmappedDataException: Found model-type {aws.greengrass#ConfigurationUpdateEvents} which does not map into Java class: software.amazon.awssdk.aws.greengrass.model.SubscribeToConfigurationUpdateResponse
```

Fixes it by using an atomicboolean which is set to true once the IPC subscription response has been sent to the client. Only when this flag is `true` will a configuration update cause the data to actually send.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
