### PR TITLE
fix(plugins): allow multiple GG plugins per classloader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -787,6 +787,11 @@
                             <outputDirectory>
                                 src/integrationtests/resources/com/aws/greengrass/integrationtests/provisioning/
                             </outputDirectory>
+                            <archive>
+                                <manifestEntries>
+                                    <GG-Plugin-Class>com.aws.greengrass.integrationtests.provisioning.resource.AdditionalDeviceProvisioningPluginForJar</GG-Plugin-Class>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When we load plugins from the trusted plugin directory, we create a single classloader that contains all the Jars. This breaks the new plugin loading logic which assumed there could be only 1 plugin per classloader. This change now properly iterates through all possible entries in order to discover all plugins within a classloader.

**Why is this change necessary:**

**How was this change tested:**
Verified locally using fleet provisioning and the CLI and verified that both were loaded at the same time.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
