### PR TITLE
fix(windows): lookup SYSTEM username from SID

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
@@ -77,7 +77,7 @@ public class WindowsPlatform extends Platform {
     protected static final String EVERYONE_SID = "S-1-1-0";
     protected static final String LOCAL_SYSTEM_SID = "S-1-5-18";
     protected static final String ADMINISTRATORS_SID = "S-1-5-32-544";
-    protected static final String LOCAL_SYSTEM_USERNAME = "SYSTEM";
+    protected static final String LOCAL_SYSTEM_USERNAME = Advapi32Util.getAccountBySid(LOCAL_SYSTEM_SID).name;
     private static final String EVERYONE_GROUP_NAME = Advapi32Util.getAccountBySid(EVERYONE_SID).name;
     private static final String ADMINISTRATORS_GROUP_NAME = Advapi32Util.getAccountBySid(ADMINISTRATORS_SID).name;
     protected static final WindowsUserAttributes LOCAL_SYSTEM_USER_ATTRIBUTES =


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Lookup SYSTEM username from SID just like we did for the EVERYONE group previously.

**Why is this change necessary:**

**How was this change tested:**
Manually verified the lookup works.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
