### PR TITLE
fix: suppress oshi logs when reading process info

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.util.platforms.unix;
 
 import com.aws.greengrass.logging.api.LogEventBuilder;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.FileSystemPermission;
 import com.aws.greengrass.util.Permissions;
@@ -84,6 +85,8 @@ public class UnixPlatform extends Platform {
      */
     public UnixPlatform() {
         super();
+        // avoid spamming DEBUG-level oshi logs when reading process stats
+        LogManager.getLogger(oshi.util.FileUtil.class.getName()).setLevel("INFO");
         runWithGenerator = new UnixRunWithGenerator(this);
     }
 


### PR DESCRIPTION
**Description of changes:**
1. suppress `oshi.util.FileUtil` log level to INFO.

**Why is this change necessary:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/913 switched to oshi library which prints very verbose DEBUG-level logs while reading process info:
```
2022-12-15T00:26:11.975Z [DEBUG] (pool-2-thread-7) oshi.util.FileUtil: Reading file /proc/1129/stat. {}
2022-12-15T00:26:11.975Z [DEBUG] (pool-2-thread-7) oshi.util.FileUtil: Reading file /proc/1129/stat. {}
2022-12-15T00:26:11.975Z [DEBUG] (pool-2-thread-7) oshi.util.FileUtil: Reading file /proc/1130/stat. {}
2022-12-15T00:26:11.975Z [DEBUG] (pool-2-thread-7) oshi.util.FileUtil: Reading file /proc/1130/stat. {}
2022-12-15T00:26:11.975Z [DEBUG] (pool-2-thread-7) oshi.util.FileUtil: Reading file /proc/1131/stat. {}
.....
```
Since these logs provide little value, suppressing them.

**How was this change tested:**
Tested with UATs and saw these log suppressed.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
