### PR TITLE
feat: use SUB_DEPLOYMENTS term

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
@@ -109,7 +109,7 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
     private static final String ROOT_GROUP_DEPLOYMENT_CONFIG = "FleetConfigWithSimpleAppv1.json";
     private static final Map<String, String> ROOT_GROUP_SERVICE_MAP = Utils.immutableMap("SimpleApp", "1.0.0");
     private static final List<String> REQUIRED_CAPABILITY =
-            Arrays.asList(DeploymentCapability.SUBGROUP_DEPLOYMENTS.toString());
+            Arrays.asList(DeploymentCapability.SUB_DEPLOYMENTS.toString());
 
     private Kernel kernel;
     private DeviceConfiguration deviceConfiguration;

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -105,7 +105,7 @@ public class Kernel {
     private static final List<String> SUPPORTED_CAPABILITIES =
             Arrays.asList(DeploymentCapability.LARGE_CONFIGURATION.toString(),
                     DeploymentCapability.LINUX_RESOURCE_LIMITS.toString(),
-                    DeploymentCapability.SUBGROUP_DEPLOYMENTS.toString());
+                    DeploymentCapability.SUB_DEPLOYMENTS.toString());
 
     @Getter
     private final Context context;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Rename SUBGROUP_DEPLOYMENTS after terminology alignment to SUB_DEPLOYMENTS.

**Why is this change necessary:**
We are changing the terminology.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
