### PR TITLE
fix(windows): fixes for root path with spaces

### DIFF
--- a/scripts/loader.cmd
+++ b/scripts/loader.cmd
@@ -51,14 +51,14 @@ IF !IS_SYMLINK! EQU 1 (
 )
 
 @REM EXIST works for files, directories, and symlink dirs
-IF NOT EXIST %LAUNCH_DIR% (
-    ECHO FATAL: No Nucelus found!
+IF NOT EXIST "%LAUNCH_DIR%" (
+    ECHO FATAL: No Nucleus found!
     EXIT /B 1
 )
 
 @REM Get JVM_OPTIONS from launch.params if it exists
-IF EXIST %LAUNCH_DIR%\launch.params (
-    FOR /F "delims=" %%A IN (%LAUNCH_DIR%\launch.params) DO SET JVM_OPTIONS=%%A
+IF EXIST "%LAUNCH_DIR%\launch.params" (
+    FOR /F "usebackq delims=" %%A IN ("%LAUNCH_DIR%\launch.params") DO SET JVM_OPTIONS=%%A
 )
 
 SET JVM_OPTIONS=%JVM_OPTIONS% -Droot="%GG_ROOT%"
@@ -79,17 +79,17 @@ ECHO Nucleus options: %OPTIONS%
 SET /A MAX_RETRIES=3
 @REM Attempt to start the nucleus 3 times
 FOR /L %%i IN (1,1,%MAX_RETRIES%) DO (
-    %JAVA_EXE% -Dlog.store=FILE %JVM_OPTIONS% -jar "%LAUNCH_DIR%\distro\lib\Greengrass.jar" %OPTIONS%
+    "%JAVA_EXE%" -Dlog.store=FILE %JVM_OPTIONS% -jar "%LAUNCH_DIR%\distro\lib\Greengrass.jar" %OPTIONS%
     SET KERNEL_EXIT_CODE=!ERRORLEVEL!
 
     IF !KERNEL_EXIT_CODE! EQU 0 (
         ECHO Restarting Nucleus
-        call %LAUNCH_DIR%\distro\bin\loader.cmd
+        call "%LAUNCH_DIR%\distro\bin\loader.cmd"
         EXIT /B !ERRORLEVEL!
     ) ELSE (
     IF !KERNEL_EXIT_CODE! EQU 100 (
         ECHO Restarting Nucleus
-        call %LAUNCH_DIR%\distro\bin\loader.cmd
+        call "%LAUNCH_DIR%\distro\bin\loader.cmd"
         EXIT /B !ERRORLEVEL!
     ) ELSE (
     IF !KERNEL_EXIT_CODE! EQU 101 (

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/pubsub.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/pubsub.yaml
@@ -32,10 +32,8 @@ services:
       - SubscribeAndPublishWildcard
     lifecycle:
       run:
-        windows:
-          powershell -command sleep 1
-        posix:
-          sleep 1
+        windows: exit
+        posix: sleep 1
     configuration:
       accessControl:
         aws.greengrass.ipc.pubsub:
@@ -47,12 +45,7 @@ services:
               - '*'
 
   SubscribeNotPublish:
-    lifecycle:
-      run:
-        windows:
-          powershell -command sleep 1
-        posix:
-          sleep 1
+    lifecycle: {}
     configuration:
       accessControl:
         aws.greengrass.ipc.pubsub:
@@ -66,12 +59,7 @@ services:
               - '*'
 
   OnlyPublish:
-    lifecycle:
-      run:
-        windows:
-          powershell -command sleep 1
-        posix:
-          sleep 1
+    lifecycle: {}
     configuration:
       accessControl:
         aws.greengrass.ipc.pubsub:
@@ -84,12 +72,7 @@ services:
               - /longer/topic/example/
               - '*'
   DoAll1:
-    lifecycle:
-      run:
-        windows:
-          powershell -command sleep 1
-        posix:
-          sleep 1
+    lifecycle: {}
     configuration:
       accessControl:
         aws.greengrass.ipc.pubsub:
@@ -101,12 +84,7 @@ services:
               - '*'
 
   DoAll2:
-    lifecycle:
-      run:
-        windows:
-          powershell -command sleep 1
-        posix:
-          sleep 1
+    lifecycle: {}
     configuration:
       accessControl:
         aws.greengrass.ipc.pubsub:
@@ -118,12 +96,7 @@ services:
               - '*'
 
   SubscribeAndPublishWildcard:
-    lifecycle:
-      run:
-        windows:
-          powershell -command sleep 1
-        posix:
-          sleep 1
+    lifecycle: {}
     configuration:
       accessControl:
         aws.greengrass.ipc.pubsub:

--- a/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
@@ -97,7 +97,8 @@ class IPCEventStreamServiceTest {
         CountDownLatch connectionLatch = new CountDownLatch(1);
         EventStreamRPCConnection connection = null;
         try (EventLoopGroup elg = new EventLoopGroup(1);
-             ClientBootstrap clientBootstrap = new ClientBootstrap(elg, new HostResolver(elg));
+             HostResolver hostResolver = new HostResolver(elg);
+             ClientBootstrap clientBootstrap = new ClientBootstrap(elg, hostResolver);
              SocketOptions socketOptions = TestUtils.getSocketOptionsForIPC()) {
 
             String ipcServerSocketPath = Platform.getInstance().prepareIpcFilepathForComponent(mockRootPath);


### PR DESCRIPTION
**Issue #, if available:**
#1301.

**Description of changes:**
Fixes `loader.cmd` and service installation when the Greengrass root directory has spaces, such as `C:\Program Files\greengrass`. There are possibly other edge cases where spaces in the path will not work, but this is the initial blocker now removed.

**Why is this change necessary:**

**How was this change tested:**
Manually tested on windows by installing Greengrass to program files and validated the Greengrass was able to run.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
