### PR TITLE
fix: do not modify launch directory if sigterm is received

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -93,8 +93,9 @@ while [ $j -le 3 ] && [ $sigterm_received -eq 0 ];  do
   j=$(( j + 1 ))
 done
 
-# when reaching here, Nucleus has restarted 3 times and fails. Keep the current status and flip symlink.
-if is_directory_link "${GG_ROOT}/alts/old" && is_directory_link "${LAUNCH_DIR}"; then
+# If Nucleus did not receive a SIGTERM, then when reaching here, Nucleus has restarted 3 times and fails.
+# Keep the current status and flip symlink.
+if [ $sigterm_received -eq 0 ] && is_directory_link "${GG_ROOT}/alts/old" && is_directory_link "${LAUNCH_DIR}"; then
   flip_link "${LAUNCH_DIR}" "${GG_ROOT}/alts/broken"
   flip_link "${GG_ROOT}/alts/old" "${LAUNCH_DIR}"
 fi


### PR DESCRIPTION
**Description of changes:**
1. Do not modify launch directory if `SIGTERM` is received.

**Why is this change necessary:**
Before this change, if nucleus is finishing bootstrap steps of a deployment when a SIGTERM is received, the loader script would assume that the nucleus restart failed and roll back launch directory, resulting in deployment failure.

After this change, nucleus would pick up from where it's left in deployment after restart, if a SIGTERM is received.

Windows loader.cmd is handling this scenario correctly and exiting on 130 or -1073741510 without modifying launch directory.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
