### PR TITLE
fix: truncate job status detail values if over limit

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.SerializerFactory;
+import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -429,6 +430,10 @@ public class IotJobsHelper implements InjectionActions {
                             .log("Job status updated rejected");
                     gotResponse.completeExceptionally(new Exception(response.message));
                 });
+
+        // Truncate status detail map values longer than the 1024 characters limit
+        statusDetailsMap.entrySet().forEach(e -> statusDetailsMap.put(e.getKey(), Utils.truncate(e.getValue(), 1024)));
+
         UpdateJobExecutionRequest updateJobRequest = new UpdateJobExecutionRequest();
         updateJobRequest.jobId = jobId;
         updateJobRequest.status = status;

--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -746,4 +746,15 @@ public final class Utils {
             return true;
         });
     }
+
+    /**
+     * Truncate given string to given length.
+     *
+     * @param s string to truncate.
+     * @param l desired length.
+     * @return truncated string, or original string if length is greater than string length.
+     */
+    public static String truncate(String s, int l) {
+        return s.substring(0, Math.min(s.length(), l));
+    }
 }

--- a/src/test/java/com/aws/greengrass/util/UtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/UtilsTest.java
@@ -170,4 +170,13 @@ class UtilsTest {
         }
         verify(mockRunnable, times(1)).run();
     }
+
+    @Test
+    void GIVEN_string_WHEN_truncate_THEN_get_substring_with_correct_length() {
+        assertEquals("abcdefghij", Utils.truncate("abcdefghij", 15));
+        assertEquals("abcdefghij", Utils.truncate("abcdefghij", 10));
+        assertEquals("abcdefghi", Utils.truncate("abcdefghij", 9));
+        assertEquals("abcdef", Utils.truncate("abcdefghij", 6));
+        assertEquals("", Utils.truncate("abcdefghij", 0));
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**
-

**Description of changes:**
Job status detail values have a limit of 1024 chars https://docs.aws.amazon.com/general/latest/gr/iot_device_management.html#iot_device_management_quotas which is currently not respected, can lead to failures in publishing deployment status back. Only truncating these values for Jobs because full messages can still be helpful, and hence are retained for other deployment types and FSS

**Why is this change necessary:**
To avoid failures publishing job status due to large failure messages that exceed the limit.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
