### PR TITLE
fix: update ggc version env on version update

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -328,7 +328,7 @@ public class DeviceConfiguration {
     void initializeNucleusVersion(String nucleusComponentName, String nucleusComponentVersion) {
         kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC, nucleusComponentName,
                 VERSION_CONFIG_KEY).dflt(nucleusComponentVersion);
-        kernel.getConfig().lookup(SETENV_CONFIG_NAMESPACE, GGC_VERSION_ENV).dflt(nucleusComponentVersion);
+        kernel.getConfig().lookup(SETENV_CONFIG_NAMESPACE, GGC_VERSION_ENV).overrideValue(nucleusComponentVersion);
     }
 
     void initializeComponentStore(KernelAlternatives kernelAlts, String nucleusComponentName,


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
Version env should be set up on launch but with preloaded config.tlog config value does not get updated due to the use of `lookup` then `dflt`

**Why is this change necessary:**
In order to correctly update the ggc_version env var for component processes when they're restarted after version update

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
