### PR TITLE
fix: restrict fss errored component triggered update

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/local_store_content/recipes/CustomerApp-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/local_store_content/recipes/CustomerApp-1.0.0.yaml
@@ -7,6 +7,9 @@ ComponentVersion: '1.0.0'
 ComponentConfiguration:
   DefaultConfiguration:
     sampleText: This is a test
+ComponentDependencies:
+  Mosquitto:
+    VersionRequirement: 1.0.0
 
 Manifests:
   - Platform:
@@ -18,9 +21,6 @@ Manifests:
     Lifecycle:
       run: |-
         echo Hello Greengrass. {configuration:/sampleTest}
-    Dependencies:
-      Mosquitto:
-        VersionRequirement: 1.0.0
     Artifacts:
       - URI: s3://mock-bucket/customerApp
   - Platform:
@@ -32,8 +32,5 @@ Manifests:
     Lifecycle:
       run:
         echo "Hello Greengrass. {configuration:/sampleTest}"
-    Dependencies:
-      Mosquitto:
-        VersionRequirement: 1.0.0
     Artifacts:
       - URI: s3://mock-bucket/customerApp


### PR DESCRIPTION
**Description of changes:**
1. Restrict FSS updates triggered by errored component to only send info of the errored component itself.
2. Updated relevant testing.

**Why is this change necessary:**
If a deployment is in progress, other components in the errored component update would not have the updated fleet config arn. If these other components did not observe state change after the update, the cloud would not display them in console table, due to missing fleet config arn value.


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
