### PR TITLE
fix(plugins): flip isAssignableFrom to correctly find implementing classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -764,6 +764,11 @@
                             <outputDirectory>
                                 src/integrationtests/resources/com/aws/greengrass/integrationtests/provisioning/
                             </outputDirectory>
+                            <archive>
+                                <manifestEntries>
+                                    <GG-Plugin-Class>com.aws.greengrass.integrationtests.provisioning.resource.TestDeviceProvisioningPluginForJar</GG-Plugin-Class>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </execution>
                     <execution>

--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -272,7 +272,7 @@ public class EZPlugins implements Closeable {
         }
         matchers.add(fcs -> fcs.matchClassesImplementing(c, m));
         classMatchers.add(x -> {
-            if (x.isAssignableFrom(c)) {
+            if (c.isAssignableFrom(x)) {
                 m.processMatch((Class<? extends T>) x);
             }
         });


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Flip the `isAssignableFrom` to correctly find subclasses/interface implementors. This code is only used for the provisioning plugin which is why it was not found previously. I have now manually tested this with the fleet provisioning by claim plugin so that it now supports the fast loading procedure.

**Why is this change necessary:**

**How was this change tested:**
Manually tested loading the fleet provisioning plugin with the GG-Plugin-Class option included in the manifest and observed that the plugin is loaded and starts trying to provision.

Updated integration test plugin jar file to include the GG-Plugin-Class specification so this code path is exercised during testing.

- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
