### PR TITLE
fix: send error code only on errored and broken, fix typo

### DIFF
--- a/src/main/java/com/aws/greengrass/dependency/ComponentStatusCode.java
+++ b/src/main/java/com/aws/greengrass/dependency/ComponentStatusCode.java
@@ -26,7 +26,7 @@ public enum ComponentStatusCode {
             + " the runWith section of your recipe and try your request again."),
     INSTALL_TIMEOUT(
             "Install script didn't finish within the timeout period. Increase the timeout to give it more "
-                    + "time to run or check you code."),
+                    + "time to run or check your code."),
     STARTUP_ERROR("An error occurred during startup.",
             "The startup script exited with code %s."),
     STARTUP_CONFIG_NOT_VALID(
@@ -37,7 +37,7 @@ public enum ComponentStatusCode {
             + "Check the runWith section of your recipe and try your request again."),
     STARTUP_TIMEOUT(
             "Startup script didn't finish within the timeout period. Increase the timeout to give it more "
-                    + "time to run or check you code."),
+                    + "time to run or check your code."),
     RUN_ERROR("An error occurred while running the component.",
             "The run script exited with code %s."),
     RUN_MISSING_DEFAULT_RUNWITH("Couldn't determine the user or group to use when running the component. Check"
@@ -47,11 +47,11 @@ public enum ComponentStatusCode {
                     + " the run section and try your request again."),
     RUN_IO_ERROR("There was an I/O error running the component. Check the component log for more information."),
     RUN_TIMEOUT("Run script didn't finish within the timeout period. Increase the timeout to give it more time to run "
-            + "or check you code."),
+            + "or check your code."),
     SHUTDOWN_ERROR("An error occurred while shutting down the component.",
             "The shutdown script exited with code %s."),
     SHUTDOWN_TIMEOUT("Shutdown script didn't finish within the timeout period. Increase the timeout to give it more "
-            + "time to run or check you code.");
+            + "time to run or check your code.");
 
     @Getter
     private String description;

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -122,11 +122,6 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     private ScheduledThreadPoolExecutor ses;
     private FleetStatusService fleetStatusService;
     private static final String VERSION = "2.0.0";
-    private static final ComponentStatusDetails TEST_HEALTHY_COMPONENT_STATUS_DETAILS =
-            ComponentStatusDetails.builder()
-                    .statusCodes(Arrays.asList(ComponentStatusCode.NONE.name()))
-                    .statusReason(ComponentStatusCode.NONE.getDescription())
-                    .build();
     private static final ComponentStatusDetails TEST_BROKEN_COMPONENT_STATUS_DETAILS =
             ComponentStatusDetails.builder()
                     .statusCodes(Arrays.asList(ComponentStatusCode.RUN_ERROR.name()))
@@ -186,12 +181,14 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
-        when(mockGreengrassService1.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
+        when(mockGreengrassService1.inState(State.BROKEN)).thenReturn(false);
+        when(mockGreengrassService1.inState(State.ERRORED)).thenReturn(false);
         when(mockGreengrassService2.getName()).thenReturn("MockService2");
         when(mockGreengrassService2.getServiceConfig()).thenReturn(config);
-        when(mockGreengrassService2.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService2.getState()).thenReturn(State.RUNNING);
+        when(mockGreengrassService2.inState(State.BROKEN)).thenReturn(false);
+        when(mockGreengrassService2.inState(State.ERRORED)).thenReturn(false);
         when(mockGreengrassService2.isBuiltin()).thenReturn(true);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
@@ -253,12 +250,12 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals(2, fleetStatusDetails.getComponentDetails().size());
         assertServiceIsRootOrNot(fleetStatusDetails.getComponentDetails().get(0));
         serviceNamesToCheck.remove(fleetStatusDetails.getComponentDetails().get(0).getComponentName());
-        assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
+        assertNull(fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
         assertEquals(State.RUNNING, fleetStatusDetails.getComponentDetails().get(0).getState());
         assertEquals(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"), fleetStatusDetails.getComponentDetails().get(1).getFleetConfigArns());
         assertServiceIsRootOrNot(fleetStatusDetails.getComponentDetails().get(1));
         serviceNamesToCheck.remove(fleetStatusDetails.getComponentDetails().get(1).getComponentName());
-        assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, fleetStatusDetails.getComponentDetails().get(1).getComponentStatusDetails());
+        assertNull(fleetStatusDetails.getComponentDetails().get(1).getComponentStatusDetails());
         assertEquals(State.RUNNING, fleetStatusDetails.getComponentDetails().get(1).getState());
         assertEquals(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"), fleetStatusDetails.getComponentDetails().get(1).getFleetConfigArns());
         assertThat(serviceNamesToCheck, is(IsEmptyCollection.empty()));
@@ -287,6 +284,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService1.getStatusDetails()).thenReturn(TEST_BROKEN_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService1.getState()).thenReturn(State.BROKEN);
+        when(mockGreengrassService1.inState(State.BROKEN)).thenReturn(true);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
@@ -425,8 +423,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
-        when(mockGreengrassService1.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
+        when(mockGreengrassService1.inState(State.BROKEN)).thenReturn(false);
+        when(mockGreengrassService1.inState(State.ERRORED)).thenReturn(false);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
@@ -457,7 +456,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(1, fleetStatusDetails.getComponentDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentDetails().get(0).getComponentName());
-        assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
+        assertNull(fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
         assertEquals(State.RUNNING, fleetStatusDetails.getComponentDetails().get(0).getState());
         assertEquals(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"), fleetStatusDetails.getComponentDetails().get(0).getFleetConfigArns());
     }
@@ -535,8 +534,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
-        when(mockGreengrassService1.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
+        when(mockGreengrassService1.inState(State.BROKEN)).thenReturn(false);
+        when(mockGreengrassService1.inState(State.ERRORED)).thenReturn(false);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singletonList(mockDeploymentService));
@@ -592,7 +592,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         fleetStatusDetails.getComponentDetails().forEach(System.out::println);
         assertEquals(1, fleetStatusDetails.getComponentDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentDetails().get(0).getComponentName());
-        assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
+        assertNull(fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
         assertEquals(State.RUNNING, fleetStatusDetails.getComponentDetails().get(0).getState());
         assertThat(fleetStatusDetails.getComponentDetails().get(0).getFleetConfigArns(), is(IsEmptyCollection.empty()));
     }
@@ -620,6 +620,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
         when(mockGreengrassService1.getStatusDetails()).thenReturn(TEST_BROKEN_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService1.getState()).thenReturn(State.BROKEN);
+        when(mockGreengrassService1.inState(State.BROKEN)).thenReturn(true);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
 
@@ -707,12 +708,14 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
-        when(mockGreengrassService1.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
+        when(mockGreengrassService1.inState(State.BROKEN)).thenReturn(false);
+        when(mockGreengrassService1.inState(State.ERRORED)).thenReturn(false);
         when(mockGreengrassService2.getName()).thenReturn("MockService2");
         when(mockGreengrassService2.getServiceConfig()).thenReturn(config);
-        when(mockGreengrassService2.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService2.getState()).thenReturn(State.RUNNING);
+        when(mockGreengrassService2.inState(State.BROKEN)).thenReturn(false);
+        when(mockGreengrassService2.inState(State.ERRORED)).thenReturn(false);
         when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.locate("MockService2")).thenReturn(mockGreengrassService2);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
@@ -775,14 +778,14 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
                 assertEquals("MockService", componentDetails.getComponentName());
                 assertEquals("testJob", fleetStatusDetails.getDeploymentInformation().getDeploymentId());
                 assertNull(fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
-                assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, componentDetails.getComponentStatusDetails());
+                assertNull(componentDetails.getComponentStatusDetails());
                 assertEquals(State.RUNNING, componentDetails.getState());
                 assertEquals(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"),
                         componentDetails.getFleetConfigArns());
             } else {
                 assertEquals(Trigger.RECONNECT, fleetStatusDetails.getTrigger());
                 assertEquals("MockService2", componentDetails.getComponentName());
-                assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, componentDetails.getComponentStatusDetails());
+                assertNull(componentDetails.getComponentStatusDetails());
             }
         }
     }
