### PR TITLE
fix(windows): bootstrap script works with spaces in root path

### DIFF
--- a/conf/recipe.yaml
+++ b/conf/recipe.yaml
@@ -59,4 +59,4 @@ Manifests:
       bootstrap:
         RequiresPrivilege: true
         script: >-
-          copy {kernel:rootPath}\alts\current\distro\bin\greengrass.xml {artifacts:decompressedPath}\aws.greengrass.nucleus\bin\greengrass.xml& del /q {kernel:rootPath}\alts\current\*&& for /d %x in ({kernel:rootPath}\alts\current\*) do @rd /s /q "%x"&& echo {configuration:/jvmOptions} > {kernel:rootPath}\alts\current\launch.params&& mklink /d {kernel:rootPath}\alts\current\distro {artifacts:decompressedPath}\aws.greengrass.nucleus&& exit 100
+          copy "{kernel:rootPath}\alts\current\distro\bin\greengrass.xml" "{artifacts:decompressedPath}\aws.greengrass.nucleus\bin\greengrass.xml"& del /q "{kernel:rootPath}\alts\current\*"&& for /d %x in ("{kernel:rootPath}\alts\current\*") do @rd /s /q "%x"&& echo {configuration:/jvmOptions} > "{kernel:rootPath}\alts\current\launch.params"&& mklink /d "{kernel:rootPath}\alts\current\distro" "{artifacts:decompressedPath}\aws.greengrass.nucleus"&& exit 100


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix nucleus bootstrap script for windows to work when there can be spaces in greengrass root path
Published a private component with the following bootstrap script and verified that deployment to update nucleus version passes when there is space in root path. 

{
  "bootstrap": {
    "requiresPrivilege": "true",
    "script": "copy \"{kernel:rootPath}\\alts\\current\\distro\\bin\\greengrass.xml\" \"{artifacts:decompressedPath}\\aws.greengrass.nucleus\\bin\\greengrass.xml\"& del /q \"{kernel:rootPath}\\alts\\current\\*\"&& for /d %x in (\"{kernel:rootPath}\\alts\\current\\*\") do @rd /s /q \"%x\"&& echo {configuration:/jvmOptions} > \"{kernel:rootPath}\\alts\\current\\launch.params\"&& mklink /d \"{kernel:rootPath}\\alts\\current\\distro\" \"{artifacts:decompressedPath}\\aws.greengrass.nucleus\"&& exit 100"
  }
}



**Why is this change necessary:**
Without this fix, when root path includes space(s), the nucleus version update fails

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
