### PR TITLE
fix(plugins): safer fallback when missing GG-Plugin-Class

### DIFF
--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -99,7 +99,10 @@ public class EZPlugins implements Closeable {
         try {
             if (cls instanceof URLClassLoader) {
                 Collection<Class<?>> classes = findGreengrassPlugin((URLClassLoader) cls);
-                if (!classes.isEmpty()) {
+                // Expect that we have 1 plugin per jar. If we do not, then fallback to the classpath scanner
+                // to make sure that we aren't missing loading any plugins which haven't added the GG-Plugin-Class
+                // manifest entry.
+                if (((URLClassLoader) cls).getURLs().length == classes.size()) {
                     classes.forEach(c -> classMatchers.forEach(m -> m.accept(c)));
                     return;
                 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Trusted plugins are all loaded from the same classloader, rather than having one classloader per plugin. This means that we may fail to find all trusted plugins if the trusted plugins has a mix of plugins with and without GG-Plugin-Class manifest entry. This change has us fallback to classpath scanning if the number of classes found with the fast path does not match the number of jars loaded. This way we can still be fast, but only when all trusted plugins can use the fast path and ensure that we aren't missing any trusted plugins either.

**Why is this change necessary:**

**How was this change tested:**
Manually verified with fleet provisioning build that has the manifest entry and CLI which does not have the manifest entry. And observe that we use the slow path which loads both CLI and FP. When both CLI and FP have the fast path, then we use the fast path.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
