### PR TITLE
fix: finish current deployment before deployment task completes

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.CurrentDeploymentFinisher;
 import com.aws.greengrass.deployment.DefaultDeploymentTask;
 import com.aws.greengrass.deployment.DeploymentConfigMerger;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
@@ -159,6 +160,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
     private Topics groupToRootComponentsTopics;
     private Topics deploymentServiceTopics;
     private static ThingGroupHelper thingGroupHelper;
+    private CurrentDeploymentFinisher deploymentServiceFinisher;
 
     @BeforeAll
     static void initialize() {
@@ -1255,7 +1257,8 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                 new DefaultDeploymentTask(dependencyResolver, componentManager, kernelConfigResolver,
                         deploymentConfigMerger, logger,
                         new Deployment(sampleJobDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
-                        deploymentServiceTopics, kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper);
+                        deploymentServiceTopics, kernel.getContext().get(ExecutorService.class),
+                        deploymentDocumentDownloader, thingGroupHelper, deploymentServiceFinisher);
         return executorService.submit(deploymentTask);
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.deployment.DeploymentDocumentDownloader;
 import com.aws.greengrass.deployment.DefaultDeploymentTask;
 import com.aws.greengrass.deployment.DeploymentConfigMerger;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
+import com.aws.greengrass.deployment.CurrentDeploymentFinisher;
 import com.aws.greengrass.deployment.DeploymentService;
 import com.aws.greengrass.deployment.ThingGroupHelper;
 import com.aws.greengrass.deployment.activator.KernelUpdateActivator;
@@ -101,6 +102,7 @@ class PluginComponentTest extends BaseITCase {
     static final ComponentIdentifier componentId = new ComponentIdentifier(componentName, new Semver("1.0.0"));
     static final ComponentIdentifier brokenComponentId = new ComponentIdentifier(brokenComponentName,
             new Semver("1.0.0"));
+    private static CurrentDeploymentFinisher deploymentServiceFinisher;
     private Kernel kernel;
     private static ThingGroupHelper thingGroupHelper;
 
@@ -116,7 +118,8 @@ class PluginComponentTest extends BaseITCase {
                         deploymentConfigMerger, LogManager.getLogger("Deployer"),
                         new Deployment(sampleJobDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
                         Topics.of(kernel.getContext(), DeploymentService.DEPLOYMENT_SERVICE_TOPICS, null),
-                        kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper);
+                        kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader,
+                        thingGroupHelper, deploymentServiceFinisher);
         return kernel.getContext().get(ExecutorService.class).submit(deploymentTask);
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/CurrentDeploymentFinisher.java
+++ b/src/main/java/com/aws/greengrass/deployment/CurrentDeploymentFinisher.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorCodeUtils;
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.Pair;
+import com.aws.greengrass.util.Utils;
+import lombok.Setter;
+import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+
+import static com.aws.greengrass.deployment.DefaultDeploymentTask.DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX;
+import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_DETAILED_STATUS_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_STACK_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_TYPES_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ID_LOG_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentService.GG_DEPLOYMENT_ID_LOG_KEY_NAME;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_CONFIG_ARN_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TIMESTAMP_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY;
+import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
+import static com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED;
+
+
+public class CurrentDeploymentFinisher {
+
+    private final Logger logger;
+    @Inject
+    @Setter
+    private Deployment deployment;
+    private final DeploymentStatusKeeper deploymentStatusKeeper;
+    private final DeploymentDirectoryManager deploymentDirectoryManager;
+    private final Topics config;
+
+    @Inject
+    private final Kernel kernel;
+
+    /**
+     * Constructor for DeploymentFinisher.
+     *
+     * @param logger                     Logger instance
+     * @param deployment                 Deployment instance
+     * @param deploymentStatusKeeper     {@link DeploymentStatusKeeper}
+     * @param deploymentDirectoryManager {@link DeploymentDirectoryManager}
+     * @param kernel                     {@link Kernel}
+     * @param config                     root Configuration topic for Deployment service
+     */
+    public CurrentDeploymentFinisher(Logger logger, Deployment deployment,
+                                     DeploymentStatusKeeper deploymentStatusKeeper,
+                                     DeploymentDirectoryManager deploymentDirectoryManager, Topics config,
+                                     Kernel kernel) {
+        this.logger = logger;
+        this.deployment = deployment;
+        this.deploymentStatusKeeper = deploymentStatusKeeper;
+        this.deploymentDirectoryManager = deploymentDirectoryManager;
+        this.config = config;
+        this.kernel = kernel;
+    }
+
+    void finishCurrentDeployment(DeploymentResult result, boolean isKernelUpdateTask) throws InterruptedException {
+        String deploymentId = deployment.getId();
+        String ggDeploymentId = deployment.getGreengrassDeploymentId();
+        String configurationArn = deployment.getConfigurationArn();
+        Deployment.DeploymentType type = deployment.getDeploymentType();
+        List<String> rootPackages = deployment.getDeploymentDocumentObj().getRootPackages();
+
+        logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY_NAME, deploymentId).kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, ggDeploymentId)
+                .log("Current deployment finished");
+        try {
+            // No timeout is set here. Detection of error is delegated to downstream components like
+            // dependency resolver, package downloader, kernel which will have more visibility
+            // if something is going wrong
+            // DeploymentResult result = currentDeploymentTaskMetadata.getDeploymentResultFuture().get();
+            if (result != null) {
+                DeploymentResult.DeploymentStatus deploymentStatus = result.getDeploymentStatus();
+                Map<String, Object> statusDetails = new HashMap<>();
+                statusDetails.put(DEPLOYMENT_DETAILED_STATUS_KEY, deploymentStatus.name());
+                if (DeploymentResult.DeploymentStatus.SUCCESSFUL.equals(deploymentStatus)) {
+                    //Add the root packages of successful deployment to the configuration
+                    persistGroupToRootComponents(deployment.getDeploymentDocumentObj());
+
+                    deploymentStatusKeeper.persistAndPublishDeploymentStatus(deploymentId, ggDeploymentId,
+                            configurationArn, type, JobStatus.SUCCEEDED.toString(), statusDetails, rootPackages);
+
+                    if (isKernelUpdateTask) {
+                        try {
+                            kernel.getContext().get(KernelAlternatives.class).activationSucceeds();
+                        } catch (IOException e) {
+                            logger.atError().log("Failed to reset Nucleus activate directory", e);
+                        }
+                    }
+                    deploymentDirectoryManager.persistLastSuccessfulDeployment();
+                } else if (DeploymentResult.DeploymentStatus.REJECTED.equals(deploymentStatus)) {
+                    if (result.getFailureCause() != null) {
+                        logger.atWarn().log("Deployment task rejected with following errors");
+                        updateStatusDetailsFromException(statusDetails, result.getFailureCause(),
+                                deployment.getDeploymentType());
+                        logger.atWarn().setCause(result.getFailureCause()).kv(DEPLOYMENT_ID_LOG_KEY_NAME, deploymentId)
+                                .kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, ggDeploymentId)
+                                .kv(DEPLOYMENT_DETAILED_STATUS_KEY, result.getDeploymentStatus())
+                                .kv(DEPLOYMENT_ERROR_STACK_KEY, statusDetails.get(DEPLOYMENT_ERROR_STACK_KEY))
+                                .kv(DEPLOYMENT_ERROR_TYPES_KEY, statusDetails.get(DEPLOYMENT_ERROR_TYPES_KEY))
+                                .log("Deployment task rejected with following errors");
+                    }
+                    deploymentStatusKeeper.persistAndPublishDeploymentStatus(deploymentId, ggDeploymentId,
+                            configurationArn, type, JobStatus.REJECTED.toString(), statusDetails, rootPackages);
+                } else {
+                    if (result.getFailureCause() != null) {
+                        updateStatusDetailsFromException(statusDetails, result.getFailureCause(),
+                                deployment.getDeploymentType());
+                        logger.atError().setCause(result.getFailureCause()).kv(DEPLOYMENT_ID_LOG_KEY_NAME, deploymentId)
+                                .kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, ggDeploymentId)
+                                .kv(DEPLOYMENT_DETAILED_STATUS_KEY, result.getDeploymentStatus())
+                                .kv(DEPLOYMENT_ERROR_STACK_KEY, statusDetails.get(DEPLOYMENT_ERROR_STACK_KEY))
+                                .kv(DEPLOYMENT_ERROR_TYPES_KEY, statusDetails.get(DEPLOYMENT_ERROR_TYPES_KEY))
+                                .log("Deployment task failed with following errors");
+                    }
+
+                    if (FAILED_ROLLBACK_NOT_REQUESTED.equals(result.getDeploymentStatus())) {
+                        // Update the groupToRootComponents mapping in config for the case where there is no rollback
+                        // and now the components deployed for the current group are not the same as before deployment
+                        persistGroupToRootComponents(deployment.getDeploymentDocumentObj());
+                    }
+
+                    deploymentStatusKeeper.persistAndPublishDeploymentStatus(deploymentId, ggDeploymentId,
+                            configurationArn, type, JobStatus.FAILED.toString(), statusDetails, rootPackages);
+
+                    if (isKernelUpdateTask) {
+                        try {
+                            kernel.getContext().get(KernelAlternatives.class).rollbackCompletes();
+                        } catch (IOException e) {
+                            logger.atError().log("Failed to reset Nucleus rollback directory", e);
+                        }
+                    }
+                    deploymentDirectoryManager.persistLastFailedDeployment();
+                }
+            }
+        } catch (CancellationException e) {
+            logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY_NAME, deploymentId)
+                    .kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, ggDeploymentId).log("Deployment task is cancelled");
+        }
+        // Setting this to null to indicate there is no current deployment being processed
+        // Did not use optionals over null due to performance
+        //        currentDeploymentTaskMetadata = null;
+    }
+
+    private void persistGroupToRootComponents(DeploymentDocument deploymentDocument) {
+        Topics deploymentGroupTopics = config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS);
+        Topics groupLastDeploymentTopics = config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS);
+
+        // clean up group
+        cleanupGroupData(deploymentGroupTopics, groupLastDeploymentTopics);
+
+        // persist group to root components
+        Map<String, Object> deploymentGroupToRootPackages = new HashMap<>();
+        deploymentDocument.getDeploymentPackageConfigurationList().stream().forEach(pkgConfig -> {
+            if (pkgConfig.isRootComponent()) {
+                Map<String, Object> pkgDetails = new HashMap<>();
+                pkgDetails.put(GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, pkgConfig.getResolvedVersion());
+                pkgDetails.put(GROUP_TO_ROOT_COMPONENTS_GROUP_NAME, deploymentDocument.getGroupName());
+                String configurationArn =
+                        Utils.isEmpty(deploymentDocument.getConfigurationArn()) ? deploymentDocument.getDeploymentId()
+                                : deploymentDocument.getConfigurationArn();
+                pkgDetails.put(GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN, configurationArn);
+                deploymentGroupToRootPackages.put(pkgConfig.getPackageName(), pkgDetails);
+            }
+        });
+
+        // persist last deployment details
+        Map<String, Object> lastDeploymentDetails = new HashMap<>();
+        lastDeploymentDetails.put(GROUP_TO_LAST_DEPLOYMENT_TIMESTAMP_KEY, deploymentDocument.getTimestamp());
+        lastDeploymentDetails.put(GROUP_TO_LAST_DEPLOYMENT_CONFIG_ARN_KEY, deploymentDocument.getConfigurationArn());
+        groupLastDeploymentTopics.lookupTopics(deploymentDocument.getGroupName()).replaceAndWait(lastDeploymentDetails);
+
+        // persist group to root packages mapping
+        deploymentGroupTopics.lookupTopics(deploymentDocument.getGroupName())
+                .replaceAndWait(deploymentGroupToRootPackages);
+        setComponentsToGroupsMapping(deploymentGroupTopics);
+    }
+
+    /**
+     * Group memberships for a device can change. If the device is no longer part of a group, then perform cleanup.
+     */
+    private void cleanupGroupData(Topics deploymentGroupTopics, Topics groupLastDeploymentTopics) {
+        Topics groupMembershipTopics = config.lookupTopics(GROUP_MEMBERSHIP_TOPICS);
+        deploymentGroupTopics.forEach(node -> {
+            if (node instanceof Topics) {
+                Topics groupTopics = (Topics) node;
+                if (groupMembershipTopics.find(groupTopics.getName()) == null && !groupTopics.getName()
+                        .startsWith(DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX) && !groupTopics.getName()
+                        .equals(LOCAL_DEPLOYMENT_GROUP_NAME)) {
+                    logger.debug("Removing mapping for thing group " + groupTopics.getName());
+                    groupTopics.remove();
+                }
+            }
+        });
+
+        groupLastDeploymentTopics.forEach(node -> {
+            if (node instanceof Topics) {
+                Topics groupTopics = (Topics) node;
+                if (groupMembershipTopics.find(groupTopics.getName()) == null && !groupTopics.getName()
+                        .startsWith(DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX) && !groupTopics.getName()
+                        .equals(LOCAL_DEPLOYMENT_GROUP_NAME)) {
+                    logger.debug("Removing last deployment information for thing group " + groupTopics.getName());
+                    groupTopics.remove();
+                }
+            }
+        });
+        groupMembershipTopics.remove();
+    }
+
+    void setComponentsToGroupsMapping(Topics groupsToRootComponents) {
+        Set<String> pendingComponents = new HashSet<>();
+        Map<String, Object> componentsToGroupsMappingCache = new ConcurrentHashMap<>();
+        Topics componentsToGroupsTopics = config.lookupTopics(COMPONENTS_TO_GROUPS_TOPICS);
+        /*
+         * Structure of COMPONENTS_TO_GROUPS_TOPICS is:
+         * COMPONENTS_TO_GROUPS_TOPICS :
+         * |_ <componentName> :
+         *     |_ <deploymentID> : <GroupName>
+         * This stores all the components with the list of deployment IDs associated to it along with the thing group
+         * (if available) to be associated to the deployment.
+         */
+        // Get all the groups associated to the root components.
+        groupsToRootComponents.forEach(groupNode -> ((Topics) groupNode).forEach(componentNode -> {
+            Topics componentTopics = (Topics) componentNode;
+
+            Topic groupConfigTopic = componentTopics.lookup(GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN);
+            String groupConfig = Coerce.toString(groupConfigTopic);
+
+            Topic groupNameTopic = componentTopics.lookup(GROUP_TO_ROOT_COMPONENTS_GROUP_NAME);
+            String groupName = Coerce.toString(groupNameTopic);
+
+            Map<String, Object> groupDeploymentIdSet =
+                    (Map<String, Object>) componentsToGroupsMappingCache.getOrDefault(componentTopics.getName(),
+                            new HashMap<>());
+            groupDeploymentIdSet.putIfAbsent(groupConfig, groupName);
+            componentsToGroupsMappingCache.put(componentTopics.getName(), groupDeploymentIdSet);
+            pendingComponents.add(componentTopics.getName());
+        }));
+
+        // Associate the groups to the dependant services based on the services it is depending on.
+        while (!pendingComponents.isEmpty()) {
+            String componentName = pendingComponents.iterator().next();
+            try {
+                GreengrassService greengrassService = kernel.locate(componentName);
+                Map<String, Object> groupNamesForComponent =
+                        (Map<String, Object>) componentsToGroupsMappingCache.getOrDefault(greengrassService.getName(),
+                                new HashMap<>());
+
+                greengrassService.getDependencies().forEach((greengrassService1, dependencyType) -> {
+                    pendingComponents.add(greengrassService1.getName());
+                    Map<String, Object> groupNamesForDependentComponent =
+                            (Map<String, Object>) componentsToGroupsMappingCache.getOrDefault(
+                                    greengrassService1.getName(), new HashMap<>());
+                    groupNamesForDependentComponent.putAll(groupNamesForComponent);
+                    componentsToGroupsMappingCache.put(greengrassService1.getName(), groupNamesForDependentComponent);
+                });
+            } catch (ServiceLoadException ex) {
+                logger.atError().cause(ex).log("Unable to get status for {}.", componentName);
+            }
+            pendingComponents.remove(componentName);
+        }
+
+        if (componentsToGroupsTopics != null) {
+            componentsToGroupsTopics.replaceAndWait(componentsToGroupsMappingCache);
+        }
+    }
+
+    Map<String, Object> updateStatusDetailsFromException(Map<String, Object> statusDetails, Throwable failureCause,
+                                                         Deployment.DeploymentType deploymentType) {
+        Pair<List<String>, List<String>> errorReport =
+                DeploymentErrorCodeUtils.generateErrorReportFromExceptionStack(failureCause, deploymentType);
+        statusDetails.put(DEPLOYMENT_ERROR_STACK_KEY, errorReport.getLeft());
+        statusDetails.put(DEPLOYMENT_ERROR_TYPES_KEY, errorReport.getRight());
+        statusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, Utils.generateFailureMessage(failureCause));
+
+        return statusDetails;
+    }
+}

