### PR TITLE
fix: write files with SYNC in unarchive and download

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/Unarchiver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/Unarchiver.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -46,7 +47,10 @@ public class Unarchiver {
                     Utils.createPaths(newFile.getParentFile().toPath());
                     // Only unarchive when the destination file doesn't exist or the file sizes don't match
                     if (!newFile.exists() || zipEntry.getSize() != newFile.length()) {
-                        try (OutputStream fos = Files.newOutputStream(newFile.toPath());
+                        try (OutputStream fos = Files.newOutputStream(newFile.toPath(),
+                                StandardOpenOption.CREATE,
+                                StandardOpenOption.TRUNCATE_EXISTING,
+                                StandardOpenOption.SYNC);
                              InputStream is = zf.getInputStream(zipEntry)) {
                             IOUtils.copy(is, fos);
                         }

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
@@ -162,7 +162,8 @@ public abstract class ArtifactDownloader {
     protected long download(InputStream inputStream, MessageDigest messageDigest) throws PackageDownloadException {
         long totalReadBytes = 0;
         try (OutputStream artifactFile = Files.newOutputStream(saveToPath,
-                    StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.WRITE)) {
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND,
+                    StandardOpenOption.SYNC)) {
             byte[] buffer = new byte[DOWNLOAD_BUFFER_SIZE];
             int readBytes = inputStream.read(buffer);
             while (readBytes > -1) {

--- a/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
+++ b/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
@@ -191,8 +191,8 @@ public class ConfigurationWriter implements Closeable, ChildChanged {
      * @throws IOException if I/O error creating output file or writer
      */
     private static Writer newTlogWriter(Path outputPath) throws IOException {
-        return Files.newBufferedWriter(outputPath, StandardOpenOption.WRITE, StandardOpenOption.APPEND,
-                StandardOpenOption.DSYNC, StandardOpenOption.CREATE);
+        return Files.newBufferedWriter(outputPath, StandardOpenOption.APPEND,
+                StandardOpenOption.SYNC, StandardOpenOption.CREATE);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -334,7 +334,7 @@ public class DeviceProvisioningHelper {
 
             try (InputStream inputStream = executeResponse.responseBody().get();
                  OutputStream outputStream = Files.newOutputStream(f.toPath(), StandardOpenOption.CREATE,
-                         StandardOpenOption.APPEND)) {
+                         StandardOpenOption.APPEND, StandardOpenOption.SYNC)) {
                 IoUtils.copy(inputStream, outputStream);
             }
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
All usages of `newOutputStream` now use `SYNC` write mode so that all writes will be synced to disk as much as we are able to guarantee that.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
