### PR TITLE
fix: improvements to config loading logic

### DIFF
--- a/src/main/java/com/aws/greengrass/config/Configuration.java
+++ b/src/main/java/com/aws/greengrass/config/Configuration.java
@@ -269,6 +269,7 @@ public class Configuration {
                 mergeMap(timestamp, yamlMapper.readValue(in, Map.class));
                 break;
             case "tlog":
+            case "tlog~":
                 ConfigurationReader.mergeTLogInto(this, in, false, null);
                 break;
             default:

--- a/src/main/java/com/aws/greengrass/config/ConfigurationReader.java
+++ b/src/main/java/com/aws/greengrass/config/ConfigurationReader.java
@@ -107,7 +107,7 @@ public final class ConfigurationReader {
      * Validate the tlog contents at the given path.
      *
      * @param tlogPath path to the file to validate.
-     * @return true if all entries in the file are valid
+     * @return true if all entries in the file are valid;
      *         false if file doesn't exist, is empty, or contains invalid entry
      */
     public static boolean validateTlog(Path tlogPath) {

--- a/src/main/java/com/aws/greengrass/config/ConfigurationReader.java
+++ b/src/main/java/com/aws/greengrass/config/ConfigurationReader.java
@@ -104,41 +104,56 @@ public final class ConfigurationReader {
     }
 
     /**
-     * Validate the tlog contents at the given path. Throws an IOException if any entry is invalid.
+     * Validate the tlog contents at the given path.
      *
      * @param tlogPath path to the file to validate.
-     * @throws IOException if any entry is invalid.
+     * @return true if all entries in the file are valid
+     *         false if file doesn't exist, is empty, or contains invalid entry
      */
-    public static void validateTlog(Path tlogPath) throws IOException {
-        try (BufferedReader in = Files.newBufferedReader(tlogPath)) {
-            // We have seen two different file corruption scenarios
-            // 1. The last line of config file is corrupted with non-UTF8 characters and BufferedReader::readLine
-            // throws a MalformedInputException.
-            // 2. The config file is filled with kilobytes of null bytes and the first line read from file is not
-            // parseable.
-            // To handle both scenarios and make sure we can fall back to backup config files, we decided to validate
-            // the entire file.
-
-            // Specific description of scenario 2:
-            // We have been seeing that very rarely the transaction log gets corrupted when a device (specifically
-            // raspberry pi using an SD card) has a power outage.
-            // The corruption is happening at the hardware level and there really isn't anything that we can do
-            // about it right now.
-            // The corruption that we see is that the tlog file is filled with kilobytes of null
-            // bytes, depending on how large the configuration was before dumping the entire config to disk.
-
-            String l = in.readLine();
-            // if file is empty, throw an IOException so that nucleus can recover with backup config files
-            if (l == null) {
-                throw new IOException(String.format("Empty transaction log file at %s", tlogPath));
+    public static boolean validateTlog(Path tlogPath) {
+        try {
+            if (!Files.exists(tlogPath)) {
+                logger.atError().setEventType("validate-tlog").kv("path", tlogPath)
+                        .log("Transaction log file does not exist at given path");
+                return false;
             }
+            try (BufferedReader in = Files.newBufferedReader(tlogPath)) {
+                // We have seen two different file corruption scenarios
+                // 1. The last line of config file is corrupted with non-UTF8 characters and BufferedReader::readLine
+                // throws a MalformedInputException.
+                // 2. The config file is filled with kilobytes of null bytes and the first line read from file is not
+                // parseable.
+                // To handle both scenarios and make sure we can fall back to backup config files, we decided to
+                // validate the entire file.
 
-            // if file is not empty, validate that the entire file is parseable
-            while (l != null) {
-                Coerce.toObject(l, TLOG_LINE_REF);
-                l = in.readLine();
+                // Specific description of scenario 2:
+                // We have been seeing that very rarely the transaction log gets corrupted when a device (specifically
+                // raspberry pi using an SD card) has a power outage.
+                // The corruption is happening at the hardware level and there really isn't anything that we can do
+                // about it right now.
+                // The corruption that we see is that the tlog file is filled with kilobytes of null
+                // bytes, depending on how large the configuration was before dumping the entire config to disk.
+
+                String l = in.readLine();
+                // if file is empty, return false
+                if (l == null) {
+                    logger.atError().setEventType("validate-tlog").kv("path", tlogPath)
+                            .log("Empty transaction log file");
+                    return false;
+                }
+
+                // if file is not empty, validate that the entire file is parseable
+                while (l != null) {
+                    Coerce.toObject(l, TLOG_LINE_REF);
+                    l = in.readLine();
+                }
             }
+        } catch (IOException e) {
+            logger.atError().setCause(e).setEventType("validate-tlog").kv("path", tlogPath)
+                    .log("Unable to validate the transaction log content");
+            return false;
         }
+        return true;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
+++ b/src/main/java/com/aws/greengrass/config/ConfigurationWriter.java
@@ -195,13 +195,17 @@ public class ConfigurationWriter implements Closeable, ChildChanged {
                 StandardOpenOption.SYNC, StandardOpenOption.CREATE);
     }
 
+    public static Path getOldTlogPath(Path tlogPath) {
+        return tlogPath.resolveSibling(tlogPath.getFileName() + ".old");
+    }
+
     /**
      * Discard current tlog. Start a new tlog with the current kernel configs.
      */
     private synchronized void truncateTlog() {
         logger.atDebug(TRUNCATE_TLOG_EVENT).log("started");
         truncateQueued.set(false);
-        Path oldTlogPath = tlogOutputPath.resolveSibling(tlogOutputPath.getFileName() + ".old");
+        Path oldTlogPath = getOldTlogPath(tlogOutputPath);
         // close existing writer
         flush(out);
         if (out instanceof Commitable) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -302,6 +302,7 @@ public class KernelLifecycle {
                 // If there is no tlog, or the path was provided via commandline, read in that file
                 if ((externalConfigFromCmd || !transactionTlogValid) && externalConfigExists) {
                     kernel.getConfig().read(externalConfig);
+                    readFromTlog = false;
                 }
 
                 // If no bootstrap was present, then write one out now that we've loaded our config so that we can

--- a/src/test/java/com/aws/greengrass/config/ConfigurationReaderTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationReaderTest.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
@@ -21,10 +22,11 @@ import java.nio.file.Paths;
 
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFECYCLE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(GGExtension.class)
 class ConfigurationReaderTest {
@@ -207,12 +209,13 @@ class ConfigurationReaderTest {
     }
 
     @Test
-    void GIVEN_corrupted_tlog_WHEN_validate_tlog_THEN_correct_exception_is_thrown() throws Exception {
+    void GIVEN_corrupted_tlog_WHEN_validate_tlog_THEN_return_false(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, MalformedInputException.class);
         Path emptyTlogPath = Files.createTempFile(tempDir, null, null);
-        assertThrows(IOException.class, () -> ConfigurationReader.validateTlog(emptyTlogPath));
+        assertFalse(ConfigurationReader.validateTlog(emptyTlogPath));
 
         // test a config file with non-UTF8 encoding
         Path corruptedTlogPath = Paths.get(this.getClass().getResource("corruptedConfig.tlog").toURI());
-        assertThrows(MalformedInputException.class, () -> ConfigurationReader.validateTlog(corruptedTlogPath));
+        assertFalse(ConfigurationReader.validateTlog(corruptedTlogPath));
     }
 }


### PR DESCRIPTION
**Description of changes:**
1. Refactor config loading logic.
2. Call tlog recovery logic when `config.tlog` file does not exist.
3. Check the existence of `config.tlog.old` before loading `config.tlog`. If the old tlog exists, then last tlog truncation was interrupted and we should overwrite the `config.tlog`.
4. Add `tlog~` in config read supported extension.
5. Improvements to logging.

**Why is this change necessary:**
To fix a bug in current config recovery logic. Today, if `config.tlog` file does not at nucleus start, no backup files are read into the config and kernel launches with an empty config.

Furthermore, the condition of `config.tlog` missing may be triggered if nucleus is terminated during tlog truncation. Specifically, `config.tlog` is moved to `config.tlog.old` and new configs are written to `config.tlog+` and moved to `config.tlog` only after write is complete.

The `initConfigAndTlog` is also huge. Attempted to refactor it by breaking down to multiple methods .

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
