### PR TITLE
feat(mqtt5): implement reconnect for mqtt 5 client

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqttClient.java
@@ -245,10 +245,10 @@ class AwsIotMqttClient implements IndividualMqttClient {
     }
 
     @Override
-    public void reconnect() throws TimeoutException, ExecutionException, InterruptedException {
+    public void reconnect(long timeoutMs) throws TimeoutException, ExecutionException, InterruptedException {
         logger.atInfo().log("Reconnecting MQTT client most likely due to device configuration change");
-        disconnect().get(getTimeout(), TimeUnit.MILLISECONDS);
-        connect().get(getTimeout(), TimeUnit.MILLISECONDS);
+        disconnect().get(timeoutMs, TimeUnit.MILLISECONDS);
+        connect().get(timeoutMs, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/mqttclient/IndividualMqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/IndividualMqttClient.java
@@ -42,7 +42,7 @@ interface IndividualMqttClient extends Closeable {
     @Override
     void close();
 
-    void reconnect() throws TimeoutException, ExecutionException, InterruptedException;
+    void reconnect(long operationTimeoutMs) throws TimeoutException, ExecutionException, InterruptedException;
 
     CompletableFuture<?> connect();
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -316,7 +316,7 @@ public class MqttClient implements Closeable {
                         }
 
                         try {
-                            connection.reconnect();
+                            connection.reconnect(getMqttOperationTimeoutMillis());
                             brokenConnections.remove(connection);
                         } catch (InterruptedException | ExecutionException | TimeoutException e) {
                             logger.atError().setCause(e).kv(CLIENT_ID_KEY, connection.getClientId())

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqttClientTest.java
@@ -165,7 +165,7 @@ class AwsIotMqttClientTest {
         client.subscribe(Subscribe.builder().topic("A").build());
 
         assertTrue(client.connected());
-        client.reconnect();
+        client.reconnect(100);
         verify(connection, times(2)).close();
         verify(connection, times(2)).disconnect();
         assertTrue(client.connected());
@@ -188,7 +188,6 @@ class AwsIotMqttClientTest {
     void GIVEN_individual_client_THEN_it_tracks_subscriptions_correctly(ExtensionContext context)
             throws ExecutionException, InterruptedException, TimeoutException {
         ignoreExceptionOfType(context, CompletionException.class);
-        when(mockTopic.findOrDefault(any(), any())).thenReturn(1000);
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
         when(connection.subscribe(any(), any())).thenReturn(CompletableFuture.completedFuture(0));
         when(connection.unsubscribe(any())).thenReturn(CompletableFuture.completedFuture(0));
@@ -205,7 +204,7 @@ class AwsIotMqttClientTest {
         client.subscribe(Subscribe.builder().topic("A").qos(QOS.AT_LEAST_ONCE).build()).get();
         assertEquals(expectedSubs, client.getSubscriptionTopics());
 
-        client.reconnect();
+        client.reconnect(100);
         assertEquals(expectedSubs, client.getSubscriptionTopics());
 
         expectedSubs.put("B", QualityOfService.AT_MOST_ONCE);
@@ -410,7 +409,6 @@ class AwsIotMqttClientTest {
                 callbackEventManager, executorService, ses);
         client.disableRateLimiting();
 
-        when(mockTopic.findOrDefault(any(), any())).thenReturn(1000);
         when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
         when(connection.disconnect()).thenAnswer((a) -> {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -429,7 +427,7 @@ class AwsIotMqttClientTest {
         assertTrue(client.connected());
         assertEquals(3, client.subscriptionCount());
 
-        client.reconnect();
+        client.reconnect(100);
 
         // verify with some timeout to allow thread to spin up etc.
         verify(connection, timeout(VERIFY_TIMEOUT_MILLIS).times(2)).subscribe(eq("A"), any());

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -288,17 +288,17 @@ class MqttClientTest {
 
         // no reconnect if no connections
         cc.getValue().childChanged(WhatHappened.childChanged, config.lookupTopics("test1"));
-        verify(iClient1, never()).reconnect();
+        verify(iClient1, never()).reconnect(anyLong());
 
         client.subscribe(SubscribeRequest.builder().topic("A/B/+").callback(cb).build());
 
         // no reconnect if unrelated node changes
         cc.getValue().childChanged(WhatHappened.childChanged, config.lookupTopics("test2"));
-        verify(iClient1, never()).reconnect();
+        verify(iClient1, never()).reconnect(anyLong());
 
         // no reconnect if aws region changed but no proxy configured
         cc.getValue().childChanged(WhatHappened.childChanged, config.lookupTopics(DEVICE_PARAM_AWS_REGION));
-        verify(iClient1, never()).reconnect();
+        verify(iClient1, never()).reconnect(anyLong());
 
         // do reconnect if changed node is relevant to client config and reconnect is required
         // this increases branch coverage
@@ -308,7 +308,7 @@ class MqttClientTest {
         int reconnectCount = 0;
         for (String topic : topicsToTest) {
             cc.getValue().childChanged(WhatHappened.childChanged, config.lookupTopics(topic, "test"));
-            verify(iClient1, timeout(5000).times(++reconnectCount)).reconnect();
+            verify(iClient1, timeout(5000).times(++reconnectCount)).reconnect(anyLong());
         }
 
         client.close();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Implement the basic reconnection logic for the MQTT 5 client for when the configuration changes.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
