### PR TITLE
feat(sub-group deploy): add sub-group deployment feature

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.deployment;
+
+import com.amazon.aws.iot.greengrass.component.common.DependencyType;
+import com.amazon.aws.iot.greengrass.configuration.common.Configuration;
+import com.amazon.aws.iot.greengrass.configuration.common.DeploymentCapability;
+import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.DeploymentQueue;
+import com.aws.greengrass.deployment.DeploymentStatusKeeper;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.ThingGroupHelper;
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.helper.PreloadComponentStoreHelper;
+import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_SERVICE_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_STATUS_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentStatusKeeper.GG_DEPLOYMENT_ID_KEY_NAME;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_SERVICE_TOPICS;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.aws.greengrass.util.Utils.copyFolderRecursively;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+
+public class SubGroupDeploymentIntegrationTest extends BaseITCase {
+
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    private static final String THING_GROUP_PREFIX = "thinggroup/";
+    private static final String ROOT_GROUP_NAME = "parentGroup";
+    private static final String ROOT_GROUP_DEPLOYMENT_CONFIG = "FleetConfigWithSimpleAppv1.json";
+    private static final Map<String, String> ROOT_GROUP_SERVICE_MAP = Utils.immutableMap("SimpleApp", "1.0.0");
+    private static final List<String> REQUIRED_CAPABILITY =
+            Arrays.asList(DeploymentCapability.SUBGROUP_DEPLOYMENTS.toString());
+
+    private Kernel kernel;
+    private DeploymentQueue deploymentQueue;
+    private Path localStoreContentPath;
+    @Mock
+    private ThingGroupHelper thingGroupHelper;
+    @Mock
+    private MqttClient mqttClient;
+
+    private Map<String, CountDownLatch> groupLatchMap;
+
+    @BeforeEach
+    void before(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, PackageDownloadException.class);
+        ignoreExceptionOfType(context, SdkClientException.class);
+
+        groupLatchMap = new ConcurrentHashMap<>();
+
+        kernel = new Kernel();
+        kernel.getContext().put(ThingGroupHelper.class, thingGroupHelper);
+        kernel.getContext().put(MqttClient.class, mqttClient);
+
+        NoOpPathOwnershipHandler.register(kernel);
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel, this.getClass().getResource("onlyMain.yaml"));
+
+        // ensure deployment service starts
+        CountDownLatch deploymentServiceLatch = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals(DEPLOYMENT_SERVICE_TOPICS) && newState.equals(State.RUNNING)) {
+                deploymentServiceLatch.countDown();
+            }
+        });
+
+        // set up device config
+        setDeviceConfig(kernel, DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS, 1L);
+
+        // launch kernel
+        kernel.launch();
+        assertTrue(deploymentServiceLatch.await(10, TimeUnit.SECONDS));
+
+        // get kernel details after launch
+        localStoreContentPath =
+                Paths.get(DeploymentTaskIntegrationTest.class.getResource("local_store_content").toURI());
+        deploymentQueue = kernel.getContext().get(DeploymentQueue.class);
+
+        // setup fss such that it could send mqtt messages to the mock listener
+        FleetStatusService fleetStatusService = (FleetStatusService) kernel.locate(FLEET_STATUS_SERVICE_TOPICS);
+        fleetStatusService.getIsConnected().set(false);
+    }
+
+    @AfterEach
+    void after() {
+        if (kernel != null) {
+            kernel.shutdown();
+        }
+    }
+
+    @Test
+    void GIVEN_root_deployment_success_WHEN_subgroup_deploy_with_component_changes_THEN_deployment_overrides()
+            throws Exception {
+        // Given
+        // deploys SimpleApp 1.0.0
+        setupRootParentGroupDeploymentFor("subGroup1");
+
+        // When
+        // sub-group deployment overrides SimpleApp to 2.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv2.json", 1, "subGroup1", ROOT_GROUP_NAME);
+
+        // Then
+        verifyServices(Utils.immutableMap("SimpleApp", "2.0.0"));
+    }
+
+    @Test
+    void GIVEN_root_deployment_success_WHEN_multiple_sibling_subgroups_deploy_with_different_component_versions_and_deploy_received_in_order_THEN_most_recent_created_deploy_wins()
+            throws Exception {
+        // Given
+        // deploys SimpleApp 1.0.0
+        setupRootParentGroupDeploymentFor("subGroup1", "subGroup2", "subGroup3");
+
+        // When
+        // sub-group deployment maintains SimpleApp 1.0.0 and adds GreenSignal 1.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv1AndGreenSignal.json", 1, "subGroup1",
+                ROOT_GROUP_NAME);
+        verifyServices(Utils.immutableMap("SimpleApp", "1.0.0", "GreenSignal", "1.0.0"));
+        // sub-group deployment overrides SimpleApp to 2.0.0 and removes GreenSignal
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv2.json", 1, "subGroup2", ROOT_GROUP_NAME);
+        // sub-group deployment overrides SimpleApp to 3.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv3.json", 1, "subGroup3", ROOT_GROUP_NAME);
+
+        // Then
+        verifyServices(Utils.immutableMap("SimpleApp", "3.0.0"));
+        verifyServicesRemoved("GreenSignal");
+    }
+
+    @Test
+    void GIVEN_root_deployment_success_WHEN_nested_subgroups_deploy_with_different_component_versions_and_deploy_received_in_order_THEN_most_recent_created_deploy_wins()
+            throws Exception {
+        // Given
+        // deploys SimpleApp 1.0.0
+        setupRootParentGroupDeploymentFor("subGroup1", "subGroup2", "subGroup11", "subGroup12");
+
+        // When
+        // redeployment without change
+        createSubGroupDeploymentAndWait(ROOT_GROUP_DEPLOYMENT_CONFIG, 1, "subGroup1", ROOT_GROUP_NAME);
+        // redeployment without change
+        createSubGroupDeploymentAndWait(ROOT_GROUP_DEPLOYMENT_CONFIG, 1, "subGroup2", ROOT_GROUP_NAME);
+        // sub-group deployment overrides SimpleApp to 2.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv2.json", 1, "subGroup11", "subGroup1");
+        // sub-group deployment overrides SimpleApp to 3.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv3.json", 1, "subGroup12", "subGroup1");
+
+        // Then
+        verifyServices(Utils.immutableMap("SimpleApp", "3.0.0"));
+    }
+
+    @Test
+    void GIVEN_root_deployment_success_with_multiple_sibling_subgroups_WHEN_new_root_deployment_revision_THEN_root_deployment_overrides_subgroups()
+            throws Exception {
+        // Given
+        // deploys SimpleApp 1.0.0
+        setupRootParentGroupDeploymentFor("subGroup1", "subGroup2", "subGroup3");
+
+        // When
+        // sub-group deployment maintains SimpleApp 1.0.0 and adds GreenSignal 1.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv1AndGreenSignal.json", 1, "subGroup1",
+                ROOT_GROUP_NAME);
+        verifyServices(Utils.immutableMap("SimpleApp", "1.0.0", "GreenSignal", "1.0.0"));
+        // sub-group deployment overrides SimpleApp to 2.0.0 and removes GreenSignal
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv2.json", 1, "subGroup2", ROOT_GROUP_NAME);
+
+        // deploys revision overrides all sub-groups to SimpleApp 3.0.0
+        groupLatchMap.put(ROOT_GROUP_NAME, new CountDownLatch(1));
+        createRootParentDeploymentAndWait("FleetConfigWithSimpleAppv3.json", 2);
+
+        // Then
+        verifyServices(Utils.immutableMap("SimpleApp", "3.0.0"));
+        verifyServicesRemoved("GreenSignal");
+    }
+
+    private void verifyServices(Map<String, String> serviceVersions) {
+        Topics groupToRootTopic = kernel.getConfig()
+                .lookupTopics(SERVICES_NAMESPACE_TOPIC, DEPLOYMENT_SERVICE_TOPICS, GROUP_TO_ROOT_COMPONENTS_TOPICS);
+
+        List<String> groupNames = new ArrayList<>();
+        groupToRootTopic.forEach(node -> groupNames.add(node.getName()));
+        assertTrue(groupNames.containsAll(Arrays.asList(THING_GROUP_PREFIX + ROOT_GROUP_NAME)),
+                "Device should only " + "belong to " + ROOT_GROUP_NAME);
+
+        Map<GreengrassService, DependencyType> dependenciesAfter = kernel.getMain().getDependencies();
+        List<String> serviceNames =
+                dependenciesAfter.keySet().stream().map(service -> service.getName()).collect(Collectors.toList());
+        assertTrue(serviceNames.containsAll(serviceVersions.keySet()));
+
+        for (Map.Entry<String, String> serviceEntry : serviceVersions.entrySet()) {
+            // check service version
+            Topic serviceVersion =
+                    groupToRootTopic.find(THING_GROUP_PREFIX + ROOT_GROUP_NAME, serviceEntry.getKey(), "version");
+            assertEquals(serviceEntry.getValue(), Coerce.toString(serviceVersion.getOnce()));
+        }
+    }
+
+    private void verifyServicesRemoved(String... services) {
+        Topics groupToRootTopic = kernel.getConfig()
+                .lookupTopics(SERVICES_NAMESPACE_TOPIC, DEPLOYMENT_SERVICE_TOPICS, GROUP_TO_ROOT_COMPONENTS_TOPICS);
+        for (String service : services) {
+            Topic serviceVersion = groupToRootTopic.find(THING_GROUP_PREFIX + ROOT_GROUP_NAME, service, "version");
+            assertNull(serviceVersion);
+        }
+    }
+
+    private void setupRootParentGroupDeploymentFor(@Nonnull String... subGroupNames) throws Exception {
+        for (String subGroup : subGroupNames) {
+            groupLatchMap.put(subGroup, new CountDownLatch(1));
+        }
+        groupLatchMap.put(ROOT_GROUP_NAME, new CountDownLatch(1));
+
+        DeploymentStatusKeeper deploymentStatusKeeper = kernel.getContext().get(DeploymentStatusKeeper.class);
+        deploymentStatusKeeper.registerDeploymentStatusConsumer(Deployment.DeploymentType.IOT_JOBS, (status) -> {
+            String groupName = (String) status.get(GG_DEPLOYMENT_ID_KEY_NAME);
+            String deploymentStatus = (String) status.get(DEPLOYMENT_STATUS_KEY_NAME);
+            if ("SUCCEEDED".equals(deploymentStatus) || "REJECTED".equals(deploymentStatus)) {
+                CountDownLatch latch = groupLatchMap.get(groupName);
+                if (latch != null) {
+                    latch.countDown();
+                }
+            }
+            return true;
+        }, "dummyValue");
+
+        final Set<String> thingGroups = new HashSet<>(groupLatchMap.size());
+        thingGroups.addAll(groupLatchMap.keySet());
+
+        when(thingGroupHelper.listThingGroupsForDevice(anyInt())).thenReturn(
+                Optional.of(Collections.unmodifiableSet(thingGroups)));
+        createRootParentDeploymentAndWait(ROOT_GROUP_DEPLOYMENT_CONFIG, 1);
+        verifyServices(ROOT_GROUP_SERVICE_MAP);
+    }
+
+    private void createSubGroupDeploymentAndWait(String jsonDoc, int revision, String subGroupName,
+                                                 String parentGroupName) throws Exception {
+        createDeployment(jsonDoc, revision, subGroupName, parentGroupName, ROOT_GROUP_NAME, true);
+    }
+
+    private void createRootParentDeploymentAndWait(String jsonDoc, int revision) throws Exception {
+        createDeployment(jsonDoc, revision, ROOT_GROUP_NAME, null, null, true);
+    }
+
+    private Deployment createDeployment(String jsonDoc, int revision, String targetGroup, String parentGroup,
+                                        String onBehalfOf, boolean startDeployment) throws Exception {
+        // to create visible gaps between deployments sleep for sometime
+        Thread.sleep(1000L);
+
+        URI uri = this.getClass().getResource(jsonDoc).toURI();
+        Configuration deploymentConfiguration = OBJECT_MAPPER.readValue(new File(uri), Configuration.class);
+        deploymentConfiguration.setCreationTimestamp(System.currentTimeMillis());
+        deploymentConfiguration.setConfigurationArn(
+                String.format("arn:aws:greengrass:us-east-1:123456789012" + ":configuration:thinggroup/%s:%d",
+                        targetGroup, revision));
+        deploymentConfiguration.setDeploymentId(targetGroup);
+        deploymentConfiguration.setParentTargetArn(parentGroup == null ? null
+                : String.format("arn:aws:iot:us-east-1:123456789012:thinggroup/%s", parentGroup));
+        deploymentConfiguration.setOnBehalfOf(onBehalfOf == null ? null
+                : String.format("arn:aws:iot:us-east-1:123456789012:thinggroup/%s", onBehalfOf));
+        deploymentConfiguration.setRequiredCapabilities(REQUIRED_CAPABILITY);
+
+        Deployment deployment = new Deployment(OBJECT_MAPPER.writeValueAsString(deploymentConfiguration),
+                Deployment.DeploymentType.IOT_JOBS, deploymentConfiguration.getConfigurationArn());
+        if (startDeployment) {
+            queueDeploymentAndWait(targetGroup, deployment);
+        }
+        return deployment;
+    }
+
+    private void queueDeploymentAndWait(String groupName, Deployment deployment)
+            throws IOException, InterruptedException {
+        // need to copy for each deployment because component clean up happens after each deployment.
+        copyRecipeAndArtifacts();
+        deploymentQueue.offer(deployment);
+        assertTrue(groupLatchMap.get(groupName).await(10, TimeUnit.SECONDS));
+    }
+
+    private void copyRecipeAndArtifacts() throws IOException {
+        // pre-load contents to package store
+        PreloadComponentStoreHelper.preloadRecipesFromTestResourceDir(localStoreContentPath.resolve("recipes"),
+                kernel.getNucleusPaths().recipePath());
+        copyFolderRecursively(localStoreContentPath.resolve("artifacts"), kernel.getNucleusPaths().artifactPath(),
+                REPLACE_EXISTING);
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithSimpleAppv1AndGreenSignal.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithSimpleAppv1AndGreenSignal.json
@@ -1,0 +1,21 @@
+{
+  "deploymentId": "TestSimpleApp",
+  "configurationArn": "Test",
+  "components": {
+    "SimpleApp": {
+      "version": "1.0.0"
+    },
+    "GreenSignal": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithSimpleAppv3.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithSimpleAppv3.json
@@ -1,0 +1,18 @@
+{
+  "deploymentId": "TestSimpleApp2",
+  "configurationArn": "Test",
+  "components": {
+    "SimpleApp": {
+      "version": "3.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -85,10 +85,10 @@ public class DeploymentDirectoryManager {
     private void persistPointerToLastFinishedDeployment(Path symlink) {
         logger.atInfo().kv(LINK_LOG_KEY, symlink).log("Persist link to last deployment");
         try {
-            Path deploymentPath = getDeploymentDirectoryPath();
             cleanupPreviousDeployments(previousSuccessDir);
             cleanupPreviousDeployments(previousFailureDir);
 
+            Path deploymentPath = getDeploymentDirectoryPath();
             Files.createSymbolicLink(symlink, deploymentPath);
             Files.delete(ongoingDir);
         } catch (IOException e) {

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentDocument.java
@@ -5,6 +5,8 @@
 
 package com.aws.greengrass.deployment.model;
 
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -63,6 +65,12 @@ public class DeploymentDocument {
     @JsonProperty("GroupName")
     private String groupName;
 
+    @JsonProperty("OnBehalfOf")
+    private String onBehalfOf;
+
+    @JsonProperty("ParentGroupName")
+    private String parentGroupName;
+
     @Setter
     @JsonProperty("Timestamp")
     private Long timestamp;
@@ -81,6 +89,17 @@ public class DeploymentDocument {
     @JsonDeserialize(converter = SDKDeserializer.class)
     private DeploymentConfigurationValidationPolicy configurationValidationPolicy =
             DeploymentConfigurationValidationPolicy.builder().build();
+
+
+    /**
+     * For sub-group deployments root group name is used otherwise group name.
+     *
+     * @return if available root group name, otherwise group name
+     */
+    @JsonGetter("GroupName")
+    public String getGroupName() {
+        return Utils.isEmpty(onBehalfOf) ? groupName : onBehalfOf;
+    }
 
     /**
      * Get a list of root component names from the deploymentPackageConfigurationList.

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -104,7 +104,8 @@ public class Kernel {
             YAMLMapper.builder().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET).build();
     private static final List<String> SUPPORTED_CAPABILITIES =
             Arrays.asList(DeploymentCapability.LARGE_CONFIGURATION.toString(),
-                    DeploymentCapability.LINUX_RESOURCE_LIMITS.toString());
+                    DeploymentCapability.LINUX_RESOURCE_LIMITS.toString(),
+                    DeploymentCapability.SUBGROUP_DEPLOYMENTS.toString());
 
     @Getter
     private final Context context;

--- a/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
+++ b/src/test/greengrass-nucleus-benchmark/src/main/java/com/aws/greengrass/jmh/packagemanager/DependencyResolverBenchmark.java
@@ -50,7 +50,7 @@ public class DependencyResolverBenchmark {
         private final DeploymentDocument jobDoc = new DeploymentDocument("mockJob1", "mockarn",
                 Arrays.asList(new DeploymentPackageConfiguration("boto3", true, "1.9.128"),
                         new DeploymentPackageConfiguration("awscli", true, "1.16.144")), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS),
+                "mockGroup1", null, null, 1L, FailureHandlingPolicy.DO_NOTHING, new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS),
                 DeploymentConfigurationValidationPolicy.builder().timeoutInSeconds(20).build());
 
         private DependencyResolver resolver;

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -144,7 +144,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1", Collections
                 .singletonList(
                         new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
 
@@ -209,7 +209,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1", Collections
                 .singletonList(
                         new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
 
@@ -305,7 +305,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1", Collections
                 .singletonList(
                         new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
 
@@ -363,7 +363,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1", Collections
                 .singletonList(
                         new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
 
@@ -440,7 +440,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1", Collections
                 .singletonList(
                         new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         groupToTargetComponentsTopics.lookupTopics("mockGroup1").lookupTopics(componentA)
                 .replaceAndWait(ImmutableMap.of(GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
@@ -510,7 +510,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
                         new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
         List<ComponentIdentifier> result = dependencyResolver.resolveDependencies(doc, new HashMap<>());
@@ -590,7 +590,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
                         new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
         context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
         assertThrows(NoAvailableComponentVersionException.class,
@@ -660,7 +660,7 @@ class DependencyResolverTest {
         DeploymentDocument doc = new DeploymentDocument("mockId","mockJob1",
                 Arrays.asList(new DeploymentPackageConfiguration(componentA, true, v1_0_0.getValue()),
                         new DeploymentPackageConfiguration(componentB2, true, v1_1_0.getValue())), Collections.emptyList(),
-                "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
+                "mockGroup1", "mockGroup1", "mockGroup1", 1L, FailureHandlingPolicy.DO_NOTHING, componentUpdatePolicy, configurationValidationPolicy);
 
 
         Map<String, Set<ComponentRequirementIdentifier>> otherGroupRootPackages = new HashMap<>();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

1. Allow subgroup deployment to override parent group components.
2. Enforce deployments to be processed based on creation time sequence. All stale deployments would be rejected.
3. Fleet status update for rejection status would have detailed status.
4. Maintain last rejected deployment record similar to success and failed deployments.
5. Update unit tests for group to last deployment topic lookup in deployment config.
6. Add integration tests for subgroup deployments covering siblings, hierarchical, nested and out-of-order deployment scenarios.

**Why is this change necessary:**
To enable customers troubleshoot and help them reduce their time to recover by empowering them with tools like sub-group deployments. Sub-group deployments let's customers override part of their fleet with the changes they want to:
1. retry a failed deployment configuration
2. fix a bug which occurs only in limited device configurations

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
