### PR TITLE
fix: ignore builtin plugins when bootstrapping

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
@@ -161,6 +161,7 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
     private boolean willRemovePlugins(Map<String, Object> serviceConfig) {
         Set<String> pluginsToRemove = kernel.orderedDependencies().stream()
                 .filter(s -> s instanceof PluginService)
+                .filter(s -> !s.isBuiltin())
                 .filter(s -> !serviceConfig.containsKey(s.getName()))
                 .map(GreengrassService::getName)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
#1362 adds a bootstrap when removing plugins, however this is not necessary or desirable when there isn't any plugin actually being removed because the plugin is "builtin" meaning that it is in the plugin directory. This impacts our testing which installs the CLI into the plugin directory, so now all our tests are restarting the Nucleus unnecessarily.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
