### PR TITLE
docs: fix grammar in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ necessarily.  Some have all of these, some have only one.
 
 You can think of the nucleus as a mash-up of `make`, a super-lightweight publish/subscribe system, and a small
  hierarchic key-value data store.  The various services have continuously varying states that the nucleus monitors and manages.
-   A dependent service is not started until it's dependencies are started, and if they become unstable, the dependent service is notified.
+   A dependent service is not started until its dependencies are started, and if they become unstable, the dependent service is notified.
      The internal interconnections are handled via dependency injection. Restarts are managed automatically.
 
 When configuration changes, all users of them are notified.  Everything adapts continuously.


### PR DESCRIPTION
**Description of changes:** Removing an errant apostrophe. This should be the possessive "its", not the contraction "it's."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
