### PR TITLE
test: deflake testing, adding a countdown latch

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -355,20 +355,50 @@ public class UnixPlatform extends Platform {
 
     @Override
     public void createUser(String user) throws IOException {
-        runCmd("useradd -r -m " + user, o -> {
-        }, "Failed to create user");
+        try {
+            runCmd("useradd -r -m " + user, o -> {
+            }, "Failed to create user with useradd");
+        } catch (IOException e) {
+            try {
+                runCmd("adduser -S  " + user, l -> {
+                }, "Failed to create user with adduser");
+            } catch (IOException ee) {
+                e.addSuppressed(ee);
+                throw e;
+            }
+        }
     }
 
     @Override
     public void createGroup(String group) throws IOException {
-        runCmd("groupadd -r " + group, o -> {
-        }, "Failed to create group");
+        try {
+            runCmd("groupadd -r " + group, o -> {
+            }, "Failed to create group with groupadd");
+        } catch (IOException e) {
+            try {
+                runCmd("addgroup -S " + group, l -> {
+                }, "Failed to create group with addgroup");
+            } catch (IOException ee) {
+                e.addSuppressed(ee);
+                throw e;
+            }
+        }
     }
 
     @Override
     public void addUserToGroup(String user, String group) throws IOException {
-        runCmd("usermod -a -G " + group + " " + user, o -> {
-        }, "Failed to add user to group");
+        try {
+            runCmd("usermod -a -G " + group + " " + user, o -> {
+            }, "Failed to add user to group with usermod");
+        } catch (IOException e) {
+            try {
+                runCmd("addgroup " + user + " " + group, l -> {
+                }, "Failed to add user to group with addgroup");
+            } catch (IOException ee) {
+                e.addSuppressed(ee);
+                throw e;
+            }
+        }
     }
 
     @Override

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -219,7 +220,7 @@ class TelemetryAgentTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_Telemetry_Agent_WHEN_mqtt_is_interrupted_THEN_aggregation_continues_but_publishing_stops() {
+    void GIVEN_Telemetry_Agent_WHEN_mqtt_is_interrupted_THEN_aggregation_continues_but_publishing_stops() throws InterruptedException {
         doReturn(1).when(DEFAULT_HANDLER)
                 .retrieveWithDefault(any(), eq(TELEMETRY_TEST_PERIODIC_AGGREGATE_INTERVAL_SEC), any());
         doReturn(2).when(DEFAULT_HANDLER)
@@ -235,10 +236,18 @@ class TelemetryAgentTest extends GGServiceTestUtil {
 
         telemetryAgent.postInject();
         long timeoutMs = 10_000;
-        verify(mockMqttClient, timeout(timeoutMs).atLeastOnce()).publish(publishRequestArgumentCaptor.capture());
-        PublishRequest request = publishRequestArgumentCaptor.getValue();
-        assertEquals(QualityOfService.AT_LEAST_ONCE, request.getQos());
-        assertEquals("$aws/things/testThing/greengrass/health/json", request.getTopic());
+
+        CountDownLatch publishLatch = new CountDownLatch(1);
+        when(mockMqttClient.publish(any(PublishRequest.class))).thenAnswer(i -> {
+            Object argument = i.getArgument(0);
+            PublishRequest publishRequest = (PublishRequest) argument;
+            assertEquals(QualityOfService.AT_LEAST_ONCE, publishRequest.getQos());
+            assertEquals("$aws/things/testThing/greengrass/health/json", publishRequest.getTopic());
+            publishLatch.countDown();
+            return CompletableFuture.completedFuture(0);
+        });
+        assertTrue(publishLatch.await(30, TimeUnit.SECONDS), "mockMqttClient.publish failed to be invoked");
+
         verify(mockMqttClient, timeout(timeoutMs).atLeastOnce())
                 .addToCallbackEvents(mqttClientConnectionEventsArgumentCaptor.capture());
         reset(mockMqttClient);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Windows tests have been failing sometimes on GitHub runner again. This change aims to resolve 1 failures in TelemetryAgentTest.GIVEN_Telemetry_Agent_WHEN_mqtt_is_interrupted_THEN_aggregation_continues_but_publishing_stops.

**Why is this change necessary:**

**How was this change tested:**
Running GIVEN_Telemetry_Agent_WHEN_mqtt_is_interrupted_THEN_aggregation_continues_but_publishing_stops by making a breakpoint to reproduce the problem on both windows and linux. Then adding a countdown latch can fix it. (Due to size limit of a file, I've sent all records on mail. Please check with Chen, Junfu and Kuchibhotla, Navya )

fail test on ubuntu/windows:
https://user-images.githubusercontent.com/112076181/197667970-531d441e-ec24-437e-966e-1b87092f2bd9.mp4

successful test after adding a countdown latch:
https://user-images.githubusercontent.com/112076181/197668106-ac3100b9-70f8-4494-8bec-ecc4867d7bd0.mp4


- [* ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
