### PR TITLE
perf(plugins): add a fast path to load plugins without scanning

### DIFF
--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.dependency;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.util.Utils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.ClassAnnotationMatchProcessor;
@@ -16,13 +15,14 @@ import lombok.Getter;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 
@@ -39,6 +41,7 @@ public class EZPlugins implements Closeable {
     private static final Logger logger = LogManager.getLogger(EZPlugins.class);
     public static final String JAR_FILE_EXTENSION = ".jar";
     private final List<Consumer<FastClasspathScanner>> matchers = new ArrayList<>();
+    private final List<Consumer<Class<?>>> classMatchers = new ArrayList<>();
     private Path cacheDirectory;
     @Getter
     private Path trustedCacheDirectory;
@@ -84,14 +87,29 @@ public class EZPlugins implements Closeable {
 
     private synchronized void loadPlugins(boolean trusted, ClassLoader cls) {
         doneFirstLoad = true;
+        if (trusted) {
+            root = cls;
+        }
+
+        // Try and find the Greengrass plugin class (fast path)
+        try {
+            if (cls instanceof URLClassLoader) {
+                Class<?> clazz = findGreengrassPlugin((URLClassLoader) cls);
+                if (clazz != null) {
+                    classMatchers.forEach(m -> m.accept(clazz));
+                    return;
+                }
+            }
+        } catch (IOException e) {
+            logger.atWarn().log("Problem looking for Greengrass plugin with the fast path."
+                            + " Falling back to classpath scanner", e);
+        }
+
         FastClasspathScanner sc = new FastClasspathScanner("com.aws.greengrass");
         sc.strictWhitelist();
         sc.addClassLoader(cls);
         matchers.forEach(m -> m.accept(sc));
         sc.scan(executorService, 1);
-        if (trusted) {
-            root = cls;
-        }
     }
 
     @SuppressWarnings("PMD.CloseResource")
@@ -106,24 +124,67 @@ public class EZPlugins implements Closeable {
      * Load a single plugin with the classpath scanner.
      *
      * @param p       path to jar file
+     * @param annotationClass annotation to search for
+     * @param <T> annotation class type
      * @param matcher matcher to use
      * @throws IOException if loading the class fails
      */
     // Class loader must stay open, otherwise we won't be able to load all classes from the jar
     @SuppressWarnings("PMD.CloseResource")
-    public synchronized ClassLoader loadPlugin(Path p, Consumer<FastClasspathScanner> matcher) throws IOException {
+    public synchronized <T extends Annotation> ClassLoader loadPluginAnnotatedWith(Path p, Class<T> annotationClass,
+                                                           Consumer<Class<?>> matcher) throws IOException {
         URL[] urls = {p.toUri().toURL()};
         return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
             URLClassLoader cl = new URLClassLoader(urls, root);
             classLoaders.add(cl);
             root = cl;
+
+            // Try and find the Greengrass plugin class (fast path)
+            try {
+                Class<?> clazz = findGreengrassPlugin(cl);
+                if (clazz != null) {
+                    if (clazz.isAnnotationPresent(annotationClass)) {
+                        matcher.accept(clazz);
+                        return cl;
+                    } else {
+                        logger.atWarn().log("Class {} was found, but not annotated with {}",
+                                clazz.getSimpleName(), annotationClass.getSimpleName());
+                    }
+                }
+            } catch (IOException e) {
+                logger.atWarn().log("IOException reading from {}. Falling back to classpath scanner", p, e);
+            }
+
             FastClasspathScanner sc = new FastClasspathScanner();
             sc.ignoreParentClassLoaders();
             sc.addClassLoader(cl);
-            matcher.accept(sc);
+            sc.matchClassesWithAnnotation(annotationClass, matcher::accept);
             sc.scan(executorService, 1);
             return cl;
         });
+    }
+
+    private synchronized Class<?> findGreengrassPlugin(URLClassLoader cls) throws IOException {
+        URL url = cls.findResource("META-INF/MANIFEST.MF");
+        if (url == null) {
+            return null;
+        }
+        URLConnection conn = url.openConnection();
+        // Workaround JDK bug: https://bugs.openjdk.org/browse/JDK-8246714
+        conn.setUseCaches(false);
+        try (InputStream is = conn.getInputStream()) {
+            Manifest manifest = new Manifest(is);
+            Attributes attr = manifest.getMainAttributes();
+            if (attr != null) {
+                String className = attr.getValue("GG-Plugin-Class");
+                if (className != null) {
+                    return cls.loadClass(className);
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            logger.atWarn().log("Class specified by the GG-Plugin-Class manifest entry was not found", e);
+        }
+        return null;
     }
 
     // Only use in tests to scan our own classpath for @ImplementsService
@@ -197,73 +258,6 @@ public class EZPlugins implements Closeable {
     }
 
     /**
-     * Delete all plugins.
-     *
-     * @return this
-     * @throws IOException if deletion fails
-     */
-    public EZPlugins clearCache() throws IOException {
-        IOException ioe = new IOException("One or more file deletion failed");
-        walk(cacheDirectory, p -> {
-            if (p.toString().endsWith(JAR_FILE_EXTENSION)) {
-                try {
-                    Files.delete(p);
-                } catch (IOException e) {
-                    ioe.addSuppressed(e);
-                }
-            }
-        });
-        if (ioe.getSuppressed().length > 0) {
-            throw ioe;
-        }
-        return this;
-    }
-
-    /**
-     * Load a jar from a URL into the plugin cache.
-     *
-     * @param trusted true if the plugin should be set as trusted
-     * @param u       URL to load the jar from
-     * @return this
-     * @throws IOException if loading fails
-     */
-    public EZPlugins loadToCache(boolean trusted, URL u) throws IOException {
-        String nm = Utils.namePart(u.getPath());
-        if (!nm.endsWith(JAR_FILE_EXTENSION)) {
-            throw new IOException("Only .jar files can be cached: " + u);
-        }
-        Path d = (trusted ? trustedCacheDirectory : untrustedCacheDirectory).resolve(nm);
-        Files.copy(u.openStream(), d, StandardCopyOption.REPLACE_EXISTING);
-        loadPlugins(trusted, d);
-        return this;
-    }
-
-    /**
-     * Move a jar from the path into the plugin cache.
-     *
-     * @param trusted true if it should be moved into the trusted plugin cache
-     * @param u       path to the jar to move
-     * @return this
-     * @throws IOException if moving fails
-     */
-    public EZPlugins moveToCache(boolean trusted, Path u) throws IOException {
-        Path p = u.getFileName();
-        if (p == null) {
-            throw new IOException("Filename was null");
-        }
-        String nm = p.toString();
-        if (!nm.endsWith(JAR_FILE_EXTENSION)) {
-            throw new IOException("Only .jar files can be cached: " + u);
-        }
-        Path d = (trusted ? trustedCacheDirectory : untrustedCacheDirectory).resolve(nm);
-        if (!d.equals(u)) {
-            Files.copy(u, d, StandardCopyOption.REPLACE_EXISTING);
-        }
-        loadPlugins(trusted, d);
-        return this;
-    }
-
-    /**
      * Find plugins implementing the given class.
      *
      * @param c   Class that the plugin should implement
@@ -277,6 +271,11 @@ public class EZPlugins implements Closeable {
             throw new IllegalStateException("EZPlugins: all matchers must be specified before the first class load");
         }
         matchers.add(fcs -> fcs.matchClassesImplementing(c, m));
+        classMatchers.add(x -> {
+            if (x.isAssignableFrom(c)) {
+                m.processMatch((Class<? extends T>) x);
+            }
+        });
         return this;
     }
 
@@ -294,6 +293,11 @@ public class EZPlugins implements Closeable {
             throw new IllegalStateException("EZPlugins: all matchers must be specified before the first class load");
         }
         matchers.add(fcs -> fcs.matchClassesWithAnnotation(c, m));
+        classMatchers.add((x) -> {
+            if (x.isAnnotationPresent(c)) {
+                m.processMatch(x);
+            }
+        });
         return this;
     }
 

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -550,7 +550,7 @@ public class Kernel {
         try {
             AtomicReference<Class<?>> classReference = new AtomicReference<>();
             EZPlugins ezPlugins = context.get(EZPlugins.class);
-            ezPlugins.loadPlugin(pluginJar, (sc) -> sc.matchClassesWithAnnotation(ImplementsService.class, (c) -> {
+            ezPlugins.loadPluginAnnotatedWith(pluginJar, ImplementsService.class, (c) -> {
                 // Only use the class whose name matches what we want
                 ImplementsService serviceImplementation = c.getAnnotation(ImplementsService.class);
                 if (serviceImplementation.name().equals(name)) {
@@ -562,7 +562,7 @@ public class Kernel {
                     }
                     classReference.set(c);
                 }
-            }));
+            });
             clazz = classReference.get();
         } catch (Throwable e) {
             throw new ServiceLoadException(String.format("Unable to load %s as a plugin", name), e);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds a fast path to EZPlugins to load the class based on a Jar manifest entry `GG-Plugin-Class`. Keeps full backward compatibility with existing plugins because we'll try to find the class using this method, but if it fails for any reason at all we will go back to the classpath scanner method.

This saves us quite a lot of time. On my M1 Mac, loading the CLI server from the trusted plugins directory took 190ms without the change and only 27ms with this change. This is an approximate 7x speedup. Real world speedup would be very dependent on the number of plugins, disk speed, and CPU speed.

Plugins must be updated to support this fast path by adding an entry to their manifest like so:

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-jar-plugin</artifactId>
    <version>3.3.0</version>
    <configuration>
        <archive>
            <manifestEntries>
                <GG-Plugin-Class>com.aws.greengrass.cli.CLIService</GG-Plugin-Class>
            </manifestEntries>
        </archive>
    </configuration>
</plugin>
```

This PR is also removing unused methods from the EZPlugins class.

**Why is this change necessary:**

**How was this change tested:**
Validated that I'm able to load the CLI service from trusted plugins. Full test suite will need to run to complete the validation.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
