### PR TITLE
fix: protect generateFailureMessage from null messages

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -193,13 +193,24 @@ public final class Utils {
      * @return String chain of exceptions and messages.
      */
     public static String generateFailureMessage(Throwable t) {
-        StringBuilder failureMessage = new StringBuilder(t.getMessage());
+        if (t == null) {
+            return "No error, null throwable";
+        }
+        StringBuilder failureMessage = new StringBuilder(getMessageFromThrowable(t));
         Throwable temp = t;
         while (temp.getCause() != null) {
             temp = temp.getCause();
-            failureMessage.append(". ").append(temp.getMessage());
+            failureMessage.append(". ").append(getMessageFromThrowable(temp));
         }
         return failureMessage.toString();
+    }
+
+    private static String getMessageFromThrowable(Throwable t) {
+        if (t.getMessage() == null) {
+            return t.getClass().getName();
+        } else {
+            return t.getMessage();
+        }
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`Throwable.getMessage()` can return null, specifically it always returns null for NullPointerException. Ironically, this causes a NPE to be thrown from the StringBuilder's constructor. This change protects this method from null messages and will add the exception classname instead of the message when there is no message.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
