### PR TITLE
feat(reject deployment): reject stale deployments

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
@@ -13,9 +13,13 @@ import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeploymentQueue;
+import com.aws.greengrass.deployment.DeploymentService;
 import com.aws.greengrass.deployment.DeploymentStatusKeeper;
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.IotJobsClientWrapper;
+import com.aws.greengrass.deployment.IotJobsHelper;
 import com.aws.greengrass.deployment.ThingGroupHelper;
+import com.aws.greengrass.deployment.exceptions.DeploymentRejectedException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.helper.PreloadComponentStoreHelper;
 import com.aws.greengrass.integrationtests.BaseITCase;
@@ -23,24 +27,36 @@ import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.status.model.DeploymentInformation;
+import com.aws.greengrass.status.model.FleetStatusDetails;
+import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
+import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
+import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
+import software.amazon.awssdk.iot.iotjobs.model.UpdateJobExecutionRequest;
+import software.amazon.awssdk.iot.iotjobs.model.UpdateJobExecutionResponse;
+import software.amazon.awssdk.iot.iotjobs.model.UpdateJobExecutionSubscriptionRequest;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,9 +65,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
@@ -63,11 +82,21 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAM
 import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_SERVICE_TOPICS;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.util.Utils.copyFolderRecursively;
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 
@@ -83,20 +112,27 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
             Arrays.asList(DeploymentCapability.SUBGROUP_DEPLOYMENTS.toString());
 
     private Kernel kernel;
+    private DeviceConfiguration deviceConfiguration;
     private DeploymentQueue deploymentQueue;
     private Path localStoreContentPath;
     @Mock
     private ThingGroupHelper thingGroupHelper;
     @Mock
     private MqttClient mqttClient;
-
+    private IotJobsClientWrapper iotJobsClientWrapper;
     private Map<String, CountDownLatch> groupLatchMap;
+    private Map<String, Map<String, Object>> groupDeploymentStatus;
+    private Map<String, AtomicReference<FleetStatusDetails>> fleetStatusUpdates;
+    private Map<String, UpdateJobExecutionRequest> jobStatusUpdates;
 
     @BeforeEach
     void before(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, PackageDownloadException.class);
         ignoreExceptionOfType(context, SdkClientException.class);
 
+        groupDeploymentStatus = new ConcurrentHashMap<>();
+        fleetStatusUpdates = new ConcurrentHashMap<>();
+        jobStatusUpdates = new ConcurrentHashMap<>();
         groupLatchMap = new ConcurrentHashMap<>();
 
         kernel = new Kernel();
@@ -117,6 +153,42 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
         // set up device config
         setDeviceConfig(kernel, DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS, 1L);
 
+        // listen to mqtt deployment status updates
+        when(mqttClient.getMqttOperationTimeoutMillis()).thenReturn(10000);
+        when(mqttClient.publish(any(PublishRequest.class))).thenAnswer(i -> {
+            PublishRequest publishRequest = i.getArgument(0);
+            if (publishRequest.getTopic().endsWith("namespace-aws-gg-deployment/update")) {
+                try {
+                    UpdateJobExecutionRequest updateJobExecReq =
+                            OBJECT_MAPPER.readValue(publishRequest.getPayload(), UpdateJobExecutionRequest.class);
+                    String resource = Arn.fromString(updateJobExecReq.jobId).resource().resource();
+                    String groupName = resource;
+                    if (resource.startsWith(THING_GROUP_PREFIX)) {
+                        groupName = groupName.substring(THING_GROUP_PREFIX.length());
+                    }
+                    jobStatusUpdates.put(groupName, updateJobExecReq);
+                } catch (JsonMappingException ignored) {
+                }
+            }
+
+            if (publishRequest.getTopic().endsWith("greengrassv2/health/json")) {
+                try {
+                    FleetStatusDetails statusDetails =
+                            OBJECT_MAPPER.readValue(publishRequest.getPayload(), FleetStatusDetails.class);
+                    if (Trigger.THING_GROUP_DEPLOYMENT.equals(statusDetails.getTrigger())) {
+                        // record only deployment status
+                        String groupName = statusDetails.getDeploymentInformation().getDeploymentId();
+                        AtomicReference<FleetStatusDetails> ref =
+                                fleetStatusUpdates.getOrDefault(groupName, new AtomicReference<>());
+                        ref.set(statusDetails);
+                        fleetStatusUpdates.put(groupName, ref);
+                    }
+                } catch (JsonMappingException ignored) {
+                }
+            }
+            return CompletableFuture.completedFuture(0);
+        });
+
         // launch kernel
         kernel.launch();
         assertTrue(deploymentServiceLatch.await(10, TimeUnit.SECONDS));
