### PR TITLE
feat(mqtt5): add MQTT 5 publish/subscribe models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.10.6</version>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Publish.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Publish.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.List;
+
+@SuppressWarnings({"PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal", "PMD.ExcessiveParameterList"})
+@Value
+public class Publish {
+    @NonNull String topic;
+    @NonNull QOS qos;
+    /**
+     * Retain the message in the cloud MQTT broker (only last message with retain is actually kept).
+     * Subscribers will immediately receive the last retained message when they first subscribe.
+     */
+    boolean retain;
+    byte[] payload;
+    PayloadFormatIndicator payloadFormat;
+    Long messageExpiryIntervalSeconds;
+    String responseTopic;
+    byte[] correlationData;
+    String contentType;
+    List<UserProperty> userProperties;
+
+    // Readonly - Not used for Publish, only set for received messages
+    List<Long> subscriptionIdentifiers;
+
+    @Builder
+    protected Publish(String topic, QOS qos, boolean retain, byte[] payload, PayloadFormatIndicator payloadFormat,
+                      Long messageExpiryIntervalSeconds, String responseTopic, byte[] correlationData,
+                      String contentType, List<UserProperty> userProperties, List<Long> subscriptionIdentifiers) {
+        // Intern the string to deduplicate topic strings in memory
+        this.topic = topic.intern();
+        if (qos == null) {
+            qos = QOS.AT_LEAST_ONCE;
+        }
+        this.qos = qos;
+        this.retain = retain;
+        this.payload = payload;
+        this.payloadFormat = payloadFormat;
+        this.messageExpiryIntervalSeconds = messageExpiryIntervalSeconds;
+        if (responseTopic != null) {
+            responseTopic = responseTopic.intern();
+        }
+        this.responseTopic = responseTopic;
+        this.correlationData = correlationData;
+        if (contentType != null) {
+            contentType = contentType.intern();
+        }
+        this.contentType = contentType;
+        this.userProperties = userProperties;
+        this.subscriptionIdentifiers = subscriptionIdentifiers;
+    }
+
+    public enum PayloadFormatIndicator {
+        /**
+         * The payload is arbitrary binary data.
+         */
+        BYTES(0),
+
+        /**
+         * The payload is a well-formed utf-8 string value.
+         */
+        UTF8(1);
+
+        private final int indicator;
+
+        PayloadFormatIndicator(int value) {
+            indicator = value;
+        }
+
+        /**
+         * Get the integer value.
+         * @return The native enum integer value associated with this Java enum value.
+         */
+        public int getValue() {
+            return indicator;
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/QOS.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/QOS.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+public enum QOS {
+    /**
+     * The message is delivered according to the capabilities of the underlying network. No response is sent by the
+     * receiver and no retry is performed by the sender. The message arrives at the receiver either once or not at all.
+     */
+    AT_MOST_ONCE(0),
+
+    /**
+     * A level of service that ensures that the message arrives at the receiver at least once.
+     */
+    AT_LEAST_ONCE(1),
+
+    /**
+     * A level of service that ensures that the message arrives at the receiver exactly once.
+     */
+    EXACTLY_ONCE(2);
+
+    private final int qos;
+
+    QOS(int value) {
+        qos = value;
+    }
+
+    /**
+     * Get the integer value.
+     * @return The native enum integer value associated with this Java enum value
+     */
+    public int getValue() {
+        return qos;
+    }
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
@@ -19,11 +19,14 @@ public class Subscribe {
     @Builder.Default
     @NonNull QOS qos = QOS.AT_LEAST_ONCE;
 
+    @Builder.Default
     boolean noLocal = false;
 
     // True by default to request that the broker forwards MQTT packets with their original retain value.
+    @Builder.Default
     boolean retainAsPublished = true;
     // Default to SEND_ON_SUBSCRIBE which is the 0 value and the only value for MQTT 3.
+    @Builder.Default
     RetainHandlingType retainHandlingType = RetainHandlingType.SEND_ON_SUBSCRIBE;
     List<UserProperty> userProperties;
     @NonNull Consumer<Publish> callback;

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+@Builder
+@Value
+public class Subscribe {
+    @NonNull String topic;
+    @Builder.Default
+    @NonNull QOS qos = QOS.AT_LEAST_ONCE;
+
+    Boolean noLocal;
+    Boolean retainAsPublished;
+    RetainHandlingType retainHandlingType;
+    List<UserProperty> userProperties;
+    @NonNull Consumer<Publish> callback;
+
+    public enum RetainHandlingType {
+        /**
+         * The server should always send all retained messages on topics that match a subscription's filter.
+         */
+        SEND_ON_SUBSCRIBE(0),
+
+        /**
+         * The server should send retained messages on topics that match the subscription's filter, but only for the
+         * first matching subscription, per session.
+         */
+        SEND_ON_SUBSCRIBE_IF_NEW(1),
+
+        /**
+         * Subscriptions must not trigger any retained message publishes from the server.
+         */
+        DONT_SEND(2);
+
+        private final int type;
+
+        RetainHandlingType(int code) {
+            type = code;
+        }
+
+        public int getValue() {
+            return type;
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
@@ -19,9 +19,12 @@ public class Subscribe {
     @Builder.Default
     @NonNull QOS qos = QOS.AT_LEAST_ONCE;
 
-    Boolean noLocal;
-    Boolean retainAsPublished;
-    RetainHandlingType retainHandlingType;
+    boolean noLocal = false;
+
+    // True by default to request that the broker forwards MQTT packets with their original retain value.
+    boolean retainAsPublished = true;
+    // Default to SEND_ON_SUBSCRIBE which is the 0 value and the only value for MQTT 3.
+    RetainHandlingType retainHandlingType = RetainHandlingType.SEND_ON_SUBSCRIBE;
     List<UserProperty> userProperties;
     @NonNull Consumer<Publish> callback;
 

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Unsubscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Unsubscribe.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.function.Consumer;
+
+@Builder
+@Value
+public class Unsubscribe {
+    @NonNull String topic;
+    @NonNull Consumer<Publish> callback;
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Unsubscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Unsubscribe.java
@@ -15,5 +15,6 @@ import java.util.function.Consumer;
 @Value
 public class Unsubscribe {
     @NonNull String topic;
-    @NonNull Consumer<Publish> callback;
+    // The callback provided in Subscribe which should be removed from the MQTT client's callback mapping.
+    @NonNull Consumer<Publish> subscriptionCallback;
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/UserProperty.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/UserProperty.java
@@ -7,14 +7,8 @@ package com.aws.greengrass.mqttclient.v5;
 
 import lombok.Value;
 
-import java.util.Map;
-
 @Value
 public class UserProperty {
     String key;
     String value;
-
-    public static UserProperty fromEntry(Map.Entry<String, String> e) {
-        return new UserProperty(e.getKey(), e.getValue());
-    }
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/UserProperty.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/UserProperty.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.Value;
+
+import java.util.Map;
+
+@Value
+public class UserProperty {
+    String key;
+    String value;
+
+    public static UserProperty fromEntry(Map.Entry<String, String> e) {
+        return new UserProperty(e.getKey(), e.getValue());
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This PR adds classes for publish/subscribe/unsubscribe into the Nucleus so that we will be able to update the MQTT client to support MQTT5 and utilize these models for the public interface. I chose not to extend the existing interfaces and instead create new interfaces because the currently existing interfaces depend on objects that are in the CRT's MQTT 3 implementation such as `QualityOfService` and `MqttMessage`. In order to maintain compatibility with MQTT 3, the MQTT client in Nucleus can be updated to support both `Publish` (v5) and `PublishRequest` (v3) using translation code to copy the common fields. The same will also apply for subscriptions and message receipt events.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
