### PR TITLE
2.9.x no fast path for plugin loading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -764,11 +764,6 @@
                             <outputDirectory>
                                 src/integrationtests/resources/com/aws/greengrass/integrationtests/provisioning/
                             </outputDirectory>
-                            <archive>
-                                <manifestEntries>
-                                    <GG-Plugin-Class>com.aws.greengrass.integrationtests.provisioning.resource.TestDeviceProvisioningPluginForJar</GG-Plugin-Class>
-                                </manifestEntries>
-                            </archive>
                         </configuration>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -787,11 +787,6 @@
                             <outputDirectory>
                                 src/integrationtests/resources/com/aws/greengrass/integrationtests/provisioning/
                             </outputDirectory>
-                            <archive>
-                                <manifestEntries>
-                                    <GG-Plugin-Class>com.aws.greengrass.integrationtests.provisioning.resource.AdditionalDeviceProvisioningPluginForJar</GG-Plugin-Class>
-                                </manifestEntries>
-                            </archive>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -26,10 +26,6 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -98,9 +94,9 @@ public class EZPlugins implements Closeable {
         // Try and find the Greengrass plugin class (fast path)
         try {
             if (cls instanceof URLClassLoader) {
-                Collection<Class<?>> classes = findGreengrassPlugin((URLClassLoader) cls);
-                if (!classes.isEmpty()) {
-                    classes.forEach(c -> classMatchers.forEach(m -> m.accept(c)));
+                Class<?> clazz = findGreengrassPlugin((URLClassLoader) cls);
+                if (clazz != null) {
+                    classMatchers.forEach(m -> m.accept(clazz));
                     return;
                 }
             }
@@ -145,20 +141,14 @@ public class EZPlugins implements Closeable {
 
             // Try and find the Greengrass plugin class (fast path)
             try {
-                Collection<Class<?>> classes = findGreengrassPlugin(cl);
-                if (!classes.isEmpty()) {
-                    AtomicReference<ClassLoader> loaderRef = new AtomicReference<>();
-                    classes.forEach((clazz) -> {
-                        if (clazz.isAnnotationPresent(annotationClass)) {
-                            matcher.accept(clazz);
-                            loaderRef.set(cl);
-                        } else {
-                            logger.atWarn().log("Class {} was found, but not annotated with {}",
-                                    clazz.getSimpleName(), annotationClass.getSimpleName());
-                        }
-                    });
-                    if (loaderRef.get() != null) {
-                        return loaderRef.get();
+                Class<?> clazz = findGreengrassPlugin(cl);
+                if (clazz != null) {
+                    if (clazz.isAnnotationPresent(annotationClass)) {
+                        matcher.accept(clazz);
+                        return cl;
+                    } else {
+                        logger.atWarn().log("Class {} was found, but not annotated with {}",
+                                clazz.getSimpleName(), annotationClass.getSimpleName());
                     }
                 }
             } catch (IOException e) {
@@ -174,32 +164,27 @@ public class EZPlugins implements Closeable {
         });
     }
 
-    private synchronized Collection<Class<?>> findGreengrassPlugin(URLClassLoader cls) throws IOException {
-        Enumeration<URL> urls = cls.findResources("META-INF/MANIFEST.MF");
-        if (urls == null) {
-            return Collections.emptyList();
+    private synchronized Class<?> findGreengrassPlugin(URLClassLoader cls) throws IOException {
+        URL url = cls.findResource("META-INF/MANIFEST.MF");
+        if (url == null) {
+            return null;
         }
-
-        List<Class<?>> classes = new LinkedList<>();
-        while (urls.hasMoreElements()) {
-            URL url = urls.nextElement();
-            URLConnection conn = url.openConnection();
-            // Workaround JDK bug: https://bugs.openjdk.org/browse/JDK-8246714
-            conn.setUseCaches(false);
-            try (InputStream is = conn.getInputStream()) {
-                Manifest manifest = new Manifest(is);
-                Attributes attr = manifest.getMainAttributes();
-                if (attr != null) {
-                    String className = attr.getValue("GG-Plugin-Class");
-                    if (className != null) {
-                        classes.add(cls.loadClass(className));
-                    }
+        URLConnection conn = url.openConnection();
+        // Workaround JDK bug: https://bugs.openjdk.org/browse/JDK-8246714
+        conn.setUseCaches(false);
+        try (InputStream is = conn.getInputStream()) {
+            Manifest manifest = new Manifest(is);
+            Attributes attr = manifest.getMainAttributes();
+            if (attr != null) {
+                String className = attr.getValue("GG-Plugin-Class");
+                if (className != null) {
+                    return cls.loadClass(className);
                 }
-            } catch (ClassNotFoundException e) {
-                logger.atWarn().log("Class specified by the GG-Plugin-Class manifest entry was not found", e);
             }
+        } catch (ClassNotFoundException e) {
+            logger.atWarn().log("Class specified by the GG-Plugin-Class manifest entry was not found", e);
         }
-        return classes;
+        return null;
     }
 
     // Only use in tests to scan our own classpath for @ImplementsService

--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -99,10 +99,7 @@ public class EZPlugins implements Closeable {
         try {
             if (cls instanceof URLClassLoader) {
                 Collection<Class<?>> classes = findGreengrassPlugin((URLClassLoader) cls);
-                // Expect that we have 1 plugin per jar. If we do not, then fallback to the classpath scanner
-                // to make sure that we aren't missing loading any plugins which haven't added the GG-Plugin-Class
-                // manifest entry.
-                if (((URLClassLoader) cls).getURLs().length == classes.size()) {
+                if (!classes.isEmpty()) {
                     classes.forEach(c -> classMatchers.forEach(m -> m.accept(c)));
                     return;
                 }

--- a/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
+++ b/src/main/java/com/aws/greengrass/dependency/EZPlugins.java
@@ -272,7 +272,7 @@ public class EZPlugins implements Closeable {
         }
         matchers.add(fcs -> fcs.matchClassesImplementing(c, m));
         classMatchers.add(x -> {
-            if (c.isAssignableFrom(x)) {
+            if (x.isAssignableFrom(c)) {
                 m.processMatch((Class<? extends T>) x);
             }
         });

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -550,7 +550,7 @@ public class Kernel {
         try {
             AtomicReference<Class<?>> classReference = new AtomicReference<>();
             EZPlugins ezPlugins = context.get(EZPlugins.class);
-            ezPlugins.loadPluginAnnotatedWith(pluginJar, ImplementsService.class, (c) -> {
+            ezPlugins.loadPlugin(pluginJar, (sc) -> sc.matchClassesWithAnnotation(ImplementsService.class, (c) -> {
                 // Only use the class whose name matches what we want
                 ImplementsService serviceImplementation = c.getAnnotation(ImplementsService.class);
                 if (serviceImplementation.name().equals(name)) {
@@ -562,7 +562,7 @@ public class Kernel {
                     }
                     classReference.set(c);
                 }
-            });
+            }));
             clazz = classReference.get();
         } catch (Throwable e) {
             throw new ServiceLoadException(String.format("Unable to load %s as a plugin", name), e);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
