### PR TITLE
fix(mqtt5): use proxy tunneling mode

### DIFF
--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -195,6 +195,7 @@ public final class ProxyUtils {
         HttpProxyOptions httpProxyOptions = new HttpProxyOptions();
         httpProxyOptions.setHost(ProxyUtils.getHostFromProxyUrl(proxyUrl));
         httpProxyOptions.setPort(ProxyUtils.getPortFromProxyUrl(proxyUrl));
+        httpProxyOptions.setConnectionType(HttpProxyOptions.HttpProxyConnectionType.Tunneling);
 
         if ("https".equalsIgnoreCase(getSchemeFromProxyUrl(proxyUrl))) {
             httpProxyOptions.setTlsContext(tlsContext);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set http proxy to tunneling mode which is what it would be doing behind the scenes anyway. This is required for MQTT 5 now.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
