### PR TITLE
fix: parse status codes from greengrass cloud exceptions

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtils.java
+++ b/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtils.java
@@ -67,6 +67,8 @@ import static com.aws.greengrass.deployment.errorcode.DeploymentErrorCode.THROTT
 
 public final class DeploymentErrorCodeUtils {
 
+    private static final int CONFLICTED_REQUEST_STATUS_CODE = 409;
+
     private static final Logger logger = LogManager.getLogger(DeploymentErrorCodeUtils.class);
 
     private static final List<Class<? extends Exception>> NETWORK_OFFLINE_EXCEPTION =
@@ -170,17 +172,17 @@ public final class DeploymentErrorCodeUtils {
     private static void collectErrorCodesFromGreengrassV2DataException(Set<DeploymentErrorCode> errorCodeSet,
                                                                        GreengrassV2DataException e) {
         errorCodeSet.add(CLOUD_API_ERROR);
-        if (e instanceof ResourceNotFoundException) {
+        if (e instanceof ResourceNotFoundException || e.statusCode() == HttpStatusCode.NOT_FOUND) {
             errorCodeSet.add(RESOURCE_NOT_FOUND);
-        } else if (e instanceof AccessDeniedException) {
+        } else if (e instanceof AccessDeniedException || e.statusCode() == HttpStatusCode.FORBIDDEN) {
             errorCodeSet.add(ACCESS_DENIED);
-        } else if (e instanceof ValidationException) {
+        } else if (e instanceof ValidationException || e.statusCode() == HttpStatusCode.BAD_REQUEST) {
             errorCodeSet.add(BAD_REQUEST);
-        } else if (e instanceof ThrottlingException) {
+        } else if (e instanceof ThrottlingException || e.statusCode() == HttpStatusCode.THROTTLING) {
             errorCodeSet.add(THROTTLING_ERROR);
-        } else if (e instanceof ConflictException) {
+        } else if (e instanceof ConflictException || e.statusCode() == CONFLICTED_REQUEST_STATUS_CODE) {
             errorCodeSet.add(CONFLICTED_REQUEST);
-        } else if (e instanceof InternalServerException) {
+        } else if (e instanceof InternalServerException || e.statusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR) {
             errorCodeSet.add(SERVER_ERROR);
         }
     }


### PR DESCRIPTION
**Description of changes:**
1. Parse status codes from greengrass exceptions instead of relying on its type.

**Why is this change necessary:**
Sometimes when a cloud api call fails due to missing permissions, a generic `GreengrassV2DataException` is thrown instead of a specific `AccessDeniedException`, which causes the error code logic to handle it incorrectly.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
