### PR TITLE
fix: set and report config arn correctly for shadow deployments

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -57,7 +57,7 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILE
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_STACK_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_TYPES_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
-import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.CONFIGURATION_ARN_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
@@ -334,7 +334,7 @@ public class ShadowDeploymentListener implements InjectionActions {
             iotShadowClient.PublishUpdateNamedShadow(updateNamedShadowRequest, QualityOfService.AT_LEAST_ONCE)
                     .get(TIMEOUT_FOR_PUBLISHING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
 
-            logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME))
+            logger.atInfo().kv(CONFIGURATION_ARN_LOG_KEY_NAME, deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME))
                     .kv(STATUS_KEY, shadowState.reported.get(STATUS_KEY))
                     .log("Updated reported state for deployment");
             return true;
@@ -362,7 +362,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         statusDetails.put(ERROR_TYPES_KEY, deploymentStatusDetails.get(DEPLOYMENT_ERROR_TYPES_KEY));
 
         HashMap<String, Object> reported = new HashMap<>();
-        reported.put(ARN_FOR_STATUS_KEY, deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME));
+        reported.put(ARN_FOR_STATUS_KEY, deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME));
         reported.put(STATUS_KEY, deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME));
         reported.put(STATUS_DETAILS_KEY, statusDetails);
         reported.put(GGC_VERSION_KEY, deviceConfiguration.getNucleusVersion());
@@ -454,7 +454,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         if (cancelDeployment) {
             deployment = new Deployment(DeploymentType.SHADOW, UUID.randomUUID().toString(), true);
         } else {
-            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configurationArn);
+            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configuration.getDeploymentId());
         }
         if (deploymentQueue.offer(deployment)) {
             logger.atInfo().kv("ID", deployment.getId()).log("Added shadow deployment job");
@@ -467,7 +467,7 @@ public class ShadowDeploymentListener implements InjectionActions {
             logger.debug("Last known deployment status is empty, nothing to report");
             return;
         }
-        if (!reported.get(ARN_FOR_STATUS_KEY).equals(lastDeploymentStatus.get().get(DEPLOYMENT_ID_KEY_NAME))
+        if (!reported.get(ARN_FOR_STATUS_KEY).equals(lastDeploymentStatus.get().get(CONFIGURATION_ARN_KEY_NAME))
                 || !reported.get(STATUS_KEY).equals(lastDeploymentStatus.get().get(DEPLOYMENT_STATUS_KEY_NAME))) {
             logger.info("Updating reported section of shadow with the latest deployment status");
             updateReportedSectionOfShadowWithDeploymentStatus();


### PR DESCRIPTION
**Issue #, if available:**
-
**Description of changes:**
Fix for reporting config arn correctly for shadow deployments which https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1273/files broke in an attempt to consistently send deployment id and config arn in FSS, this change had to be reverted https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1296/files

**Why is this change necessary:**
Changing the values tracked for deployment id and config arn in deployment metadata also flips the value for config arn in persisted deployment status which is used to populate the reported section of deployment shadow - the key used was 'DeploymentId' but the value used to be the config arn before the commit linked above. In order for that change to work without breaking the reporting for shadow deployments, we now need to use the correct key.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
