### PR TITLE
fix(mqtt): ensure new clients are created with unused client IDs

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -64,6 +64,8 @@ class AwsIotMqttClient implements Closeable {
     private final Provider<AwsIotMqttConnectionBuilder> builderProvider;
     @Getter
     private final String clientId;
+    @Getter
+    private final int clientIdNum;
     private MqttClientConnection connection;
     private CompletableFuture<Boolean> connectionFuture = null;
     private final AtomicBoolean currentlyConnected = new AtomicBoolean();
@@ -125,11 +127,12 @@ class AwsIotMqttClient implements Closeable {
     };
 
     AwsIotMqttClient(Provider<AwsIotMqttConnectionBuilder> builderProvider,
-                     Function<AwsIotMqttClient, Consumer<MqttMessage>> messageHandler, String clientId,
+                     Function<AwsIotMqttClient, Consumer<MqttMessage>> messageHandler, String clientId, int clientIdNum,
                      Topics mqttTopics, CallbackEventManager callbackEventManager, ExecutorService executorService,
                      ScheduledExecutorService ses) {
         this.builderProvider = builderProvider;
         this.clientId = clientId;
+        this.clientIdNum = clientIdNum;
         this.mqttTopics = mqttTopics;
         this.messageHandler = messageHandler.apply(this);
         this.callbackEventManager = callbackEventManager;

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -105,7 +105,7 @@ class AwsIotMqttClientTest {
     @Test
     void GIVEN_client_WHEN_disconnect_without_ever_connecting_THEN_succeeds()
             throws ExecutionException, InterruptedException {
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertNull(client.disconnect().get());
@@ -121,7 +121,7 @@ class AwsIotMqttClientTest {
         doNothing().when(connection).onMessage(any());
         when(builder.build()).thenReturn(connection);
 
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertThrows(ExecutionException.class, () -> {
@@ -135,7 +135,7 @@ class AwsIotMqttClientTest {
         doNothing().when(connection).onMessage(any());
         when(builder.build()).thenReturn(connection);
 
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertThrows(ExecutionException.class, () -> {
@@ -153,7 +153,7 @@ class AwsIotMqttClientTest {
         when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
 
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertFalse(client.connected());
@@ -193,7 +193,7 @@ class AwsIotMqttClientTest {
         when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
 
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         when(builder.build()).thenReturn(connection);
@@ -227,7 +227,7 @@ class AwsIotMqttClientTest {
         when(connection.publish(any(), any(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(0));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
 
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         when(builder.build()).thenReturn(connection);
@@ -243,7 +243,7 @@ class AwsIotMqttClientTest {
         when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
         when(builder.build()).thenReturn(connection);
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
 
@@ -277,7 +277,7 @@ class AwsIotMqttClientTest {
         when(connection.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));
         when(builder.withConnectionEventCallbacks(events.capture())).thenReturn(builder);
 
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertFalse(client.connected());
@@ -297,10 +297,10 @@ class AwsIotMqttClientTest {
     @Test
     void GIVEN_multiple_callbacks_in_callbackEventManager_WHEN_connections_are_resumed_THEN_oneTimeCallbacks_would_be_executed_once() {
 
-        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client1.disableRateLimiting();
-        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", mockTopic,
+        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client2.disableRateLimiting();
         boolean sessionPresent = false;
@@ -325,11 +325,11 @@ class AwsIotMqttClientTest {
     }
 
     @Test
-    void GIVEN_multiple_callbacks_in_callbackEventManager_WHEN_connections_are_interrupted_purpposely_THEN_no_callbacks_are_called() {
-        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+    void GIVEN_multiple_callbacks_in_callbackEventManager_WHEN_connections_are_interrupted_purposely_THEN_no_callbacks_are_called() {
+        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client1.disableRateLimiting();
-        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", mockTopic,
+        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client2.disableRateLimiting();
         callbackEventManager.runOnConnectionResumed(false);
@@ -352,10 +352,10 @@ class AwsIotMqttClientTest {
     @Test
     void GIVEN_multiple_callbacks_in_callbackEventManager_WHEN_connections_are_interrupted_THEN_oneTimeCallbacks_would_be_executed_once() {
 
-        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", mockTopic,
+        AwsIotMqttClient client1 = new AwsIotMqttClient(() -> builder, (x) -> null, "A", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client1.disableRateLimiting();
-        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", mockTopic,
+        AwsIotMqttClient client2 = new AwsIotMqttClient(() -> builder, (x) -> null, "B", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client2.disableRateLimiting();
         callbackEventManager.runOnConnectionResumed(false);
@@ -384,7 +384,7 @@ class AwsIotMqttClientTest {
     void GIVEN_no_topic_subscribed_WHEN_connection_interrupt_and_resume_THEN_no_resub_task_submitted()
             throws ExecutionException, InterruptedException {
         ExecutorService mockExecutor = mock(ExecutorService.class);
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", 0, mockTopic,
                 callbackEventManager, mockExecutor, ses);
         client.disableRateLimiting();
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
@@ -404,7 +404,7 @@ class AwsIotMqttClientTest {
         // setup mocks
         AwsIotMqttClient.setSubscriptionRetryMillis(500);
         AwsIotMqttClient.setWaitTimeJitterMaxMillis(10);
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
 
@@ -442,7 +442,7 @@ class AwsIotMqttClientTest {
         ignoreExceptionUltimateCauseOfType(context, Exception.class);
         AwsIotMqttClient.setSubscriptionRetryMillis(500);
         AwsIotMqttClient.setWaitTimeJitterMaxMillis(1);
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
 
@@ -502,7 +502,7 @@ class AwsIotMqttClientTest {
     void GIVEN_mqttClient_has_subscribed_to_any_topic_or_has_inprgoress_subscritpion_WHEN_isConnectionClosable_THEN_returns_false() {
         AwsIotMqttClient.setSubscriptionRetryMillis(500);
         AwsIotMqttClient.setWaitTimeJitterMaxMillis(1);
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
 
@@ -522,7 +522,7 @@ class AwsIotMqttClientTest {
     void GIVEN_mqttClient_has_no_subscribed_topic_or_any_inprgoress_subscritpion_WHEN_isConnectionClosable_THEN_returns_true() {
         AwsIotMqttClient.setSubscriptionRetryMillis(500);
         AwsIotMqttClient.setWaitTimeJitterMaxMillis(1);
-        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", mockTopic,
+        AwsIotMqttClient client = new AwsIotMqttClient(() -> builder, (x) -> null, "testClient", 0, mockTopic,
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertTrue(client.isConnectionClosable());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, our MQTT client spawns new connections as needed when each individual connection reaches 50 subscriptions. As subscriptions are then removed, the connections will be closed. Connections will not be closed in a deterministic order. Since connections are not necessarily closed in the reverse order, when we try to spawn a new connection, it determines the next client ID to use by looking only the size of the connection list. This may result in us choosing a client ID which we're already using, thus making the old and new connection unusable due to duplicate client IDs.

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
