### PR TITLE
test: ignore MQTT 5 exception when closing connection in test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
@@ -191,6 +191,8 @@ public class BaseE2ETestCase implements AutoCloseable {
         ignoreExceptionUltimateCauseWithMessageSubstring(context, "The connection was closed unexpectedly");
         ignoreExceptionUltimateCauseWithMessageSubstring(context,
                 "Old requests from the previous session are cancelled");
+        ignoreExceptionUltimateCauseWithMessageSubstring(context,
+                "client connection interrupted by user request");
     }
 
     @BeforeAll

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/MultipleDeploymentsTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/deployment/MultipleDeploymentsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import software.amazon.awssdk.services.greengrassv2.model.ComponentDeploymentSpecification;
 import software.amazon.awssdk.services.greengrassv2.model.CreateDeploymentRequest;
 import software.amazon.awssdk.services.greengrassv2.model.CreateDeploymentResponse;
@@ -37,6 +38,7 @@ import static com.aws.greengrass.deployment.DeploymentStatusKeeper.DEPLOYMENT_ST
 import static com.aws.greengrass.deployment.DeploymentStatusKeeper.PROCESSED_DEPLOYMENTS_TOPICS;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseWithMessageSubstring;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(GGExtension.class)
@@ -48,7 +50,10 @@ class MultipleDeploymentsTest extends BaseE2ETestCase {
     }
 
     @BeforeEach
-    void beforeEach() throws Exception {
+    void beforeEach2(ExtensionContext context) throws Exception {
+        // Depending on the order that we receive the jobs, we expect that the job may already be canceled, so this
+        // exception is fine and we want the test to continue.
+        ignoreExceptionUltimateCauseWithMessageSubstring(context, "finished with status CANCELED");
         initKernel();
     }
 

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -242,7 +242,8 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                     .thenApply(SubscribeResponse::fromCrtSubAck)
                     .whenComplete((r, error) -> {
                         synchronized (this) {
-                            if (error == null && (r.getReasonCodes() == null || r.getReasonCodes().stream()
+                            if (error == null && r != null
+                                    && (r.getReasonCodes() == null || r.getReasonCodes().stream()
                                     // reason codes less than or equal to 2 are positive responses
                                     .allMatch(i -> i <= 2))) {
                                 subscriptionTopics.add(subscribe);
@@ -254,11 +255,13 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                                 if (error != null) {
                                     l.cause(error);
                                 }
-                                if (r.getReasonCodes() != null) {
-                                    l.kv("reasonCodes", r.getReasonCodes());
-                                }
-                                if (Utils.isNotEmpty(r.getReasonString())) {
-                                    l.kv("reason", r.getReasonString());
+                                if (r != null) {
+                                    if (r.getReasonCodes() != null) {
+                                        l.kv("reasonCodes", r.getReasonCodes());
+                                    }
+                                    if (Utils.isNotEmpty(r.getReasonString())) {
+                                        l.kv("reason", r.getReasonString());
+                                    }
                                 }
                                 l.log("Error subscribing to topic");
                             }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding new ignore rule for an exception which is thrown by the MQTT 5 client when the client shutsdown while some work is still pending.

Also fixes a possible NPE for a SubscribeResponse found when running the E2E tests.

**Why is this change necessary:**

**How was this change tested:**
Ran e2e tests locally to verify this error doesn't cause the tests to fail.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [x] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