@@ -845,8 +848,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         when(mockDeploymentStatusKeeper.registerDeploymentStatusConsumer(any(), consumerArgumentCaptor.capture(), anyString())).thenReturn(true);
         when(mockGreengrassService1.getName()).thenReturn("MockService");
         when(mockGreengrassService1.getServiceConfig()).thenReturn(config);
-        when(mockGreengrassService1.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
         when(mockGreengrassService1.getState()).thenReturn(State.RUNNING);
+        when(mockGreengrassService1.inState(State.BROKEN)).thenReturn(false);
+        when(mockGreengrassService1.inState(State.ERRORED)).thenReturn(false);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         when(mockKernel.locate("MockService")).thenReturn(mockGreengrassService1);
         when(mockKernel.orderedDependencies()).thenReturn(Collections.singleton(mockGreengrassService1));
@@ -883,7 +887,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(1, fleetStatusDetails.getComponentDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentDetails().get(0).getComponentName());
-        assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
+        assertNull(fleetStatusDetails.getComponentDetails().get(0).getComponentStatusDetails());
         assertEquals(State.RUNNING, fleetStatusDetails.getComponentDetails().get(0).getState());
         assertEquals(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"), fleetStatusDetails.getComponentDetails().get(0).getFleetConfigArns());
     }
@@ -908,8 +912,9 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             allComponentToGroupsTopics.children.put(new CaseInsensitiveString(serviceName), groupsTopics);
             GreengrassService greengrassService = mock(GreengrassService.class);
             when(greengrassService.getName()).thenReturn(serviceName);
-            when(greengrassService.getStatusDetails()).thenReturn(TEST_HEALTHY_COMPONENT_STATUS_DETAILS);
             when(greengrassService.getState()).thenReturn(State.RUNNING);
+            when(greengrassService.inState(State.BROKEN)).thenReturn(false);
+            when(greengrassService.inState(State.ERRORED)).thenReturn(false);
             when(greengrassService.getServiceConfig()).thenReturn(config);
             greengrassServices.add(greengrassService);
             serviceNamesToCheck.add(serviceName);
@@ -965,7 +970,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             assertEquals(publishRequests.size(), fleetStatusDetails.getChunkInfo().getTotalChunks());
             for (ComponentDetails componentDetails : fleetStatusDetails.getComponentDetails()) {
                 serviceNamesToCheck.remove(componentDetails.getComponentName());
-                assertEquals(TEST_HEALTHY_COMPONENT_STATUS_DETAILS, componentDetails.getComponentStatusDetails());
+                assertNull(componentDetails.getComponentStatusDetails());
                 assertEquals(State.RUNNING, componentDetails.getState());
                 assertEquals(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"),
                         componentDetails.getFleetConfigArns());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
avoid sending component error codes for states other than ERRORED and BROKEN
Fix typo in status messages

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
