### PR TITLE
feat(mqtt-ipc): mqtt IPC use mqtt 5

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/mqttclient/MqttClientPublishTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/mqttclient/MqttClientPublishTest.java
@@ -14,8 +14,8 @@ import com.aws.greengrass.integrationtests.ipc.IPCTestUtils;
 import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
-import com.aws.greengrass.mqttclient.PublishRequest;
 import com.aws.greengrass.mqttclient.spool.Spool;
+import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.Coerce;
@@ -31,7 +31,6 @@ import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.QOS;
 import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
-import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5Client;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
 import software.amazon.awssdk.crt.mqtt5.OnConnectionSuccessReturn;
@@ -171,12 +170,12 @@ public class MqttClientPublishTest extends BaseITCase {
         greengrassCoreIPCClient.publishToIoTCore(publishToIoTCoreRequest, Optional.empty()).getResponse()
                 .get(TIMEOUT_FOR_MQTTPROXY_SECONDS, TimeUnit.SECONDS);
 
-        ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+        ArgumentCaptor<Publish> publishRequestArgumentCaptor = ArgumentCaptor.forClass(Publish.class);
         verify(mqttClient).publish(publishRequestArgumentCaptor.capture());
-        PublishRequest capturedPublishRequest = publishRequestArgumentCaptor.getValue();
+        Publish capturedPublishRequest = publishRequestArgumentCaptor.getValue();
         assertThat(capturedPublishRequest.getPayload(), is(TEST_GOOD_PAYLOAD));
         assertThat(capturedPublishRequest.getTopic(), is(TEST_GOOD_PUBLISH_TOPIC));
-        assertThat(capturedPublishRequest.getQos(), is(QualityOfService.AT_LEAST_ONCE));
+        assertThat(capturedPublishRequest.getQos(), is(com.aws.greengrass.mqttclient.v5.QOS.AT_LEAST_ONCE));
     }
 
     @Test

--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -11,9 +11,13 @@ import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.MqttClient;
-import com.aws.greengrass.mqttclient.PublishRequest;
-import com.aws.greengrass.mqttclient.SubscribeRequest;
-import com.aws.greengrass.mqttclient.UnsubscribeRequest;
+import com.aws.greengrass.mqttclient.MqttRequestException;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
+import com.aws.greengrass.mqttclient.v5.Unsubscribe;
+import com.aws.greengrass.mqttclient.v5.UserProperty;
+import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Utils;
 import lombok.AccessLevel;
 import lombok.Setter;
@@ -22,6 +26,7 @@ import software.amazon.awssdk.aws.greengrass.GeneratedAbstractSubscribeToIoTCore
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 import software.amazon.awssdk.aws.greengrass.model.IoTCoreMessage;
 import software.amazon.awssdk.aws.greengrass.model.MQTTMessage;
+import software.amazon.awssdk.aws.greengrass.model.PayloadFormat;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreResponse;
 import software.amazon.awssdk.aws.greengrass.model.QOS;
@@ -29,20 +34,19 @@ import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreResponse;
 import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
