### PR TITLE
chore(TES): adjust expired credential response

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -226,7 +226,7 @@ public class CredentialRequestHandler implements HttpHandler {
                     Instant expiry = Instant.parse(expiryString);
 
                     if (expiry.isBefore(Instant.now(clock))) {
-                        String responseString = "TES responded with expired credentials: " + credentials;
+                        String responseString = "TES responded with expired credentials";
                         response = responseString.getBytes(StandardCharsets.UTF_8);
                         tesCache.get(iotCredentialsPath).responseCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
                         LOGGER.atError().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)

--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -354,6 +354,7 @@ public class CredentialRequestHandler implements HttpHandler {
                             credentials.get(SESSION_TOKEN_DOWNSTREAM_STR));
         } catch (IOException e) {
             LOGGER.atError().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
+                    .kv("credentialData", new String(data, StandardCharsets.UTF_8))
                     .log("Error in retrieving AwsCredentials from TES");
             return null;
         }

--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -226,7 +226,7 @@ public class CredentialRequestHandler implements HttpHandler {
                     Instant expiry = Instant.parse(expiryString);
 
                     if (expiry.isBefore(Instant.now(clock))) {
-                        String responseString = "TES responded with expired credentials";
+                        String responseString = "TES responded with credentials that expired at " + expiry;
                         response = responseString.getBytes(StandardCharsets.UTF_8);
                         tesCache.get(iotCredentialsPath).responseCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
                         LOGGER.atError().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)

--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -354,7 +354,6 @@ public class CredentialRequestHandler implements HttpHandler {
                             credentials.get(SESSION_TOKEN_DOWNSTREAM_STR));
         } catch (IOException e) {
             LOGGER.atError().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
-                    .kv("credentialData", new String(data, StandardCharsets.UTF_8))
                     .log("Error in retrieving AwsCredentials from TES");
             return null;
         }

--- a/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
@@ -313,7 +313,7 @@ class CredentialRequestHandlerTest {
         when(mockAuthZHandler.isAuthorized(any(), any())).thenReturn(true);
         CredentialRequestHandler handler = setupHandler();
         handler.handle(mockExchange);
-        byte[] expectedResponse = ("TES responded with expired credentials: " + responseStr).getBytes();
+        byte[] expectedResponse = ("TES responded with expired credentials").getBytes();
         int expectedStatus = 500;
         verify(mockCloudHelper, times(1)).sendHttpRequest(any(), any(), any(), any(), any());
         verify(mockExchange, times(1)).sendResponseHeaders(expectedStatus, expectedResponse.length);

--- a/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
@@ -313,7 +313,7 @@ class CredentialRequestHandlerTest {
         when(mockAuthZHandler.isAuthorized(any(), any())).thenReturn(true);
         CredentialRequestHandler handler = setupHandler();
         handler.handle(mockExchange);
-        byte[] expectedResponse = ("TES responded with expired credentials").getBytes();
+        byte[] expectedResponse = ("TES responded with credentials that expired at " + expirationTime).getBytes();
         int expectedStatus = 500;
         verify(mockCloudHelper, times(1)).sendHttpRequest(any(), any(), any(), any(), any());
         verify(mockExchange, times(1)).sendResponseHeaders(expectedStatus, expectedResponse.length);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adjust the response TES gives upon encountering expired credentials, such that the response does not contain the expired credentials.  This prevents expired credentials from being logged [later on](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/4bb96750c21bc02de3fd3fd6182afb8ecba41b46/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java#L357).

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
