### PR TITLE
fix: save deployment error type across kernel restart

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
@@ -16,10 +16,12 @@ import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
 import com.aws.greengrass.lifecyclemanager.KernelLifecycle;
+import com.aws.greengrass.util.Pair;
 import com.aws.greengrass.util.Utils;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
@@ -107,8 +109,10 @@ public class KernelUpdateActivator extends DeploymentActivator {
                 .kv(DEPLOYMENT_ID_LOG_KEY, deployment.getDeploymentDocumentObj().getDeploymentId())
                 .log("Rolling back failed deployment");
 
-        deployment.setErrorStack(
-                DeploymentErrorCodeUtils.generateErrorReportFromExceptionStack(failureCause).getLeft());
+        Pair<List<String>, List<String>> errorReport =
+                DeploymentErrorCodeUtils.generateErrorReportFromExceptionStack(failureCause);
+        deployment.setErrorStack(errorReport.getLeft());
+        deployment.setErrorTypes(errorReport.getRight());
         deployment.setStageDetails(Utils.generateFailureMessage(failureCause));
 
         deployment.setDeploymentStage(KERNEL_ROLLBACK);

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentException.java
@@ -71,9 +71,11 @@ public class DeploymentException extends Exception {
         this.errorCodes.addAll(errorCodes);
     }
 
-    public DeploymentException(String message, List<DeploymentErrorCode> errorCodes) {
+    public DeploymentException(String message, List<DeploymentErrorCode> errorCodes,
+                               List<DeploymentErrorType> errorTypes) {
         super(message);
         this.errorCodes.addAll(errorCodes);
+        this.errorTypes.addAll(errorTypes);
     }
 
     public DeploymentException withErrorContext(Throwable t, DeploymentErrorCode errorCode) {

--- a/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
@@ -35,8 +35,9 @@ public class Deployment {
     @Setter
     private String stageDetails;
 
-    // persist error code stack across restart
+    // persist error code stack and error types across restart
     private List<String> errorStack;
+    private List<String> errorTypes;
 
     /**
      * Constructor for regular deployments.

--- a/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
@@ -10,6 +10,8 @@ import com.aws.greengrass.config.ConfigurationWriter;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
 import com.aws.greengrass.deployment.bootstrap.BootstrapManager;
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorType;
 import com.aws.greengrass.deployment.exceptions.DeploymentException;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
@@ -30,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -121,7 +124,8 @@ class KernelUpdateActivatorTest {
         verify(bootstrapManager).persistBootstrapTaskList(eq(bootstrapFilePath));
         verify(deployment).setDeploymentStage(eq(KERNEL_ROLLBACK));
         verify(deployment).setStageDetails(eq("mock error"));
-        verify(deployment).setErrorStack(Arrays.asList("DEPLOYMENT_FAILURE", "IO_ERROR"));
+        verify(deployment).setErrorStack(eq(Arrays.asList("DEPLOYMENT_FAILURE", "IO_ERROR")));
+        verify(deployment).setErrorTypes(eq(Collections.emptyList()));
         verify(kernelAlternatives).prepareRollback();
         verify(kernel).shutdown(eq(30), eq(REQUEST_RESTART));
     }
@@ -135,7 +139,8 @@ class KernelUpdateActivatorTest {
         doReturn(bootstrapFilePath).when(deploymentDirectoryManager).getBootstrapTaskFilePath();
         Path targetConfigFilePath = mock(Path.class);
         doReturn(targetConfigFilePath).when(deploymentDirectoryManager).getTargetConfigFilePath();
-        ServiceUpdateException mockSUE = new ServiceUpdateException("mock error");
+        ServiceUpdateException mockSUE = new ServiceUpdateException("mock error", DeploymentErrorCode.COMPONENT_BROKEN,
+                DeploymentErrorType.USER_COMPONENT_ERROR);
         doThrow(mockSUE).when(bootstrapManager).executeAllBootstrapTasksSequentially(eq(bootstrapFilePath));
         doThrow(new IOException()).when(kernelAlternatives).prepareRollback();
 
@@ -145,7 +150,9 @@ class KernelUpdateActivatorTest {
         verify(kernelAlternatives).prepareBootstrap(eq("testId"));
         verify(deployment).setDeploymentStage(eq(KERNEL_ROLLBACK));
         verify(deployment).setStageDetails("mock error");
-        verify(deployment).setErrorStack(Arrays.asList("DEPLOYMENT_FAILURE", "COMPONENT_UPDATE_ERROR"));
+        verify(deployment).setErrorStack(eq(Arrays.asList("DEPLOYMENT_FAILURE", "COMPONENT_UPDATE_ERROR",
+                "COMPONENT_BROKEN")));
+        verify(deployment).setErrorTypes(eq(Collections.singletonList("USER_COMPONENT_ERROR")));
         verify(deploymentDirectoryManager).writeDeploymentMetadata(eq(deployment));
         verify(kernel).shutdown(eq(30), eq(REQUEST_RESTART));
     }


### PR DESCRIPTION
**Description of changes:**
1. Save deployment error types across restart.
2. Update unit tests.

**Why is this change necessary:**
Sometimes deployment error type for a given error is generated from runtime context (for example, if a component is broken, we check recipe metadata to see if it's an AWS component). The deployment error type would be lost if nucleus restarts during deployment failure(bootstrap or rollback).

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
