### PR TITLE
fix: do not create duplicate builtin services

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -475,8 +475,9 @@ public class Kernel {
                     ret = (GreengrassService) context.newInstance(clazz);
                 }
 
-                // Force plugins to be singletons
-                if (clazz.getAnnotation(Singleton.class) != null || PluginService.class.isAssignableFrom(clazz)) {
+                // Force plugins and built-in services to be singletons
+                if (clazz.getAnnotation(Singleton.class) != null || PluginService.class.isAssignableFrom(clazz)
+                    || clazz.getAnnotation(ImplementsService.class) != null) {
                     context.put(ret.getClass(), v);
                 }
                 if (clazz.getAnnotation(ImplementsService.class) != null) {


### PR DESCRIPTION
**Description of changes:**
1. Force built-in services to be singleton.

**Why is this change necessary:**
1. Avoid creating multiple instances of built-in services if any of them is injected.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
