### PR TITLE
fix: shutdown external services with the old version of the shutdown command

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -392,8 +392,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
             componentShutdown.get(0, TimeUnit.SECONDS);
         }
 
-        // Now when we shutdown it should use the latest version which is 1.0.1
-        kernel.locate("service_with_dynamic_config").requestStop();
+        // Now when we shut down it should use the latest version which is 1.0.1
         CompletableFuture<Void> componentShutdown2 = new CompletableFuture<>();
         try (AutoCloseable a = createCloseableLogListener((m) -> {
             if (!m.getLoggerName().equals("service_with_dynamic_config")) {
@@ -406,6 +405,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
                 componentShutdown2.complete(null);
             }
         })) {
+            kernel.locate("service_with_dynamic_config").requestStop();
             componentShutdown2.get(5, TimeUnit.SECONDS);
         }
     }
@@ -422,7 +422,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         });
         kernel.launch();
 
-        assertTrue(mainRunning.await(5, TimeUnit.SECONDS));
+        assertTrue(mainRunning.await(20, TimeUnit.SECONDS));
 
         GenericExternalService service = spy((GenericExternalService) kernel.locate("service_with_dynamic_config"));
         assertEquals(State.RUNNING, service.getState());
@@ -464,7 +464,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         });
         service.getServiceConfig().find(SETENV_CONFIG_NAMESPACE, "my_env_var").withValue("var2");
 
-        assertTrue(serviceRestarted.await(5, TimeUnit.SECONDS));
+        assertTrue(serviceRestarted.await(35, TimeUnit.SECONDS));
     }
 
     @Test
@@ -647,7 +647,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         AtomicReference<Long> timestamp = new AtomicReference<>(System.currentTimeMillis());
         kernel.launch();
 