@@ -126,9 +198,32 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
                 Paths.get(DeploymentTaskIntegrationTest.class.getResource("local_store_content").toURI());
         deploymentQueue = kernel.getContext().get(DeploymentQueue.class);
 
+        // setup spy device configuration for FSS
+        deviceConfiguration = spy(kernel.getContext().get(DeviceConfiguration.class));
+        doNothing().when(deviceConfiguration).validate();
+
         // setup fss such that it could send mqtt messages to the mock listener
         FleetStatusService fleetStatusService = (FleetStatusService) kernel.locate(FLEET_STATUS_SERVICE_TOPICS);
-        fleetStatusService.getIsConnected().set(false);
+        fleetStatusService.setDeviceConfiguration(deviceConfiguration);
+        fleetStatusService.postInject();
+
+        // setup jobs helper such that it could send mqtt messages to the mock listener
+        IotJobsHelper jobsHelper = kernel.getContext().get(IotJobsHelper.class);
+        jobsHelper.setDeviceConfiguration(deviceConfiguration);
+        jobsHelper.postInject();
+        iotJobsClientWrapper = spy(jobsHelper.getIotJobsClientWrapper());
+
+        // mimic response back from cloud to update job accepted topic
+        doAnswer((i) -> {
+            Consumer<UpdateJobExecutionResponse> handler = i.getArgument(2);
+            handler.accept(new UpdateJobExecutionResponse());
+            return CompletableFuture.completedFuture(0);
+        }).when(iotJobsClientWrapper)
+                .SubscribeToUpdateJobExecutionAccepted(any(UpdateJobExecutionSubscriptionRequest.class),
+                        any(QualityOfService.class), any(Consumer.class));
+
+        // replace with spied version
+        jobsHelper.setIotJobsClientWrapper(iotJobsClientWrapper);
     }
 
     @AfterEach
@@ -197,6 +292,36 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
     }
 
     @Test
+    void GIVEN_root_deployment_success_WHEN_nested_subgroups_deploy_with_different_component_versions_and_deploy_received_not_in_order_THEN_stale_deployment_rejected(
+            ExtensionContext context) throws Exception {
+        // expect a rejection exception
+        ignoreExceptionOfType(context, DeploymentRejectedException.class);
+
+        // Given
+        // deploys SimpleApp 1.0.0
+        setupRootParentGroupDeploymentFor("subGroup1", "subGroup2", "subGroup3");
+
+        // When
+        // sub-group deployment maintains SimpleApp 1.0.0 and adds GreenSignal 1.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv1AndGreenSignal.json", 1, "subGroup1",
+                ROOT_GROUP_NAME);
+        verifyServices(Utils.immutableMap("SimpleApp", "1.0.0", "GreenSignal", "1.0.0"));
+        // create a stale deployment which should override SimpleApp to 2.0.0
+        Deployment oldDeployment =
+                createDeployment("FleetConfigWithSimpleAppv2.json", 1, "subGroup2", ROOT_GROUP_NAME, ROOT_GROUP_NAME,
+                        false);
+        // sub-group deployment overrides SimpleApp to 3.0.0
+        createSubGroupDeploymentAndWait("FleetConfigWithSimpleAppv3.json", 1, "subGroup3", ROOT_GROUP_NAME);
+        // queue stale deployment received in bad order, which should get rejected
+        queueDeploymentAndWait("subGroup2", oldDeployment);
+
+        // Then
+        verifyServices(Utils.immutableMap("SimpleApp", "3.0.0"));
+        verifyServicesRemoved("GreenSignal");
+        verifyRejectionStatus("subGroup2");
+    }
+
+    @Test
     void GIVEN_root_deployment_success_with_multiple_sibling_subgroups_WHEN_new_root_deployment_revision_THEN_root_deployment_overrides_subgroups()
             throws Exception {
         // Given
@@ -251,6 +376,40 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
         }
     }
 
