### PR TITLE
fix: allows a closing component to be restarted by a new deployment

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -800,9 +800,11 @@ public class Lifecycle {
      * Start Service.
      */
     final void requestStart() {
-        // Ignore start requests if the service is closed
-        if (isClosed.get()) {
-            return;
+        // If the lifecycle thread is still running when isClosed is true, then it must be still executing
+        // the shutdown lifecycle. In this case it's ok to start service again.
+        if (isClosed.compareAndSet(true, false)) {
+            logger.atWarn("service-shutdown-interrupted")
+                    .log("Requesting service to start while it is closing");
         }
         synchronized (desiredStateList) {
             if (desiredStateList.isEmpty() || desiredStateList.equals(Collections.singletonList(State.FINISHED))) {


### PR DESCRIPTION
**Description of changes:**
1. Allows a closing component to start again.

**Why is this change necessary:**
It is a dependency for https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1375.

Before this change, if deployment A removes a component -> the component is closing -> deployment B adds the component back and cancels deployment A, deployment B would fail to restart the component because the component is already closed.

After this change, the component would be restarted.

The change should be safe because service is only closed when 1) kernel shutdown; 2) removed by a deployment; 3) replace unloadable service. `requestStart` is only called when 1) kernel launched, 2) added by a deployment; 3) service errors.

**How was this change tested:**
It will be tested in https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1375

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