-        assertTrue(serviceBrokenLatch.await(15, TimeUnit.SECONDS));
+        assertTrue(serviceBrokenLatch.await(55, TimeUnit.SECONDS));
         assertTrue(serviceErroredLatch.await(15, TimeUnit.SECONDS));
         componentStatus.forEach(status -> {
             assertThat(status.getRight(), greaterThan(timestamp.getAndSet(status.getRight())));

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user_shell.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/config_run_with_user_shell.yaml
@@ -17,10 +17,12 @@ services:
     lifecycle:
       install:
         posix: |-
-          echo "install as `id -u -n`"
+          rm -f ./install-file
+          rm -f ./run-file
           touch ./install-file
+          echo "install as `id -u -n`"
       run:
         posix: |-
-          echo "run as `id -u -n`"
           touch ./run-file
+          echo "run as `id -u -n`"
     version: 1.0.0

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/service_with_dynamic_config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/service_with_dynamic_config.yaml
@@ -26,6 +26,9 @@ services:
           echo "Running service_with_dynamic_config" && sleep 1000
         windows:
           powershell -command echo \"Running service_with_dynamic_config\"; sleep 1000
+      shutdown:
+        all:
+          echo shutdown v1.0.0
     version: 1.0.0
     setenv:
       my_env_var: var1

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.lifecyclemanager.exceptions.ServiceException;
 import com.aws.greengrass.logging.api.LogEventBuilder;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.CrashableSupplier;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.Platform;
@@ -71,6 +72,7 @@ public class GenericExternalService extends GreengrassService {
     @Inject
     protected RunWithPathOwnershipHandler ownershipHandler;
     protected RunWith runWith;
+    protected volatile RunResult shutdownExecCache = null;
 
     private final AtomicBoolean paused = new AtomicBoolean();
 
@@ -224,7 +226,7 @@ public class GenericExternalService extends GreengrassService {
         RunResult runResult = run(Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC, exitCode -> {
             atomicExitCode.set(exitCode);
             timeoutLatch.countDown();
-        }, lifecycleProcesses);
+        }, lifecycleProcesses, true);
         try (Exec exec = runResult.getExec()) {
             if (exec == null) {
                 if (runResult.getRunStatus() == RunStatus.Errored) {
@@ -339,7 +341,7 @@ public class GenericExternalService extends GreengrassService {
         // reset runWith in case we moved from NEW -> INSTALLED -> change runwith -> NEW
         resetRunWith();
 
-        RunResult runResult = run(Lifecycle.LIFECYCLE_INSTALL_NAMESPACE_TOPIC, null, lifecycleProcesses);
+        RunResult runResult = run(Lifecycle.LIFECYCLE_INSTALL_NAMESPACE_TOPIC, null, lifecycleProcesses, true);
         if (runResult.getRunStatus() == RunStatus.Errored) {
             if (runResult.getStatusCode() == null) {
                 serviceErrored("Script errored in install");
@@ -353,6 +355,13 @@ public class GenericExternalService extends GreengrassService {
     // to operate properly
     @Override
     protected synchronized void startup() throws InterruptedException {
+        // Cache the proper shutdown command right when we're starting up (if desired).
+        // This guarantees that the shutdown command that we eventually run will be the same
+        // shutdown command which *should* be applied to *this* startup.
+        // If the component version changes, we will restart by shutting down. Without caching
+        // the shutdown command, we'd end up shutting down this component using the *new*
+        // shutdown command, and not the one which is associated with the current startup.
+        cacheShutdownExec();
         stopAllLifecycleProcesses();
 
         long startingStateGeneration = getStateGeneration();
@@ -373,7 +382,7 @@ public class GenericExternalService extends GreengrassService {
                     }
                 }
             }
-        }, lifecycleProcesses);
+        }, lifecycleProcesses, true);
 
         if (runResult.getRunStatus() == RunStatus.Errored) {
             if (runResult.getStatusCode() == null) {
@@ -388,6 +397,20 @@ public class GenericExternalService extends GreengrassService {
             updateSystemResourceLimits();
             systemResourceController.addComponentProcess(this, runResult.getExec().getProcess());
         }
+    }
+
+    @SuppressWarnings("PMD.NullAssignment")
+    protected void cacheShutdownExec() throws InterruptedException {
+        if (!shouldCacheShutdownExec()) {
+            shutdownExecCache = null;
+            return;
+        }
+        // Cache the Exec without calling it
+        shutdownExecCache = run(Lifecycle.LIFECYCLE_SHUTDOWN_NAMESPACE_TOPIC, null, lifecycleProcesses, false);
+    }
+
+    protected boolean shouldCacheShutdownExec() {
+        return true;
     }
 
     /**
@@ -478,7 +501,7 @@ public class GenericExternalService extends GreengrassService {
                     }
                 }
             }
-        }, lifecycleProcesses);
+        }, lifecycleProcesses, true);
 
         if (runResult.getRunStatus() == RunStatus.NothingDone) {
             reportState(State.FINISHED);
@@ -534,7 +557,13 @@ public class GenericExternalService extends GreengrassService {
         }
 
         try {
-            run(Lifecycle.LIFECYCLE_SHUTDOWN_NAMESPACE_TOPIC, null, lifecycleProcesses);
+            RunResult cached = shutdownExecCache;
+            if (shouldCacheShutdownExec() && cached != null && cached.getDoExec() != null) {
+                logger.atDebug().log("Using cached shutdown command");
+                cached.getDoExec().apply();
+            } else {
+                run(Lifecycle.LIFECYCLE_SHUTDOWN_NAMESPACE_TOPIC, null, lifecycleProcesses, true);
+            }
         } catch (InterruptedException ex) {
             logger.atWarn("generic-service-shutdown").log("Thread interrupted while shutting down service");
         } finally {
@@ -584,7 +613,8 @@ public class GenericExternalService extends GreengrassService {
                 Lifecycle.TIMEOUT_NAMESPACE_TOPIC));
 
         CountDownLatch handlerExecutionCdl = new CountDownLatch(1);
-        run(Lifecycle.LIFECYCLE_RECOVER_NAMESPACE_TOPIC, c -> handlerExecutionCdl.countDown(), lifecycleProcesses);
+        run(Lifecycle.LIFECYCLE_RECOVER_NAMESPACE_TOPIC, c -> handlerExecutionCdl.countDown(), lifecycleProcesses,
+                true);
 
         if (!handlerExecutionCdl.await(timeout, TimeUnit.SECONDS)) {
             logger.atError().log(String.format("Error recovery handler timed out after %d seconds", timeout));
@@ -634,13 +664,14 @@ public class GenericExternalService extends GreengrassService {
     /**
      * Run one of the commands defined in the config on the command line.
      *
-     * @param name         name of the command to run ("run", "install", "startup", "bootstrap").
-     * @param background   IntConsumer to and run the command as background process and receive the exit code. If null,
-     *                     the command will run as a foreground process and blocks indefinitely.
-     * @param trackingList List used to track running processes.
+     * @param name           name of the command to run ("run", "install", "startup", "bootstrap").
+     * @param background     IntConsumer to and run the command as background process and receive the exit code. If
+     *                       null, the command will run as a foreground process and blocks indefinitely.
+     * @param trackingList   List used to track running processes.
+     * @param runImmediately True if the command should be run immediately, false to construct without running
      * @return the status of the run and the Exec.
      */
-    protected RunResult run(String name, IntConsumer background, List<Exec> trackingList)
+    protected RunResult run(String name, IntConsumer background, List<Exec> trackingList, boolean runImmediately)
             throws InterruptedException {
         Node n = (getLifecycleTopic() == null) ? null : getLifecycleTopic().getChild(name);
         if (n == null) {
@@ -648,17 +679,18 @@ public class GenericExternalService extends GreengrassService {
         }
 
         if (n instanceof Topic) {
-            return run(name, (Topic) n, Coerce.toString(n), background, trackingList, isPrivilegeRequired(name));
+            return run(name, (Topic) n, Coerce.toString(n), background,
+                    trackingList, isPrivilegeRequired(name), runImmediately);
         }
         if (n instanceof Topics) {
-            return run(name, (Topics) n, background, trackingList, isPrivilegeRequired(name));
+            return run(name, (Topics) n, background, trackingList, isPrivilegeRequired(name), runImmediately);
         }
         return new RunResult(RunStatus.NothingDone, null, null);
     }
 
     @SuppressWarnings("PMD.CloseResource")
     protected RunResult run(String name, Topic t, String cmd, IntConsumer background, List<Exec> trackingList,
-                                        boolean requiresPrivilege) throws InterruptedException {
+                                        boolean requiresPrivilege, boolean runImmediately) throws InterruptedException {
         if (runWith == null) {
             Optional<RunWith> opt = computeRunWithConfiguration();
             if (!opt.isPresent()) {
@@ -698,19 +730,28 @@ public class GenericExternalService extends GreengrassService {
         exec = addShell(exec);
 
         addEnv(exec, t.parent);
-        logger.atDebug().setEventType("generic-service-run").log();
 
-        // Track all running processes that we fork
-        if (exec.isRunning()) {
-            trackingList.add(exec);
+        Exec finalExec = exec;
+        CrashableSupplier<RunStatus, InterruptedException> doRun = () -> {
+            logger.atDebug().setEventType("generic-service-run").log();
+            // Track all running processes that we fork
+            if (finalExec.isRunning()) {
+                trackingList.add(finalExec);
+            }
+            return shellRunner.successful(finalExec, t.getFullName(),
+                    background, this) ? RunStatus.OK : RunStatus.Errored;
+        };
+
+        if (runImmediately) {
+            RunStatus ret = doRun.apply();
+            return new RunResult(ret, exec, null);
+        } else {
+            return new RunResult(null, exec, null, doRun);
         }
-        RunStatus ret =
-                shellRunner.successful(exec, t.getFullName(), background, this) ? RunStatus.OK : RunStatus.Errored;
-        return new RunResult(ret, exec, null);
     }
 
     protected RunResult run(String name, Topics t, IntConsumer background, List<Exec> trackingList,
-                                        boolean requiresPrivilege)
+                                        boolean requiresPrivilege, boolean runImmediately)
             throws InterruptedException {
         try {
             if (shouldSkip(t)) {
@@ -723,7 +764,8 @@ public class GenericExternalService extends GreengrassService {
 
         Node script = t.getChild("script");
         if (script instanceof Topic) {
-            return run(name, (Topic) script, Coerce.toString(script), background, trackingList, requiresPrivilege);
+            return run(name, (Topic) script, Coerce.toString(script), background, trackingList, requiresPrivilege,
+                    runImmediately);
         } else {
             logger.atError().setEventType("generic-service-invalid-config").addKeyValue(CONFIG_NODE, t.getFullName())
                     .log("Missing script");
@@ -839,5 +881,12 @@ public class GenericExternalService extends GreengrassService {
         private RunStatus runStatus;
         private Exec exec;
         private ComponentStatusCode statusCode;
+        private CrashableSupplier<RunStatus, InterruptedException> doExec;
+
+        RunResult(RunStatus runStatus, Exec exec, ComponentStatusCode statusCode) {
+            this.runStatus = runStatus;
+            this.exec = exec;
+            this.statusCode = statusCode;
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, a deployment simply updates the configuration of a component, and the component itself is responsible for updating itself appropriately in reaction to that change. What this means is that if a component is updated from v1 to v2, the component will have v2's lifecycle configuration immediately. The component reacts by reinstalling since the version changed. As part of reinstallation, the component will first shutdown. However, the shutdown command that it will use is the shutdown command for v2 because the configuration has already been changed. This means that the process of v1 will try to be stopped by the v2 shutdown script; this may or may not work.

This change fixes this problem by caching the correct shutdown script at `startup` time. The shutdown will then use this cached value instead of reading from the updated config value.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.
Added a new case into an existing test to verify that the correct shutdown script is used when the version changes.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
