### PR TITLE
fix: clean up shadow failure details on deployment success

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -613,7 +613,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         assertTrue(serviceErroredLatch.await(15, TimeUnit.SECONDS));
         componentStatus.forEach(status -> {
             assertThat(status.getRight(), greaterThan(timestamp.getAndSet(status.getRight())));
-            assertThat(status.getLeft().getStatusCode(), contains(ComponentStatusCode.STARTUP_ERROR.toString()));
+            assertThat(status.getLeft().getStatusCodes(), contains(ComponentStatusCode.STARTUP_ERROR.toString()));
             assertThat(status.getLeft().getStatusReason(),
                     is(ComponentStatusCode.STARTUP_ERROR.getDescriptionWithExitCode(1)));
         });
@@ -653,7 +653,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         kernel.launch();
 
         assertTrue(serviceErroredLatch.await(15, TimeUnit.SECONDS));
-        assertThat(status.get().getStatusCode(),
+        assertThat(status.get().getStatusCodes(),
                 contains(ComponentStatusCode.RUN_CONFIG_NOT_VALID.toString()));
         assertThat(status.get().getStatusReason(),
                 containsString(ComponentStatusCode.RUN_CONFIG_NOT_VALID.getDescription()));
@@ -676,7 +676,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         kernel.launch();
 
         assertTrue(serviceErroredLatch.await(15, TimeUnit.SECONDS));
-        assertThat(status.get().getStatusCode(),
+        assertThat(status.get().getStatusCodes(),
                 contains(ComponentStatusCode.STARTUP_MISSING_DEFAULT_RUNWITH.toString()));
         assertThat(status.get().getStatusReason(),
                 containsString(ComponentStatusCode.STARTUP_MISSING_DEFAULT_RUNWITH.getDescription()));
@@ -705,10 +705,10 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         kernel.launch();
 
         assertTrue(serviceErroredLatch.await(15, TimeUnit.SECONDS));
-        assertThat(statusA.get().getStatusCode(), contains(ComponentStatusCode.STARTUP_TIMEOUT.toString()));
+        assertThat(statusA.get().getStatusCodes(), contains(ComponentStatusCode.STARTUP_TIMEOUT.toString()));
         assertThat(statusA.get().getStatusReason(),
                 containsString(ComponentStatusCode.STARTUP_TIMEOUT.getDescription()));
-        assertThat(statusB.get().getStatusCode(), contains(ComponentStatusCode.RUN_TIMEOUT.toString()));
+        assertThat(statusB.get().getStatusCodes(), contains(ComponentStatusCode.RUN_TIMEOUT.toString()));
         assertThat(statusB.get().getStatusReason(), containsString(ComponentStatusCode.RUN_TIMEOUT.getDescription()));
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -30,8 +30,8 @@ import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.status.FleetStatusService;
-import com.aws.greengrass.status.model.ComponentStatusDetails;
 import com.aws.greengrass.status.model.ComponentDetails;
+import com.aws.greengrass.status.model.ComponentStatusDetails;
 import com.aws.greengrass.status.model.FleetStatusDetails;
 import com.aws.greengrass.status.model.MessageType;
 import com.aws.greengrass.status.model.OverallStatus;
@@ -305,7 +305,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
                         ComponentDetails.builder().componentName("BrokenRun").version("1.0.0")
                                 .state(State.ERRORED).fleetConfigArns(Collections.EMPTY_LIST).componentStatusDetails(
                                         ComponentStatusDetails.builder()
-                                                .statusCode(Arrays.asList(ComponentStatusCode.RUN_ERROR.toString()))
+                                                .statusCodes(Arrays.asList(ComponentStatusCode.RUN_ERROR.toString()))
                                                 .statusReason(ComponentStatusCode.RUN_ERROR.getDescriptionWithExitCode(1))
                                                 .build()).build();
                 assertTrue(errorStatusDetails.getComponentDetails().contains(expectedErrorStatus));
@@ -442,7 +442,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
                         ComponentDetails.builder().componentName("BrokenRun").version("1.0.0")
                                 .state(State.ERRORED).fleetConfigArns(Collections.EMPTY_LIST).componentStatusDetails(
                                         ComponentStatusDetails.builder()
-                                                .statusCode(Arrays.asList(ComponentStatusCode.RUN_ERROR.toString()))
+                                                .statusCodes(Arrays.asList(ComponentStatusCode.RUN_ERROR.toString()))
                                                 .statusReason(ComponentStatusCode.RUN_ERROR.getDescriptionWithExitCode(1))
                                                 .build()).build();
                 assertTrue(errorStatusDetails.getComponentDetails().contains(expectedErrorStatus));

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -39,8 +39,10 @@ import software.amazon.awssdk.iot.iotshadow.model.UpdateNamedShadowRequest;
 import software.amazon.awssdk.iot.iotshadow.model.UpdateNamedShadowSubscriptionRequest;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -357,9 +359,16 @@ public class ShadowDeploymentListener implements InjectionActions {
 
         HashMap<String, Object> statusDetails = new HashMap<>();
         statusDetails.put(DETAILED_STATUS_KEY, deploymentStatusDetails.get(DEPLOYMENT_DETAILED_STATUS_KEY));
-        statusDetails.put(FAILURE_CAUSE_KEY, deploymentStatusDetails.get(DEPLOYMENT_FAILURE_CAUSE_KEY));
-        statusDetails.put(ERROR_STACK_KEY, deploymentStatusDetails.get(DEPLOYMENT_ERROR_STACK_KEY));
-        statusDetails.put(ERROR_TYPES_KEY, deploymentStatusDetails.get(DEPLOYMENT_ERROR_TYPES_KEY));
+        // if the field doesn't exist, report an empty string/list to clear the existing values
+        statusDetails.put(FAILURE_CAUSE_KEY,
+                Optional.ofNullable(deploymentStatusDetails.get(DEPLOYMENT_FAILURE_CAUSE_KEY))
+                        .orElse(""));
+        statusDetails.put(ERROR_STACK_KEY,
+                Optional.ofNullable(deploymentStatusDetails.get(DEPLOYMENT_ERROR_STACK_KEY))
+                        .orElse(Collections.emptyList()));
+        statusDetails.put(ERROR_TYPES_KEY,
+                Optional.ofNullable(deploymentStatusDetails.get(DEPLOYMENT_ERROR_TYPES_KEY))
+                        .orElse(Collections.emptyList()));
 
         HashMap<String, Object> reported = new HashMap<>();
         reported.put(ARN_FOR_STATUS_KEY, deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME));

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -262,7 +262,7 @@ public class Lifecycle {
 
     protected ComponentStatusDetails getStatusDetails() {
         return ComponentStatusDetails.builder()
-                .statusCode(Coerce.toStringList(statusCodeTopic))
+                .statusCodes(Coerce.toStringList(statusCodeTopic))
                 .statusReason(Coerce.toString(statusReasonTopic))
                 .build();
     }

--- a/src/main/java/com/aws/greengrass/status/model/ComponentStatusDetails.java
+++ b/src/main/java/com/aws/greengrass/status/model/ComponentStatusDetails.java
@@ -17,6 +17,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ComponentStatusDetails {
-    private List<String> statusCode;
+    private List<String> statusCodes;
     private String statusReason;
 }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -86,22 +86,22 @@ class LifecycleTest {
     private static final Integer DEFAULT_TEST_TIMEOUT = 1;
 
     private static final ComponentStatusDetails STATUS_DETAIL_HEALTHY = ComponentStatusDetails.builder()
-            .statusCode(Arrays.asList(ComponentStatusCode.NONE.name()))
+            .statusCodes(Arrays.asList(ComponentStatusCode.NONE.name()))
             .statusReason(ComponentStatusCode.NONE.getDescription())
             .build();
 
     private static final ComponentStatusDetails STATUS_DETAIL_INSTALL_TIMEOUT = ComponentStatusDetails.builder()
-            .statusCode(Arrays.asList(ComponentStatusCode.INSTALL_TIMEOUT.name()))
+            .statusCodes(Arrays.asList(ComponentStatusCode.INSTALL_TIMEOUT.name()))
             .statusReason(ComponentStatusCode.INSTALL_TIMEOUT.getDescription())
             .build();
 
     private static final ComponentStatusDetails STATUS_DETAIL_STARTUP_ERRORED = ComponentStatusDetails.builder()
-            .statusCode(Arrays.asList(ComponentStatusCode.STARTUP_ERROR.name()))
+            .statusCodes(Arrays.asList(ComponentStatusCode.STARTUP_ERROR.name()))
             .statusReason(ComponentStatusCode.STARTUP_ERROR.getDescription())
             .build();
 
     private static final ComponentStatusDetails STATUS_DETAIL_RUN_ERRORED = ComponentStatusDetails.builder()
-            .statusCode(Arrays.asList(ComponentStatusCode.RUN_ERROR.name()))
+            .statusCodes(Arrays.asList(ComponentStatusCode.RUN_ERROR.name()))
             .statusReason(ComponentStatusCode.RUN_ERROR.getDescription())
             .build();
 

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -21,8 +21,8 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.PublishRequest;
-import com.aws.greengrass.status.model.ComponentStatusDetails;
 import com.aws.greengrass.status.model.ComponentDetails;
+import com.aws.greengrass.status.model.ComponentStatusDetails;
 import com.aws.greengrass.status.model.FleetStatusDetails;
 import com.aws.greengrass.status.model.MessageType;
 import com.aws.greengrass.status.model.OverallStatus;
@@ -120,12 +120,12 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
     private static final String VERSION = "2.0.0";
     private static final ComponentStatusDetails TEST_HEALTHY_COMPONENT_STATUS_DETAILS =
             ComponentStatusDetails.builder()
-                    .statusCode(Arrays.asList(ComponentStatusCode.NONE.name()))
+                    .statusCodes(Arrays.asList(ComponentStatusCode.NONE.name()))
                     .statusReason(ComponentStatusCode.NONE.getDescription())
                     .build();
     private static final ComponentStatusDetails TEST_BROKEN_COMPONENT_STATUS_DETAILS =
             ComponentStatusDetails.builder()
-                    .statusCode(Arrays.asList(ComponentStatusCode.RUN_ERROR.name()))
+                    .statusCodes(Arrays.asList(ComponentStatusCode.RUN_ERROR.name()))
                     .statusReason(ComponentStatusCode.RUN_ERROR.getDescription())
                     .build();
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Clean up shadow failure details on deployment success, by setting failure cause to empty string and error stack/type to empty list.
2. Rename `ComponentStatusDetails.statusCode` to `ComponentStatusDetails.statusCodes`

**Why is this change necessary:**
1. Before this change, if a failed shadow deployment is followed by a successful shadow deployment, the device would report `null` for failure detail fields and the updated shadow document would still contain the failure reasons from past deployments. After this change, these fields would be cleaned up on deployment success.
2. Rename `statusCode` to `statusCodes` since it's a list and it conforms to cloud naming.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
