### PR TITLE
fix: restart nucleus if deployment removes a plugin

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
@@ -46,6 +47,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;
 
@@ -136,7 +138,10 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
             }
         });
         if (componentsRequiresBootstrapTask.isEmpty()) {
-            return nucleusConfigValidAndNeedsRestart;
+            // Force restart if
+            // 1. any nucleus config change requires restart or
+            // 2. if any plugin will be removed in the deployment to ensure plugin cleanup
+            return nucleusConfigValidAndNeedsRestart || willRemovePlugins(serviceConfig);
         }
         List<String> errors = new ArrayList<>();
         // Figure out the dependency order within the subset of components which require changes
@@ -151,6 +156,19 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
         dependencyFound.forEach(name -> bootstrapTaskStatusList.add(new BootstrapTaskStatus(name)));
 
         return nucleusConfigValidAndNeedsRestart || !bootstrapTaskStatusList.isEmpty();
+    }
+
+    private boolean willRemovePlugins(Map<String, Object> serviceConfig) {
+        Set<String> pluginsToRemove = kernel.orderedDependencies().stream()
+                .filter(s -> s instanceof PluginService)
+                .filter(s -> !serviceConfig.containsKey(s.getName()))
+                .map(GreengrassService::getName)
+                .collect(Collectors.toSet());
+        if (!pluginsToRemove.isEmpty()) {
+            logger.atInfo().kv("plugins-to-remove", pluginsToRemove)
+                    .log("Bootstrap required for cleaning up plugin(s)");
+        }
+        return !pluginsToRemove.isEmpty();
     }
 
     private boolean networkProxyHasChanged(Map<String, Object> newNucleusParameters,


### PR DESCRIPTION
**Issue #, if available:**
-
**Description of changes:**
If a deployment is about to remove a plugin component, force nucleus restart to unload the plugin's code
Draft PR for discussion and early feedback, fix and test are a little silly, will improve if we decide to take this route

**Why is this change necessary:**
Without this, subsequent deployment of the same plugin can cause unexpected behavior when nucleus hasn't restarted between the the two deployments

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
