### PR TITLE
fix: do not persist or load queued deployments that target the nucleus itself

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -367,9 +367,7 @@ public class DeploymentService extends GreengrassService {
             });
             // do not load deployments that target the nucleus itself, as doing so can cause undesired behavior.
             deserializedDeployments.removeIf(this::doesDeploymentChangeTheNucleusVersion);
-            deserializedDeployments.forEach(deployment -> {
-                this.deploymentQueue.offer(deployment);
-            });
+            deserializedDeployments.forEach(this.deploymentQueue::offer);
         } catch (Exception e) {
             logger.atError().cause(e).log("Failed to load deployment queue");
         } finally {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -324,7 +324,7 @@ public class DeploymentService extends GreengrassService {
                 return;
             }
             // do not persist deployments that target the nucleus itself, as doing so can cause undesired behavior.
-            deploymentsToSave.removeIf(deployment -> doesDeploymentChangeTheNucleusVersion(deployment));
+            deploymentsToSave.removeIf(this::doesDeploymentChangeTheNucleusVersion);
             final List<String> serializedDeploymentsToSave = new ArrayList<>();
             for (Deployment d : deploymentsToSave) {
                 serializedDeploymentsToSave.add(SerializerFactory.getFailSafeJsonObjectMapper().writeValueAsString(d));
@@ -338,9 +338,10 @@ public class DeploymentService extends GreengrassService {
     }
 
     private boolean doesDeploymentChangeTheNucleusVersion(final Deployment deployment) {
+        final DeviceConfiguration deviceConfig = context.get(DeviceConfiguration.class);
         final String targetNucleusVersion = deployment.getDeploymentDocumentObj()
-                .getTargetVersionForRootPackage(context.get(DeviceConfiguration.class).getNucleusComponentName());
-        return !targetNucleusVersion.isEmpty() && !targetNucleusVersion.contentEquals(kernel.getNucleusVersion());
+                .getTargetVersionForRootPackage(deviceConfig.getNucleusComponentName());
+        return !targetNucleusVersion.isEmpty() && !targetNucleusVersion.contentEquals(deviceConfig.getNucleusVersion());
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
@@ -365,7 +366,7 @@ public class DeploymentService extends GreengrassService {
                 }
             });
             // do not load deployments that target the nucleus itself, as doing so can cause undesired behavior.
-            deserializedDeployments.removeIf(deployment -> doesDeploymentChangeTheNucleusVersion(deployment));
+            deserializedDeployments.removeIf(this::doesDeploymentChangeTheNucleusVersion);
             deserializedDeployments.forEach(deployment -> {
                 this.deploymentQueue.offer(deployment);
             });

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
@@ -96,6 +96,28 @@ public class DeploymentDocument {
                 .map(DeploymentPackageConfiguration::getPackageName).collect(Collectors.toList());
     }
 
+    /**
+     * If the provided package is a root package in this deployment, then return that package's target version.
+     * Otherwise, return the empty string.
+     *
+     * @param packageName the provided root package name
+     * @return the target version for the provided root package
+     */
+    @JsonIgnore
+    public String getTargetVersionForRootPackage(String packageName) {
+        if (deploymentPackageConfigurationList == null || deploymentPackageConfigurationList.isEmpty()) {
+            return "";
+        }
+        final DeploymentPackageConfiguration config = deploymentPackageConfigurationList.stream()
+                .filter((c) -> {
+                    return c.isRootComponent() && c.getPackageName().contentEquals(packageName);
+                }).findFirst().orElse(null);
+        if (config == null) {
+            return "";
+        }
+        return config.getResolvedVersion();
+    }
+
     // Custom serializer for AWS SDK model since Jackson can't figure it out itself
     private static class SDKSerializer extends JsonSerializer {
         SDKSerializer() {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -681,8 +681,4 @@ public class Kernel {
     public List<String> getSupportedCapabilities() {
         return SUPPORTED_CAPABILITIES;
     }
-
-    public String getNucleusVersion() {
-        return (String) getConfig().lookup(SETENV_CONFIG_NAMESPACE, GGC_VERSION_ENV).getOnce();
-    }
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -75,13 +75,11 @@ import javax.inject.Singleton;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.config.Topic.DEFAULT_VALUE_TIMESTAMP;
 import static com.aws.greengrass.dependency.EZPlugins.JAR_FILE_EXTENSION;
-import static com.aws.greengrass.deployment.DeviceConfiguration.GGC_VERSION_ENV;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_REBOOT;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.greengrass.lifecyclemanager.KernelCommandLine.MAIN_SERVICE_NAME;
 
 /**

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -75,11 +75,13 @@ import javax.inject.Singleton;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.config.Topic.DEFAULT_VALUE_TIMESTAMP;
 import static com.aws.greengrass.dependency.EZPlugins.JAR_FILE_EXTENSION;
+import static com.aws.greengrass.deployment.DeviceConfiguration.GGC_VERSION_ENV;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_REBOOT;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_DEPENDENCIES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.greengrass.lifecyclemanager.KernelCommandLine.MAIN_SERVICE_NAME;
 
 /**
@@ -678,5 +680,9 @@ public class Kernel {
 
     public List<String> getSupportedCapabilities() {
         return SUPPORTED_CAPABILITIES;
+    }
+
+    public String getNucleusVersion() {
+        return (String) getConfig().lookup(SETENV_CONFIG_NAMESPACE, GGC_VERSION_ENV).getOnce();
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

We have a nucleus feature that, in response to nucleus shutdown, persists queued and in-progress deployments so they can be reloaded at nucleus startup.

This PR tweaks the feature so that deployments targeting the nucleus itself are excluded.

**Why is this change necessary:**

Loading a persisted deployment at startup can cause unexpected behavior when that deployment targets the nucleus.

Example:

Nucleus @ 2.8.x is running.

Deployment A comes along, downgrading Nucleus to 2.2.x.

Deployment A succeeds, but deployment A is persisted to disk during the downgrade.

Now, Nucleus @ 2.2.x is running. Deployment A remains serialized to disk (2.2.x doesn't have the persistence/loading feature).

Deployment B comes along, upgrading Nucleus to 2.8.x.

Deployment B succeeds, and Nucleus starts up @ 2.8.x.  At startup, Nucleus loads deployment A, which immediately causes a downgrade to 2.2.x (undesired behavior).

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
