### PR TITLE
feat: get interpolate config value from new nucleus config when able

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_INTERPOLATE_COMPONENT_CONFIGURATION;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.POSIX_USER_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUN_WITH_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
@@ -158,7 +159,7 @@ public class KernelConfigResolver {
         for (ComponentIdentifier resolvedComponentsToDeploy : componentsToDeploy) {
             ComponentRecipe componentRecipe = componentStore.getPackageRecipe(resolvedComponentsToDeploy);
 
-            if (Coerce.toBoolean(deviceConfiguration.getInterpolateComponentConfiguration())) {
+            if (shouldInterpolateConfiguration(servicesConfig)) {
                 Object existingConfiguration = ((Map) servicesConfig.get(resolvedComponentsToDeploy.getName()))
                         .get(CONFIGURATION_CONFIG_KEY);
 
@@ -186,6 +187,29 @@ public class KernelConfigResolver {
 
         // Services need to be under the services namespace in kernel config
         return Collections.singletonMap(SERVICES_NAMESPACE_TOPIC, servicesConfig);
+    }
+
+    @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
+    private boolean shouldInterpolateConfiguration(Map<String, Object> servicesConfig) {
+        // Try and find the new configuration to be applied to Nucleus. If it specifies an opinion
+        // about the interpolation, then we will use that value and not the value currently within the Nucleus
+        String newNucleusName = getNucleusComponentName(servicesConfig);
+        if (servicesConfig.containsKey(newNucleusName)) {
+            Object nucleusSection = servicesConfig.get(newNucleusName);
+            if (nucleusSection instanceof Map) {
+                Object nucleusConfig = ((Map) nucleusSection).get(CONFIGURATION_CONFIG_KEY);
+                if (nucleusConfig instanceof Map) {
+                    Object interpolateOption =
+                            ((Map) nucleusConfig).get(DEVICE_PARAM_INTERPOLATE_COMPONENT_CONFIGURATION);
+                    if (interpolateOption != null) {
+                        return Coerce.toBoolean(interpolateOption);
+                    }
+                }
+            }
+        }
+
+        // No opinion from new Nucleus config, use what we have currently
+        return Coerce.toBoolean(deviceConfiguration.getInterpolateComponentConfiguration());
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, deployments that want to use config interpolation need to be in 2 stages, 1 to enable interpolation and 2 to use the interpolation. This is a terrible experience.

This change fixes this by looking at the value of the interpolate option in the updated Nucleus configuration if it exists.

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