--- a/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
@@ -75,6 +75,9 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
             }
 
             componentManager.cleanupStaleVersions();
+
+            // TODO: finish current deployment
+
             return result;
         } catch (InterruptedException e) {
             logger.atError("deployment-interrupted", e).log();

--- a/src/test/java/com/aws/greengrass/deployment/CurrentDeploymentFinisherTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/CurrentDeploymentFinisherTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.amazon.aws.iot.greengrass.component.common.DependencyType;
+import com.amazon.aws.iot.greengrass.configuration.common.Configuration;
+import com.aws.greengrass.config.CaseInsensitiveString;
+import com.aws.greengrass.config.Node;
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorCodeUtils;
+import com.aws.greengrass.deployment.exceptions.DeploymentTaskFailureException;
+import com.aws.greengrass.deployment.exceptions.InvalidRequestException;
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Pair;
+import com.aws.greengrass.util.SerializerFactory;
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.event.Level;
+import software.amazon.awssdk.iot.iotjobs.model.JobStatus;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_STACK_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_ERROR_TYPES_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE_CAUSE_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
+import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class CurrentDeploymentFinisherTest {
+
+    private static final String TEST_JOB_ID_1 = "TEST_JOB_1";
+    private static final String TEST_UUID = "testDeploymentId";
+
+    private static final String CONFIG_ARN_PLACEHOLDER = "TARGET_CONFIGURATION_ARN";
+    private static final String TEST_CONFIGURATION_ARN =
+            "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1";
+
+    private static final String GROUP_NAME = "thinggroup/group1";
+    private static final String EXPECTED_ROOT_PACKAGE_NAME = "component1";
+    private static final List<String> EXPECTED_ROOT_PACKAGE_LIST = Collections.singletonList("component1");
+
+    private static Logger logger = LogManager.getLogger(CurrentDeploymentFinisher.class);
+
+    @Mock
+    protected DeploymentStatusKeeper deploymentStatusKeeper;
+    @Mock
+    protected DeploymentDirectoryManager deploymentDirectoryManager;
+    protected Topics config = mock(Topics.class);
+    @Mock
+    private Kernel kernel;
+    @Mock
+    private GreengrassService mockGreengrassService;
+    @Mock
+    protected Context context;
+
+    private CurrentDeploymentFinisher currentDeploymentFinisher;
+
+    /**
+     * Default deployment with id=1
+     */
+    private final Deployment deployment = new Deployment(
+            getTestDeploymentDocument(),
+            Deployment.DeploymentType.IOT_JOBS,
+            TEST_JOB_ID_1);
+
+    @BeforeEach
+    void beforeEach() {
+        logger.setLevel(String.valueOf(Level.DEBUG));
+        currentDeploymentFinisher = new CurrentDeploymentFinisher(logger, deployment, deploymentStatusKeeper,
+                deploymentDirectoryManager, config, kernel);
+    }
+
+    @Test
+    void GIVEN_successful_deployment_result_WHEN_finishCurrentDeployment_THEN_deployment_completes_successfully()
+            throws InterruptedException, InvalidRequestException, JsonProcessingException, ServiceLoadException {
+        updateDeploymentObject(currentDeploymentFinisher);
+
+        DeploymentResult result = new DeploymentResult(DeploymentResult.DeploymentStatus.SUCCESSFUL, null);
+
+        String expectedGroupName = GROUP_NAME;
+        Topics allGroupTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        Topics deploymentGroupTopics = Topics.of(context, expectedGroupName, allGroupTopics);
+
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        Topics lastDeploymentGroupTopics = Topics.of(context, expectedGroupName, groupToLastDeploymentTopics);
+        groupToLastDeploymentTopics.children.put(new CaseInsensitiveString(expectedGroupName), lastDeploymentGroupTopics);
+
+        Topics groupMembershipTopics = Topics.of(context, GROUP_MEMBERSHIP_TOPICS, null);
+        groupMembershipTopics.lookup(expectedGroupName);
+        Topic pkgTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0");
+        Topic groupTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN,
+                "arn:aws:greengrass:testRegion:12345:configuration:testGroup:12");
+        Topic groupNameTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME,
+                expectedGroupName);
+        Map<CaseInsensitiveString, Node> pkgDetails = new HashMap<>();
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY),
+                pkgTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN),
+                groupTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME),
+                groupNameTopic1);
+        Topics pkgTopics = Topics.of(context, EXPECTED_ROOT_PACKAGE_NAME, deploymentGroupTopics);
+        pkgTopics.children.putAll(pkgDetails);
+        deploymentGroupTopics.children.put(new CaseInsensitiveString(EXPECTED_ROOT_PACKAGE_NAME), pkgTopics);
+        allGroupTopics.children.put(new CaseInsensitiveString(expectedGroupName), deploymentGroupTopics);
+
+        when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
+        when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
+        when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
+
+
+        when(kernel.locate(any())).thenReturn(mockGreengrassService);
+        when(mockGreengrassService.getName()).thenReturn(EXPECTED_ROOT_PACKAGE_NAME);
+
+        currentDeploymentFinisher.finishCurrentDeployment(result, false);
+
+        verify(deploymentStatusKeeper, timeout(1000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.SUCCEEDED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+
+    }
+
+    @Test
+    void GIVEN_successful_deployment_result_WHEN_finishCurrentDeployment_THEN_clean_group_data()
+            throws InterruptedException, InvalidRequestException, JsonProcessingException, ServiceLoadException {
+        updateDeploymentObject(currentDeploymentFinisher);
+
+        DeploymentResult result = new DeploymentResult(DeploymentResult.DeploymentStatus.SUCCESSFUL, null);
+
+        String expectedGroupName = GROUP_NAME;
+        Topics allGroupTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        Topics deploymentGroupTopics = Topics.of(context, expectedGroupName, allGroupTopics);
+
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        Topics lastDeploymentGroupTopics = Topics.of(context, expectedGroupName, groupToLastDeploymentTopics);
+        groupToLastDeploymentTopics.children.put(new CaseInsensitiveString(expectedGroupName), lastDeploymentGroupTopics);
+
+        Topics groupMembershipTopics = Topics.of(context, GROUP_MEMBERSHIP_TOPICS, null);
+        Topic pkgTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0");
+        Topic groupTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN,
+                "arn:aws:greengrass:testRegion:12345:configuration:testGroup:12");
+        Topic groupNameTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME,
+                expectedGroupName);
+        Map<CaseInsensitiveString, Node> pkgDetails = new HashMap<>();
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY),
+                pkgTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN),
+                groupTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME),
+                groupNameTopic1);
+        Topics pkgTopics = Topics.of(context, EXPECTED_ROOT_PACKAGE_NAME, deploymentGroupTopics);
+        pkgTopics.children.putAll(pkgDetails);
+        deploymentGroupTopics.children.put(new CaseInsensitiveString(EXPECTED_ROOT_PACKAGE_NAME), pkgTopics);
+        allGroupTopics.children.put(new CaseInsensitiveString(expectedGroupName), deploymentGroupTopics);
+
+
+        when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
+        when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
+        when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
+
+        currentDeploymentFinisher.finishCurrentDeployment(result, false);
+
+        verify(deploymentStatusKeeper, timeout(1000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.SUCCEEDED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+
+    }
+
+    @Test
+    void GIVEN_rejected_deployment_result_WHEN_finishCurrentDeployment_THEN_deployment_completes_with_rejection(
+            ExtensionContext extContext)
+            throws InterruptedException, InvalidRequestException, JsonProcessingException {
+
+        updateDeploymentObject(currentDeploymentFinisher);
+        ignoreExceptionUltimateCauseOfType(extContext, Exception.class);
+        DeploymentResult result = new DeploymentResult(
+                DeploymentResult.DeploymentStatus.REJECTED,
+                new Exception("Deployment Rejected"));
+
+        currentDeploymentFinisher.finishCurrentDeployment(result, false);
+
+        verify(deploymentStatusKeeper, timeout(1000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.REJECTED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+
+    }
+
+    @Test
+    void GIVEN_failed_deployment_result_WHEN_finishCurrentDeployment_THEN_deployment_completes_with_failure(
+            ExtensionContext extContext)
+            throws InterruptedException, InvalidRequestException, JsonProcessingException, ServiceLoadException {
+        updateDeploymentObject(currentDeploymentFinisher);
+
+        ignoreExceptionUltimateCauseOfType(extContext, Exception.class);
+        DeploymentResult result = new DeploymentResult(
+                DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED,
+                new Exception("Deployment Failed"));
+
+        String expectedGroupName = GROUP_NAME;
+        Topics allGroupTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        Topics deploymentGroupTopics = Topics.of(context, expectedGroupName, allGroupTopics);
+
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        Topics lastDeploymentGroupTopics = Topics.of(context, expectedGroupName, groupToLastDeploymentTopics);
+        groupToLastDeploymentTopics.children.put(new CaseInsensitiveString(expectedGroupName), lastDeploymentGroupTopics);
+
+        Topics groupMembershipTopics = Topics.of(context, GROUP_MEMBERSHIP_TOPICS, null);
+        groupMembershipTopics.lookup(expectedGroupName);
+        Topic pkgTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0");
+        Topic groupTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN,
+                "arn:aws:greengrass:testRegion:12345:configuration:testGroup:12");
+        Topic groupNameTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME,
+                expectedGroupName);
+        Map<CaseInsensitiveString, Node> pkgDetails = new HashMap<>();
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY),
+                pkgTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN),
+                groupTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME),
+                groupNameTopic1);
+        Topics pkgTopics = Topics.of(context, EXPECTED_ROOT_PACKAGE_NAME, deploymentGroupTopics);
+        pkgTopics.children.putAll(pkgDetails);
+        deploymentGroupTopics.children.put(new CaseInsensitiveString(EXPECTED_ROOT_PACKAGE_NAME), pkgTopics);
+        allGroupTopics.children.put(new CaseInsensitiveString(expectedGroupName), deploymentGroupTopics);
+
+        when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
+        when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
+        when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
+
+
+        when(kernel.locate(any())).thenReturn(mockGreengrassService);
+        when(mockGreengrassService.getName()).thenReturn(EXPECTED_ROOT_PACKAGE_NAME);
+
+        currentDeploymentFinisher.finishCurrentDeployment(result, false);
+
+        verify(deploymentStatusKeeper, timeout(1000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.FAILED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+    }
+
+    @Test
+    void GIVEN_deployment_failed_with_exception_WHEN_updateStatusDetailsFromException_THEN_return_failure_status() {
+        Deployment.DeploymentType deploymentType = Deployment.DeploymentType.IOT_JOBS;
+        Throwable failureCause = new DeploymentTaskFailureException("Deployment Failed");
+
+        Map<String, Object> expectedStatusDetails = new HashMap<>();
+        Pair<List<String>, List<String>> errorReport =
+                DeploymentErrorCodeUtils.generateErrorReportFromExceptionStack(failureCause, deploymentType);
+        expectedStatusDetails.put(DEPLOYMENT_ERROR_STACK_KEY, errorReport.getLeft());
+        expectedStatusDetails.put(DEPLOYMENT_ERROR_TYPES_KEY, errorReport.getRight());
+        expectedStatusDetails.put(DEPLOYMENT_FAILURE_CAUSE_KEY, Utils.generateFailureMessage(failureCause));
+
+        Map<String, Object> actualStatusDetails = currentDeploymentFinisher.updateStatusDetailsFromException(
+                new HashMap<>(),
+                failureCause,
+                deploymentType);
+
+        assertNotNull(actualStatusDetails);
+        assertEquals(expectedStatusDetails, actualStatusDetails, "Failed to update Status Details correctly");
+    }
+
+    @Test
+    void GIVEN_groupsToRootComponents_WHEN_setComponentsToGroupsMapping_THEN_get_correct_componentsToGroupsTopics()
+            throws Exception {
+        // GIVEN
+        //   GroupToRootComponents:
+        //      LOCAL_DEPLOYMENT:
+        //        component1:
+        //          groupConfigArn: "asdf"
+        //          groupConfigName: "LOCAL_DEPLOYMENT"
+        //          version: "1.0.0"
+        //        AnotherRootComponent:
+        //          groupConfigArn: "asdf"
+        //          groupConfigName: "LOCAL_DEPLOYMENT"
+        //          version: "2.0.0"
+        //      thinggroup/group1:
+        //        component1:
+        //          groupConfigArn: "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1"
+        //          groupConfigName: "thinggroup/group1"
+        //          version: "1.0.0"
+        Topics allGroupTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        Topics deploymentGroupTopics = Topics.of(context, GROUP_NAME, allGroupTopics);
+        Topics deploymentGroupTopics2 = Topics.of(context, LOCAL_DEPLOYMENT_GROUP_NAME, allGroupTopics);
+
+        // Set up 1st deployment for EXPECTED_GROUP_NAME
+        Topics pkgTopics = Topics.of(context, EXPECTED_ROOT_PACKAGE_NAME, deploymentGroupTopics);
+        pkgTopics.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        pkgTopics.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN, TEST_CONFIGURATION_ARN));
+        pkgTopics.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME, GROUP_NAME));
+
+        deploymentGroupTopics.children.put(new CaseInsensitiveString(EXPECTED_ROOT_PACKAGE_NAME), pkgTopics);
+        allGroupTopics.children.putIfAbsent(new CaseInsensitiveString(GROUP_NAME), deploymentGroupTopics);
+
+        // Set up 2nd deployment for LOCAL_DEPLOYMENT_GROUP_NAME
+        Topics pkgTopics2 = Topics.of(context, "AnotherRootComponent", deploymentGroupTopics2);
+        pkgTopics2.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "2.0.0"));
+        pkgTopics2.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN, "asdf"));
+        pkgTopics2.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME, LOCAL_DEPLOYMENT_GROUP_NAME));
+        deploymentGroupTopics2.children.put(new CaseInsensitiveString("AnotherRootComponent"), pkgTopics2);
+
+        Topics pkgTopics3 = Topics.of(context, EXPECTED_ROOT_PACKAGE_NAME, deploymentGroupTopics2);
+        pkgTopics3.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        pkgTopics3.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN, "asdf"));
+        pkgTopics3.children.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME),
+                Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME, LOCAL_DEPLOYMENT_GROUP_NAME));
+        deploymentGroupTopics2.children.put(new CaseInsensitiveString(EXPECTED_ROOT_PACKAGE_NAME), pkgTopics3);
+
+        allGroupTopics.children.putIfAbsent(new CaseInsensitiveString(LOCAL_DEPLOYMENT_GROUP_NAME),
+                deploymentGroupTopics2);
+
+        // Set up mocks
+        Topics componentsToGroupsTopics = mock(Topics.class);
+        doReturn(componentsToGroupsTopics).when(config).lookupTopics(eq(COMPONENTS_TO_GROUPS_TOPICS));
+        GreengrassService expectedRootService = mock(GreengrassService.class);
+        GreengrassService anotherRootService = mock(GreengrassService.class);
+        GreengrassService dependencyService = mock(GreengrassService.class);
+        doReturn(expectedRootService).when(kernel).locate(eq(EXPECTED_ROOT_PACKAGE_NAME));
+        doReturn(anotherRootService).when(kernel).locate(eq("AnotherRootComponent"));
+        doReturn(dependencyService).when(kernel).locate(eq("Dependency"));
+        doReturn(new HashMap<GreengrassService, DependencyType>() {{ put(dependencyService, DependencyType.HARD);}})
+                .when(expectedRootService).getDependencies();
+        doReturn(new HashMap<GreengrassService, DependencyType>() {{ put(dependencyService, DependencyType.HARD);}})
+                .when(anotherRootService).getDependencies();
+        doReturn(emptyMap()).when(dependencyService).getDependencies();
+        doReturn(EXPECTED_ROOT_PACKAGE_NAME).when(expectedRootService).getName();
+        doReturn("AnotherRootComponent").when(anotherRootService).getName();
+        doReturn("Dependency").when(dependencyService).getName();
+
+        // WHEN
+        currentDeploymentFinisher.setComponentsToGroupsMapping(allGroupTopics);
+
+        // THEN
+        //   ComponentToGroups:
+        //      component1:
+        //        "asdf": "LOCAL_DEPLOYMENT"
+        //        "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1": "thinggroup/group1"
+        //      AnotherRootComponent:
+        //        "asdf": "LOCAL_DEPLOYMENT"
+        //      Dependency:
+        //        "asdf": "LOCAL_DEPLOYMENT"
+        //        "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1": "thinggroup/group1"
+        ArgumentCaptor<Map<String, Object>> mapCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(componentsToGroupsTopics).replaceAndWait(mapCaptor.capture());
+        Map<String, Object> groupToRootPackages = mapCaptor.getValue();
+
+        assertThat(groupToRootPackages, hasKey(EXPECTED_ROOT_PACKAGE_NAME));
+        Map<String, String> expectedRootComponentMap =
+                (Map<String, String>) groupToRootPackages.get(EXPECTED_ROOT_PACKAGE_NAME);
+        assertEquals(2, expectedRootComponentMap.size());
+        assertThat(expectedRootComponentMap, hasEntry(TEST_CONFIGURATION_ARN, GROUP_NAME));
+        assertThat(expectedRootComponentMap, hasEntry("asdf", LOCAL_DEPLOYMENT_GROUP_NAME));
+
+        assertThat(groupToRootPackages, hasKey("AnotherRootComponent"));
+        Map<String, String> anotherRootComponentMap = (Map<String, String>) groupToRootPackages.get(
+                "AnotherRootComponent");
+        assertEquals(1, anotherRootComponentMap.size());
+        assertThat(anotherRootComponentMap, hasEntry("asdf", LOCAL_DEPLOYMENT_GROUP_NAME));
+
+        assertThat(groupToRootPackages, hasKey("Dependency"));
+        Map<String, String> expectedDepComponentMap =
+                (Map<String, String>) groupToRootPackages.get(EXPECTED_ROOT_PACKAGE_NAME);
+        assertEquals(2, expectedDepComponentMap.size());
+        assertThat(expectedDepComponentMap, hasEntry(TEST_CONFIGURATION_ARN, GROUP_NAME));
+        assertThat(expectedDepComponentMap, hasEntry("asdf", LOCAL_DEPLOYMENT_GROUP_NAME));
+    }
+
+    String getTestDeploymentDocument() {
+        return new BufferedReader(new InputStreamReader(
+                getClass().getResourceAsStream("TestDeploymentDocument.json"), StandardCharsets.UTF_8))
+                .lines()
+                .collect(Collectors.joining("\n")).replace(CONFIG_ARN_PLACEHOLDER, TEST_CONFIGURATION_ARN);
+    }
+
+    private void updateDeploymentObject(CurrentDeploymentFinisher currentDeploymentFinisher) throws JsonProcessingException, InvalidRequestException {
+        String jobDocumentString = deployment.getDeploymentDocument();
+        Configuration configuration = SerializerFactory.getFailSafeJsonObjectMapper()
+                .readValue(jobDocumentString, Configuration.class);
+        DeploymentDocument document = DeploymentDocumentConverter.convertFromDeploymentConfiguration(configuration);
+        deployment.setDeploymentDocumentObj(document);
+        currentDeploymentFinisher.setDeployment(deployment);
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
@@ -97,6 +97,9 @@ class DeploymentTaskTest {
     @Mock
     private ThingGroupHelper mockThingGroupHelper;
 
+    @Mock
+    private CurrentDeploymentFinisher deploymentServiceFinisher;
+
     @BeforeAll
     static void setupContext() {
         context = new Context();
@@ -122,7 +125,8 @@ class DeploymentTaskTest {
                 new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager, mockKernelConfigResolver,
                         mockDeploymentConfigMerger, logger,
                         new Deployment(deploymentDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
-                        mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, mockThingGroupHelper);
+                        mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader,
+                        mockThingGroupHelper, deploymentServiceFinisher);
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle finishCurrentDeployment as soon as deployment task finishes instead of relying on deployment polling logic.


**Why is this change necessary:**
To avoid conditions where anything happens to Nucleus while the deployment status is being updated (such as a shutdown or deployment cancellation) and status is lost.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
