### PR TITLE
fix: report correct value of deployment id

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
@@ -70,7 +70,11 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
 import static com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus.SUCCESSFUL;
 import static com.aws.greengrass.lifecyclemanager.GenericExternalService.LIFECYCLE_RUN_NAMESPACE_TOPIC;
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.*;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUN_WITH_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.greengrass.testcommons.testutilities.SudoUtil.assumeCanSudoShell;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.createCloseableLogListener;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.createServiceStateChangeWaiter;
@@ -588,7 +592,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
 
         assertTrue(postComponentUpdateRecieved.await(15,TimeUnit.SECONDS));
         assertEquals(2, preComponentUpdateCount.get());
-        String deploymentId = testDeployment.getDeploymentDocumentObj().getDeploymentId();
+        String deploymentId = testDeployment.getGreengrassDeploymentId();
         assertNotNull(preUpdateDeploymentId);
         assertEquals(deploymentId, preUpdateDeploymentId.get());
         assertNotNull(postUpdateDeploymentId);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -738,7 +738,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
 
             FleetStatusDetails shadowDeploymentStatus = fleetStatusDetailsList.get().get(1);
             assertEquals(Trigger.THING_DEPLOYMENT, shadowDeploymentStatus.getTrigger());
-            assertEquals("shadow_deployment", shadowDeploymentStatus.getDeploymentInformation().getDeploymentId());
+            assertEquals("TestShadowDeploymentUuid", shadowDeploymentStatus.getDeploymentInformation().getDeploymentId());
             assertEquals("arn:aws:greengrass:us-east-1:12345678910:configuration:thing/ThingName:1",
                     shadowDeploymentStatus.getDeploymentInformation().getFleetConfigurationArnForStatus());
             assertNotNull(shadowDeploymentStatus.getDeploymentInformation().getUnchangedRootComponents());
@@ -746,7 +746,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
 
             FleetStatusDetails iotJobsDeploymentStatus = fleetStatusDetailsList.get().get(2);
             assertEquals(Trigger.THING_GROUP_DEPLOYMENT, iotJobsDeploymentStatus.getTrigger());
