### PR TITLE
fix: do not log full data, only key path in config error

### DIFF
--- a/src/main/java/com/aws/greengrass/config/Topics.java
+++ b/src/main/java/com/aws/greengrass/config/Topics.java
@@ -123,7 +123,8 @@ public class Topics extends Node implements Iterable<Node> {
         if (n instanceof Topic) {
             return (Topic) n;
         } else {
-            throw new IllegalArgumentException(name + " in " + this + " is already a container, cannot become a leaf");
+            throw new IllegalArgumentException(name + " in "
+                    + getFullName() + " is already a container, cannot become a leaf");
         }
     }
 
@@ -159,7 +160,8 @@ public class Topics extends Node implements Iterable<Node> {
         if (n instanceof Topics) {
             return (Topics) n;
         } else {
-            throw new IllegalArgumentException(name + " in " + this + " is already a leaf, cannot become a container");
+            throw new IllegalArgumentException(name + " in "
+                    + getFullName() + " is already a leaf, cannot become a container");
         }
     }
 

--- a/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({"PMD.DetachedTestCase", "PMD.UnusedLocalVariable"})
@@ -317,6 +318,18 @@ class ConfigurationTest {
         config.read(getClass().getResource("test.json").toURI().toURL(), false);
         assertEquals("echo main service installed",
                 config.find(SERVICES_NAMESPACE_TOPIC, "main", "lifecycle", "install").getOnce());
+    }
+
+    @Test
+    void GIVEN_config_WHEN_converting_leaf_to_container_THEN_I_get_a_good_error() {
+        config.lookup("a", "somekey");
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> config.lookupTopics("a", "somekey"));
+        assertEquals("somekey in a is already a leaf, cannot become a container", ex.getMessage());
+
+        config.lookupTopics("a", "somekey2");
+        ex = assertThrows(IllegalArgumentException.class, () -> config.lookup("a", "somekey2"));
+        assertEquals("somekey2 in a is already a container, cannot become a leaf", ex.getMessage());
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Previous error example
```
java.lang.IllegalArgumentException: configuration in services.aws.greengrass.crypto.Pkcs11Provider:{version=services.aws.greengrass.crypto.Pkcs11Provider.version:0.0.0, library=services.aws.greengrass.crypto.Pkcs11Provider.library:/lib64/libsofthsm2.so, _private=services.aws.greengrass.crypto.Pkcs11Provider._private:{_State=services.aws.greengrass.crypto.Pkcs11Provider._private._State:1}, configuration=services.aws.greengrass.crypto.Pkcs11Provider.configuration:null, slot=services.aws.greengrass.crypto.Pkcs11Provider.slot:0, name=services.aws.greengrass.crypto.Pkcs11Provider.name:softhsm_pkcs11, dependencies=services.aws.greengrass.crypto.Pkcs11Provider.dependencies:[]} is already a leaf, cannot become a container
```

New error example
```
java.lang.IllegalArgumentException: configuration in services.aws.greengrass.crypto.Pkcs11Provider is already a leaf, cannot become a container
```


**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
