### PR TITLE
chore: bump version to 2.9.0

### DIFF
--- a/conf/recipe.yaml
+++ b/conf/recipe.yaml
@@ -9,7 +9,7 @@ ComponentName: aws.greengrass.Nucleus
 ComponentType: aws.greengrass.nucleus
 ComponentDescription: Core functionality for device side orchestration of deployments and lifecycle management for execution of Greengrass components and applications. This includes features such as starting, stopping, and monitoring execution of components and apps, inter-process communication server for communication between components, component installation and configuration management. This is a fundamental cornerstone of open-sourcing Greengrass, providing documentation and ability to debug Greengrass Core.
 ComponentPublisher: AWS
-ComponentVersion: '2.8.0'
+ComponentVersion: '2.9.0'
 ComponentConfiguration:
   DefaultConfiguration:
     iotDataEndpoint: ""

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>nucleus</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -821,7 +821,7 @@
         <excludedGroups>E2E,E2E-INTRUSIVE</excludedGroups>
         <groups></groups>
         <greengrassjar.name>Greengrass</greengrassjar.name>
-        <lastVersion>2.6.0-SNAPSHOT</lastVersion>
+        <lastVersion>2.8.0-SNAPSHOT</lastVersion>
     </properties>
     <distributionManagement>
         <snapshotRepository>

--- a/src/test/greengrass-nucleus-benchmark/pom.xml
+++ b/src/test/greengrass-nucleus-benchmark/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.aws.greengrass</groupId>
     <artifactId>greengrass-nucleus-benchmark</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JMH benchmark sample: Java</name>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.8.0-SNAPSHOT</version>
+            <version>2.9.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
