### PR TITLE
chore: exception and logging for incompatible platform claim

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/exceptions/IncompatiblePlatformClaimByComponentException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/exceptions/IncompatiblePlatformClaimByComponentException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.exceptions;
+
+import java.util.Map;
+
+import static com.aws.greengrass.deployment.errorcode.DeploymentErrorCode.COMPONENT_VERSION_REQUIREMENTS_NOT_MET;
+import static com.aws.greengrass.deployment.errorcode.DeploymentErrorCode.NO_AVAILABLE_COMPONENT_VERSION;
+
+@SuppressWarnings("checkstyle:MissingJavadocMethod")
+public class IncompatiblePlatformClaimByComponentException extends PackagingException {
+
+    static final long serialVersionUID = -3387516993124229948L;
+
+
+    public IncompatiblePlatformClaimByComponentException(String initialMessage, String componentName,
+                                                         Map<String, String> platform) {
+        super(makeMessage(initialMessage, componentName, platform));
+        super.addErrorCode(NO_AVAILABLE_COMPONENT_VERSION);
+        super.addErrorCode(COMPONENT_VERSION_REQUIREMENTS_NOT_MET);
+    }
+
+    private static String makeMessage(String initialMessage, String componentName,
+                                      Map<String, String> platformRequirements) {
+        StringBuilder sb = new StringBuilder(initialMessage.trim());
+        sb.append(" Check whether the platform constraints conflict and that the component platform mentioned in the "
+                    + "recipe matches the platform constraints. "
+                    + "If the platform constraints conflict, revise deployments to resolve the conflict. "
+                    + "Component ")
+                .append(componentName)
+                .append(" claimed platform:");
+        for (Map.Entry<String, String> requirement : platformRequirements.entrySet()) {
+            sb.append(' ').append(requirement.getKey()).append(' ').append(requirement.getValue()).append(',');
+        }
+        if (sb.charAt(sb.length() - 1) == ',') {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        sb.append('.');
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.componentmanager;
 
+import com.aws.greengrass.componentmanager.exceptions.IncompatiblePlatformClaimByComponentException;
 import com.aws.greengrass.componentmanager.exceptions.NoAvailableComponentVersionException;
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
@@ -122,9 +123,10 @@ class ComponentServiceHelperTest {
     @Test
     void GIVEN_component_version_requirements_WHEN_service_no_resource_found_THEN_throw_no_available_version_exception()
             throws DeviceConfigurationException {
+        String expMessage = "Component A has no usable version satisfying requirements B";
         when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
         when(client.resolveComponentCandidates(any(ResolveComponentCandidatesRequest.class)))
-                .thenThrow(ResourceNotFoundException.class);
+                .thenThrow(ResourceNotFoundException.builder().message(expMessage).build());
 
         Exception exp = assertThrows(NoAvailableComponentVersionException.class, () -> helper
                 .resolveComponentVersion(COMPONENT_A, v1_0_0,
@@ -134,6 +136,21 @@ class ComponentServiceHelperTest {
                 containsString("Component A version constraints: X requires >=1.0.0 <2.0.0."));
         assertThat(exp.getMessage(),
                 containsString("No cloud component version satisfies the requirements"));
+    }
+
+    @Test
+    void GIVEN_component_version_requirements_WHEN_service_incompatible_platform_claim_THEN_throw_incompatible_platform_claim_exception()
+            throws DeviceConfigurationException {
+        String expMessage = "The latest version of Component A doesn't claim platform B compatibility";
+        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
+        when(client.resolveComponentCandidates(any(ResolveComponentCandidatesRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().message(expMessage).build());
+
+        Exception exp = assertThrows(IncompatiblePlatformClaimByComponentException.class, () -> helper
+                .resolveComponentVersion(COMPONENT_A, v1_0_0, Collections.emptyMap()));
+
+        assertThat(exp.getMessage(),
+                containsString("The version of component requested does not claim platform compatibility"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use substring matching to handle the incompatible platform claim and unavailable component exceptions differently, added a new exception class and message to be emitted to console in case of an incompatible platform claim exception

**Why is this change necessary:**
Cloud throws an ItemNotFoundException when resolveComponentCandidates API request is called with an incompatible platform claim. The message which needs to be emitted to the console should different from NoAvailableComponentVersionException in this case

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
