### PR TITLE
feat(mqtt5): make mqtt 5 client optional, default to mqtt 5

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -120,6 +120,8 @@ public class MqttClient implements Closeable {
     public static final int MAX_LENGTH_OF_TOPIC = 256;
 
     public static final String CONNECT_LIMIT_PERMITS_FEATURE = "connectLimitPermits";
+    // Default to MQTT 5 for now. TODO: default to mqtt3 for release.
+    public static final String DEFAULT_MQTT_VERSION = "mqtt5";
 
     // Use read lock for MQTT operations and write lock when changing the MQTT connection
     private final ReadWriteLock connectionLock = new ReentrantReadWriteLock(true);
@@ -929,18 +931,20 @@ public class MqttClient implements Closeable {
                 : "#" + (clientIdNum + 1));
         logger.atDebug().kv("clientId", clientId).log("Getting new MQTT connection");
 
-        return new AwsIotMqtt5Client(() -> {
-            try {
-                return builderProvider.apply(clientBootstrap).toAwsIotMqtt5ClientBuilder();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }, this::getMessageHandlerForClient, clientId, clientIdNum, mqttTopics, callbackEventManager, executorService,
-                ses);
-        /*
+        String mqttVersion = Coerce.toString(mqttTopics.findOrDefault(DEFAULT_MQTT_VERSION, "version"));
+        if ("mqtt5".equalsIgnoreCase(mqttVersion)) {
+            return new AwsIotMqtt5Client(() -> {
+                try {
+                    return builderProvider.apply(clientBootstrap).toAwsIotMqtt5ClientBuilder();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }, this::getMessageHandlerForClient, clientId, clientIdNum, mqttTopics, callbackEventManager,
+                    executorService, ses);
+        }
+
         return new AwsIotMqttClient(() -> builderProvider.apply(clientBootstrap), this::getMessageHandlerForClient,
                 clientId, clientIdNum, mqttTopics, callbackEventManager, executorService, ses);
-         */
     }
 
     public boolean connected() {

--- a/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.deployment.bootstrap;
 
 import com.amazon.aws.iot.greengrass.component.common.ComponentType;
 import com.aws.greengrass.componentmanager.ComponentStore;
+import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.ComponentConfigurationValidationException;
@@ -96,6 +97,10 @@ class BootstrapManagerTest {
         when(kernel.getContext()).thenReturn(context);
         when(context.get(DeviceConfiguration.class)).thenReturn(deviceConfiguration);
         when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(Collections.emptyMap());
+        Topics mockMqttTopics = mock(Topics.class);
+        when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
+
         BootstrapManager bootstrapManager = spy(new BootstrapManager(kernel));
         doReturn(false).when(bootstrapManager).serviceBootstrapRequired(any(), any());
         assertFalse(bootstrapManager.isBootstrapRequired(new HashMap<String, Object>() {{
@@ -189,6 +194,9 @@ class BootstrapManagerTest {
         when(kernel.getContext()).thenReturn(context);
         when(context.get(DeviceConfiguration.class)).thenReturn(deviceConfiguration);
         when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(runWith);
+        Topics mockMqttTopics = mock(Topics.class);
+        when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
 
         GenericExternalService nucleus = mock(GenericExternalService.class);
         doReturn(false).when(nucleus).isBootstrapRequired(anyMap());
@@ -395,6 +403,10 @@ class BootstrapManagerTest {
             throws ServiceUpdateException, ComponentConfigurationValidationException, ServiceLoadException {
         when(kernel.getContext()).thenReturn(context);
         when(context.get(DeviceConfiguration.class)).thenReturn(deviceConfiguration);
+        Topics mockMqttTopics = mock(Topics.class);
+        when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
+
         GenericExternalService service = mock(GenericExternalService.class);
         doReturn(false).when(service).isBootstrapRequired(anyMap());
         when(kernel.locate(DEFAULT_NUCLEUS_COMPONENT_NAME)).thenReturn(service);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Put MQTT 5 client behind a version flag. Defaulting to MQTT 5 client for now, we will switch to MQTT 3 as the default before releasing publicly. Eventually we will remove the MQTT 3 client and just use the MQTT 5 client.
Switching the version will cause Nucleus to restart as tearing down the old version client and then using the new client (and re-subscribing) is a bit tricky. Customers should very very rarely change their MQTT version, if ever.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
