### PR TITLE
fix: save deployment error code across bootstrap

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.deployment.DeploymentQueue;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.activator.DeploymentActivatorFactory;
 import com.aws.greengrass.deployment.bootstrap.BootstrapManager;
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorCodeUtils;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
@@ -210,7 +211,11 @@ public class Kernel {
                     try {
                         Deployment deployment = deploymentDirectoryManager.readDeploymentMetadata();
                         deployment.setDeploymentStage(DeploymentStage.KERNEL_ROLLBACK);
-                        deployment.setStageDetails(e.getMessage());
+                        Pair<List<String>, List<String>> errorReport =
+                                DeploymentErrorCodeUtils.generateErrorReportFromExceptionStack(e);
+                        deployment.setErrorStack(errorReport.getLeft());
+                        deployment.setErrorTypes(errorReport.getRight());
+                        deployment.setStageDetails(Utils.generateFailureMessage(e));
                         deploymentDirectoryManager.writeDeploymentMetadata(deployment);
                         kernelAlts.prepareRollback();
                     } catch (IOException ioException) {

--- a/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
@@ -139,7 +139,7 @@ class KernelUpdateActivatorTest {
         doReturn(bootstrapFilePath).when(deploymentDirectoryManager).getBootstrapTaskFilePath();
         Path targetConfigFilePath = mock(Path.class);
         doReturn(targetConfigFilePath).when(deploymentDirectoryManager).getTargetConfigFilePath();
-        ServiceUpdateException mockSUE = new ServiceUpdateException("mock error", DeploymentErrorCode.COMPONENT_BROKEN,
+        ServiceUpdateException mockSUE = new ServiceUpdateException("mock error", DeploymentErrorCode.COMPONENT_BOOTSTRAP_ERROR,
                 DeploymentErrorType.USER_COMPONENT_ERROR);
         doThrow(mockSUE).when(bootstrapManager).executeAllBootstrapTasksSequentially(eq(bootstrapFilePath));
         doThrow(new IOException()).when(kernelAlternatives).prepareRollback();
@@ -151,7 +151,7 @@ class KernelUpdateActivatorTest {
         verify(deployment).setDeploymentStage(eq(KERNEL_ROLLBACK));
         verify(deployment).setStageDetails("mock error");
         verify(deployment).setErrorStack(eq(Arrays.asList("DEPLOYMENT_FAILURE", "COMPONENT_UPDATE_ERROR",
-                "COMPONENT_BROKEN")));
+                "COMPONENT_BOOTSTRAP_ERROR")));
         verify(deployment).setErrorTypes(eq(Collections.singletonList("USER_COMPONENT_ERROR")));
         verify(deploymentDirectoryManager).writeDeploymentMetadata(eq(deployment));
         verify(kernel).shutdown(eq(30), eq(REQUEST_RESTART));


### PR DESCRIPTION
**Description of changes:**
Save deployment error code and error type when a bootstrap step fails.

**Why is this change necessary:**
To persist deployment error codes and error types when a deployment contains multiple bootstrap tasks. It's a follow-up to https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1299.
 
**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
