### PR TITLE
Finish deployment change

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentStatusKeeper.java
@@ -6,6 +6,9 @@
 package com.aws.greengrass.deployment;
 
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.deployment.model.DeploymentTask;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
@@ -17,7 +20,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -170,5 +175,17 @@ public class DeploymentStatusKeeper {
             processedDeployments = deploymentService.getRuntimeConfig().lookupTopics(PROCESSED_DEPLOYMENTS_TOPICS);
         }
         return processedDeployments;
+    }
+
+    public CompletableFuture<DeploymentResult> submitDeploymentTask(ExecutorService executorService,
+                                                                    DeploymentTask deploymentTask) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return deploymentTask.call();
+            } catch (InterruptedException ex) {
+                logger.atError().log("Error in Completing Deployment", ex);
+                return null;
+            }
+        }, executorService);
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle finishCurrentDeployment as soon as deployment task finishes instead of relying on deployment polling logic. 

**Why is this change necessary:**
To avoid conditions where anything happens to Nucleus while the deployment status is being updated (such as a shutdown or deployment cancellation) and status is lost. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
