### PR TITLE
test(windows): deflake windows testing, increasing timeouts

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCTestUtils.java
@@ -73,7 +73,7 @@ public final class IPCTestUtils {
         kernel.getContext().addGlobalStateChangeListener(listener);
 
         kernel.launch();
-        assertTrue(awaitIpcServiceLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(awaitIpcServiceLatch.await(30, TimeUnit.SECONDS));
         kernel.getContext().removeGlobalStateChangeListener(listener);
         return kernel;
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -730,13 +730,13 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         AtomicReference<ComponentStatusDetails> statusB = new AtomicReference<>();
         kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
             if (State.ERRORED.equals(newState)) {
-                serviceErroredLatch.countDown();
                 if ("ServiceA".equals(service.getName())) {
                     statusA.set(service.getStatusDetails());
                 }
                 if ("ServiceB".equals(service.getName())) {
                     statusB.set(service.getStatusDetails());
                 }
+                serviceErroredLatch.countDown();
             }
         });
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelTest.java
@@ -316,7 +316,7 @@ class KernelTest extends BaseITCase {
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
                 this.getClass().getResource("config_broken.yaml"));
         kernel.launch();
-        if (!assertionLatch.await(60, TimeUnit.SECONDS) && !expectedStateTransitionList.isEmpty()) {
+        if (!assertionLatch.await(120, TimeUnit.SECONDS) && !expectedStateTransitionList.isEmpty()) {
             expectedStateTransitionList.stream().filter(x -> !x.seen).forEach(e -> System.err.println(
                     String.format("Fail to see state event for service %s: %s=> %s", e.serviceName, e.was, e.current)));
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Windows tests have been failing sometimes on GitHub runner again. This change aims to resolve 2 common failures which both appear to simply be timeouts that are too short, and not indicative of any true problem.

Fixed non-windows test issue in `GIVEN_service_starts_up_WHEN_startup_times_out_THEN_timeout_error_code_persisted` which got a NPE when reading the status because the countdown happened before the atomicreference was set.

**Why is this change necessary:**

**How was this change tested:**
Running GIVEN_expected_state_transitions_WHEN_services_error_out_THEN_all_expectations_should_be_seen in a loop on my workspace shows no errors (ran 100 times). I'll ensure the GitHub runner also passes at least 3 times.

Passes
1. https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/3252845391/jobs/5339504930
2. https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/3252879874/jobs/5339579044
3. https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/3252879874/jobs/5340022148
4. https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/3253377835/jobs/5340593168

- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
