### PR TITLE
fix: remove nucleus_restart_failure

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
@@ -121,8 +121,9 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
     private DeploymentException getDeploymentStatusDetails() {
         if (Utils.isEmpty(deployment.getStageDetails())) {
             return new DeploymentException(
-                    "Nucleus update workflow failed to restart Nucleus. See loader logs for more details",
-                    DeploymentErrorCode.NUCLEUS_RESTART_FAILURE);
+                    "An IO error occurred while persisting deployment failure reasons before deployment rollback. "
+                            + "Please check greengrass.log for detailed deployment failure",
+                    DeploymentErrorCode.IO_ERROR, DeploymentErrorType.DEVICE_ERROR);
         }
         List<DeploymentErrorCode> errorStack = deployment.getErrorStack() == null ? Collections.emptyList()
                 : deployment.getErrorStack().stream().map(DeploymentErrorCode::valueOf).collect(Collectors.toList());

--- a/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
+++ b/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
@@ -128,6 +128,7 @@ public enum DeploymentErrorCode {
 
     // Nucleus errors
     NUCLEUS_VERSION_NOT_FOUND(DeploymentErrorType.NUCLEUS_ERROR),
+    // the usage of this error code has been removed since https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1420
     NUCLEUS_RESTART_FAILURE(DeploymentErrorType.NUCLEUS_ERROR),
     INSTALLED_COMPONENT_NOT_FOUND(DeploymentErrorType.NUCLEUS_ERROR),
 

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/DeploymentException.java
@@ -78,6 +78,12 @@ public class DeploymentException extends Exception {
         this.errorTypes.addAll(errorTypes);
     }
 
+    public DeploymentException(String message, DeploymentErrorCode errorCode, DeploymentErrorType errorType) {
+        super(message);
+        addErrorCode(errorCode);
+        addErrorType(errorType);
+    }
+
     public DeploymentException withErrorContext(Throwable t, DeploymentErrorCode errorCode) {
         errorContext.putIfAbsent(t.getClass().getSimpleName(), errorCode);
         return this;

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -219,9 +219,14 @@ public class Kernel {
                         deployment.setErrorTypes(errorReport.getRight());
                         deployment.setStageDetails(Utils.generateFailureMessage(e));
                         deploymentDirectoryManager.writeDeploymentMetadata(deployment);
-                        kernelAlts.prepareRollback();
                     } catch (IOException ioException) {
                         logger.atError().setCause(ioException).log("Something went wrong while preparing for rollback");
+                    }
+                    try {
+                        kernelAlts.prepareRollback();
+                    } catch (IOException ioException) {
+                        logger.atError().setCause(ioException).log("Something went wrong while setting up rollback "
+                                + "directory");
                     }
                     shutdown(30, REQUEST_RESTART);
                 }

--- a/src/main/java/com/aws/greengrass/util/Utils.java
+++ b/src/main/java/com/aws/greengrass/util/Utils.java
@@ -206,7 +206,7 @@ public final class Utils {
     }
 
     private static String getMessageFromThrowable(Throwable t) {
-        if (t.getMessage() == null) {
+        if (isEmpty(t.getMessage())) {
             return t.getClass().getName();
         } else {
             return t.getMessage();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Replace the usage of NUCLEUS_RESTART_FAILURE with an IO error since the failure indicates an io error while persisting deployment failure reason across nucleus restarts.
2. Make sure `Utils::generateFailureMessage` never returns empty string.
3. Always prepare rollback directory even if there is an IO error with processing deployment metadata

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
