### PR TITLE
fix: FSS robustness improvements

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.status.model.FleetStatusDetails;
 import com.aws.greengrass.status.model.MessageType;
+import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Coerce;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -91,6 +92,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
         assertThat(()-> fleetStatusDetails.get(), eventuallyEval(notNullValue(), Duration.ofSeconds(30)));
         assertEquals("ThingName", fleetStatusDetails.get().getThing());
         assertEquals(MessageType.COMPLETE, fleetStatusDetails.get().getMessageType());
+        assertEquals(Trigger.NUCLEUS_LAUNCH, fleetStatusDetails.get().getTrigger());
     }
 
     @Test
@@ -116,7 +118,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         // Verify have 1 publish request for each of IoTJobs, ShadowDeploymentService, and FSS
         ArgumentCaptor<PublishRequest> publishRequestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
-        verify(mqttClient, timeout(5000).atLeast(3)).publish(publishRequestCaptor.capture());
+        verify(mqttClient, timeout(5000).times(3)).publish(publishRequestCaptor.capture());
         List<PublishRequest> publishRequests = publishRequestCaptor.getAllValues();
 
         String IoTJobsTopic = "$aws/things/ThingName/shadow/name/AWSManagedGreengrassV2Deployment/get";

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.WrapperMqttClientConnection;
 import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.SerializerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -343,7 +344,9 @@ public class IotJobsHelper implements InjectionActions {
                 }
                 this.isSubscribedToIotJobsTopics.set(true);
                 deploymentStatusKeeper.publishPersistedStatusUpdates(DeploymentType.IOT_JOBS);
-                this.fleetStatusService.updateFleetStatusUpdateForAllComponents(isConfigurationUpdate);
+                if (isConfigurationUpdate) {
+                    this.fleetStatusService.updateFleetStatusUpdateForAllComponents(Trigger.NETWORK_RECONFIGURE);
+                }
             });
         }
     }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -180,6 +180,15 @@ public class KernelLifecycle {
         logger.atInfo().setEventType("system-start").addKeyValue("main", kernel.getMain()).log();
         startupAllServices();
 
+        try {
+            GreengrassService fleetStatusService = kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS);
+            if (fleetStatusService instanceof FleetStatusService) {
+                ((FleetStatusService) fleetStatusService).triggerFleetStatusUpdateAtKernelLaunch();
+            }
+        } catch (ServiceLoadException e) {
+            logger.atError().setCause(e).log("Failed to send status update at kernel launch because kernel was "
+                    + "unable to locate FleetStatusService");
+        }
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.WrapperMqttClientConnection;
 import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -155,7 +156,6 @@ class IotJobsHelperTest {
         verify(mockIotJobsClientWrapper).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(mockIotJobsClientWrapper).SubscribeToDescribeJobExecutionAccepted(any(), any(), any());
         verify(mockIotJobsClientWrapper).SubscribeToDescribeJobExecutionRejected(any(), any(), any());
-        verify(mockFleetStatusService).updateFleetStatusUpdateForAllComponents(false);
     }
 
     @Test
@@ -166,7 +166,6 @@ class IotJobsHelperTest {
         verify(mockIotJobsClientWrapper, times(0)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(0)).SubscribeToDescribeJobExecutionAccepted(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(0)).SubscribeToDescribeJobExecutionRejected(any(), any(), any());
-        verify(mockFleetStatusService, times(0)).updateFleetStatusUpdateForAllComponents(false);
     }
 
     @Test
@@ -182,7 +181,7 @@ class IotJobsHelperTest {
         verify(mockIotJobsClientWrapper, times(1)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(1)).SubscribeToDescribeJobExecutionAccepted(any(), any(), any());
         verify(mockIotJobsClientWrapper, times(1)).SubscribeToDescribeJobExecutionRejected(any(), any(), any());
-        verify(mockFleetStatusService, times(1)).updateFleetStatusUpdateForAllComponents(true);
+        verify(mockFleetStatusService, times(1)).updateFleetStatusUpdateForAllComponents(Trigger.NETWORK_RECONFIGURE);
     }
 
     @Test


### PR DESCRIPTION
**Description of changes:**
1. Always initialize overall status to healthy instead of null;
2. Avoid spamming FSS updates when mqtt client disconnects and reconnects without component state change by adding a 60 second time window;
3. Send nucleus launch message at the end of `KernelLifecycle::launch` instead of when setting up iot job communication.

**Why is this change necessary:**
Improve the robustness of FSS.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
