### PR TITLE
fix: send unchangedRootComponents to FSS even when deployment fails

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -317,7 +317,8 @@ class EventFleetStatusServiceTest extends BaseITCase {
             assertEquals("ThingName", brokenStatusDetails.getThing());
             assertEquals(MessageType.PARTIAL, brokenStatusDetails.getMessageType());
             assertNull(brokenStatusDetails.getChunkInfo());
-            assertNull(brokenStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
+            assertListEquals(Collections.singletonList("CustomerApp"),
+                    brokenStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
             assertEquals(OverallStatus.UNHEALTHY, brokenStatusDetails.getOverallStatus());
             assertListEquals(Arrays.asList(DeploymentErrorCode.DEPLOYMENT_FAILURE.name(),
                             DeploymentErrorCode.COMPONENT_UPDATE_ERROR.name(),
@@ -452,7 +453,8 @@ class EventFleetStatusServiceTest extends BaseITCase {
             // Last FSS publish request should have info for broken component BrokenRun v1
             FleetStatusDetails brokenStatusDetails = fleetStatusDetailsList.get().get(2);
             assertEquals("ThingName", brokenStatusDetails.getThing());
-            assertNull(brokenStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
+            assertListEquals(Collections.emptyList(),
+                    brokenStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
             assertEquals(OverallStatus.UNHEALTHY, brokenStatusDetails.getOverallStatus());
             assertEquals(MessageType.PARTIAL, brokenStatusDetails.getMessageType());
             assertNull(brokenStatusDetails.getChunkInfo());
@@ -502,7 +504,8 @@ class EventFleetStatusServiceTest extends BaseITCase {
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
             assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
             assertNull(fleetStatusDetails.getChunkInfo());
-            assertNull(fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
+            assertListEquals(Collections.singletonList("AppInvalidRecipe"),
+                    fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
             assertNotNull(fleetStatusDetails.getComponentDetails());
             // DEPLOYMENT_FAILURE, COMPONENT_PACKAGE_LOADING_ERROR, IO_ERROR, IO_MAPPING_ERROR, RECIPE_PARSE_ERROR
             assertListEquals(Arrays.asList(DeploymentErrorCode.DEPLOYMENT_FAILURE.name(),

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -575,10 +575,7 @@ public class FleetStatusService extends GreengrassService {
             deploymentInformation.setStatusDetails(statusDetails);
         }
         // Use unchangedRootComponents to update lastInstallationSource and lastReportedTimestamp in cloud.
-        // Only update the unchangedRootComponents list if a deployment is successful, because we should not display
-        // a failed deployment as component's last installation source.
-        if (deploymentDetails.containsKey(DEPLOYMENT_ROOT_PACKAGES_KEY_NAME)
-                && JobStatus.SUCCEEDED.toString().equals(deploymentInformation.getStatus())) {
+        if (deploymentDetails.containsKey(DEPLOYMENT_ROOT_PACKAGES_KEY_NAME)) {
             // Setting the unchangedRootComponents to be the entire list of root packages, and then later
             // if a component changed state since last FSS update we will remove it from this list.
             deploymentInformation.setUnchangedRootComponents((List<String>) deploymentDetails


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Making this change as a result of discussion with the cloud team.

Before: for a failed deployment, the FSS update field `unchangedRootComponents` is always `null`.

After: `unchangedRootComponents` is populated regardless of deployment failure/success; that way, cloud logic can decide what to do with this information.

**Why is this change necessary:**

There are scenarios where we'd like to update the last-reported-timestamp for unchanged components, even though the deployment failed.  This change provides the necessary information to the cloud.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
