### PR TITLE
fix: increase file download buffer size

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/Unarchiver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/Unarchiver.java
@@ -38,6 +38,9 @@ public class Unarchiver {
     static void unzip(File zipFile, File destDir) throws IOException {
         try (ZipFile zf = new ZipFile(zipFile)) {
             Enumeration<? extends ZipEntry> entries = zf.entries();
+            // IOUtils uses a 4K buffer by default. Using 64K will make things go faster.
+            byte[] buffer = new byte[1024 * 64];
+
             while (entries.hasMoreElements()) {
                 ZipEntry zipEntry = entries.nextElement();
                 File newFile = safeNewZipFile(destDir, zipEntry);
@@ -52,7 +55,7 @@ public class Unarchiver {
                                 StandardOpenOption.TRUNCATE_EXISTING,
                                 StandardOpenOption.SYNC);
                              InputStream is = zf.getInputStream(zipEntry)) {
-                            IOUtils.copy(is, fos);
+                            IOUtils.copyLarge(is, fos, buffer);
                         }
                     }
                 }

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
@@ -40,7 +40,8 @@ public abstract class ArtifactDownloader {
     protected static final String HTTP_RANGE_HEADER_KEY = "Range";
     static final String ARTIFACT_DOWNLOAD_EXCEPTION_FMT =
             "Failed to download artifact name: '%s' for component %s-%s, reason: ";
-    private static final int DOWNLOAD_BUFFER_SIZE = 1024;
+    private static final int DOWNLOAD_BUFFER_SIZE = 1024 * 64; // Download/write with 64KB buffer
+    private static final int READ_BUFFER_SIZE = 8192;
     protected final Logger logger;
     protected final ComponentIdentifier identifier;
     protected final ComponentArtifact artifact;
@@ -64,7 +65,7 @@ public abstract class ArtifactDownloader {
 
     private void updateDigestFromFile(Path filePath, MessageDigest digest) throws IOException {
         try (InputStream existingArtifact = Files.newInputStream(filePath)) {
-            byte[] buffer = new byte[DOWNLOAD_BUFFER_SIZE];
+            byte[] buffer = new byte[READ_BUFFER_SIZE];
             int readBytes = existingArtifact.read(buffer);
             while (readBytes > -1) {
                 digest.update(buffer, 0, readBytes);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Increase download/write buffer size to 64K from 1K. 1K is too small to be efficient. Particularly since we're writing to disk with SYNC, we want each write to be as efficient as possible and using 64K blocks should be closer to ideal.

Writing 1GB on mac with 1K buffer size takes 28s. Writing using 8KB buffer takes 4s. Using 64KB takes us to ~1.5s.

Writing 1GB on mac without SYNC using a 1K buffer size takes 2.6s.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
