### PR TITLE
fix: reject before putting deployment in in_progress

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -14,8 +14,6 @@ import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.ComponentRequirementIdentifier;
 import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
-import com.aws.greengrass.deployment.exceptions.DeploymentRejectedException;
 import com.aws.greengrass.deployment.exceptions.DeploymentTaskFailureException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
@@ -43,8 +41,6 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_ID_LOG_KEY;
-import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_CONFIG_ARN_KEY;
-import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TIMESTAMP_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 
@@ -115,14 +111,6 @@ public class DefaultDeploymentTask implements DeploymentTask {
                     .kv("Deployment service config", deploymentServiceConfig.toPOJO().toString())
                     .log("Starting deployment task");
 
-            /*
-             * Enforce deployments are received for a given deployment target (thing or thingGroup) in sequence such
-             * that old deployments for that target does not override a new deployment.
-             */
-            if (checkIfDeploymentReceivedIsStale(deploymentDocument)) {
-                return prepareRejectionResult(deploymentDocument);
-            }
-
             Map<String, Set<ComponentRequirementIdentifier>> nonTargetGroupsToRootPackagesMap =
                     getNonTargetGroupToRootPackagesMap(deploymentDocument);
 
@@ -191,80 +179,6 @@ public class DefaultDeploymentTask implements DeploymentTask {
             // Populate the exception up to the stack
             throw e;
         }
-    }
-
-    /*
-     * Enforce deployments are received for a given deployment target (thing or thingGroup) in sequence such
-     * that old deployments for that target does not override a new deployment.
-     *
-     * For thing deployments, we don't consider them here as they are always in sequence and always for only
-     * one target.
-     *
-     * For thingGroup deployments sent to different targets (thingGroup A & B), nucleus allows components from
-     * both groups to be deployment as long as they don't have a conflicting component versions. This
-     * behavior is not changed.
-     *
-     * For thingGroup deployments sent to the same target (thingGroup A) are always in sequence, however if
-     * receive a bad/stale deployment due to cloud error we don't want that stale deployment to override a
-     * new deployment already performed on device.
-     *
-     * For a subgroup deployments targeted for a parent fleet group (subgroup A1, A2 & A3 targeted for
-     * thingGroup A), as there could be multiple subgroup deployments each of these sent as different jobs to
-     * the device could be received in any order yielding an unpredictable behavior. To resolve this, nucleus
-     * enforces processing these subgroup deployment in-order of their creation irrespective of when these
-     * signals are received. For example:
-     *
-     * Order of deployment creation is: A1, A2, A3
-     * So these, have to be processed in this order.
-     *
-     * Order of deployments received: A2, A1, A3
-     * then A2 and A3 deployment will succeed, but A1 would be rejected as nucleus has already processed
-     * newer deployment A2.
-     *
-     * @return true if deployment is considered stale, false otherwise
-     */
-    private boolean checkIfDeploymentReceivedIsStale(DeploymentDocument deploymentDocument) {
-        // Check if group deployment
-        boolean isGroupDeployment = Deployment.DeploymentType.IOT_JOBS.equals(deployment.getDeploymentType())
-                                        && deploymentDocument.getGroupName() != null;
-
-        // if not a group deployment, then not stale
-        if (!isGroupDeployment) {
-            return false;
-        }
-
-        // Get timestamp for the root target group
-        Topics lastDeployment = deploymentServiceConfig
-                .lookupTopics(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS, deploymentDocument.getGroupName());
-
-        long timestamp = Coerce.toLong(lastDeployment.find(GROUP_TO_LAST_DEPLOYMENT_TIMESTAMP_KEY));
-
-        // if don't have last deployment detail, then its a new deployment
-        if (timestamp == 0 || deploymentDocument.getTimestamp() == null) {
-            return false;
-        }
-
-        // if the new deployment creation timestamp is smaller than last deployment creation timestamp then its stale
-        return deploymentDocument.getTimestamp() < timestamp;
-    }
-
-    private DeploymentResult prepareRejectionResult(DeploymentDocument deploymentDocument) {
-        logger.atInfo().setEventType(DEPLOYMENT_TASK_EVENT_TYPE)
-                .log("Nucleus has a newer deployment for '{}' target. Rejecting the deployment",
-                        deploymentDocument.getGroupName());
-
-        Topics lastDeployment =
-                deploymentServiceConfig.lookupTopics(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS,
-                        deploymentDocument.getGroupName());
-
-        String lastDeploymentConfigArn =
-                Coerce.toString(lastDeployment.find(GROUP_TO_LAST_DEPLOYMENT_CONFIG_ARN_KEY));
-        return new DeploymentResult(DeploymentResult.DeploymentStatus.REJECTED, new DeploymentRejectedException(
-                String.format("Nucleus has a newer deployment for '%s' target deployed by '%s'. Rejecting the "
-                                + "deployment from '%s'", deploymentDocument.getGroupName(), lastDeploymentConfigArn,
-                        deploymentDocument.getConfigurationArn()),
-                DeploymentErrorCode.REJECTED_STALE_DEPLOYMENT));
-
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -79,6 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -407,6 +408,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         allGroupTopics.children.put(new CaseInsensitiveString(expectedGroupName), deploymentGroupTopics);
 
         when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
+        lenient().when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
         when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
         when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
         lenient().when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS, expectedGroupName))
