### PR TITLE
fix: change multi-group dependency resolution

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -595,62 +595,6 @@ public class ComponentManager implements InjectionActions {
         return new Semver(Coerce.toString(versionTopic));
     }
 
-    /**
-     * Find the package metadata for a package if it's active version satisfies the requirement.
-     *
-     * @param componentName the component name
-     * @param requirement   the version requirement
-     * @return Optional of the package metadata for the package; empty if this package doesn't have active version or
-     *         the active version doesn't satisfy the requirement.
-     * @throws PackagingException if fails to find the target recipe or parse the recipe
-     */
-    private Optional<ComponentMetadata> findActiveAndSatisfiedPackageMetadata(String componentName,
-                                                                              Requirement requirement)
-            throws PackagingException {
-        Optional<Semver> activeVersionOptional = findActiveVersion(componentName);
-
-        if (!activeVersionOptional.isPresent()) {
-            logger.atInfo().log("No active version found for {}", componentName);
-            return Optional.empty();
-        }
-
-        Semver activeVersion = activeVersionOptional.get();
-
-        if (!requirement.isSatisfiedBy(activeVersion)) {
-            logger.atInfo().log("Active version {} for component {} does not satisfy requirement {}", activeVersion,
-                    componentName, requirement);
-            return Optional.empty();
-        }
-
-        return Optional.of(getComponentMetadata(new ComponentIdentifier(componentName, activeVersion)));
-    }
-
-    /**
-     * Get active component version and dependencies, the component version satisfies dependent version requirements.
-     *
-     * @param componentName  component name to be queried for active version
-     * @param requirementMap component dependents version requirement map
-     * @return active component metadata which satisfies version requirement
-     * @throws PackagingException no available version exception
-     */
-    ComponentMetadata getActiveAndSatisfiedComponentMetadata(String componentName,
-                                                             Map<String, Requirement> requirementMap)
-            throws PackagingException {
-        return getActiveAndSatisfiedComponentMetadata(componentName, mergeVersionRequirements(requirementMap));
-    }
-
-    private ComponentMetadata getActiveAndSatisfiedComponentMetadata(String componentName, Requirement requirement)
-            throws PackagingException {
-        Optional<ComponentMetadata> componentMetadataOptional =
-                findActiveAndSatisfiedPackageMetadata(componentName, requirement);
-        if (!componentMetadataOptional.isPresent()) {
-            throw new NoAvailableComponentVersionException(INSTALLED_COMPONENT_NOT_FOUND_FAILURE_MESSAGE, componentName,
-                    requirement);
-        }
-
-        return componentMetadataOptional.get();
-    }
-
     private Optional<ComponentIdentifier> findActiveAndSatisfiedComponent(String componentName,
                                                                           Requirement requirement) {
         Optional<Semver> activeVersionOptional = findActiveVersion(componentName);

--- a/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/DependencyResolver.java
@@ -89,30 +89,37 @@ public class DependencyResolver {
         // A map of component name to its resolved version.
         Map<String, ComponentMetadata> resolvedComponents = new HashMap<>();
 
+        // Get the target components with version requirements in the deployment document
+        List<String> targetComponentsToResolve = new ArrayList<>();
+        // Add the constraints of the target group to componentNameToVersionConstraints before
+        // trying to resolve the other group so that the resolved version will be compatible with
+        // both versions (if possible)
+        document.getDeploymentPackageConfigurationList().stream()
+                .filter(DeploymentPackageConfiguration::isRootComponent).forEach(e -> {
+                    logger.atDebug().kv(COMPONENT_NAME_KEY, e.getPackageName()).kv(VERSION_KEY, e.getResolvedVersion())
+                            .log("Found component configuration");
+                    componentNameToVersionConstraints.putIfAbsent(e.getPackageName(), new HashMap<>());
+                    componentNameToVersionConstraints.get(e.getPackageName())
+                            .put(document.getGroupName(), Requirement.buildNPM(e.getResolvedVersion()));
+                    targetComponentsToResolve.add(e.getPackageName());
+                });
+
         Set<String> otherGroupTargetComponents =
                 getOtherGroupsTargetComponents(otherGroupsToRootComponents, componentNameToVersionConstraints);
-        logger.atDebug().kv("otherGroupTargets", otherGroupTargetComponents)
-                .log("Found the other group target components");
+        logger.atInfo().setEventType("resolve-non-target-group-dependencies-start")
+                .kv("otherGroupTargets", otherGroupTargetComponents)
+                .kv(COMPONENT_VERSION_REQUIREMENT_KEY, componentNameToVersionConstraints)
+                .log("Start to resolve other group dependencies");
         // populate other groups target components dependencies
-        // retrieve only dependency active version, update version requirement map
+        // resolve updated version from the cloud, update version requirement map
         for (String targetComponent : otherGroupTargetComponents) {
             resolveComponentDependencies(targetComponent, componentNameToVersionConstraints,
                     resolvedComponents, componentIncomingReferenceCount,
                     (name, requirements) ->
-                            componentManager.getActiveAndSatisfiedComponentMetadata(name, requirements));
+                            componentManager.resolveComponentVersion(name, requirements));
         }
-
-        // Get the target components with version requirements in the deployment document
-        List<String> targetComponentsToResolve = new ArrayList<>();
-        document.getDeploymentPackageConfigurationList().stream()
-                .filter(DeploymentPackageConfiguration::isRootComponent).forEach(e -> {
-            logger.atDebug().kv(COMPONENT_NAME_KEY, e.getPackageName()).kv(VERSION_KEY, e.getResolvedVersion())
-                    .log("Found component configuration");
-            componentNameToVersionConstraints.putIfAbsent(e.getPackageName(), new HashMap<>());
-            componentNameToVersionConstraints.get(e.getPackageName())
-                    .put(document.getGroupName(), Requirement.buildNPM(e.getResolvedVersion()));
-            targetComponentsToResolve.add(e.getPackageName());
-        });
+        logger.atInfo().setEventType("resolve-non-target-group-dependencies-end")
+                .log("Done resolving other group dependencies");
 
         logger.atInfo().setEventType("resolve-group-dependencies-start")
                 .kv("targetComponents", targetComponentsToResolve)
@@ -130,8 +137,8 @@ public class DependencyResolver {
             detectCircularDependency(component, resolvedComponents);
         }
 
-        List<ComponentIdentifier> resolvedComponentIdentifiers =  resolvedComponents.entrySet()
-                .stream().map(Map.Entry::getValue).map(md -> md.getComponentIdentifier())
+        List<ComponentIdentifier> resolvedComponentIdentifiers =  resolvedComponents.values()
+                .stream().map(ComponentMetadata::getComponentIdentifier)
                 .collect(Collectors.toList());
 
         checkNonExplicitNucleusUpdate(targetComponentsToResolve, resolvedComponentIdentifiers);

--- a/src/main/java/com/aws/greengrass/componentmanager/exceptions/NoAvailableComponentVersionException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/exceptions/NoAvailableComponentVersionException.java
@@ -10,21 +10,12 @@ import com.vdurmont.semver4j.Requirement;
 import java.util.Map;
 
 import static com.aws.greengrass.deployment.errorcode.DeploymentErrorCode.COMPONENT_VERSION_REQUIREMENTS_NOT_MET;
-import static com.aws.greengrass.deployment.errorcode.DeploymentErrorCode.INSTALLED_COMPONENT_NOT_FOUND;
 import static com.aws.greengrass.deployment.errorcode.DeploymentErrorCode.NO_AVAILABLE_COMPONENT_VERSION;
 
 @SuppressWarnings("checkstyle:MissingJavadocMethod")
 public class NoAvailableComponentVersionException extends PackagingException {
 
     static final long serialVersionUID = -3387516993124229948L;
-
-    public NoAvailableComponentVersionException(String initialMessage, String componentName, Requirement requirement) {
-        // this constructor is only used when loading active components
-        super(String.format("%s Component: %s version: %s", initialMessage.trim(), componentName,
-                requirement.toString()));
-        super.addErrorCode(NO_AVAILABLE_COMPONENT_VERSION);
-        super.addErrorCode(INSTALLED_COMPONENT_NOT_FOUND);
-    }
 
     public NoAvailableComponentVersionException(String initialMessage, String componentName,
                                                 Map<String, Requirement> requirements) {

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -52,6 +52,7 @@ import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMP
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -641,10 +642,6 @@ class DependencyResolverTest {
                 new ComponentMetadata(new ComponentIdentifier(componentC1, v1_2_0), Collections.emptyMap());
         when(componentManager.resolveComponentVersion(eq(componentC1), any()))
                 .thenReturn(componentC_1_2_0);
-        ComponentMetadata componentC_1_1_0 =
-                new ComponentMetadata(new ComponentIdentifier(componentC1, v1_1_0), Collections.emptyMap());
-        when(componentManager.getActiveAndSatisfiedComponentMetadata(eq(componentC1), any()))
-                .thenReturn(componentC_1_1_0);
 
         // prepare X
         Map<String, String> dependenciesX_2_x = new HashMap<>();
@@ -652,7 +649,7 @@ class DependencyResolverTest {
 
         ComponentMetadata componentX_2_0_0 =
                 new ComponentMetadata(new ComponentIdentifier(componentX, v2_0_0), dependenciesX_2_x);
-        when(componentManager.getActiveAndSatisfiedComponentMetadata(eq(componentX), any()))
+        when(componentManager.resolveComponentVersion(eq(componentX), any()))
                 .thenReturn(componentX_2_0_0);
 
 
@@ -678,17 +675,17 @@ class DependencyResolverTest {
                 new ComponentIdentifier(componentC1, v1_2_0), new ComponentIdentifier(componentX, v2_0_0)));
         ArgumentCaptor<String> componentNameCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Map<String, Requirement>> versionRequirementsCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(componentManager, times(5))
+        verify(componentManager, times(7))
                 .resolveComponentVersion(componentNameCaptor.capture(), versionRequirementsCaptor.capture());
         List<String> componentNameList = componentNameCaptor.getAllValues();
-        assertThat(componentNameList, contains("A", "B1", "C1", "B2", "C1"));
+        assertThat(componentNameList, containsInRelativeOrder("A", "B1", "C1", "B2", "C1"));
         List<Map<String, Requirement>> versionRequirementsList = versionRequirementsCaptor.getAllValues();
-        assertThat(versionRequirementsList.size(), is(5));
-        Map<String, Requirement> versionRequirements = versionRequirementsList.get(2);
+        assertThat(versionRequirementsList.size(), is(7));
+        Map<String, Requirement> versionRequirements = versionRequirementsList.get(4);
         assertThat(versionRequirements.size(), is(2));
         assertThat(versionRequirements, IsMapContaining.hasEntry("B1", Requirement.buildNPM(">=1.1.0")));
         assertThat(versionRequirements, IsMapContaining.hasEntry("X", Requirement.buildNPM(">=1.0.0")));
-        versionRequirements = versionRequirementsList.get(4);
+        versionRequirements = versionRequirementsList.get(6);
         assertThat(versionRequirements.size(), is(3));
         assertThat(versionRequirements, IsMapContaining.hasEntry("X", Requirement.buildNPM(">=1.0.0")));
         assertThat(versionRequirements, IsMapContaining.hasEntry("B1", Requirement.buildNPM(">=1.1.0")));

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -24,7 +24,6 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
-import org.bouncycastle.cert.ocsp.Req;
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +33,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.greengrassv2.model.Component;
 import software.amazon.awssdk.services.greengrassv2.model.DeploymentConfigurationValidationPolicy;
 import software.amazon.awssdk.utils.ImmutableMap;
 
@@ -697,7 +695,7 @@ class DependencyResolverTest {
         group1RootPackages.add(new ComponentRequirementIdentifier(componentA, Requirement.buildNPM("1.0.0")));
         otherGroupRootPackages.put("mockGroup1", group1RootPackages);
 
-        context.runOnPublishQueueAndWait(() -> System.out.println("Waiting for queue to finish updating the config"));
+        context.waitForPublishQueueToClear();
 
         List<ComponentIdentifier> result2 = dependencyResolver.resolveDependencies(doc2, otherGroupRootPackages);
 
@@ -792,7 +790,7 @@ class DependencyResolverTest {
         Map<String, Requirement> versionRequirements = versionRequirementsList.get(4);
         assertThat(versionRequirements.size(), is(2));
         assertThat(versionRequirements, IsMapContaining.hasEntry("B1", Requirement.buildNPM(">=1.1.0")));
-        assertThat(versionRequirements, IsMapContaining.hasEntry("X", Requirement.buildNPM(">=1.0.0")));
+        assertThat(versionRequirements, IsMapContaining.hasEntry("B2", Requirement.buildNPM("<=1.2.0")));
         versionRequirements = versionRequirementsList.get(6);
         assertThat(versionRequirements.size(), is(3));
         assertThat(versionRequirements, IsMapContaining.hasEntry("X", Requirement.buildNPM(">=1.0.0")));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change the multi-group dependency resolution to re-resolve all group dependencies by asking the cloud instead of trying to lock to the active version. This change completely removes the INSTALLED_COMPONENT_NOT_FOUND root cause.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
