### PR TITLE
fix(mqtt5): prevent npe in unsubscribe

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -577,7 +577,11 @@ public class MqttClient implements Closeable {
             }
 
             Pair<String, Consumer<MqttMessage>> lookup = new Pair<>(request.getTopic(), request.getCallback());
-            unsubscribe(Unsubscribe.builder().subscriptionCallback(cbMapping.get(lookup).getCallback())
+            Subscribe subReq = cbMapping.get(lookup);
+            if (subReq == null) {
+                return;
+            }
+            unsubscribe(Unsubscribe.builder().subscriptionCallback(subReq.getCallback())
                     .topic(request.getTopic()).build()).thenAccept((m) -> cbMapping.remove(lookup))
                     .get(getMqttOperationTimeoutMillis(), TimeUnit.MILLISECONDS);
         } catch (MqttRequestException e) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes possible null pointer exception if we can't find the callback for a given subscription.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