@@ -443,14 +446,18 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_deployment_job_WHEN_deployment_completes_with_non_retryable_error_THEN_report_failed_job_status(
-            ExtensionContext context)
+            ExtensionContext extContext)
             throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+
         String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
         CompletableFuture<DeploymentResult> mockFutureWithException = new CompletableFuture<>();
-        ignoreExceptionUltimateCauseOfType(context, DeploymentTaskFailureException.class);
+        ignoreExceptionUltimateCauseOfType(extContext, DeploymentTaskFailureException.class);
 
         Throwable t = new DeploymentTaskFailureException("");
         mockFutureWithException.completeExceptionally(t);
@@ -469,14 +476,18 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_deployment_job_WHEN_deployment_metadata_setup_fails_THEN_report_failed_job_status(
-            ExtensionContext context)
+            ExtensionContext extContext)
             throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+
         String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
 
-        ignoreExceptionUltimateCauseWithMessage(context, "mock error");
+        ignoreExceptionUltimateCauseWithMessage(extContext, "mock error");
 
         when(deploymentDirectoryManager.createNewDeploymentDirectory(any()))
                 .thenThrow(new IOException("mock error"));
@@ -511,6 +522,8 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         when(allGroupTopics.lookupTopics(EXPECTED_GROUP_NAME)).thenReturn(deploymentGroupTopics);
         when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
         when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
         when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
         when(config.lookupTopics(COMPONENTS_TO_GROUPS_TOPICS)).thenReturn(mockComponentsToGroupPackages);
@@ -547,8 +560,11 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_deployment_job_with_auto_rollback_requested_WHEN_deployment_fails_and_rollback_succeeds_THEN_report_failed_job_status()
             throws Exception {
-        String deploymentDocument = getTestDeploymentDocument();
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
 
+        String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
                 Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
@@ -569,6 +585,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_deployment_job_with_auto_rollback_requested_WHEN_deployment_fails_and_rollback_fails_THEN_report_failed_job_status()
             throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+
         String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
@@ -590,6 +610,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_deployment_job_cancelled_WHEN_waiting_for_safe_time_THEN_then_cancel_deployment()
             throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+
         String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
@@ -615,6 +639,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_deployment_job_cancelled_WHEN_already_executing_update_THEN_then_finish_deployment()
             throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+
         String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,
@@ -640,6 +668,10 @@ class DeploymentServiceTest extends GGServiceTestUtil {
     @Test
     void GIVEN_deployment_job_cancelled_WHEN_already_finished_deployment_task_THEN_then_do_nothing()
             throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+
         String deploymentDocument = getTestDeploymentDocument();
 
         deploymentQueue.offer(new Deployment(deploymentDocument,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
An IoT job execution can't transition to `REJECTED` from `IN_PROGRESS` state. Valid transition would be `QUEUED` to `REJECTED`. This change either moves the `QUEUED` job to `IN_PROGRESS` or `REJECTED` state.

**Why is this change necessary:**
This change is necessary to fix to correctly perform `REJECTED` state change.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