-import software.amazon.awssdk.crt.mqtt.MqttMessage;
-import software.amazon.awssdk.crt.mqtt.QualityOfService;
+import software.amazon.awssdk.crt.mqtt5.packets.SubAckPacket;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
+import static com.aws.greengrass.mqttclient.v5.QOS.AT_LEAST_ONCE;
+import static com.aws.greengrass.mqttclient.v5.QOS.AT_MOST_ONCE;
 
 public class MqttProxyIPCAgent {
     private static final Logger LOGGER = LogManager.getLogger(MqttProxyIPCAgent.class);
@@ -86,7 +90,7 @@ public class MqttProxyIPCAgent {
 
         }
 
-        @SuppressWarnings("PMD.PreserveStackTrace")
+        @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.AvoidInstanceofChecksInCatchClause"})
         @Override
         public PublishToIoTCoreResponse handleRequest(PublishToIoTCoreRequest request) {
             return translateExceptions(() -> {
@@ -101,16 +105,32 @@ public class MqttProxyIPCAgent {
                 }
 
                 byte[] payload = validatePayload(request.getPayload(), serviceName);
-                QualityOfService qos = validateQoS(request.getQosAsString(), serviceName);
-                PublishRequest publishRequest = PublishRequest.builder().payload(payload).topic(topic).qos(qos).build();
-                CompletableFuture<Integer> future = mqttClient.publish(publishRequest);
+                com.aws.greengrass.mqttclient.v5.QOS qos = validateQoS(request.getQosAsString(), serviceName);
+                Publish publishRequest = Publish.builder()
+                        .payload(payload)
+                        .topic(topic)
+                        .qos(qos)
+                        .retain(Coerce.toBoolean(request.isRetain()))
+                        .correlationData(request.getCorrelationData())
+                        .responseTopic(request.getResponseTopic())
+                        .messageExpiryIntervalSeconds(request.getMessageExpiryIntervalSeconds())
+                        .userProperties(request.getUserProperties() == null ? null :
+                                request.getUserProperties().stream()
+                                        .map((u) -> new UserProperty(u.getKey(), u.getValue()))
+                                        .collect(Collectors.toList()))
+                        .payloadFormat(
+                                request.getPayloadFormat() == null || request.getPayloadFormat() == PayloadFormat.BYTES
+                                        ? Publish.PayloadFormatIndicator.BYTES : Publish.PayloadFormatIndicator.UTF8)
+                        .build();
 
-                // If the future is completed exceptionally then the MqttClient was unable to spool the request
                 try {
-                    future.getNow(0);
-                } catch (CompletionException e) {
+                    mqttClient.publish(publishRequest);
+                } catch (MqttRequestException | SpoolerStoreException | InterruptedException e) {
+                    if (e instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
                     throw new ServiceError(String.format("Publish to topic %s failed: %s", topic,
-                            e.getCause().getMessage()));
+                            Utils.getUltimateMessage(e)));
                 }
 
                 return new PublishToIoTCoreResponse();
@@ -129,7 +149,7 @@ public class MqttProxyIPCAgent {
 
         private String subscribedTopic;
 
-        private Consumer<MqttMessage> subscriptionCallback;
+        private Consumer<Publish> subscriptionCallback;
 
         protected SubscribeToIoTCoreOperationHandler(OperationContinuationHandlerContext context) {
             super(context);
@@ -139,21 +159,33 @@ public class MqttProxyIPCAgent {
         @Override
         protected void onStreamClosed() {
             if (!Utils.isEmpty(subscribedTopic)) {
-                UnsubscribeRequest unsubscribeRequest =
-                        UnsubscribeRequest.builder().callback(subscriptionCallback).topic(subscribedTopic).build();
+                Unsubscribe unsubscribeRequest =
+                        Unsubscribe.builder().subscriptionCallback(subscriptionCallback).topic(subscribedTopic).build();
 
                 try {
-                    mqttClient.unsubscribe(unsubscribeRequest);
-                } catch (ExecutionException | InterruptedException | TimeoutException e) {
+                    mqttClient.unsubscribe(unsubscribeRequest).exceptionally((t) -> {
+                        LOGGER.atError()
+                                .kv(COMPONENT_NAME, serviceName)
+                                .kv(TOPIC_KEY, subscribedTopic)
+                                .cause(t)
+                                .log("Stream closed but unable to unsubscribe from topic");
+                        return null;
+                    });
+                } catch (MqttRequestException e) {
                     LOGGER.atError().cause(e).kv(TOPIC_KEY, subscribedTopic).kv(COMPONENT_NAME, serviceName)
                             .log("Stream closed but unable to unsubscribe from topic");
                 }
             }
         }
 
-        @SuppressWarnings("PMD.PreserveStackTrace")
         @Override
         public SubscribeToIoTCoreResponse handleRequest(SubscribeToIoTCoreRequest request) {
+            return null;
+        }
+
+        @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.AvoidCatchingGenericException"})
+        @Override
+        public CompletableFuture<SubscribeToIoTCoreResponse> handleRequestAsync(SubscribeToIoTCoreRequest request) {
             return translateExceptions(() -> {
                 String topic = validateTopic(request.getTopicName(), serviceName);
 
@@ -164,23 +196,43 @@ public class MqttProxyIPCAgent {
                     throw new UnauthorizedError(UNAUTHORIZED_ERROR);
                 }
 
-                Consumer<MqttMessage> callback = this::forwardToSubscriber;
-                QualityOfService qos = validateQoS(request.getQosAsString(), serviceName);
-                SubscribeRequest subscribeRequest = SubscribeRequest.builder().callback(callback).topic(topic)
+                Consumer<Publish> callback = this::forwardToSubscriber;
+                com.aws.greengrass.mqttclient.v5.QOS qos = validateQoS(request.getQosAsString(), serviceName);
+                Subscribe subscribeRequest = Subscribe.builder().callback(callback).topic(topic)
                         .qos(qos).build();
 
                 try {
-                    mqttClient.subscribe(subscribeRequest);
-                } catch (ExecutionException | InterruptedException | TimeoutException e) {
+                    subscribedTopic = topic;
+                    subscriptionCallback = callback;
+
+                    return mqttClient.subscribe(subscribeRequest).exceptionally((t) -> {
+                        LOGGER.atError().cause(t).kv(TOPIC_KEY, topic).kv(COMPONENT_NAME, serviceName)
+                                .log("Unable to subscribe to topic");
+                        throw new ServiceError(String.format("Subscribe to topic %s failed with error %s", topic, t));
+                    }).thenApply((i) -> {
+                        if (i != null) {
+                            int rc = i.getReasonCode();
+                            if (rc > 2) {
+                                String rcString = SubAckPacket.SubAckReasonCode.UNSPECIFIED_ERROR.name();
+                                try {
+                                    rcString = SubAckPacket.SubAckReasonCode.getEnumValueFromInteger(rc).name();
+                                } catch (RuntimeException ignored) {
+                                }
+
+                                throw new ServiceError(
+                                        String.format("Subscribe to topic %s failed with error %s", topic,
+                                                rcString))
+                                        .withContext(Utils.immutableMap("reasonString", i.getReasonString(),
+                                                "reasonCode", i.getReasonCode()));
+                            }
+                        }
+                        return new SubscribeToIoTCoreResponse();
+                    });
+                } catch (MqttRequestException e) {
                     LOGGER.atError().cause(e).kv(TOPIC_KEY, topic).kv(COMPONENT_NAME, serviceName)
                             .log("Unable to subscribe to topic");
                     throw new ServiceError(String.format("Subscribe to topic %s failed with error %s", topic, e));
                 }
-
-                subscribedTopic = topic;
-                subscriptionCallback = callback;
-
-                return new SubscribeToIoTCoreResponse();
             });
         }
 
@@ -189,14 +241,25 @@ public class MqttProxyIPCAgent {
 
         }
 
-        private void forwardToSubscriber(MqttMessage message) {
-            MQTTMessage mqttMessage = new MQTTMessage();
-            mqttMessage.setTopicName(message.getTopic());
-            mqttMessage.setPayload(message.getPayload());
+        private void forwardToSubscriber(Publish m) {
 
-            IoTCoreMessage iotCoreMessage = new IoTCoreMessage();
-            iotCoreMessage.setMessage(mqttMessage);
-            this.sendStreamEvent(iotCoreMessage);
+            this.sendStreamEvent(new IoTCoreMessage().withMessage(
+                    new MQTTMessage()
+                            .withTopicName(m.getTopic())
+                            .withPayload(m.getPayload())
+                            .withCorrelationData(m.getCorrelationData())
+                            .withMessageExpiryIntervalSeconds(m.getMessageExpiryIntervalSeconds())
+                            .withResponseTopic(m.getResponseTopic())
+                            .withRetain(m.isRetain())
+                            .withContentType(m.getContentType()).withPayloadFormat(
+                                    m.getPayloadFormat() == null || m.getPayloadFormat()
+                                            == Publish.PayloadFormatIndicator.BYTES ? PayloadFormat.BYTES :
+                                            PayloadFormat.UTF8)
+                            .withUserProperties(m.getUserProperties() == null ? null : m.getUserProperties().stream()
+                                    .map((u) -> new software.amazon.awssdk.aws.greengrass.model.UserProperty()
+                                            .withKey(u.getKey()).withValue(u.getValue()))
+                                    .collect(Collectors.toList()))
+            ));
         }
     }
 
@@ -216,16 +279,16 @@ public class MqttProxyIPCAgent {
         return payload;
     }
 
-    private QualityOfService validateQoS(String qosAsString, String serviceName) {
+    private com.aws.greengrass.mqttclient.v5.QOS validateQoS(String qosAsString, String serviceName) {
         if (qosAsString == null) {
             LOGGER.atError().kv(COMPONENT_NAME, serviceName).log(NO_QOS_ERROR);
             throw new InvalidArgumentsError(NO_QOS_ERROR);
         }
 
         if (qosAsString.equals(QOS.AT_LEAST_ONCE.getValue())) {
-            return QualityOfService.AT_LEAST_ONCE;
+            return AT_LEAST_ONCE;
         } else if (qosAsString.equals(QOS.AT_MOST_ONCE.getValue())) {
-            return QualityOfService.AT_MOST_ONCE;
+            return AT_MOST_ONCE;
         } else {
             LOGGER.atError().kv(COMPONENT_NAME, serviceName).kv("QoS", qosAsString).log(INVALID_QOS_ERROR);
             throw new InvalidArgumentsError(INVALID_QOS_ERROR + ": " + qosAsString);

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -242,10 +242,8 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                     .thenApply(SubscribeResponse::fromCrtSubAck)
                     .whenComplete((r, error) -> {
                         synchronized (this) {
-                            if (error == null && r != null
-                                    && (r.getReasonCodes() == null || r.getReasonCodes().stream()
-                                    // reason codes less than or equal to 2 are positive responses
-                                    .allMatch(i -> i <= 2))) {
+                            // reason codes less than or equal to 2 are positive responses
+                            if (error == null && r != null && r.getReasonCode() <= 2) {
                                 subscriptionTopics.add(subscribe);
                                 logger.atDebug().kv(TOPIC_KEY, subscribe.getTopic())
                                         .kv(QOS_KEY, subscribe.getQos().name())
@@ -256,9 +254,7 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                                     l.cause(error);
                                 }
                                 if (r != null) {
-                                    if (r.getReasonCodes() != null) {
-                                        l.kv("reasonCodes", r.getReasonCodes());
-                                    }
+                                    l.kv("reasonCode", r.getReasonCode());
                                     if (Utils.isNotEmpty(r.getReasonString())) {
                                         l.kv("reason", r.getReasonString());
                                     }

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -195,7 +195,7 @@ class AwsIotMqttClient implements IndividualMqttClient {
     public CompletableFuture<SubscribeResponse> subscribe(Subscribe subscribe) {
         return subscribe(subscribe.getTopic(),
                 QualityOfService.getEnumValueFromInteger(subscribe.getQos().getValue()))
-                .thenApply((i) -> new SubscribeResponse(null, null, null));
+                .thenApply((i) -> new SubscribeResponse(null, subscribe.getQos().getValue(), null));
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/SubscribeResponse.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/SubscribeResponse.java
@@ -18,8 +18,9 @@ import javax.annotation.Nullable;
 public class SubscribeResponse {
     @Nullable
     String reasonString;
-    @Nullable
-    List<Integer> reasonCodes;
+
+    // Our subscribe only lets us specify a single topic, so we will only get a single reason code back
+    int reasonCode;
     @Nullable
     List<UserProperty> userProperties;
 
@@ -30,10 +31,10 @@ public class SubscribeResponse {
      * @return SubscribeResponse
      */
     public static SubscribeResponse fromCrtSubAck(SubAckPacket r) {
-        return new SubscribeResponse(r.getReasonString(), r.getReasonCodes() == null ? null
-                : r.getReasonCodes().stream().map(SubAckPacket.SubAckReasonCode::getValue).collect(Collectors.toList()),
-                r.getUserProperties() == null ? null
-                        : r.getUserProperties().stream().map((u) -> new UserProperty(u.key, u.value))
-                                .collect(Collectors.toList()));
+        return new SubscribeResponse(r.getReasonString(), r.getReasonCodes() == null ? 0
+                : r.getReasonCodes().stream().map(SubAckPacket.SubAckReasonCode::getValue).max(Integer::compareTo)
+                        .orElse(0), r.getUserProperties() == null ? null
+                : r.getUserProperties().stream().map((u) -> new UserProperty(u.key, u.value))
+                        .collect(Collectors.toList()));
     }
 }

--- a/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
@@ -9,10 +9,12 @@ import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.AuthorizationHandler.ResourceLookupPolicy;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.mqttclient.MqttClient;
-import com.aws.greengrass.mqttclient.PublishRequest;
-import com.aws.greengrass.mqttclient.SubscribeRequest;
-import com.aws.greengrass.mqttclient.UnsubscribeRequest;
+import com.aws.greengrass.mqttclient.MqttRequestException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.PublishResponse;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
+import com.aws.greengrass.mqttclient.v5.Unsubscribe;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,13 +33,12 @@ import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreResponse;
 import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
-import software.amazon.awssdk.crt.mqtt.MqttMessage;
-import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
@@ -74,13 +75,15 @@ class MqttProxyIPCAgentTest {
     private MqttProxyIPCAgent mqttProxyIPCAgent;
 
     @BeforeEach
-    void setup() {
+    void setup() throws MqttRequestException {
         lenient().when(mockContext.getContinuation()).thenReturn(mock(ServerConnectionContinuation.class));
         lenient().when(mockContext.getAuthenticationData()).thenReturn(mockAuthenticationData);
         lenient().when(mockAuthenticationData.getIdentityLabel()).thenReturn(TEST_SERVICE);
         mqttProxyIPCAgent = new MqttProxyIPCAgent();
         mqttProxyIPCAgent.setMqttClient(mqttClient);
         mqttProxyIPCAgent.setAuthorizationHandler(authorizationHandler);
+        lenient().when(mqttClient.subscribe(any(Subscribe.class))).thenReturn(CompletableFuture.completedFuture(null));
+        lenient().when(mqttClient.unsubscribe(any(Unsubscribe.class))).thenReturn(CompletableFuture.completedFuture(null));
     }
 
     @Test
@@ -90,11 +93,9 @@ class MqttProxyIPCAgentTest {
         publishToIoTCoreRequest.setTopicName(TEST_TOPIC);
         publishToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
 
-        CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
-        completableFuture.complete(0);
-        when(mqttClient.publish(any(PublishRequest.class))).thenReturn(completableFuture);
+        when(mqttClient.publish(any(Publish.class))).thenReturn(new PublishResponse());
         when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
-        ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+        ArgumentCaptor<Publish> publishRequestArgumentCaptor = ArgumentCaptor.forClass(Publish.class);
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getPublishToIoTCoreOperationHandler(mockContext)) {
@@ -107,10 +108,10 @@ class MqttProxyIPCAgentTest {
                     .resource(TEST_TOPIC).build(), ResourceLookupPolicy.MQTT_STYLE);
 
             verify(mqttClient).publish(publishRequestArgumentCaptor.capture());
-            PublishRequest capturedPublishRequest = publishRequestArgumentCaptor.getValue();
+            Publish capturedPublishRequest = publishRequestArgumentCaptor.getValue();
             assertThat(capturedPublishRequest.getPayload(), is(TEST_PAYLOAD));
             assertThat(capturedPublishRequest.getTopic(), is(TEST_TOPIC));
-            assertThat(capturedPublishRequest.getQos(), is(QualityOfService.AT_LEAST_ONCE));
+            assertThat(capturedPublishRequest.getQos(), is(com.aws.greengrass.mqttclient.v5.QOS.AT_LEAST_ONCE));
         }
     }
 
@@ -121,9 +122,7 @@ class MqttProxyIPCAgentTest {
         publishToIoTCoreRequest.setTopicName(TEST_TOPIC);
         publishToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
 
-        CompletableFuture<Integer> f = new CompletableFuture<>();
-        f.completeExceptionally(new SpoolerStoreException("Spool full"));
-        when(mqttClient.publish(any(PublishRequest.class))).thenReturn(f);
+        when(mqttClient.publish(any(Publish.class))).thenThrow(new SpoolerStoreException("Spool full"));
         when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
 
         try (MqttProxyIPCAgent.PublishToIoTCoreOperationHandler publishToIoTCoreOperationHandler
@@ -141,16 +140,17 @@ class MqttProxyIPCAgentTest {
         subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
 
         when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
-        ArgumentCaptor<SubscribeRequest> subscribeRequestArgumentCaptor
-                = ArgumentCaptor.forClass(SubscribeRequest.class);
-        ArgumentCaptor<UnsubscribeRequest> unsubscribeRequestArgumentCaptor
-                = ArgumentCaptor.forClass(UnsubscribeRequest.class);
+        ArgumentCaptor<Subscribe> subscribeRequestArgumentCaptor
+                = ArgumentCaptor.forClass(Subscribe.class);
+        ArgumentCaptor<Unsubscribe> unsubscribeRequestArgumentCaptor
+                = ArgumentCaptor.forClass(Unsubscribe.class);
         ArgumentCaptor<IoTCoreMessage> ioTCoreMessageArgumentCaptor = ArgumentCaptor.forClass(IoTCoreMessage.class);
 
         try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
                      = spy(mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext))) {
-            SubscribeToIoTCoreResponse subscribeToIoTCoreResponse
-                    = subscribeToIoTCoreOperationHandler.handleRequest(subscribeToIoTCoreRequest);
+            SubscribeToIoTCoreResponse subscribeToIoTCoreResponse =
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS);
 
             assertNotNull(subscribeToIoTCoreResponse);
             verify(authorizationHandler).isAuthorized(MQTT_PROXY_SERVICE_NAME, Permission.builder().principal(TEST_SERVICE)
@@ -158,12 +158,12 @@ class MqttProxyIPCAgentTest {
                     .resource(TEST_TOPIC).build(), ResourceLookupPolicy.MQTT_STYLE);
 
             verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
-            SubscribeRequest capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
+            Subscribe capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
             assertThat(capturedSubscribeRequest.getTopic(), is(TEST_TOPIC));
-            assertThat(capturedSubscribeRequest.getQos(), is(QualityOfService.AT_LEAST_ONCE));
+            assertThat(capturedSubscribeRequest.getQos(), is(com.aws.greengrass.mqttclient.v5.QOS.AT_LEAST_ONCE));
 
-            Consumer<MqttMessage> callback = capturedSubscribeRequest.getCallback();
-            MqttMessage message = new MqttMessage(TEST_TOPIC, TEST_PAYLOAD);
+            Consumer<Publish> callback = capturedSubscribeRequest.getCallback();
+            Publish message = Publish.builder().payload(TEST_PAYLOAD).topic(TEST_TOPIC).build();
             doReturn(new CompletableFuture<>()).when(subscribeToIoTCoreOperationHandler).sendStreamEvent(any());
             callback.accept(message);
             verify(subscribeToIoTCoreOperationHandler).sendStreamEvent(ioTCoreMessageArgumentCaptor.capture());
@@ -173,9 +173,9 @@ class MqttProxyIPCAgentTest {
 
             subscribeToIoTCoreOperationHandler.onStreamClosed();
             verify(mqttClient).unsubscribe(unsubscribeRequestArgumentCaptor.capture());
-            UnsubscribeRequest capturedUnsubscribedRequest = unsubscribeRequestArgumentCaptor.getValue();
+            Unsubscribe capturedUnsubscribedRequest = unsubscribeRequestArgumentCaptor.getValue();
             assertThat(capturedUnsubscribedRequest.getTopic(), is(TEST_TOPIC));
-            assertThat(capturedUnsubscribedRequest.getCallback(), is(callback));
+            assertThat(capturedUnsubscribedRequest.getSubscriptionCallback(), is(callback));
         }
     }
 
@@ -253,7 +253,7 @@ class MqttProxyIPCAgentTest {
         try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
             assertThrows(InvalidArgumentsError.class, () -> {
-                subscribeToIoTCoreOperationHandler.handleRequest(subscribeToIoTCoreRequest);
+                subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest).get(1, TimeUnit.SECONDS);
             });
         }
     }
@@ -268,7 +268,7 @@ class MqttProxyIPCAgentTest {
         try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
             assertThrows(InvalidArgumentsError.class, () -> {
-                subscribeToIoTCoreOperationHandler.handleRequest(subscribeToIoTCoreRequest);
+                subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest).get(1, TimeUnit.SECONDS);
             });
         }
     }
@@ -281,7 +281,7 @@ class MqttProxyIPCAgentTest {
         try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
                      = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
             assertThrows(InvalidArgumentsError.class, () -> {
-                subscribeToIoTCoreOperationHandler.handleRequest(subscribeToIoTCoreRequest);
+                subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest).get(1, TimeUnit.SECONDS);
             });
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updates the IPC MQTT proxy implementation to use MQTT 5 client and models. Makes the subscribe API async so that we don't block the IPC event loop while waiting for the subscription to complete.

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