+    private void verifyRejectionStatus(String... groups) {
+        for (String groupName : groups) {
+            Map<String, Object> statusDetails = groupDeploymentStatus.get(groupName);
+            String deploymentStatus = (String) statusDetails.get(DEPLOYMENT_STATUS_KEY_NAME);
+            assertEquals("REJECTED", deploymentStatus);
+
+            // verify fleet status update
+            assertThat(() -> fleetStatusUpdates.get(groupName),
+                    eventuallyEval(notNullValue(AtomicReference.class), Duration.ofSeconds(20)));
+            FleetStatusDetails statusUpdate = fleetStatusUpdates.get(groupName).get();
+            DeploymentInformation deploymentInfo = statusUpdate.getDeploymentInformation();
+            assertEquals("REJECTED", deploymentInfo.getStatus());
+            assertNotNull(deploymentInfo.getStatusDetails());
+            assertEquals("REJECTED", deploymentInfo.getStatusDetails().getDetailedStatus());
+            assertThat("Rejected error stack in status update doesn't match",
+                    deploymentInfo.getStatusDetails().getErrorStack(),
+                    contains("DEPLOYMENT_REJECTED", "REJECTED_STALE_DEPLOYMENT"));
+
+            // verify job status update
+            assertThat(() -> jobStatusUpdates.get(groupName),
+                    eventuallyEval(notNullValue(UpdateJobExecutionRequest.class), Duration.ofSeconds(20)));
+            UpdateJobExecutionRequest updateJobExecReq = jobStatusUpdates.get(groupName);
+            assertEquals(JobStatus.REJECTED, updateJobExecReq.status);
+            assertNotNull(updateJobExecReq.statusDetails);
+            assertEquals("REJECTED", updateJobExecReq.statusDetails
+                    .get(DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY));
+            String jobsErrorStack = updateJobExecReq.statusDetails.get(DeploymentService.DEPLOYMENT_ERROR_STACK_KEY);
+            assertThat("Rejected error stack in update job doesn't match", jobsErrorStack,
+                    containsString("DEPLOYMENT_REJECTED"));
+            assertThat("Rejected error stack in update job doesn't match", jobsErrorStack,
+                    containsString("REJECTED_STALE_DEPLOYMENT"));
+        }
+    }
+
     private void setupRootParentGroupDeploymentFor(@Nonnull String... subGroupNames) throws Exception {
         for (String subGroup : subGroupNames) {
             groupLatchMap.put(subGroup, new CountDownLatch(1));
@@ -261,6 +420,7 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
         deploymentStatusKeeper.registerDeploymentStatusConsumer(Deployment.DeploymentType.IOT_JOBS, (status) -> {
             String groupName = (String) status.get(GG_DEPLOYMENT_ID_KEY_NAME);
             String deploymentStatus = (String) status.get(DEPLOYMENT_STATUS_KEY_NAME);
+            groupDeploymentStatus.put(groupName, status);
             if ("SUCCEEDED".equals(deploymentStatus) || "REJECTED".equals(deploymentStatus)) {
                 CountDownLatch latch = groupLatchMap.get(groupName);
                 if (latch != null) {

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -104,6 +104,8 @@ public class IotJobsHelper implements InjectionActions {
     private static final long WAIT_TIME_MS_TO_SUBSCRIBE_AGAIN = Duration.ofMinutes(2).toMillis();
     private static final Random RANDOM = new Random();
 
+    // setter is only used for testing
+    @Setter
     @Inject
     private DeviceConfiguration deviceConfiguration;
 
@@ -137,6 +139,7 @@ public class IotJobsHelper implements InjectionActions {
     @Setter(AccessLevel.PACKAGE) // For tests
     private long waitTimeToSubscribeAgain = WAIT_TIME_MS_TO_SUBSCRIBE_AGAIN;
 
+    @Getter // For tests
     @Setter // For tests
     private IotJobsClientWrapper iotJobsClientWrapper;
 

--- a/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
+++ b/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
@@ -10,12 +10,14 @@ import lombok.Getter;
 public enum DeploymentErrorCode {
     // Generic types
     DEPLOYMENT_FAILURE(DeploymentErrorType.NONE),
+    DEPLOYMENT_REJECTED(DeploymentErrorType.NONE),
     DEPLOYMENT_INTERRUPTED(DeploymentErrorType.NONE),
     ARTIFACT_DOWNLOAD_ERROR(DeploymentErrorType.NONE),
     NO_AVAILABLE_COMPONENT_VERSION(DeploymentErrorType.NONE),
     COMPONENT_PACKAGE_LOADING_ERROR(DeploymentErrorType.NONE),
 
     // Deployment request error
+    REJECTED_STALE_DEPLOYMENT(DeploymentErrorType.NONE),
     NUCLEUS_MISSING_REQUIRED_CAPABILITIES(DeploymentErrorType.REQUEST_ERROR),
     COMPONENT_CIRCULAR_DEPENDENCY_ERROR(DeploymentErrorType.REQUEST_ERROR),
     UNAUTHORIZED_NUCLEUS_MINOR_VERSION_UPDATE(DeploymentErrorType.REQUEST_ERROR),

--- a/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtils.java
+++ b/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtils.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.deployment.exceptions.DeploymentException;
+import com.aws.greengrass.deployment.exceptions.DeploymentRejectedException;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
@@ -77,6 +78,13 @@ public final class DeploymentErrorCodeUtils {
     private DeploymentErrorCodeUtils() {
     }
 
+    private static DeploymentErrorCode generateDefaultErrorCode(Throwable e) {
+        if (e instanceof DeploymentRejectedException) {
+            return DeploymentErrorCode.DEPLOYMENT_REJECTED;
+        }
+        return DeploymentErrorCode.DEPLOYMENT_FAILURE;
+    }
+
     /**
      * Walk through exception chain and generate deployment error report.
      *
@@ -86,7 +94,7 @@ public final class DeploymentErrorCodeUtils {
     public static Pair<List<String>, List<String>> generateErrorReportFromExceptionStack(Throwable e) {
         // Use a linked hash set to remove duplicates while preserving order
         Set<DeploymentErrorCode> errorCodeSet =
-                new LinkedHashSet<>(Collections.singletonList(DeploymentErrorCode.DEPLOYMENT_FAILURE));
+                new LinkedHashSet<>(Collections.singletonList(generateDefaultErrorCode(e)));
         Map<String, DeploymentErrorCode> errorContext = new HashMap<>();
         List<DeploymentErrorType> errorTypesFromException = new ArrayList<>();
 

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentRejectedException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentRejectedException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.exceptions;
+
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
+
+public class DeploymentRejectedException extends DeploymentException {
+
+    private static final long serialVersionUID = -8212002201272098501L;
+
+    public DeploymentRejectedException(String message, DeploymentErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentResult.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentResult.java
@@ -24,6 +24,7 @@ public class DeploymentResult {
         FAILED_NO_STATE_CHANGE,
         FAILED_ROLLBACK_NOT_REQUESTED,
         FAILED_ROLLBACK_COMPLETE,
-        FAILED_UNABLE_TO_ROLLBACK
+        FAILED_UNABLE_TO_ROLLBACK,
+        REJECTED
     }
 }

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -86,7 +86,10 @@ public class FleetStatusService extends GreengrassService {
     private static final int MAX_PAYLOAD_LENGTH_BYTES = 128_000;
     public static final String DEVICE_OFFLINE_MESSAGE = "Device not configured to talk to AWS IoT cloud. "
             + "FleetStatusService is offline";
-    private final DeviceConfiguration deviceConfiguration;
+
+    // setter is only used for testing
+    @Setter
+    private DeviceConfiguration deviceConfiguration;
     private final GlobalStateChangeListener handleServiceStateChange = this::handleServiceStateChange;
     private final Function<Map<String, Object>, Boolean> deploymentStatusChanged = this::deploymentStatusChanged;
 

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -64,6 +64,7 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_SERVICE_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_NAME_KEY;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
@@ -385,6 +386,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         deploymentQueue.offer(new Deployment(deploymentDocument, type, TEST_JOB_ID_1));
         Topics allGroupTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         Topics groupMembershipTopics = Topics.of(context, GROUP_MEMBERSHIP_TOPICS, null);
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
         groupMembershipTopics.lookup(expectedGroupName);
         Topics deploymentGroupTopics = Topics.of(context, expectedGroupName, allGroupTopics);
         Topic pkgTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0");
@@ -404,6 +406,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         deploymentGroupTopics.children.put(new CaseInsensitiveString(EXPECTED_ROOT_PACKAGE_NAME), pkgTopics);
         allGroupTopics.children.put(new CaseInsensitiveString(expectedGroupName), deploymentGroupTopics);
 
+        when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
         when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
         when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
         lenient().when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS, expectedGroupName))
@@ -504,8 +507,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         Topics allGroupTopics = mock(Topics.class);
         Topics groupMembershipTopics = mock(Topics.class);
         Topics deploymentGroupTopics = mock(Topics.class);
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
 
         when(allGroupTopics.lookupTopics(EXPECTED_GROUP_NAME)).thenReturn(deploymentGroupTopics);
+        when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
         when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
         when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
         when(config.lookupTopics(COMPONENTS_TO_GROUPS_TOPICS)).thenReturn(mockComponentsToGroupPackages);

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.utils.ImmutableMap;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -92,6 +93,7 @@ class DeploymentTaskTest {
 
     private Topics mockGroupToRootConfig;
     private Topics mockGroupMembership;
+    private Topics mockLastDeploymentTopics;
     private DefaultDeploymentTask deploymentTask;
 
     @Mock
@@ -113,11 +115,20 @@ class DeploymentTaskTest {
         mockGroupToRootConfig.lookupTopics("group1", COMPONENT_2_ROOT_PACKAGE_NAME)
                 .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
 
+        Map<String, Object> lastDeploymentData =
+                ImmutableMap.of(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TIMESTAMP_KEY, 0,
+                        DeploymentService.GROUP_TO_LAST_DEPLOYMENT_CONFIG_ARN_KEY, "group1");
+        mockLastDeploymentTopics = Topics.of(context, DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        mockLastDeploymentTopics.lookupTopics(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS, "group1")
+                .replaceAndWait(lastDeploymentData);
+
         mockGroupMembership = Topics.of(context, DeploymentService.GROUP_MEMBERSHIP_TOPICS, null);
         lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_MEMBERSHIP_TOPICS)))
                 .thenReturn(mockGroupMembership);
         lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS)))
                 .thenReturn(mockGroupToRootConfig);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS)))
+                .thenReturn(mockLastDeploymentTopics);
         deploymentTask =
                 new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager, mockKernelConfigResolver,
                         mockDeploymentConfigMerger, logger,
@@ -127,6 +138,8 @@ class DeploymentTaskTest {
 
     @Test
     void GIVEN_deploymentDocument_WHEN_start_deploymentTask_THEN_succeeds() throws Exception {
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
 
         when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
         when(mockExecutorService.submit(any(Callable.class)))
@@ -142,6 +155,9 @@ class DeploymentTaskTest {
     @Test
     void GIVEN_deploymentDocument_WHEN_thingGroupHelper_return_forbidden_THEN_succeeds(ExtensionContext context) throws Exception {
         ignoreExceptionUltimateCauseOfType(context, GreengrassV2DataException.class);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
         when(mockExecutorService.submit(any(Callable.class)))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
@@ -161,6 +177,9 @@ class DeploymentTaskTest {
     void GIVEN_deploymentDocument_WHEN_thingGroupHelper_throws_error_THEN_deployment_result_has_chain_of_error_messages(ExtensionContext context)
             throws Exception {
         ignoreExceptionUltimateCauseOfType(context, GreengrassV2DataException.class);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
                 .thenThrow(GreengrassV2DataException.builder().message("Original error message").build());
 
@@ -174,6 +193,9 @@ class DeploymentTaskTest {
     void GIVEN_deploymentDocument_WHEN_resolveDependencies_errored_THEN_deploymentTask_aborted(ExtensionContext context)
             throws Exception {
         ignoreExceptionUltimateCauseOfType(context, PackagingException.class);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockExecutorService.submit(any(Callable.class))).thenReturn(mockResolveDependencyFuture);
         when(mockResolveDependencyFuture.get())
                 .thenThrow(new ExecutionException(new PackagingException("unknown package")));
@@ -190,6 +212,9 @@ class DeploymentTaskTest {
     void GIVEN_deploymentDocument_WHEN_resolve_kernel_config_throws_PackageLoadingException_THEN_deploymentTask_aborted(
             ExtensionContext context) throws Exception {
         ignoreExceptionUltimateCauseOfType(context, PackageLoadingException.class);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockExecutorService.submit(any(Callable.class)))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
         when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
@@ -208,6 +233,9 @@ class DeploymentTaskTest {
     void GIVEN_deployment_task_interrupted_WHEN_preparePackages_not_started_THEN_do_nothing(ExtensionContext context)
             throws Exception {
         ignoreExceptionUltimateCauseOfType(context, InterruptedException.class);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockExecutorService.submit(any(Callable.class))).thenReturn(mockResolveDependencyFuture);
         when(mockResolveDependencyFuture.get()).thenThrow(new ExecutionException(new InterruptedException()));
 
@@ -219,6 +247,9 @@ class DeploymentTaskTest {
 
     @Test
     void GIVEN_deployment_task_interrupted_WHEN_preparePackages_in_progress_THEN_cancel_prepare_packages() throws Exception {
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockExecutorService.submit(any(Callable.class)))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
         CountDownLatch preparePackagesInvoked = new CountDownLatch(1);
@@ -244,6 +275,9 @@ class DeploymentTaskTest {
 
     @Test
     void GIVEN_deployment_task_interrupted_WHEN_preparePackages_done_merge_not_started_THEN_do_nothing() throws Exception {
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockExecutorService.submit(any(Callable.class)))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
         CountDownLatch resolveConfigInvoked = new CountDownLatch(1);
@@ -268,6 +302,9 @@ class DeploymentTaskTest {
 
     @Test
     void GIVEN_deployment_task_interrupted_WHEN_merge_in_progress_THEN_cancel_merge() throws Exception {
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS),
+                eq(deploymentDocument.getGroupName()))).thenReturn(mockLastDeploymentTopics.lookupTopics("group1"));
+
         when(mockExecutorService.submit(any(Callable.class)))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
         CountDownLatch mergeConfigInvoked = new CountDownLatch(1);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Enforce deployments to be processed based on creation time sequence. All stale deployments would be rejected.
2. Fleet status update for rejection status would have detailed status.
3. Update unit tests for group to last deployment topic lookup in deployment config.
4. Add integration tests for subgroup deployments out-of-order deployment scenarios.

**Why is this change necessary:**
With the new sub-group deployment feature, a device could receive deployments which override components for one group but these could arrive in different order. The mechanism added in the PR enforce only new deployments to be processed and all stale deployments would get rejected.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
