### PR TITLE
fix: re-negotiate with cloud if local recipe metadata contains a mismatched region

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -150,7 +150,8 @@ public class ComponentManager implements InjectionActions {
         ComponentIdentifier resolvedComponentId;
 
         if (versionRequirements.containsKey(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME)
-                && localCandidateOptional.isPresent()) {
+                && localCandidateOptional.isPresent() && componentStore.componentMetadataRegionCheck(
+                localCandidateOptional.get(), Coerce.toString(deviceConfiguration.getAWSRegion()))) {
             // If local group has a requirement and a satisfying local version presents, use it and don't negotiate with
             // cloud.
             logger.atInfo().log("Local group has a requirement and found satisfying local candidate. Using the local"

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -29,6 +29,7 @@ import com.vdurmont.semver4j.Semver;
 import com.vdurmont.semver4j.SemverException;
 import lombok.NonNull;
 import org.apache.commons.io.FileUtils;
+import software.amazon.awssdk.arns.Arn;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +57,8 @@ public class ComponentStore {
 
     private static final Logger logger = LogManager.getLogger(ComponentStore.class);
     private static final String LOG_KEY_RECIPE_METADATA_FILE_PATH = "RecipeMetadataFilePath";
+    private static final String LOG_METADATA_INVALID = "Ignoring the local metadata file and proceeding with "
+            + "dependency resolution";
     private static final String RECIPE_SUFFIX = ".recipe";
 
     private final NucleusPaths nucleusPaths;
@@ -466,6 +469,62 @@ public class ComponentStore {
     }
 
     /**
+     * Get component version arn stored in local metadata and check if its region matches the expected region.
+     *
+     * @param localCandidate component to be checked
+     * @param region expected region
+     * @return true if region matches; false if region does not match or anything goes wrong
+     */
+    public boolean componentMetadataRegionCheck(ComponentIdentifier localCandidate, String region) {
+        File metadataFile;
+        try {
+            metadataFile = resolveRecipeMetadataFile(localCandidate);
+        } catch (PackageLoadingException e) {
+            // Hashing algorithm does not exist, which should never happen
+            return true;
+        }
+
+        try {
+            RecipeMetadata recipeMetadata = getRecipeMetadata(metadataFile);
+            Arn arn = Arn.fromString(recipeMetadata.getComponentVersionArn());
+            Optional<String> arnRegion = arn.region();
+            if (arnRegion.isPresent()) {
+                if (region.equals(arnRegion.get())) {
+                    // region matches
+                    return true;
+                } else {
+                    logger.atWarn().kv("componentName", localCandidate.toString())
+                            .kv("expectedRegion", region).kv("foundRegion", arnRegion.get())
+                            .kv("metadataPath", metadataFile.getAbsolutePath())
+                            .log("Component version arn in recipe metadata contains a different region from "
+                                    + "nucleus config" + LOG_METADATA_INVALID);
+                    return false;
+                }
+            } else {
+                logger.atWarn().kv("componentName", localCandidate.toString())
+                        .kv("metadataPath", metadataFile.getAbsolutePath())
+                        .log("Invalid region value for component version arn in recipe metadata. "
+                                + LOG_METADATA_INVALID);
+                return false;
+            }
+        } catch (PackageLoadingException e) {
+            if (e.getErrorCodes().contains(DeploymentErrorCode.LOCAL_RECIPE_METADATA_NOT_FOUND)) {
+                // if file does not exist, then it is likely a locally installed component
+                // if not, deployment will fail
+                return true;
+            }
+            // not logging the file path since it's already logged previously in getRecipeMetadata
+            logger.atWarn().setCause(e).log("Failed to read metadata. " + LOG_METADATA_INVALID);
+        } catch (IllegalArgumentException e) {
+            // Failed to parse the Arn string
+            logger.atWarn().kv("componentName", localCandidate.toString()).setCause(e)
+                    .kv("metadataPath", metadataFile.getAbsolutePath())
+                    .log("Failed to parse the component version arn in recipe metadata. " + LOG_METADATA_INVALID);
+        }
+        return false;
+    }
+
+    /**
      * Reads component recipe metadata file.
      *
      * @param componentIdentifier component id
@@ -473,10 +532,13 @@ public class ComponentStore {
      */
     public RecipeMetadata getRecipeMetadata(ComponentIdentifier componentIdentifier) throws PackageLoadingException {
         File metadataFile = resolveRecipeMetadataFile(componentIdentifier);
+        return getRecipeMetadata(metadataFile);
+    }
 
+    private RecipeMetadata getRecipeMetadata(File metadataFile) throws PackageLoadingException {
         if (!metadataFile.exists()) {
-            // log error because this is not expected to happen in any normal case
-            logger.atError().kv(LOG_KEY_RECIPE_METADATA_FILE_PATH, metadataFile.getAbsolutePath())
+            // this may happen if it's a locally installed component and has no metadata
+            logger.atDebug().kv(LOG_KEY_RECIPE_METADATA_FILE_PATH, metadataFile.getAbsolutePath())
                     .log("Recipe metadata file doesn't exist");
 
             throw new PackageLoadingException(String.format(

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -57,7 +57,7 @@ public class ComponentStore {
 
     private static final Logger logger = LogManager.getLogger(ComponentStore.class);
     private static final String LOG_KEY_RECIPE_METADATA_FILE_PATH = "RecipeMetadataFilePath";
-    private static final String LOG_METADATA_INVALID = "Ignoring the local metadata file and proceeding with "
+    private static final String LOG_METADATA_INVALID = "Ignoring the local recipe metadata file and proceeding with "
             + "dependency resolution";
     private static final String RECIPE_SUFFIX = ".recipe";
 
@@ -497,7 +497,7 @@ public class ComponentStore {
                             .kv("expectedRegion", region).kv("foundRegion", arnRegion.get())
                             .kv("metadataPath", metadataFile.getAbsolutePath())
                             .log("Component version arn in recipe metadata contains a different region from "
-                                    + "nucleus config" + LOG_METADATA_INVALID);
+                                    + "nucleus config. " + LOG_METADATA_INVALID);
                     return false;
                 }
             } else {
@@ -510,7 +510,7 @@ public class ComponentStore {
         } catch (PackageLoadingException e) {
             if (e.getErrorCodes().contains(DeploymentErrorCode.LOCAL_RECIPE_METADATA_NOT_FOUND)) {
                 // if file does not exist, then it is likely a locally installed component
-                // if not, deployment will fail
+                // if not, deployment will fail when downloading artifact from cloud
                 return true;
             }
             // not logging the file path since it's already logged previously in getRecipeMetadata

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
@@ -595,6 +595,41 @@ class ComponentStoreTest {
                 .getRecipeMetadata(new ComponentIdentifier("HelloWorld", new Semver("0.0.0-test-corrupted"))));
     }
 
+    @Test
+    void GIVEN_valid_component_arn_WHEN_componentMetadataRegionCheck_THEN_return_true() throws Exception {
+        // test a cloud component
+        preloadRecipeMetadataFileFromTestResource("MockAWSService@1.0.0.metadata.json");
+        assertTrue(componentStore.componentMetadataRegionCheck(new ComponentIdentifier("MockAWSService",
+                new Semver("1.0.0")), "us-west-2"));
+
+        // test a local component with no component arn
+        assertTrue(componentStore.componentMetadataRegionCheck(new ComponentIdentifier("LocalComponent",
+                new Semver("1.0.0")), "us-west-2"));
+    }
+
+    @Test
+    void GIVEN_invalid_component_arn_WHEN_componentMetadataRegionCheck_THEN_return_false(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, JsonParseException.class);
+        ignoreExceptionOfType(context, PackageLoadingException.class);
+        ignoreExceptionOfType(context, IllegalArgumentException.class);
+
+        // arn with a different region
+        preloadRecipeMetadataFileFromTestResource("MockAWSService@1.0.0-bad-region.metadata.json");
+        assertFalse(componentStore.componentMetadataRegionCheck(new ComponentIdentifier("MockAWSService",
+                new Semver("1.0.0-bad-region")), "us-west-2"));
+
+        // invalid json
+        preloadRecipeMetadataFileFromTestResource("HelloWorld@0.0.0-test-corrupted.metadata.json");
+        assertFalse(componentStore.componentMetadataRegionCheck(new ComponentIdentifier("HelloWorld",
+                new Semver("0.0.0-test-corrupted")), "us-west-2"));
+
+        // invalid arn
+        preloadRecipeMetadataFileFromTestResource("MockAWSService@1.0.0-invalid-arn.metadata.json");
+        assertFalse(componentStore.componentMetadataRegionCheck(new ComponentIdentifier("MockAWSService",
+                new Semver("1.0.0-invalid-arn")), "us-west-2"));
+    }
+
     private void preloadRecipeMetadataFileFromTestResource(String fileName) throws Exception {
         Path sourceRecipe = RECIPE_METADATA_RESOURCE_PATH.resolve(fileName);
         String componentName = fileName.split("@")[0];

--- a/src/test/resources/com/aws/greengrass/componentmanager/test_recipe_metadata_files/MockAWSService@1.0.0-bad-region.metadata.json
+++ b/src/test/resources/com/aws/greengrass/componentmanager/test_recipe_metadata_files/MockAWSService@1.0.0-bad-region.metadata.json
@@ -1,0 +1,3 @@
+{
+  "componentVersionArn":"arn:aws:greengrass:us-east-2:aws:components:MockAWSService:versions:1.0.0"
+}

--- a/src/test/resources/com/aws/greengrass/componentmanager/test_recipe_metadata_files/MockAWSService@1.0.0-invalid-arn.metadata.json
+++ b/src/test/resources/com/aws/greengrass/componentmanager/test_recipe_metadata_files/MockAWSService@1.0.0-invalid-arn.metadata.json
@@ -1,0 +1,3 @@
+{
+  "componentVersionArn":"arn0"
+}

--- a/src/test/resources/com/aws/greengrass/componentmanager/test_recipe_metadata_files/MockAWSService@1.0.0.metadata.json
+++ b/src/test/resources/com/aws/greengrass/componentmanager/test_recipe_metadata_files/MockAWSService@1.0.0.metadata.json
@@ -1,0 +1,3 @@
+{
+  "componentVersionArn":"arn:aws:greengrass:us-west-2:aws:components:MockAWSService:versions:1.0.0"
+}


### PR DESCRIPTION
**Description of changes:**
- validate the region of component version arn stored in recipe metadata of local candidate; if it doesn't match, then renegotiate with cloud.
- added unit test

**Why is this change necessary:**
We are seeing on rare occasions when customer launches nucleus in region A whereas the local recipe metadata of a 1p component is pointing to a different region B for local deployment. This changes allows deployment to renegotiate with cloud and get the correct recipe metadata.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
