### PR TITLE
feat: warning log for discontinued component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <!--
-                  Do not upgrade this version without additional testing. Newer versions have incompatible
-                  serialization changes.
-                  https://github.com/aws/aws-sdk-java-v2/issues/3127
-                 -->
-                <version>2.17.81</version>
+                <version>2.17.295</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -134,7 +129,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>greengrassv2-data</artifactId>
-            <version>2.15.x-SNAPSHOT</version>
+            <version>2.17.x-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
updating warning log
bumping awssdk + ggv2-data version

**Issue #, if available:**

Description of changes:
1. Display a warning in the logs if a discontinued component is deployed
2. Bump version of artifact GreengrassV2-Data to access vendorGuidance field from ResolvedComponentVersion api response
3. Bump version of AWSSDK BOM as a dependency of the GreengrassV2-Data version bump

Previous attempts to bump SDK version led to failure in UATs due to a `Unable to marshall request to JSON: Can not write a field name, expecting a value` [(ref)](https://github.com/aws/aws-sdk-java-v2/issues/3127)
It looks like bumping the GGV2-Data version to 2.17 resolves that issue and UATs for transitive dependencies of Nucleus pass.

Why is this change necessary:
Customers need to be made aware if their deployment consists of a discontinued component and the recommended course of action

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
