### PR TITLE
fix(spool): check for null message before dropping qos 0

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -293,10 +293,13 @@ class AwsIotMqttClient implements IndividualMqttClient {
             if (overrideCleanSession) {
                 builder.withCleanSession(true);
             }
-            connection = builder.build();
-            // Set message handler for this connection to be our global message handler in MqttClient.
-            // The handler will then send out the message to all subscribers after appropriate filtering.
-            connection.onMessage(messageHandler);
+            // Synchronize writes to connection field
+            synchronized (this) {
+                connection = builder.build();
+                // Set message handler for this connection to be our global message handler in MqttClient.
+                // The handler will then send out the message to all subscribers after appropriate filtering.
+                connection.onMessage(messageHandler);
+            }
 
             connectLimiter.acquire();
             logger.atInfo().log("Connecting to AWS IoT Core");

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 
 public class Spool {
     private static final Logger logger = LogManager.getLogger(Spool.class);
@@ -154,6 +155,7 @@ public class Spool {
         return id;
     }
 
+    @Nullable
     public SpoolMessage getMessageById(long messageId) {
         return spooler.getMessageById(messageId);
     }
@@ -184,13 +186,15 @@ public class Spool {
         Iterator<Long> messageIdIterator = queueOfMessageId.iterator();
         while (messageIdIterator.hasNext() && addJudgementWithCurrentSpoolerSize(needToCheckCurSpoolerSize)) {
             long id = messageIdIterator.next();
-            Publish request = getMessageById(id).getRequest();
-            int qos = request.getQos().getValue();
-            if (qos == 0) {
-                removeMessageById(id);
-                logger.atDebug().kv("id", id).kv("topic", request.getTopic()).kv("Qos", qos)
-                        .log("The spooler is configured to drop QoS 0 when offline. "
-                                + "Dropping message now.");
+            SpoolMessage message = getMessageById(id);
+            if (message != null) {
+                Publish request = message.getRequest();
+                int qos = request.getQos().getValue();
+                if (qos == 0) {
+                    removeMessageById(id);
+                    logger.atDebug().kv("id", id).kv("topic", request.getTopic()).kv("Qos", qos)
+                            .log("The spooler is configured to drop QoS 0 when offline. Dropping message now.");
+                }
             }
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix a NPE in the spooler where we get message by ID which could be null. Also adds synchronization when we change the connection object in `establishConnection` to try and resolve a possible race.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
