### PR TITLE
fix(sdk-clients): use http client builder to avoid leaks

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -234,7 +234,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     }
 
     SdkHttpClient getSdkHttpClient() {
-        return ProxyUtils.getSdkHttpClient();
+        return ProxyUtils.getSdkHttpClientBuilder().build();
     }
 
     private long getContentLengthLong(SdkHttpResponse sdkHttpResponse) {

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
@@ -57,7 +57,8 @@ public class EcrAccessor {
             region = Coerce.toString(deviceConfiguration.getAWSRegion());
         }
 
-        return EcrClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
+        return EcrClient.builder()
+                .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
                 .region(Region.of(region))
                 .credentialsProvider(lazyCredentialProvider).build();
     }

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -341,7 +341,7 @@ public class DeviceProvisioningHelper {
     }
 
     private SdkHttpClient getSdkHttpClient() {
-        return ProxyUtils.getSdkHttpClient();
+        return ProxyUtils.getSdkHttpClientBuilder().build();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/network/HttpClientProvider.java
+++ b/src/main/java/com/aws/greengrass/network/HttpClientProvider.java
@@ -17,7 +17,7 @@ public class HttpClientProvider {
      * @return SdkHttpClient for making http calls
      */
     public SdkHttpClient getSdkHttpClient() {
-        return ProxyUtils.getSdkHttpClient();
+        return ProxyUtils.getSdkHttpClientBuilder().build();
     }
 
 }

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -150,7 +150,7 @@ public class GreengrassServiceClientFactory {
                 // Use an empty credential provider because our requests don't need SigV4
                 // signing, as they are going through IoT Core instead
                 .credentialsProvider(AnonymousCredentialsProvider.create())
-                .httpClient(httpClient.build())
+                .httpClientBuilder(httpClient)
                 .overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(RetryMode.STANDARD).build());
 
         String region = Coerce.toString(deviceConfiguration.getAWSRegion());

--- a/src/main/java/com/aws/greengrass/util/IamSdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/IamSdkClientFactory.java
@@ -45,7 +45,8 @@ public final class IamSdkClientFactory {
      */
     public static IamClient getIamClient(String awsRegion) {
         Region globalRegionByPartition = RegionUtils.getGlobalRegion(awsRegion);
-        return IamClient.builder().region(globalRegionByPartition).httpClient(ProxyUtils.getSdkHttpClient())
+        return IamClient.builder().region(globalRegionByPartition)
+                .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
                 .overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(retryPolicy).build()).build();
     }
 }

--- a/src/main/java/com/aws/greengrass/util/IotSdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/IotSdkClientFactory.java
@@ -121,8 +121,9 @@ public final class IotSdkClientFactory {
         RetryPolicy retryPolicy = RetryPolicy.builder().numRetries(numRetries)
                 .backoffStrategy(BackoffStrategy.defaultThrottlingStrategy()).retryCondition(retryCondition).build();
         IotClientBuilder iotClientBuilder =
-                IotClient.builder().region(awsRegion).httpClient(ProxyUtils.getSdkHttpClient()).overrideConfiguration(
-                ClientOverrideConfiguration.builder().retryPolicy(retryPolicy).build());
+                IotClient.builder().region(awsRegion)
+                        .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
+                        .overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(retryPolicy).build());
 
         if (credentialsProvider != null) {
             iotClientBuilder.credentialsProvider(credentialsProvider);

--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -229,8 +229,9 @@ public final class ProxyUtils {
      * @return httpClient built with a ProxyConfiguration, if a proxy is configured, otherwise
      *         a default httpClient
      *
-     * @deprecated This method creates potential memory leak situations when wrapped by an SDK client.
-     *         Recommend to use <code>ProxyUtils.getSdkHttpClientBuilder</code> instead.
+     * @deprecated Using this method in an SDK client builder would create a non-managed HTTP client, which does not
+     *         close when the SDK client is closed. Recommend to use <code>ProxyUtils.getSdkHttpClientBuilder</code>
+     *         instead.
      *
      * @see <a href="https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1368">depreacted reason</a>
      *

--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -228,6 +228,12 @@ public final class ProxyUtils {
      *
      * @return httpClient built with a ProxyConfiguration, if a proxy is configured, otherwise
      *         a default httpClient
+     *
+     * @deprecated This method creates potential memory leak situations when wrapped by an SDK client.
+     *         Recommend to use <code>ProxyUtils.getSdkHttpClientBuilder</code> instead.
+     *
+     * @see <a href="https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1368">depreacted reason</a>
+     *
      */
     public static SdkHttpClient getSdkHttpClient() {
         return getSdkHttpClientBuilder().build();
@@ -249,12 +255,13 @@ public final class ProxyUtils {
         ProxyConfiguration proxyConfiguration = getProxyConfiguration();
 
         if (proxyConfiguration != null) {
-            return withClientSettings(ApacheHttpClient.builder())
+            return withClientSettings(ApacheHttpClient.builder().useIdleConnectionReaper(false))
                     .tlsTrustManagersProvider(ProxyUtils::createTrustManagers)
                     .proxyConfiguration(proxyConfiguration);
         }
 
-        return withClientSettings(ApacheHttpClient.builder()).tlsTrustManagersProvider(ProxyUtils::createTrustManagers);
+        return withClientSettings(ApacheHttpClient.builder().useIdleConnectionReaper(false))
+                .tlsTrustManagersProvider(ProxyUtils::createTrustManagers);
     }
 
     private static ApacheHttpClient.Builder withClientSettings(ApacheHttpClient.Builder builder) {

--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -236,6 +236,7 @@ public final class ProxyUtils {
      * @see <a href="https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1368">depreacted reason</a>
      *
      */
+    @Deprecated
     public static SdkHttpClient getSdkHttpClient() {
         return getSdkHttpClientBuilder().build();
     }

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -84,7 +84,7 @@ public class S3SdkClientFactory {
      */
     public S3Client getClientForRegion(Region r) {
         return clientCache.computeIfAbsent(r, (region) -> S3Client.builder()
-                .httpClient(ProxyUtils.getSdkHttpClient())
+                .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
                 .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build())
                 .credentialsProvider(credentialsProvider).region(r).build());
     }

--- a/src/main/java/com/aws/greengrass/util/StsSdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/StsSdkClientFactory.java
@@ -45,7 +45,8 @@ public final class StsSdkClientFactory {
      * @return StsClient instance
      */
     public static StsClient getStsClient(String awsRegion) {
-        return StsClient.builder().region(Region.of(awsRegion)).httpClient(ProxyUtils.getSdkHttpClient())
+        return StsClient.builder().region(Region.of(awsRegion))
+                .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
                 .overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(retryPolicy).build()).build();
     }
 }


### PR DESCRIPTION
**Description of changes:**
Address same memory leak situations as in https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/201.
- Searched for all usages of `.httpClient`and switched to `.httpClientBuilder`
- Deprecated `ProxyUtils::getSdkHttpClient`

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**


**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
