### PR TITLE
fix: do not replace non-default stage deployments in deployment queue

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/Deployment.java
@@ -106,38 +106,22 @@ public class Deployment {
         /**
          * Deployment workflow is non-intrusive, i.e. not impacting kernel runtime
          */
-        DEFAULT(0),
+        DEFAULT,
 
         /**
          * Deployment goes over component bootstrap steps, which can be intrusive to kernel.
          */
-        BOOTSTRAP(1),
+        BOOTSTRAP,
 
         /**
          * Deployment has finished bootstrap steps and is in the middle of applying all changes to Kernel.
          */
-        KERNEL_ACTIVATION(2),
+        KERNEL_ACTIVATION,
 
         /**
-         * Deployment tries to rollback to Kernel with previous configuration, after BOOTSTRAP or
-         * KERNEL_ACTIVATION fails.
+         * Deployment tries to rollback to Kernel with previous configuration, after BOOTSTRAP or KERNEL_ACTIVATION
+         * fails.
          */
-        KERNEL_ROLLBACK(3);
-
-        private int priority;
-
-        DeploymentStage(int priority) {
-            this.priority = priority;
-        }
-
-        /**
-         * Get the priority value associated with this deployment stage.
-         *
-         * @return the integer priority value associated with this deployment stage.
-         */
-        public int getPriority() {
-            return priority;
-        }
+        KERNEL_ROLLBACK
     }
-
 }

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
@@ -247,14 +247,15 @@ public class DeploymentQueueTest {
                 contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_BOOTSTRAP, TEST_DEPLOYMENT_3));
 
         result = deploymentQueue.offer(TEST_DEPLOYMENT_2_CANCELLED);
-        assertThat(result, is(true));
+        // a bootstrap deployment cannot be cancelled
+        assertThat(result, is(false));
         assertThat(deploymentQueue.toArray(),
-                contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_CANCELLED, TEST_DEPLOYMENT_3));
+                contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_BOOTSTRAP, TEST_DEPLOYMENT_3));
 
         result = deploymentQueue.offer(TEST_DEPLOYMENT_3_CANCELLED);
         assertThat(result, is(true));
         assertThat(deploymentQueue.toArray(),
-                contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_CANCELLED, TEST_DEPLOYMENT_3_CANCELLED));
+                contains(TEST_DEPLOYMENT_1_CANCELLED, TEST_DEPLOYMENT_2_BOOTSTRAP, TEST_DEPLOYMENT_3_CANCELLED));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Updated the replacement criteria in deployment queue to not replace any non-DEFAULT stage deployments.

**Why is this change necessary:**
To avoid offering duplicate shadow deployments if it contains bootstrap components.

For a shadow deployment with bootstrap steps, after bootstrap finishes and kernel launches, kernel initializes the deployment queue with the `KERNEL_ACTIVATION` stage deployment. After `DeploymentService` starts up, it loads from config and replaces the deployment with `DEFAULT` stage deployment, causing `ShadowDeploymentListener` to initialize with a null `lastConfigurationArn` and resubmitting a duplicate deployment.

This change would avoid such replacement.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
