### PR TITLE
fix: add logging around installed component not found

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -610,12 +610,15 @@ public class ComponentManager implements InjectionActions {
         Optional<Semver> activeVersionOptional = findActiveVersion(componentName);
 
         if (!activeVersionOptional.isPresent()) {
+            logger.atInfo().log("No active version found for {}", componentName);
             return Optional.empty();
         }
 
         Semver activeVersion = activeVersionOptional.get();
 
         if (!requirement.isSatisfiedBy(activeVersion)) {
+            logger.atInfo().log("Active version {} for component {} does not satisfy requirement {}", activeVersion,
+                    componentName, requirement);
             return Optional.empty();
         }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add more logging around the path to "No active component version satisfies the requirements of non-target groups" because it could be caused by many different causes.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
