### PR TITLE
refactor: initial refactor to support MQTT 5 client

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCMqttProxyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCMqttProxyTest.java
@@ -96,7 +96,7 @@ class IPCMqttProxyTest {
     @BeforeEach
     void beforeEach() throws Exception {
         mqttClient = mock(MqttClient.class);
-        when(mqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
+        when(mqttClient.publish(any(PublishRequest.class))).thenReturn(CompletableFuture.completedFuture(0));
         System.setProperty("root", tempRootDir.toAbsolutePath().toString());
 
         kernel = new Kernel();
@@ -225,7 +225,7 @@ class IPCMqttProxyTest {
         CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
         String spoolerExceptionMessage = "Spooler queue is full and new message would not be added into spooler";
         completableFuture.completeExceptionally(new SpoolerStoreException(spoolerExceptionMessage));
-        when(mqttClient.publish(any())).thenReturn(completableFuture);
+        when(mqttClient.publish(any(PublishRequest.class))).thenReturn(completableFuture);
 
         GreengrassCoreIPCClient greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
         PublishToIoTCoreRequest publishToIoTCoreRequest = new PublishToIoTCoreRequest();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/telemetry/TelemetryAgentTest.java
@@ -87,7 +87,7 @@ class TelemetryAgentTest extends BaseITCase {
                 .thenReturn(publishInterval);
         when(DEFAULT_HANDLER.retrieveWithDefault(any(), eq(FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC), any()))
                 .thenReturn(DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC);
-        lenient().when(mqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
+        lenient().when(mqttClient.publish(any(PublishRequest.class))).thenReturn(CompletableFuture.completedFuture(0));
     }
 
     @AfterEach

--- a/src/main/java/com/aws/greengrass/mqttclient/IndividualMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/IndividualMqttClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient;
+
+import com.aws.greengrass.mqttclient.v5.PubAck;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
+import com.aws.greengrass.mqttclient.v5.SubscribeResponse;
+import com.aws.greengrass.mqttclient.v5.UnsubscribeResponse;
+
+import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
+
+interface IndividualMqttClient extends Closeable {
+    long getThrottlingWaitTimeMicros();
+
+    boolean canAddNewSubscription();
+
+    int subscriptionCount();
+
+    boolean isConnectionClosable();
+
+    boolean connected();
+
+    String getClientId();
+
+    int getClientIdNum();
+
+    void closeOnShutdown();
+
+    CompletableFuture<SubscribeResponse> subscribe(Subscribe subscribe);
+
+    CompletableFuture<UnsubscribeResponse> unsubscribe(String topic);
+
+    CompletableFuture<PubAck> publish(Publish publish);
+
+    @Override
+    void close();
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/PublishRequest.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/PublishRequest.java
@@ -5,6 +5,8 @@
 
 package com.aws.greengrass.mqttclient;
 
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.QOS;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -32,5 +34,16 @@ public class PublishRequest {
         this.qos = qos;
         this.retain = retain;
         this.payload = payload;
+    }
+
+    /**
+     * Convert to the new Publish type.
+     *
+     * @return {@link Publish}
+     */
+    public Publish toPublish() {
+        return Publish.builder().topic(getTopic()).payload(getPayload())
+                .qos(QOS.fromInt(getQos().getValue()))
+                .retain(isRetain()).build();
     }
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -10,7 +10,7 @@ import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.mqttclient.PublishRequest;
+import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.util.Coerce;
 
 import java.util.Iterator;
@@ -106,7 +106,7 @@ public class Spool {
      * @throws InterruptedException result from the queue implementation
      * @throws SpoolerStoreException  if the message cannot be inserted into the message spool
      */
-    public synchronized SpoolMessage addMessage(PublishRequest request) throws InterruptedException,
+    public synchronized SpoolMessage addMessage(Publish request) throws InterruptedException,
             SpoolerStoreException {
         int messageSizeInBytes = request.getPayload().length;
         if (messageSizeInBytes > getSpoolConfig().getSpoolSizeInBytes()) {
@@ -184,7 +184,7 @@ public class Spool {
         Iterator<Long> messageIdIterator = queueOfMessageId.iterator();
         while (messageIdIterator.hasNext() && addJudgementWithCurrentSpoolerSize(needToCheckCurSpoolerSize)) {
             long id = messageIdIterator.next();
-            PublishRequest request = getMessageById(id).getRequest();
+            Publish request = getMessageById(id).getRequest();
             int qos = request.getQos().getValue();
             if (qos == 0) {
                 removeMessageById(id);

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/SpoolMessage.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/SpoolMessage.java
@@ -5,7 +5,7 @@
 
 package com.aws.greengrass.mqttclient.spool;
 
-import com.aws.greengrass.mqttclient.PublishRequest;
+import com.aws.greengrass.mqttclient.v5.Publish;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,5 +18,5 @@ public class SpoolMessage {
     private long id;
     @Builder.Default @Setter
     private AtomicInteger retried = new AtomicInteger(0);
-    private PublishRequest request;
+    private Publish request;
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/PubAck.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/PubAck.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class PubAck {
+    int reasonCode;
+    String reasonString;
+    List<UserProperty> userProperties;
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/PublishResponse.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/PublishResponse.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.Value;
+
+@Value
+public class PublishResponse {
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/QOS.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/QOS.java
@@ -29,6 +29,26 @@ public enum QOS {
     }
 
     /**
+     * Create a QOS from its integer value.
+     *
+     * @param value integer value
+     * @return {@link QOS}
+     * @throws IllegalArgumentException if the value is not 0, 1, or 2
+     */
+    public static QOS fromInt(int value) {
+        switch (value) {
+            case 0:
+                return QOS.AT_MOST_ONCE;
+            case 1:
+                return QOS.AT_LEAST_ONCE;
+            case 2:
+                return QOS.EXACTLY_ONCE;
+            default:
+                throw new IllegalArgumentException(String.format("Value %d is not a valid QOS", value));
+        }
+    }
+
+    /**
      * Get the integer value.
      * @return The native enum integer value associated with this Java enum value
      */

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
@@ -29,7 +29,7 @@ public class Subscribe {
     @Builder.Default
     RetainHandlingType retainHandlingType = RetainHandlingType.SEND_ON_SUBSCRIBE;
     List<UserProperty> userProperties;
-    @NonNull Consumer<Publish> callback;
+    Consumer<Publish> callback;
 
     public enum RetainHandlingType {
         /**

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/SubscribeResponse.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/SubscribeResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+@AllArgsConstructor
+@Value
+public class SubscribeResponse {
+    @Nullable
+    String reasonString;
+    @Nullable
+    List<Integer> reasonCodes;
+    @Nullable
+    List<UserProperty> userProperties;
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Unsubscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Unsubscribe.java
@@ -16,5 +16,5 @@ import java.util.function.Consumer;
 public class Unsubscribe {
     @NonNull String topic;
     // The callback provided in Subscribe which should be removed from the MQTT client's callback mapping.
-    @NonNull Consumer<Publish> subscriptionCallback;
+    Consumer<Publish> subscriptionCallback;
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/UnsubscribeResponse.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/UnsubscribeResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient.v5;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+@AllArgsConstructor
+@Value
+public class UnsubscribeResponse {
+    @Nullable
+    String reasonString;
+    @Nullable
+    List<Integer> reasonCodes;
+    @Nullable
+    List<UserProperty> userProperties;
+}

--- a/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
@@ -92,7 +92,7 @@ class MqttProxyIPCAgentTest {
 
         CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
         completableFuture.complete(0);
-        when(mqttClient.publish(any())).thenReturn(completableFuture);
+        when(mqttClient.publish(any(PublishRequest.class))).thenReturn(completableFuture);
         when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
         ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor.forClass(PublishRequest.class);
 
@@ -123,7 +123,7 @@ class MqttProxyIPCAgentTest {
 
         CompletableFuture<Integer> f = new CompletableFuture<>();
         f.completeExceptionally(new SpoolerStoreException("Spool full"));
-        when(mqttClient.publish(any())).thenReturn(f);
+        when(mqttClient.publish(any(PublishRequest.class))).thenReturn(f);
         when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -6,6 +6,9 @@
 package com.aws.greengrass.mqttclient;
 
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.QOS;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
 import software.amazon.awssdk.crt.mqtt.MqttException;
-import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
@@ -125,7 +127,7 @@ class AwsIotMqttClientTest {
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertThrows(ExecutionException.class, () -> {
-            client.subscribe("test", QualityOfService.AT_MOST_ONCE).get();
+            client.subscribe(Subscribe.builder().topic("test").build()).get();
         });
     }
 
@@ -139,7 +141,7 @@ class AwsIotMqttClientTest {
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         assertThrows(ExecutionException.class, () -> {
-            client.subscribe("test", QualityOfService.AT_MOST_ONCE).get();
+            client.subscribe(Subscribe.builder().topic("test").build()).get();
         });
     }
 
@@ -160,7 +162,7 @@ class AwsIotMqttClientTest {
 
         when(builder.build()).thenReturn(connection);
         // Call subscribe which will cause the client to connect
-        client.subscribe("A", QualityOfService.AT_LEAST_ONCE);
+        client.subscribe(Subscribe.builder().topic("A").build());
 
         assertTrue(client.connected());
         client.reconnect();
@@ -200,14 +202,14 @@ class AwsIotMqttClientTest {
 
         Map<String, QualityOfService> expectedSubs = new HashMap<>();
         expectedSubs.put("A", QualityOfService.AT_LEAST_ONCE);
-        client.subscribe("A", QualityOfService.AT_LEAST_ONCE).get();
+        client.subscribe(Subscribe.builder().topic("A").qos(QOS.AT_LEAST_ONCE).build()).get();
         assertEquals(expectedSubs, client.getSubscriptionTopics());
 
         client.reconnect();
         assertEquals(expectedSubs, client.getSubscriptionTopics());
 
         expectedSubs.put("B", QualityOfService.AT_MOST_ONCE);
-        client.subscribe("B", QualityOfService.AT_MOST_ONCE).get();
+        client.subscribe(Subscribe.builder().topic("B").qos(QOS.AT_MOST_ONCE).build()).get();
 
         events.getValue().onConnectionInterrupted(0);
         assertEquals(expectedSubs, client.getSubscriptionTopics());
@@ -231,7 +233,7 @@ class AwsIotMqttClientTest {
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
         when(builder.build()).thenReturn(connection);
-        client.publish(new MqttMessage("A", new byte[0]), QualityOfService.AT_MOST_ONCE, false).get();
+        client.publish(Publish.builder().topic("A").payload(new byte[0]).build()).get();
         verify(connection, times(1)).publish(any(), any(), anyBoolean());
     }
 
@@ -248,12 +250,12 @@ class AwsIotMqttClientTest {
         client.disableRateLimiting();
 
         //initial connect, client connects, disconnects and then connects
-        client.subscribe("A", QualityOfService.AT_LEAST_ONCE);
+        client.subscribe(Subscribe.builder().topic("A").build());
         verify(connection, times(2)).connect();
         verify(connection, times(1)).disconnect();
 
         //client connected, no change in connect/disconnect calls
-        client.subscribe("B", QualityOfService.AT_LEAST_ONCE);
+        client.subscribe(Subscribe.builder().topic("B").build());
         verify(connection, times(2)).connect();
         verify(connection, times(1)).disconnect();
         //client calls disconnect
@@ -261,7 +263,7 @@ class AwsIotMqttClientTest {
         verify(connection, times(2)).disconnect();
 
         //client calls connect
-        client.subscribe("C", QualityOfService.AT_LEAST_ONCE);
+        client.subscribe(Subscribe.builder().topic("C").build());
         verify(connection, times(3)).connect();
 
     }
@@ -285,12 +287,12 @@ class AwsIotMqttClientTest {
         when(builder.build()).thenReturn(connection);
         // Call subscribe which will cause the client to connect
         assertThrows(ExecutionException.class, () ->
-        client.subscribe("A", QualityOfService.AT_LEAST_ONCE).get());
+        client.subscribe(Subscribe.builder().topic("A").build()).get());
 
         assertFalse(client.connected());
 
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
-        client.subscribe("A", QualityOfService.AT_LEAST_ONCE).get();
+        client.subscribe(Subscribe.builder().topic("A").build()).get();
         assertTrue(client.connected());
     }
 
@@ -421,9 +423,9 @@ class AwsIotMqttClientTest {
         when(builder.build()).thenReturn(connection);
 
         // subscribe to topics A, B, C
-        client.subscribe("A", QualityOfService.AT_LEAST_ONCE).get();
-        client.subscribe("B", QualityOfService.AT_LEAST_ONCE).get();
-        client.subscribe("C", QualityOfService.AT_LEAST_ONCE).get();
+        client.subscribe(Subscribe.builder().topic("A").build()).get();
+        client.subscribe(Subscribe.builder().topic("B").build()).get();
+        client.subscribe(Subscribe.builder().topic("C").build()).get();
         assertTrue(client.connected());
         assertEquals(3, client.subscriptionCount());
 
@@ -453,9 +455,9 @@ class AwsIotMqttClientTest {
         when(builder.build()).thenReturn(connection);
 
         // subscribe to topics A, B, C
-        client.subscribe("A", QualityOfService.AT_LEAST_ONCE).get();
-        client.subscribe("B", QualityOfService.AT_LEAST_ONCE).get();
-        client.subscribe("C", QualityOfService.AT_LEAST_ONCE).get();
+        client.subscribe(Subscribe.builder().topic("A").build()).get();
+        client.subscribe(Subscribe.builder().topic("B").build()).get();
+        client.subscribe(Subscribe.builder().topic("C").build()).get();
         assertTrue(client.connected());
         assertEquals(3, client.subscriptionCount());
 

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -143,7 +143,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         lenient().when(config.lookup(FLEET_STATUS_SEQUENCE_NUMBER_TOPIC)).thenReturn(sequenceNumberTopic);
         Topic lastPeriodicUpdateTime = Topic.of(context, FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC, Instant.now().toEpochMilli());
         lenient().when(config.lookup(FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC)).thenReturn(lastPeriodicUpdateTime);
-        lenient().when(mockMqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
+        lenient().when(mockMqttClient.publish(any(PublishRequest.class))).thenReturn(CompletableFuture.completedFuture(0));
     }
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -125,7 +125,7 @@ class TelemetryAgentTest extends GGServiceTestUtil {
         configurationTopics.createLeafChild("periodicAggregateMetricsIntervalSeconds").withValue(100);
         configurationTopics.createLeafChild("periodicPublishMetricsIntervalSeconds").withValue(300);
         lenient().when(mockDeviceConfiguration.getTelemetryConfigurationTopics()).thenReturn(configurationTopics);
-        lenient().when(mockMqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
+        lenient().when(mockMqttClient.publish(any(PublishRequest.class))).thenReturn(CompletableFuture.completedFuture(0));
         telemetryAgent = new TelemetryAgent(config, mockMqttClient, mockDeviceConfiguration, ma, sme, kme, ses, executorService,
                 3, 1);
     }

--- a/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
+++ b/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
@@ -45,7 +45,7 @@ class MqttChunkedPayloadPublisherTest {
 
     @BeforeEach
     void setup() {
-        lenient().when(mqttClient.publish(any())).thenReturn(CompletableFuture.completedFuture(0));
+        lenient().when(mqttClient.publish(any(PublishRequest.class))).thenReturn(CompletableFuture.completedFuture(0));
         publisher = new MqttChunkedPayloadPublisher<>(mqttClient);
         publisher.setUpdateTopic("topic");
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactor MQTT client, adding new methods for publish/subscribe/unsubscribe using the new MQTT 5 models. Forward the old interface for those to use the new interface. Functionality should not be any different, we're still only using MQTT 3, just changing the interface.

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