-            assertEquals("iot_jobs_deployment", iotJobsDeploymentStatus.getDeploymentInformation().getDeploymentId());
+            assertEquals("TestJobDeploymentUuid", iotJobsDeploymentStatus.getDeploymentInformation().getDeploymentId());
             assertEquals("arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1",
                     iotJobsDeploymentStatus.getDeploymentInformation().getFleetConfigurationArnForStatus());
             assertNotNull(iotJobsDeploymentStatus.getDeploymentInformation().getUnchangedRootComponents());

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/FleetConfigSimpleApp.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/FleetConfigSimpleApp.json
@@ -1,5 +1,5 @@
 {
-  "deploymentId": "TestDeploymentId3",
+  "deploymentId": "TestJobDeploymentUuid",
   "configurationArn": "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1",
   "components": {
     "SimpleApp": {

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/ShadowDeploymentForMosquitto.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/ShadowDeploymentForMosquitto.json
@@ -1,5 +1,5 @@
 {
-  "deploymentId": "TestDeploymentId4",
+  "deploymentId": "TestShadowDeploymentUuid",
   "configurationArn": "arn:aws:greengrass:us-east-1:12345678910:configuration:thing/ThingName:1",
   "components": {
     "Mosquitto": {

--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -91,7 +91,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
         this.componentManager = componentManager;
         this.kernelConfigResolver = kernelConfigResolver;
         this.deploymentConfigMerger = deploymentConfigMerger;
-        this.logger = logger.dfltKv(DEPLOYMENT_ID_LOG_KEY, deployment.getDeploymentDocumentObj().getDeploymentId());
+        this.logger = logger.dfltKv(DEPLOYMENT_ID_LOG_KEY, deployment.getGreengrassDeploymentId());
         this.deployment = deployment;
         this.deploymentServiceConfig = deploymentServiceConfig;
         this.executorService = executorService;

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -115,7 +115,7 @@ public class DeploymentConfigMerger {
     private void updateActionForDeployment(Map<String, Object> newConfig, Deployment deployment,
                                            DeploymentActivator activator,
                                            CompletableFuture<DeploymentResult> totallyCompleteFuture) {
-        String deploymentId = deployment.getDeploymentDocumentObj().getDeploymentId();
+        String deploymentId = deployment.getGreengrassDeploymentId();
 
         // if the update is cancelled, don't perform merge
         if (totallyCompleteFuture.isCancelled()) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -137,7 +137,7 @@ public class DeploymentDirectoryManager {
         }
         Path filePath = getDeploymentMetadataFilePath();
         logger.atInfo().kv(FILE_LOG_KEY, filePath).kv(DEPLOYMENT_ID_LOG_KEY,
-                deployment.getDeploymentDocumentObj().getDeploymentId()).log("Persist deployment metadata");
+                deployment.getGreengrassDeploymentId()).log("Persist deployment metadata");
         writeDeploymentMetadata(filePath, deployment);
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -80,7 +80,6 @@ import static com.amazon.aws.iot.greengrass.component.common.SerializerFactory.g
 import static com.amazon.aws.iot.greengrass.component.common.SerializerFactory.getRecipeSerializerJson;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DefaultDeploymentTask.DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX;
-import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_ID_LOG_KEY;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.THING_GROUP_RESOURCE_NAME_PREFIX;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
@@ -536,7 +535,8 @@ public class DeploymentService extends GreengrassService {
     }
 
     private void createNewDeployment(Deployment deployment) {
-        logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, deployment.getId())
+        logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY_NAME, deployment.getId())
+                .kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, deployment.getGreengrassDeploymentId())
                 .kv("DeploymentType", deployment.getDeploymentType().toString())
                 .log("Received deployment in the queue");
 

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -508,7 +508,7 @@ public class DeploymentService extends GreengrassService {
             } else {
                 boolean canCancelDeployment = context.get(UpdateSystemPolicyService.class).discardPendingUpdateAction(
                         ((DefaultDeploymentTask) currentDeploymentTaskMetadata.getDeploymentTask()).getDeployment()
-                                .getDeploymentDocumentObj().getDeploymentId());
+                                .getGreengrassDeploymentId());
                 if (canCancelDeployment) {
                     currentDeploymentTaskMetadata.getDeploymentResultFuture().cancel(true);
                     if (DeploymentType.SHADOW.equals(currentDeploymentTaskMetadata.getDeploymentType())) {
@@ -567,8 +567,7 @@ public class DeploymentService extends GreengrassService {
 
             try {
                 context.get(KernelAlternatives.class).cleanupLaunchDirectoryLinks();
-                deploymentDirectoryManager.createNewDeploymentDirectory(
-                        deployment.getDeploymentDocumentObj().getDeploymentId());
+                deploymentDirectoryManager.createNewDeploymentDirectory(deployment.getGreengrassDeploymentId());
                 deploymentDirectoryManager.writeDeploymentMetadata(deployment);
             } catch (IOException ioException) {
                 logger.atError().log("Unable to create deployment directory", ioException);

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
@@ -26,7 +26,9 @@ import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 public class DeploymentStatusKeeper {
 
     public static final String PROCESSED_DEPLOYMENTS_TOPICS = "ProcessedDeployments";
+    // the field contains job id for job deployment; config arn for shadow deployment
     public static final String DEPLOYMENT_ID_KEY_NAME = "DeploymentId";
+    public static final String DEPLOYMENT_UUID_KEY_NAME = "DeploymentUuid";
     public static final String CONFIGURATION_ARN_KEY_NAME = "ConfigurationArn";
     public static final String DEPLOYMENT_TYPE_KEY_NAME = "DeploymentType";
     public static final String DEPLOYMENT_ROOT_PACKAGES_KEY_NAME = "DeploymentRootPackages";
@@ -59,7 +61,8 @@ public class DeploymentStatusKeeper {
     /**
      * Persist deployment status in kernel config.
      *
-     * @param deploymentId     id for the deployment.
+     * @param deploymentId     id for the deployment - job id for jobs and config arn for shadow
+     * @param deploymentUuid   uuid for the deployment
      * @param configurationArn arn for deployment target configuration.
      * @param deploymentType   type of deployment.
      * @param status           status of deployment.
@@ -67,17 +70,19 @@ public class DeploymentStatusKeeper {
      * @param rootPackages     root packages in the deployment.
      * @throws IllegalArgumentException for invalid deployment type
      */
-    public void persistAndPublishDeploymentStatus(String deploymentId, String configurationArn,
+    @SuppressWarnings("PMD.UseObjectForClearerAPI")
+    public void persistAndPublishDeploymentStatus(String deploymentId, String deploymentUuid, String configurationArn,
                                                   DeploymentType deploymentType, String status,
                                                   Map<String, Object> statusDetails, List<String> rootPackages) {
 
         //While this method is being run, another thread could be running the publishPersistedStatusUpdates
         // method which consumes the data in config from the same topics. These two thread needs to be synchronized
         synchronized (deploymentType) {
-            logger.atDebug().kv(DEPLOYMENT_ID_KEY_NAME, deploymentId).kv(DEPLOYMENT_STATUS_KEY_NAME, status)
+            logger.atDebug().kv(DEPLOYMENT_UUID_KEY_NAME, deploymentUuid).kv(DEPLOYMENT_STATUS_KEY_NAME, status)
                     .log("Storing deployment status");
             Map<String, Object> deploymentDetails = new HashMap<>();
             deploymentDetails.put(DEPLOYMENT_ID_KEY_NAME, deploymentId);
+            deploymentDetails.put(DEPLOYMENT_UUID_KEY_NAME, deploymentUuid);
             deploymentDetails.put(CONFIGURATION_ARN_KEY_NAME, configurationArn);
             deploymentDetails.put(DEPLOYMENT_TYPE_KEY_NAME, deploymentType.toString());
             deploymentDetails.put(DEPLOYMENT_STATUS_KEY_NAME, status);
@@ -87,7 +92,7 @@ public class DeploymentStatusKeeper {
             Topics processedDeployments = getProcessedDeployments();
             Topics thisJob = processedDeployments.createInteriorChild(String.valueOf(System.currentTimeMillis()));
             thisJob.replaceAndWait(deploymentDetails);
-            logger.atInfo().kv(DEPLOYMENT_ID_KEY_NAME, deploymentId).kv(DEPLOYMENT_STATUS_KEY_NAME, status)
+            logger.atInfo().kv(DEPLOYMENT_UUID_KEY_NAME, deploymentUuid).kv(DEPLOYMENT_STATUS_KEY_NAME, status)
                     .log("Stored deployment status");
         }
         publishPersistedStatusUpdates(deploymentType);

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
@@ -78,8 +78,8 @@ public class DeploymentStatusKeeper {
         //While this method is being run, another thread could be running the publishPersistedStatusUpdates
         // method which consumes the data in config from the same topics. These two thread needs to be synchronized
         synchronized (deploymentType) {
-            logger.atDebug().kv(GG_DEPLOYMENT_ID_KEY_NAME, ggDeploymentId).kv(DEPLOYMENT_STATUS_KEY_NAME, status)
-                    .log("Storing deployment status");
+            logger.atDebug().kv(GG_DEPLOYMENT_ID_KEY_NAME, ggDeploymentId).kv(DEPLOYMENT_ID_KEY_NAME, deploymentId)
+                    .kv(DEPLOYMENT_STATUS_KEY_NAME, status).log("Storing deployment status");
             Map<String, Object> deploymentDetails = new HashMap<>();
             deploymentDetails.put(DEPLOYMENT_ID_KEY_NAME, deploymentId);
             deploymentDetails.put(GG_DEPLOYMENT_ID_KEY_NAME, ggDeploymentId);
@@ -92,8 +92,8 @@ public class DeploymentStatusKeeper {
             Topics processedDeployments = getProcessedDeployments();
             Topics thisJob = processedDeployments.createInteriorChild(String.valueOf(System.currentTimeMillis()));
             thisJob.replaceAndWait(deploymentDetails);
-            logger.atInfo().kv(GG_DEPLOYMENT_ID_KEY_NAME, ggDeploymentId).kv(DEPLOYMENT_STATUS_KEY_NAME, status)
-                    .log("Stored deployment status");
+            logger.atInfo().kv(GG_DEPLOYMENT_ID_KEY_NAME, ggDeploymentId).kv(DEPLOYMENT_ID_KEY_NAME, deploymentId)
+                    .kv(DEPLOYMENT_STATUS_KEY_NAME, status).log("Stored deployment status");
         }
         publishPersistedStatusUpdates(deploymentType);
     }

--- a/src/main/java/com/aws/greengrass/deployment/DynamicComponentConfigurationValidator.java
+++ b/src/main/java/com/aws/greengrass/deployment/DynamicComponentConfigurationValidator.java
@@ -71,7 +71,7 @@ public class DynamicComponentConfigurationValidator {
      */
     public boolean validate(Map<String, Object> servicesConfig, Deployment deployment,
                             CompletableFuture<DeploymentResult> deploymentResultFuture) {
-        logger.addDefaultKeyValue(DEPLOYMENT_ID_LOG_KEY, deployment.getDeploymentDocumentObj().getDeploymentId());
+        logger.addDefaultKeyValue(DEPLOYMENT_ID_LOG_KEY, deployment.getGreengrassDeploymentId());
         Set<ComponentToValidate> componentsToValidate;
         try {
             componentsToValidate =

--- a/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
@@ -49,7 +49,7 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
                                       ComponentManager componentManager) {
         this.kernel = kernel;
         this.deployment = deployment;
-        this.logger = logger.dfltKv(DEPLOYMENT_ID_LOG_KEY, deployment.getDeploymentDocumentObj().getDeploymentId());
+        this.logger = logger.dfltKv(DEPLOYMENT_ID_LOG_KEY, deployment.getGreengrassDeploymentId());
         this.componentManager = componentManager;
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -463,7 +463,7 @@ public class ShadowDeploymentListener implements InjectionActions {
         if (cancelDeployment) {
             deployment = new Deployment(DeploymentType.SHADOW, UUID.randomUUID().toString(), true);
         } else {
-            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configuration.getDeploymentId());
+            deployment = new Deployment(fleetConfigStr, DeploymentType.SHADOW, configurationArn);
         }
         if (deploymentQueue.offer(deployment)) {
             logger.atInfo().kv("ID", deployment.getId()).log("Added shadow deployment job");

--- a/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
@@ -106,7 +106,7 @@ public class KernelUpdateActivator extends DeploymentActivator {
 
     void rollback(Deployment deployment, Throwable failureCause) {
         logger.atInfo(MERGE_CONFIG_EVENT_KEY, failureCause)
-                .kv(DEPLOYMENT_ID_LOG_KEY, deployment.getDeploymentDocumentObj().getDeploymentId())
+                .kv(DEPLOYMENT_ID_LOG_KEY, deployment.getGreengrassDeploymentId())
                 .log("Rolling back failed deployment");
 
         Pair<List<String>, List<String>> errorReport =

--- a/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
@@ -86,7 +86,8 @@ public class Deployment {
         this.deploymentStage = deploymentStage;
     }
 
-    // Get the deployment id created by GG cloud from deployment doc
+    // Get the deployment id set by GG cloud from deployment doc;
+    // this is different from the job id for job deployments
     public String getGreengrassDeploymentId() {
         return Objects.nonNull(deploymentDocumentObj) ? deploymentDocumentObj.getDeploymentId()
                 : null;

--- a/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
@@ -27,6 +27,8 @@ public class Deployment {
     private String deploymentDocument;
     @EqualsAndHashCode.Include
     private DeploymentType deploymentType;
+    // The field stores job id for job deployment and config arn for shadow deployment for legacy reasons.
+    // In order to maintain compatibility, it cannot be refactored.
     @EqualsAndHashCode.Include
     private String id;
     @EqualsAndHashCode.Include
@@ -84,7 +86,8 @@ public class Deployment {
         this.deploymentStage = deploymentStage;
     }
 
-    public String getDeploymentUuid() {
+    // Get the deployment id created by GG cloud from deployment doc
+    public String getGreengrassDeploymentId() {
         return Objects.nonNull(deploymentDocumentObj) ? deploymentDocumentObj.getDeploymentId()
                 : null;
     }

--- a/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Setter
@@ -81,6 +82,16 @@ public class Deployment {
         this.deploymentType = deploymentType;
         this.id = id;
         this.deploymentStage = deploymentStage;
+    }
+
+    public String getDeploymentUuid() {
+        return Objects.nonNull(deploymentDocumentObj) ? deploymentDocumentObj.getDeploymentId()
+                : null;
+    }
+
+    public String getConfigurationArn() {
+        return Objects.nonNull(deploymentDocumentObj) ? deploymentDocumentObj.getConfigurationArn()
+                : null;
     }
 
     public enum DeploymentType {

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
@@ -42,8 +42,8 @@ public class DeploymentTaskMetadata {
         return this.deployment.getId();
     }
 
-    public String getDeploymentUuid() {
-        return this.deployment.getDeploymentUuid();
+    public String getGreengrassDeploymentId() {
+        return this.deployment.getGreengrassDeploymentId();
     }
 
     public String getConfigurationArn() {

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
@@ -42,6 +42,14 @@ public class DeploymentTaskMetadata {
         return this.deployment.getId();
     }
 
+    public String getDeploymentUuid() {
+        return this.deployment.getDeploymentUuid();
+    }
+
+    public String getConfigurationArn() {
+        return this.deployment.getConfigurationArn();
+    }
+
     public Deployment.DeploymentType getDeploymentType() {
         return this.deployment.getDeploymentType();
     }

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -591,6 +591,8 @@ public class FleetStatusService extends GreengrassService {
     private DeploymentInformation getDeploymentInformation(Map<String, Object> deploymentDetails) {
         DeploymentInformation deploymentInformation = DeploymentInformation.builder()
                 .status((String) deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME))
+                // Reporting GG deployment id in FSS because ListInstalledComponents API
+                // relies on this field to set up last installation source link to deployments.
                 .deploymentId((String) deploymentDetails.get(GG_DEPLOYMENT_ID_KEY_NAME))
                 .fleetConfigurationArnForStatus((String) deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME)).build();
         if (deploymentDetails.containsKey(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)) {

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -63,11 +63,11 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_S
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_TYPES_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.CONFIGURATION_ARN_KEY_NAME;
-import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ROOT_PACKAGES_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_TYPE_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_UUID_KEY_NAME;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.IOT_JOBS;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.LOCAL;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.SHADOW;
@@ -591,7 +591,7 @@ public class FleetStatusService extends GreengrassService {
     private DeploymentInformation getDeploymentInformation(Map<String, Object> deploymentDetails) {
         DeploymentInformation deploymentInformation = DeploymentInformation.builder()
                 .status((String) deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME))
-                .deploymentId((String) deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME))
+                .deploymentId((String) deploymentDetails.get(DEPLOYMENT_UUID_KEY_NAME))
                 .fleetConfigurationArnForStatus((String) deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME)).build();
         if (deploymentDetails.containsKey(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)) {
             Map<String, Object> statusDetailsMap =

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -67,7 +67,7 @@ import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_RO
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_TYPE_KEY_NAME;
-import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_UUID_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.GG_DEPLOYMENT_ID_KEY_NAME;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.IOT_JOBS;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.LOCAL;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.SHADOW;
@@ -591,7 +591,7 @@ public class FleetStatusService extends GreengrassService {
     private DeploymentInformation getDeploymentInformation(Map<String, Object> deploymentDetails) {
         DeploymentInformation deploymentInformation = DeploymentInformation.builder()
                 .status((String) deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME))
-                .deploymentId((String) deploymentDetails.get(DEPLOYMENT_UUID_KEY_NAME))
+                .deploymentId((String) deploymentDetails.get(GG_DEPLOYMENT_ID_KEY_NAME))
                 .fleetConfigurationArnForStatus((String) deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME)).build();
         if (deploymentDetails.containsKey(DEPLOYMENT_STATUS_DETAILS_KEY_NAME)) {
             Map<String, Object> statusDetailsMap =

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
@@ -61,8 +61,8 @@ public class EcrAccessorTest {
         testContext = new Context();
         config = new Configuration(testContext);
         Topic createdTopic = config.lookup("root", "leaf").dflt(TEST_REGION);
-        lenient().when(deviceConfiguration.getAWSRegion()).thenReturn(createdTopic);
-        lenient().when(spyEcrAccessor.getClient(TEST_REGION)).thenReturn(ecrClient);
+        lenient().doReturn(createdTopic).when(deviceConfiguration).getAWSRegion();
+        lenient().doReturn(ecrClient).when(spyEcrAccessor).getClient(TEST_REGION);
     }
 
 

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -95,6 +95,7 @@ import static org.mockito.Mockito.when;
 class DeploymentServiceTest extends GGServiceTestUtil {
 
     private static final String TEST_JOB_ID_1 = "TEST_JOB_1";
+    private static final String TEST_UUID = "testDeploymentId";
     private static final String CONFIG_ARN_PLACEHOLDER = "TARGET_CONFIGURATION_ARN";
     private static final String EXPECTED_GROUP_NAME = "thinggroup/group1";
     private static final String EXPECTED_ROOT_PACKAGE_NAME = "component1";
@@ -374,10 +375,12 @@ class DeploymentServiceTest extends GGServiceTestUtil {
             throws Exception {
         String expectedGroupName = EXPECTED_GROUP_NAME;
         String expectedConfigArn = null;
+        String expectedUuid = null;
         if (type.equals(Deployment.DeploymentType.LOCAL)) {
             expectedGroupName = LOCAL_DEPLOYMENT_GROUP_NAME;
         } else {
             expectedConfigArn = TEST_CONFIGURATION_ARN;
+            expectedUuid = TEST_UUID;
         }
         String deploymentDocument = getTestDeploymentDocument();
 
@@ -415,18 +418,18 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         when(mockExecutorService.submit(any(DefaultDeploymentTask.class))).thenReturn(mockFuture);
 
         doNothing().when(deploymentStatusKeeper)
-                .persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1), eq(expectedConfigArn), eq(type),
+                .persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1), eq(expectedUuid), eq(expectedConfigArn), eq(type),
                         eq(JobStatus.IN_PROGRESS.toString()), any(), any());
 
         startDeploymentServiceInAnotherThread();
         verify(deploymentStatusKeeper, timeout(1000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(expectedConfigArn), eq(type), eq(JobStatus.IN_PROGRESS.toString()), any(), any());
+                eq(expectedUuid), eq(expectedConfigArn), eq(type), eq(JobStatus.IN_PROGRESS.toString()), any(), any());
         verify(deploymentStatusKeeper, timeout(10000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any(), any());
+                eq(expectedUuid), eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any(), any());
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any(), any());
+                eq(expectedUuid), eq(expectedConfigArn), eq(type), eq(JobStatus.SUCCEEDED.toString()), any(), any());
         ArgumentCaptor<Map<String, Object>> mapCaptor = ArgumentCaptor.forClass(Map.class);
         verify(mockComponentsToGroupPackages).replaceAndWait(mapCaptor.capture());
         Map<String, Object> groupToRootPackages = mapCaptor.getValue();
@@ -455,11 +458,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.FAILED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
 
@@ -480,11 +483,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         ArgumentCaptor<Map<String, Object>> statusDetails = ArgumentCaptor.forClass(Map.class);
 
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                statusDetails.capture(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.FAILED.toString()), statusDetails.capture(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         assertEquals("Unable to create deployment directory. mock error", statusDetails.getValue().get(DEPLOYMENT_FAILURE_CAUSE_KEY));
         assertListEquals(Arrays.asList("DEPLOYMENT_FAILURE", "IO_ERROR", "IO_WRITE_ERROR"),
                 (List<String>) statusDetails.getValue().get(DEPLOYMENT_ERROR_STACK_KEY));
@@ -516,11 +519,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.FAILED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
 
         ArgumentCaptor<Map<String, Object>> mapCaptor = ArgumentCaptor.forClass(Map.class);
         verify(deploymentGroupTopics).replaceAndWait(mapCaptor.capture());
@@ -553,11 +556,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.FAILED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     @Test
@@ -574,11 +577,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         verify(mockExecutorService, timeout(1000)).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.FAILED.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.FAILED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     @Test
@@ -600,8 +603,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         // Expecting three invocations, once for each retry attempt
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
         verify(updateSystemPolicyService, WAIT_FOUR_SECONDS).discardPendingUpdateAction(TEST_DEPLOYMENT_ID);
         verify(mockFuture, WAIT_FOUR_SECONDS).cancel(true);
     }
@@ -627,8 +630,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(updateSystemPolicyService, WAIT_FOUR_SECONDS).discardPendingUpdateAction(TEST_DEPLOYMENT_ID);
         verify(mockFuture, times(0)).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     @Test
@@ -664,8 +667,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(updateSystemPolicyService, times(0)).discardPendingUpdateAction(any());
         verify(mockFuture, times(0)).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
-                eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS), eq(JobStatus.IN_PROGRESS.toString()),
-                any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
     }
 
     String getTestDeploymentDocument() {

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentStatusKeeperTest.java
@@ -94,12 +94,12 @@ class DeploymentStatusKeeperTest {
             return true;
         }, DUMMY_SERVICE_NAME);
 
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "uuid", "group_config_arn", IOT_JOBS,
                 JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", null, LOCAL,
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", "uuid", null, LOCAL,
                 DeploymentStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
-        assertEquals(6, updateOfTypeJobs.size());
-        assertEquals(6, updateOfTypeLocal.size());
+        assertEquals(7, updateOfTypeJobs.size());
+        assertEquals(7, updateOfTypeLocal.size());
         assertEquals("iot_deployment", updateOfTypeJobs.get(DEPLOYMENT_ID_KEY_NAME));
         assertEquals(JobStatus.SUCCEEDED, Coerce.toEnum(JobStatus.class,
                 updateOfTypeJobs.get(DEPLOYMENT_STATUS_KEY_NAME)));
@@ -118,7 +118,7 @@ class DeploymentStatusKeeperTest {
     @Test
     void GIVEN_deployment_status_update_WHEN_consumer_return_true_THEN_update_is_removed_from_config() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(IOT_JOBS, (details) -> true, DUMMY_SERVICE_NAME);
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "uuid", "group_config_arn", IOT_JOBS,
                 JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         context.waitForPublishQueueToClear();
         assertEquals(0, processedDeployments.children.size());
@@ -127,7 +127,7 @@ class DeploymentStatusKeeperTest {
     @Test
     void GIVEN_local_deployment_status_update_WHEN_consumer_return_true_THEN_update_is_removed_from_config() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(LOCAL, (details) -> true, DUMMY_SERVICE_NAME);
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", null, LOCAL,
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("local_deployment", "uuid", null, LOCAL,
                 DeploymentStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         context.waitForPublishQueueToClear();
         assertEquals(0, processedDeployments.children.size());
@@ -136,7 +136,7 @@ class DeploymentStatusKeeperTest {
     @Test
     void GIVEN_deployment_status_update_WHEN_consumer_return_false_THEN_update_is_not_removed() {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(IOT_JOBS, (details) -> false, DUMMY_SERVICE_NAME);
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "uuid", "group_config_arn", IOT_JOBS,
                 JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         assertEquals(1, processedDeployments.children.size());
     }
@@ -151,7 +151,7 @@ class DeploymentStatusKeeperTest {
             return consumerReturnValue.get();
         }, DUMMY_SERVICE_NAME);
         // DeploymentStatusKeeper will retain update as consumer returns false
-        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "group_config_arn", IOT_JOBS,
+        deploymentStatusKeeper.persistAndPublishDeploymentStatus("iot_deployment", "uuid", "group_config_arn", IOT_JOBS,
                 JobStatus.SUCCEEDED.toString(), new HashMap<>(), new ArrayList<>());
         assertEquals(1, consumerInvokeCount.get());
 

--- a/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.exceptions.DeploymentException;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
-import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -89,10 +88,6 @@ class KernelUpdateDeploymentTaskTest {
         Configuration configuration = mock(Configuration.class);
         lenient().doReturn(topic).when(configuration).lookup(any());
         lenient().doReturn(configuration).when(kernel).getConfig();
-
-        DeploymentDocument document = mock(DeploymentDocument.class);
-        doReturn("mockId").when(document).getDeploymentId();
-        doReturn(document).when(deployment).getDeploymentDocumentObj();
         task = new KernelUpdateDeploymentTask(kernel, logger, deployment, componentManager);
     }
 

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -67,7 +67,7 @@ import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_TYPE_KEY_NAME;
-import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_UUID_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.GG_DEPLOYMENT_ID_KEY_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.FLEET_STATUS_CONFIG_TOPICS;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.IOT_JOBS;
@@ -736,7 +736,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         Map<String, Object> map = new HashMap<>();
         map.put(DEPLOYMENT_STATUS_KEY_NAME, JobStatus.IN_PROGRESS.toString());
         map.put(DEPLOYMENT_ID_KEY_NAME, "testJob");
-        map.put(DEPLOYMENT_UUID_KEY_NAME, "testJobUuid");
+        map.put(GG_DEPLOYMENT_ID_KEY_NAME, "testJobUuid");
         map.put(DEPLOYMENT_TYPE_KEY_NAME, "IOT_JOBS");
         consumerArgumentCaptor.getValue().apply(map);
 

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -67,6 +67,7 @@ import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ID
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_DETAILS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_TYPE_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_UUID_KEY_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.FLEET_STATUS_CONFIG_TOPICS;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType.IOT_JOBS;
@@ -735,6 +736,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         Map<String, Object> map = new HashMap<>();
         map.put(DEPLOYMENT_STATUS_KEY_NAME, JobStatus.IN_PROGRESS.toString());
         map.put(DEPLOYMENT_ID_KEY_NAME, "testJob");
+        map.put(DEPLOYMENT_UUID_KEY_NAME, "testJobUuid");
         map.put(DEPLOYMENT_TYPE_KEY_NAME, "IOT_JOBS");
         consumerArgumentCaptor.getValue().apply(map);
 
@@ -776,7 +778,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
             if (i == 0) {
                 assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());
                 assertEquals("MockService", componentDetails.getComponentName());
-                assertEquals("testJob", fleetStatusDetails.getDeploymentInformation().getDeploymentId());
+                assertEquals("testJobUuid", fleetStatusDetails.getDeploymentInformation().getDeploymentId());
                 assertNull(fleetStatusDetails.getDeploymentInformation().getUnchangedRootComponents());
                 assertNull(componentDetails.getComponentStatusDetails());
                 assertEquals(State.RUNNING, componentDetails.getState());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Add method `getGreengrassDeploymentId` to retrieve gg deployment id directly from deployment doc;
2. Report gg deployment id in FSS while keeping compatibility with other nucleus functionalities.
3. Updated relevant testings.

**Why is this change necessary:**
FSS would like to report greengrass deployment id on deployment finish events for all deployment types.

Previously FSS is reporting `id` field in `Deployment`, which hosts job id for job deployment and config arn for shadow deployment. However, the `id` field should not be changed since iot job helper uses this field to report job execution status. Creating a new field in deployment details to track greengrass deployment id instead.

Unfortunately `id` field cannot be refactored because it's persisted across Nucleus upgrade/downgrade.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
