### PR TITLE
fix: handle empty recipe content correctly when calculating digest

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/UnloadableServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/UnloadableServiceIntegTest.java
@@ -131,7 +131,7 @@ public class UnloadableServiceIntegTest extends BaseITCase {
     @Test
     void GIVEN_unloadable_plugin_digest_mismatch_WHEN_nucleus_launch_THEN_nucleus_starts_and_other_services_running(
             ExtensionContext context) throws Exception {
-        ignoreExceptionWithMessage(context, "Plugin has been modified after it was downloaded");
+        ignoreExceptionWithMessage(context, "Plugin recipe has been modified after it was downloaded");
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
                 this.getClass().getResource("unloadable_plugin.yaml"));
         setupPackageStore(kernel, componentId);

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -59,6 +59,8 @@ public class ComponentStore {
     private static final String LOG_KEY_RECIPE_METADATA_FILE_PATH = "RecipeMetadataFilePath";
     private static final String RECIPE_SUFFIX = ".recipe";
 
+    private static final String PLUGIN_LOAD_ERROR_EVENT = "plugin-load-error";
+
     private final NucleusPaths nucleusPaths;
     private final PlatformResolver platformResolver;
     private final RecipeLoader recipeLoader;
@@ -160,14 +162,14 @@ public class ComponentStore {
         try {
             Optional<String> recipeContent = findComponentRecipeContent(componentIdentifier);
             if (!recipeContent.isPresent()) {
-                logger.atError("plugin-load-error")
+                logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
                         .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
                         .log("Recipe not found for component " + componentIdentifier.getName());
                 return false;
             }
             String recipeContentStr = recipeContent.get();
             if (Utils.isEmpty(recipeContentStr)) {
-                logger.atError("plugin-load-error")
+                logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
                         .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
                         .log("Found empty recipe for component. File was likely corrupted");
                 return false;
@@ -176,14 +178,15 @@ public class ComponentStore {
             logger.atTrace("plugin-load").log("Digest from store: " + Coerce.toString(expectedDigest));
             logger.atTrace("plugin-load").log("Digest from recipe: " + Coerce.toString(digest));
             if (!Digest.isEqual(digest, expectedDigest)) {
-                logger.atError("plugin-load-error")
+                logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
                         .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
                         .log("Recipe on disk was modified after it was downloaded from cloud");
                 return false;
             }
             return true;
         } catch (PackageLoadingException | NoSuchAlgorithmException e) {
-            logger.atError("plugin-load-error").kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
+            logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
+                    .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
                     .log("Cannot validate digest for recipe");
         }
         return false;

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -16,7 +16,6 @@ import com.aws.greengrass.componentmanager.models.RecipeMetadata;
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.constants.FileSuffix;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
-import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
@@ -58,8 +57,6 @@ public class ComponentStore {
     private static final Logger logger = LogManager.getLogger(ComponentStore.class);
     private static final String LOG_KEY_RECIPE_METADATA_FILE_PATH = "RecipeMetadataFilePath";
     private static final String RECIPE_SUFFIX = ".recipe";
-
-    private static final String PLUGIN_LOAD_ERROR_EVENT = "plugin-load-error";
 
     private final NucleusPaths nucleusPaths;
     private final PlatformResolver platformResolver;
@@ -156,40 +153,28 @@ public class ComponentStore {
      * @param componentIdentifier component whose recipe is read from disk
      * @param expectedDigest      expected digest for the recipe
      * @return whether the expected digest matches the calculated digest on disk
+     * @throws PackageLoadingException if unable to load recipe from disk
      */
     public boolean validateComponentRecipeDigest(@NonNull ComponentIdentifier componentIdentifier,
-                                                 String expectedDigest) {
+                                                 String expectedDigest) throws PackageLoadingException {
+        Optional<String> recipeContent = findComponentRecipeContent(componentIdentifier);
+        if (!recipeContent.isPresent()) {
+            throw new PackageLoadingException("Recipe not found for component " + componentIdentifier.getName());
+        }
+        String recipeContentStr = recipeContent.get();
+        if (Utils.isEmpty(recipeContentStr)) {
+            throw new PackageLoadingException(
+                    String.format("Found empty recipe for component %s. File was likely corrupted",
+                            componentIdentifier.getName()));
+        }
         try {
-            Optional<String> recipeContent = findComponentRecipeContent(componentIdentifier);
-            if (!recipeContent.isPresent()) {
-                logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
-                        .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
-                        .log("Recipe not found for component " + componentIdentifier.getName());
-                return false;
-            }
-            String recipeContentStr = recipeContent.get();
-            if (Utils.isEmpty(recipeContentStr)) {
-                logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
-                        .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
-                        .log("Found empty recipe for component. File was likely corrupted");
-                return false;
-            }
             String digest = Digest.calculate(recipeContentStr);
             logger.atTrace("plugin-load").log("Digest from store: " + Coerce.toString(expectedDigest));
             logger.atTrace("plugin-load").log("Digest from recipe: " + Coerce.toString(digest));
-            if (!Digest.isEqual(digest, expectedDigest)) {
-                logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
-                        .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
-                        .log("Recipe on disk was modified after it was downloaded from cloud");
-                return false;
-            }
-            return true;
-        } catch (PackageLoadingException | NoSuchAlgorithmException e) {
-            logger.atError().setEventType(PLUGIN_LOAD_ERROR_EVENT)
-                    .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
-                    .log("Cannot validate digest for recipe");
+            return Digest.isEqual(digest, expectedDigest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new PackageLoadingException("Cannot validate digest for recipe due to missing hash algorithm", e);
         }
-        return false;
     }
 
     Optional<String> findComponentRecipeContent(@NonNull ComponentIdentifier componentId)

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -23,6 +23,7 @@ import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Digest;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.SerializerFactory;
+import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
@@ -164,7 +165,14 @@ public class ComponentStore {
                         .log("Recipe not found for component " + componentIdentifier.getName());
                 return false;
             }
-            String digest = Digest.calculate(recipeContent.get());
+            String recipeContentStr = recipeContent.get();
+            if (Utils.isEmpty(recipeContentStr)) {
+                logger.atError("plugin-load-error")
+                        .kv(GreengrassService.SERVICE_NAME_KEY, componentIdentifier.getName())
+                        .log("Found empty recipe for component. File was likely corrupted");
+                return false;
+            }
+            String digest = Digest.calculate(recipeContentStr);
             logger.atTrace("plugin-load").log("Digest from store: " + Coerce.toString(expectedDigest));
             logger.atTrace("plugin-load").log("Digest from recipe: " + Coerce.toString(digest));
             if (!Digest.isEqual(digest, expectedDigest)) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.lifecyclemanager;
 import com.amazon.aws.iot.greengrass.component.common.DependencyType;
 import com.amazon.aws.iot.greengrass.configuration.common.DeploymentCapability;
 import com.aws.greengrass.componentmanager.ComponentStore;
+import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.config.Configuration;
 import com.aws.greengrass.config.ConfigurationWriter;
@@ -532,10 +533,17 @@ public class Kernel {
             throw new ServiceLoadException("Custom plugins is not supported by this greengrass version");
         }
         ComponentStore componentStore = context.get(ComponentStore.class);
-        if (!componentStore.validateComponentRecipeDigest(componentId, Coerce.toString(storedDigest))) {
-            logger.atError("plugin-load-error").kv(GreengrassService.SERVICE_NAME_KEY, name)
-                    .log("Local plugin recipe does not match the recipe in cloud");
-            throw new ServiceLoadException("Plugin recipe has been modified or corrupted after it was downloaded");
+
+        try {
+            if (!componentStore.validateComponentRecipeDigest(componentId, Coerce.toString(storedDigest))) {
+                logger.atError("plugin-load-error").kv(GreengrassService.SERVICE_NAME_KEY, name)
+                        .log("Plugin recipe was modified after it was downloaded from cloud");
+                throw new ServiceLoadException("Plugin recipe has been modified after it was downloaded");
+            }
+        } catch (PackageLoadingException e) {
+            logger.atError("plugin-load-error").setCause(e).kv(GreengrassService.SERVICE_NAME_KEY, name)
+                    .log("Unable to calculate local plugin recipe digest");
+            throw new ServiceLoadException("Unable to calculate local plugin recipe digest", e);
         }
 
         Class<?> clazz;

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -534,8 +534,8 @@ public class Kernel {
         ComponentStore componentStore = context.get(ComponentStore.class);
         if (!componentStore.validateComponentRecipeDigest(componentId, Coerce.toString(storedDigest))) {
             logger.atError("plugin-load-error").kv(GreengrassService.SERVICE_NAME_KEY, name)
-                    .log("Local plugin does not match the version in cloud!!");
-            throw new ServiceLoadException("Plugin has been modified after it was downloaded");
+                    .log("Local plugin recipe does not match the recipe in cloud");
+            throw new ServiceLoadException("Plugin recipe has been modified or corrupted after it was downloaded");
         }
 
         Class<?> clazz;

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
@@ -296,6 +296,11 @@ class ComponentStoreTest {
         ComponentIdentifier nonExistentComponent =
                 new ComponentIdentifier(MONITORING_SERVICE_PKG_NAME, new Semver("5.0.0"));
         assertFalse(componentStore.validateComponentRecipeDigest(nonExistentComponent, Digest.calculate(recipeString)));
+
+        preloadEmptyRecipeFileFromTestResource();
+        ComponentIdentifier emptyRecipeComponent =
+                new ComponentIdentifier("EmptyRecipe", new Semver("1.0.0"));
+        assertFalse(componentStore.validateComponentRecipeDigest(emptyRecipeComponent, Digest.calculate(recipeString)));
     }
 
     @Test
@@ -454,6 +459,12 @@ class ComponentStoreTest {
         Path destinationRecipe = recipeDirectory.resolve(destinationFilename);
 
         Files.copy(RECIPE_RESOURCE_PATH.resolve(recipeFileName), destinationRecipe);
+    }
+
+    private void preloadEmptyRecipeFileFromTestResource() throws Exception {
+        String destinationFilename = getRecipeStorageFilenameFromTestSource("EmptyRecipe-1.0.0.yaml");
+        Path destinationRecipe = recipeDirectory.resolve(destinationFilename);
+        Files.createFile(destinationRecipe);
     }
 
     private void preloadArtifactFileFromTestResouce(ComponentIdentifier pkgId, String artFileName)

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
@@ -295,12 +295,17 @@ class ComponentStoreTest {
 
         ComponentIdentifier nonExistentComponent =
                 new ComponentIdentifier(MONITORING_SERVICE_PKG_NAME, new Semver("5.0.0"));
-        assertFalse(componentStore.validateComponentRecipeDigest(nonExistentComponent, Digest.calculate(recipeString)));
+        PackageLoadingException e = assertThrows(PackageLoadingException.class,
+                () -> componentStore.validateComponentRecipeDigest(nonExistentComponent,
+                Digest.calculate(recipeString)));
+        assertTrue(e.getMessage().contains("Recipe not found for component " + MONITORING_SERVICE_PKG_NAME));
 
         preloadEmptyRecipeFileFromTestResource();
         ComponentIdentifier emptyRecipeComponent =
                 new ComponentIdentifier("EmptyRecipe", new Semver("1.0.0"));
-        assertFalse(componentStore.validateComponentRecipeDigest(emptyRecipeComponent, Digest.calculate(recipeString)));
+        e = assertThrows(PackageLoadingException.class,
+                () -> componentStore.validateComponentRecipeDigest(emptyRecipeComponent, Digest.calculate(recipeString)));
+        assertTrue(e.getMessage().contains("Found empty recipe for component EmptyRecipe. File was likely corrupted"));
     }
 
     @Test


### PR DESCRIPTION
**Description of changes:**
1. Handle empty(corrupted) recipe file correctly when calculating recipe digest while loading plugin components at kernel launch.

**Why is this change necessary:**
Before this change, if a deployed plugin component's locally stored recipe is corrupted and emptied, then kernel launch would fail due to an IllegalArgumentException thrown at `Digest::calculate` and stuck in a restart loop.

After this change, a ServiceLoadException would be thrown and kernel would create a new instance of UnloadableService.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
Manually tested the fix.

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
