### PR TITLE
feat: allow cancellation of default deployments while waiting for components to start

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartup.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartup.json
@@ -1,0 +1,17 @@
+{
+  "deploymentId": "TestComponentTakesLongToStartup",
+  "components": {
+    "ComponentTakesLongToStartup": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartupNoNotify.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartupNoNotify.json
@@ -1,0 +1,17 @@
+{
+  "deploymentId": "TestComponentTakesLongToStartupNoNotify",
+  "components": {
+    "ComponentTakesLongToStartup": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "SKIP_NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentTakesLongToStartup-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentTakesLongToStartup-1.0.0.yaml
@@ -1,0 +1,23 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: ComponentTakesLongToStartup
+ComponentDescription: A component that takes 10 seconds to startup
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      install: |-
+        powershell -command "& { echo 'Finish install.'; }"
+      startup: |-
+        powershell -command "& { echo 'Start startup.'; sleep 10; echo 'Finish startup.' }"
+  - Platform:
+      os: all
+    Lifecycle:
+      install: |-
+        echo "Finish install."
+      startup: |-
+        echo "Start startup."
+        sleep 10
+        echo "Finish startup."

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/NonDisruptableService-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/NonDisruptableService-1.0.0.yaml
@@ -23,7 +23,7 @@ Manifests:
         while true; do
         echo "running non disruptable service version 1.0.0"; sleep 5
         done
-        checkIfSafeToUpdate:
+      checkIfSafeToUpdate:
         recheckPeriod: 5
         script: |-
           echo "Not SafeUpdate"

--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -278,7 +278,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
         }
         // Cancel deployment config merge future
         if (deploymentMergeFuture != null && !deploymentMergeFuture.isDone()) {
-            deploymentMergeFuture.cancel(false);
+            deploymentMergeFuture.cancel(true);
             logger.atInfo(DEPLOYMENT_TASK_EVENT_TYPE)
                     .log("Cancelled deployment merge future due to interrupt, update may not get cancelled if"
                             + " it is already being applied");

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -82,11 +82,6 @@ public class DefaultActivator extends DeploymentActivator {
             Set<GreengrassService> servicesToTrack = servicesChangeManager.servicesToTrack();
             logger.atDebug(MERGE_CONFIG_EVENT_KEY).kv("serviceToTrack", servicesToTrack).kv("mergeTime", mergeTime)
                     .log("Applied new service config. Waiting for services to complete update");
-            // There are two scenarios when a cancellation might happen.
-            // Both scenarios would throw an InterruptedException from waitForServicesToStart.
-            // 1. Thread is sleeping in waitForServicesToStart.
-            // 2. Cancellation happens at a non-blocking step (before waitForServicesToStart or while
-            //    waitForServicesToStart is checking component states).
             try {
                 waitForServicesToStart(servicesToTrack, mergeTime, kernel, totallyCompleteFuture);
             }  catch (DeploymentCancellationException e) {

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentCancellationException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentCancellationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.exceptions;
+
+public class DeploymentCancellationException extends Exception {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public DeploymentCancellationException(String message, Throwable e) {
+        super(message, e);
+    }
+
+    public DeploymentCancellationException(Throwable e) {
+        super(e);
+    }
+
+    public DeploymentCancellationException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -302,6 +303,8 @@ class DeploymentConfigMergerTest {
     void GIVEN_deployment_WHEN_check_safety_selected_THEN_check_safety_before_update() throws Exception {
         UpdateSystemPolicyService updateSystemPolicyService = mock(UpdateSystemPolicyService.class);
         when(context.get(UpdateSystemPolicyService.class)).thenReturn(updateSystemPolicyService);
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(context.get(ExecutorService.class)).thenReturn(executorService);
         DeploymentActivatorFactory deploymentActivatorFactory = mock(DeploymentActivatorFactory.class);
         DeploymentActivator deploymentActivator = mock(DeploymentActivator.class);
         when(deploymentActivatorFactory.getDeploymentActivator(any())).thenReturn(deploymentActivator);

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -63,8 +63,8 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_T
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_SERVICE_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
-import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_NAME_KEY;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
@@ -659,7 +659,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         // Expecting three invocations, once for each retry attempt
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(updateSystemPolicyService, WAIT_FOUR_SECONDS).discardPendingUpdateAction(TEST_DEPLOYMENT_ID);
-        verify(mockFuture, times(0)).cancel(true);
+        verify(mockFuture, WAIT_FOUR_SECONDS).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
                 eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
@@ -293,6 +293,6 @@ class DeploymentTaskTest {
         verify(mockComponentManager).preparePackages(anyList());
         verify(mockKernelConfigResolver).resolve(anyList(), eq(deploymentDocument), anyList());
         verify(mockDeploymentConfigMerger, timeout(4000)).mergeInNewConfig(any(), any());
-        verify(mockMergeConfigFuture, timeout(5000)).cancel(false);
+        verify(mockMergeConfigFuture, timeout(5000)).cancel(true);
     }
 }


### PR DESCRIPTION
**Description of changes:**
1. Allows default deployment to cancel while waiting for services to start.
2. Adds integration tests

**Why is this change necessary:**
Today, customers have to restart nucleus when a deployment is stuck at waiting for all tracking components to reach a terminal state. While it rarely happens, customers need a way to make sure that a deployment can always finish.

Moreover, if a deployment is taking longer than expected, customers would attempt to cancel the ongoing deployment or create a new deployment from cloud, which nucleus would ignore, if it already started new components from the ongoing deployment. Customers need a way to cancel or overwrite the ongoing deployment from cloud.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

The journey of a cancellation request when deployment is waiting for services to start:
1. `DeploymentService` checks cancellation criteria and calls `getDeploymentResultFuture().cancel(true)`
2. `DefaultDeploymentTask::call` receives the cancel signal
    a. if it's executing a blocking step, an `InterruptedException` is thrown and it calls `cancelDeploymentTask`
    b. `cancelDeploymentTask` calls `deploymentMergeFuture.cancel(true)`
3.  `updateActionForDeployment` is always running in a different thread from `DefaultDeploymentTask`
a. `updateActionForDeployment` runs `DefaultActivator::activate` which waits for services to start
b. it keeps checking if deploymentMergeFuture is cancelled and throws a `DeploymentCancellationException`
c. `DefaultActivator::activate` handles `DeploymentCancellationException` by returning directly and do nothing else.


**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
