### PR TITLE
fix: use idle connection reaper for http clients

### DIFF
--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -257,12 +257,12 @@ public final class ProxyUtils {
         ProxyConfiguration proxyConfiguration = getProxyConfiguration();
 
         if (proxyConfiguration != null) {
-            return withClientSettings(ApacheHttpClient.builder().useIdleConnectionReaper(false))
+            return withClientSettings(ApacheHttpClient.builder())
                     .tlsTrustManagersProvider(ProxyUtils::createTrustManagers)
                     .proxyConfiguration(proxyConfiguration);
         }
 
-        return withClientSettings(ApacheHttpClient.builder().useIdleConnectionReaper(false))
+        return withClientSettings(ApacheHttpClient.builder())
                 .tlsTrustManagersProvider(ProxyUtils::createTrustManagers);
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1368 disabled idle connection reaper for http clients as a preventive measure against leaking http clients. However, it seems to introduce a new FD leak in long-running deployment tests. Since the original memory leak issue can be resolved without disabling idle connection reaper, putting it back on.


**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
