### PR TITLE
fix: correct error type of multiple nucleus resolved error

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
+++ b/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
@@ -24,6 +24,8 @@ public enum DeploymentErrorCode {
     MISSING_DOCKER_APPLICATION_MANAGER(DeploymentErrorType.REQUEST_ERROR),
     MISSING_TOKEN_EXCHANGE_SERVICE(DeploymentErrorType.REQUEST_ERROR),
     COMPONENT_VERSION_REQUIREMENTS_NOT_MET(DeploymentErrorType.REQUEST_ERROR),
+    // deployment resolved multiple nucleus types
+    MULTIPLE_NUCLEUS_RESOLVED_ERROR(DeploymentErrorType.REQUEST_ERROR),
 
     // Greengrass cloud service errors
     CLOUD_API_ERROR(DeploymentErrorType.NONE),
@@ -111,8 +113,6 @@ public enum DeploymentErrorCode {
     // Cloud service errors
     // resolve component candidates returned more than one version
     RESOLVE_COMPONENT_CANDIDATES_BAD_RESPONSE(DeploymentErrorType.CLOUD_SERVICE_ERROR),
-    // deployment resolved multiple nucleus types
-    MULTIPLE_NUCLEUS_RESOLVED_ERROR(DeploymentErrorType.CLOUD_SERVICE_ERROR),
     DEPLOYMENT_DOCUMENT_SIZE_EXCEEDED(DeploymentErrorType.CLOUD_SERVICE_ERROR),
     GREENGRASS_ARTIFACT_SIZE_NOT_FOUND(DeploymentErrorType.CLOUD_SERVICE_ERROR),
 

--- a/src/test/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtilsTest.java
@@ -137,7 +137,7 @@ class DeploymentErrorCodeUtilsTest {
                 Arrays.asList("DEPLOYMENT_FAILURE", "IO_WRITE_ERROR", "S3_HEAD_OBJECT_ACCESS_DENIED",
                         "MULTIPLE_NUCLEUS_RESOLVED_ERROR", "COMPONENT_BROKEN", "COMPONENT_UPDATE_ERROR");
         List<String> expectedTypesFromE2 =
-                Arrays.asList("DEVICE_ERROR", "PERMISSION_ERROR", "CLOUD_SERVICE_ERROR");
+                Arrays.asList("DEVICE_ERROR", "PERMISSION_ERROR", "REQUEST_ERROR");
         testGenerateErrorReport(e, expectedStackFromE2, expectedTypesFromE2);
 
         // test a combination of inheritance and chain


### PR DESCRIPTION
**Description of changes:**
- correct the error type of `MULTIPLE_NUCLEUS_RESOLVED_ERROR` 

**Why is this change necessary:**
Previously we wrongly assumed that a deployment can never request two components of Nucleus type.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
