### PR TITLE
fix: retry on 5xx errors

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -28,6 +28,7 @@ import com.aws.greengrass.dependency.InjectionActions;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
+import com.aws.greengrass.deployment.exceptions.RetryableServerErrorException;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
@@ -99,7 +100,8 @@ public class ComponentManager implements InjectionActions {
     private RetryUtils.RetryConfig clientExceptionRetryConfig =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1))
                     .maxRetryInterval(Duration.ofMinutes(1)).maxAttempt(Integer.MAX_VALUE)
-                    .retryableExceptions(Arrays.asList(SdkClientException.class)).build();
+                    .retryableExceptions(Arrays.asList(SdkClientException.class,
+                            RetryableServerErrorException.class)).build();
 
     @Inject
     @Setter

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.deployment.exceptions.RetryableServerErrorException;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.ProxyUtils;
 import com.aws.greengrass.util.RetryUtils;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+
 public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     static final String CONTENT_LENGTH_HEADER = "content-length";
     private static final List<DeploymentErrorCode> HTTP_DOWNLOAD_ERROR_CODE =
@@ -56,7 +58,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1L))
                     .maxRetryInterval(Duration.ofMinutes(1L)).maxAttempt(Integer.MAX_VALUE)
                     .retryableExceptions(Arrays.asList(SdkClientException.class, IOException.class,
-                            DeviceConfigurationException.class)).build();
+                            DeviceConfigurationException.class, RetryableServerErrorException.class)).build();
 
     protected GreengrassRepositoryDownloader(GreengrassServiceClientFactory clientFactory,
                                              ComponentIdentifier identifier, ComponentArtifact artifact,
@@ -94,7 +96,9 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
         }
     }
 
-    private Long getDownloadSizeWithoutRetry() throws InterruptedException, PackageDownloadException, IOException {
+    @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.AvoidCatchingGenericException"})
+    private Long getDownloadSizeWithoutRetry() throws InterruptedException, PackageDownloadException, IOException,
+            RetryableServerErrorException {
         String url = getArtifactDownloadURL(identifier, artifact.getArtifactUri().getSchemeSpecificPart());
 
         try (SdkHttpClient client = getSdkHttpClient()) {
@@ -112,6 +116,9 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
                             DeploymentErrorCode.GREENGRASS_ARTIFACT_SIZE_NOT_FOUND);
                 }
                 return length;
+            } else if (RetryUtils.retryErrorCodes(responseCode)) {
+                throw new RetryableServerErrorException("Failed to get download size with retryable error. Error code"
+                        + responseCode);
             } else {
                 throw new PackageDownloadException(
                         getErrorString("Failed to get download size. HTTP response: " + responseCode),
@@ -131,9 +138,10 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
             return RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
                 try (SdkHttpClient client = getSdkHttpClient()) {
                     HttpExecuteRequest executeRequest = HttpExecuteRequest.builder().request(
-                            SdkHttpFullRequest.builder().uri(URI.create(url)).method(SdkHttpMethod.GET)
-                                    .putHeader(HTTP_RANGE_HEADER_KEY,
-                                            String.format(HTTP_RANGE_HEADER_FORMAT, rangeStart, rangeEnd)).build())
+                                    SdkHttpFullRequest.builder().uri(URI.create(url)).method(SdkHttpMethod.GET)
+                                            .putHeader(HTTP_RANGE_HEADER_KEY,
+                                                    String.format(HTTP_RANGE_HEADER_FORMAT, rangeStart, rangeEnd))
+                                            .build())
                             .build();
                     HttpExecuteResponse executeResponse = client.prepareRequest(executeRequest).call();
 
@@ -177,6 +185,9 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
                                 return downloaded;
                             }
                         }
+                    } else if (RetryUtils.retryErrorCodes(responseCode)) {
+                        throw new RetryableServerErrorException(
+                                "Failed to download artifact with retryable error, error code:" + responseCode);
                     } else {
                         throw new PackageDownloadException(
                                 getErrorString("Unable to download Greengrass artifact. HTTP Error: " + responseCode),
@@ -209,12 +220,20 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
 
         try {
             return RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {
-                GetComponentVersionArtifactRequest getComponentArtifactRequest =
-                        GetComponentVersionArtifactRequest.builder().artifactName(artifactName).arn(arn).build();
-                GetComponentVersionArtifactResponse getComponentArtifactResult =
-                        clientFactory.fetchGreengrassV2DataClient()
-                                .getComponentVersionArtifact(getComponentArtifactRequest);
-                return getComponentArtifactResult.preSignedUrl();
+                try {
+                    GetComponentVersionArtifactRequest getComponentArtifactRequest =
+                            GetComponentVersionArtifactRequest.builder().artifactName(artifactName).arn(arn).build();
+                    GetComponentVersionArtifactResponse getComponentArtifactResult =
+                            clientFactory.fetchGreengrassV2DataClient()
+                                    .getComponentVersionArtifact(getComponentArtifactRequest);
+                    return getComponentArtifactResult.preSignedUrl();
+                } catch (GreengrassV2DataException e) {
+                    if (RetryUtils.retryErrorCodes(e.statusCode())) {
+                        throw new RetryableServerErrorException("Failed with retryable error" + e.statusCode()
+                                + "when calling getComponentVersionArtifact", e);
+                    }
+                    throw e;
+                }
             }, "get-artifact-size", logger);
         } catch (InterruptedException e) {
             throw e;

--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -181,7 +181,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
         }
     }
 
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
     private Map<String, Set<ComponentRequirementIdentifier>> getNonTargetGroupToRootPackagesMap(
             DeploymentDocument deploymentDocument)
             throws DeploymentTaskFailureException, InterruptedException {
@@ -209,7 +209,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
                 throw new DeploymentTaskFailureException("Error fetching thing group information", e);
             }
         } catch (Exception e) {
-            if (isLocalDeployment && ThingGroupHelper.DEVICE_OFFLINE_INDICATIVE_EXCEPTIONS.contains(e.getClass())) {
+            if (isLocalDeployment && ThingGroupHelper.RETRYABLE_EXCEPTIONS.contains(e.getClass())) {
                 logger.atWarn().setCause(e).log("Failed to get thing group hierarchy, local deployment will proceed");
                 groupsForDeviceOpt = getPersistedMembershipInfo();
             } else {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.deployment.exceptions.DeploymentTaskFailureException;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.deployment.exceptions.InvalidRequestException;
 import com.aws.greengrass.deployment.exceptions.RetryableDeploymentDocumentDownloadException;
+import com.aws.greengrass.deployment.exceptions.RetryableServerErrorException;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -23,6 +24,8 @@ import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.RetryUtils;
 import com.aws.greengrass.util.SerializerFactory;
 import com.aws.greengrass.util.Utils;
+import lombok.AccessLevel;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -55,12 +58,12 @@ public class DeploymentDocumentDownloader {
     private final GreengrassServiceClientFactory greengrassServiceClientFactory;
     private final HttpClientProvider httpClientProvider;
     private final DeviceConfiguration deviceConfiguration;
-
+    @Setter(AccessLevel.PACKAGE)
     private final RetryUtils.RetryConfig clientExceptionRetryConfig =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1))
                     .maxRetryInterval(Duration.ofMinutes(1)).maxAttempt(Integer.MAX_VALUE)
                     .retryableExceptions(Arrays.asList(RetryableDeploymentDocumentDownloadException.class,
-                            DeviceConfigurationException.class)).build();
+                            DeviceConfigurationException.class, RetryableServerErrorException.class)).build();
 
     /**
      * Constructor.
@@ -111,7 +114,7 @@ public class DeploymentDocumentDownloader {
 
     protected String downloadDeploymentDocument(String deploymentId)
             throws DeploymentTaskFailureException, RetryableDeploymentDocumentDownloadException,
-            DeviceConfigurationException, HashingAlgorithmUnavailableException {
+            DeviceConfigurationException, HashingAlgorithmUnavailableException, RetryableServerErrorException {
         // 1. Get url, digest, and algorithm by calling gg data plane
         GetDeploymentConfigurationResponse response = getDeploymentConfiguration(deploymentId);
 
@@ -163,7 +166,7 @@ public class DeploymentDocumentDownloader {
 
     private GetDeploymentConfigurationResponse getDeploymentConfiguration(String deploymentId)
             throws RetryableDeploymentDocumentDownloadException, DeviceConfigurationException,
-            DeploymentTaskFailureException {
+            DeploymentTaskFailureException, RetryableServerErrorException {
         String thingName = Coerce.toString(deviceConfiguration.getThingName());
         GetDeploymentConfigurationRequest getDeploymentConfigurationRequest =
                 GetDeploymentConfigurationRequest.builder().deploymentId(deploymentId).coreDeviceThingName(thingName)
@@ -176,15 +179,19 @@ public class DeploymentDocumentDownloader {
                     .log("Calling Greengrass cloud to get full deployment configuration");
 
             deploymentConfiguration = greengrassServiceClientFactory.fetchGreengrassV2DataClient()
-                    .getDeploymentConfiguration(getDeploymentConfigurationRequest);
+                            .getDeploymentConfiguration(getDeploymentConfigurationRequest);
+
         } catch (GreengrassV2DataException e) {
-            if (e.statusCode() == HttpStatusCode.FORBIDDEN) {
+            if (RetryUtils.retryErrorCodes(e.statusCode())) {
+                throw new RetryableServerErrorException("Failed with retryable error: " + e.statusCode()
+                        + "while calling getDeploymetnConfiguration", e);
+            }
+            if (e.statusCode() == HttpStatusCode.FORBIDDEN)  {
                 throw new DeploymentTaskFailureException(
                         "Access denied when calling GetDeploymentConfiguration. Ensure "
                                 + "certificate policy grants greengrass:GetDeploymentConfiguration",
                         e).withErrorContext(e, DeploymentErrorCode.GET_DEPLOYMENT_CONFIGURATION_ACCESS_DENIED);
             }
-            // TODO: better retry handling
             throw new DeploymentTaskFailureException("Error while calling GetDeploymentConfiguration", e);
         } catch (AwsServiceException e) {
             throw new RetryableDeploymentDocumentDownloadException(
@@ -193,8 +200,6 @@ public class DeploymentDocumentDownloader {
             throw new RetryableDeploymentDocumentDownloadException(
                     "Failed to contact Greengrass cloud or unable to parse response", e);
         }
-
-
         return deploymentConfiguration;
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/RetryableServerErrorException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/RetryableServerErrorException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.exceptions;
+
+/**
+ * Exception for handling 5xx deployment failures.
+ */
+public class RetryableServerErrorException extends DeploymentException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public RetryableServerErrorException(String message) {
+        super(message);
+    }
+
+    public RetryableServerErrorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/util/RetryUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RetryUtils.java
@@ -90,4 +90,14 @@ public class RetryUtils {
         int maxAttempt = 10;
         List<Class> retryableExceptions;
     }
+
+    /**
+     * Check if given error code qualifies for triggering retry mechanism.
+     *
+     * @param errorCode     retry configuration
+     * @return boolean
+     */
+    public static boolean retryErrorCodes(int errorCode) {
+        return errorCode >= 500 || errorCode == 429 ? true : false;
+    }
 }

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/S3DownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/S3DownloaderTest.java
@@ -10,13 +10,17 @@ import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriExceptio
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.deployment.exceptions.RetryableServerErrorException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.S3SdkClientFactory;
 import com.vdurmont.semver4j.Semver;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -43,15 +47,13 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class S3DownloaderTest {
@@ -73,6 +75,8 @@ class S3DownloaderTest {
     @Mock
     private S3SdkClientFactory s3SdkClientFactory;
 
+    @Mock
+    private Context context;
     @BeforeEach
     void setup() throws DeviceConfigurationException {
         lenient().when(s3SdkClientFactory.getS3Client()).thenReturn(s3Client);
@@ -80,7 +84,12 @@ class S3DownloaderTest {
         lenient().when(s3Client.getBucketLocation(any(GetBucketLocationRequest.class)))
                 .thenReturn(mock(GetBucketLocationResponse.class));
     }
-
+    @AfterEach
+    void after() throws Exception {
+        if (context != null) {
+            context.close();
+        }
+    }
     @Test
     void GIVEN_wrong_region_WHEN_head_THEN_finds_right_region() throws Exception {
         when(s3Client.getBucketLocation(any(GetBucketLocationRequest.class))).thenThrow(S3Exception.builder().message(
@@ -173,4 +182,73 @@ class S3DownloaderTest {
             ComponentTestResourceHelper.cleanDirectory(testCache);
         }
     }
+
+    @Test
+    void GIVEN_s3_artifact_uri_WHEN_cloud_deployment_error_in_getting_from_s3_THEN_retry(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, RetryableServerErrorException.class);
+        Path testCache = ComponentTestResourceHelper.getPathForLocalTestCache();
+        Path artifactFilePath =
+                Files.write(tempDir.resolve("artifact.txt"), Collections.singletonList(VALID_ARTIFACT_CONTENT),
+                        StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        ResponseInputStream<GetObjectResponse> getObjectResponse = null;
+        try {
+            String checksum = Base64.getEncoder()
+                    .encodeToString(MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(artifactFilePath)));
+            Path saveToPath = testCache.resolve(TEST_COMPONENT_NAME).resolve(TEST_COMPONENT_VERSION);
+            if (Files.notExists(saveToPath)) {
+                Files.createDirectories(saveToPath);
+            }
+            S3Downloader s3Downloader = new S3Downloader(s3SdkClientFactory,
+                    new ComponentIdentifier(TEST_COMPONENT_NAME, new Semver(TEST_COMPONENT_VERSION)),
+                    ComponentArtifact.builder().artifactUri(new URI(VALID_ARTIFACT_URI))
+                            .checksum(checksum).algorithm(VALID_ALGORITHM).build(),
+                    saveToPath);
+            getObjectResponse = new ResponseInputStream<>(GetObjectResponse.builder().build(),
+                    AbortableInputStream.create(new ByteArrayInputStream(Files.readAllBytes(artifactFilePath))));
+            Exception e = S3Exception.builder().statusCode(500).build();
+            when(s3Client.getObject(any(GetObjectRequest.class))).thenThrow(e)
+                    .thenReturn(getObjectResponse);
+            HeadObjectResponse  headObjectResponse = HeadObjectResponse.builder()
+                    .contentLength(Files.size(artifactFilePath)).build();
+            when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
+
+            s3Downloader.download();
+            byte[] downloadedFile = Files.readAllBytes(saveToPath.resolve("artifact.txt"));
+            assertThat("Content of downloaded file should be same as the artifact content",
+                    Arrays.equals(Files.readAllBytes(artifactFilePath), downloadedFile));
+            verify(s3Client, times(2)).getObject(any(GetObjectRequest.class));
+        } finally {
+            if (getObjectResponse != null) {
+                getObjectResponse.close();
+            }
+            ComponentTestResourceHelper.cleanDirectory(testCache);
+            ComponentTestResourceHelper.cleanDirectory(artifactFilePath);
+        }
+    }
+
+    @Test
+    void GIVEN_download_size_WHEN_head_fails_with_server_error_THEN_retry(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, RetryableServerErrorException.class);
+        Path testCache = ComponentTestResourceHelper.getPathForLocalTestCache();
+        Path artifactFilePath =
+                Files.write(tempDir.resolve("artifact.txt"), Collections.singletonList(VALID_ARTIFACT_CONTENT),
+                        StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        String checksum = Base64.getEncoder()
+                .encodeToString(MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(artifactFilePath)));
+        Path saveToPath = testCache.resolve(TEST_COMPONENT_NAME).resolve(TEST_COMPONENT_VERSION);
+        S3Downloader s3Downloader = new S3Downloader(s3SdkClientFactory,
+                new ComponentIdentifier(TEST_COMPONENT_NAME, new Semver(TEST_COMPONENT_VERSION)),
+                ComponentArtifact.builder().artifactUri(new URI(VALID_ARTIFACT_URI))
+                        .checksum(checksum).algorithm(VALID_ALGORITHM).build(),
+                saveToPath);
+        Exception e = S3Exception.builder().statusCode(500).build();
+        HeadObjectResponse  headObjectResponse = HeadObjectResponse.builder()
+                .contentLength(5L).build();
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(e).thenReturn(headObjectResponse);
+        s3Downloader.getDownloadSize();
+        verify(s3Client, times(2)).headObject(any(HeadObjectRequest.class));
+
+    }
+
 }

--- a/src/test/java/com/aws/greengrass/deployment/ThingGroupHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ThingGroupHelperTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.deployment.exceptions.RetryableServerErrorException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+import software.amazon.awssdk.services.greengrassv2data.model.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.aws.greengrass.componentmanager.ComponentServiceHelper.CLIENT_RETRY_COUNT;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class ThingGroupHelperTest {
+    @Mock
+    private DeviceConfiguration deviceConfiguration;
+
+    @Mock
+    private GreengrassV2DataClient client;
+
+    @Mock
+    private GreengrassServiceClientFactory clientFactory;
+
+    @Mock
+    private final AtomicReference<String> nextToken = new AtomicReference<>();
+
+    private ThingGroupHelper helper;
+
+    @Test
+    void GIVEN_list_thing_groups_for_core_device_request_WHEN_500_error_then_retry(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, RetryableServerErrorException.class);
+        this.helper = spy(new ThingGroupHelper(clientFactory, deviceConfiguration));
+        ListThingGroupsForCoreDeviceRequest request = ListThingGroupsForCoreDeviceRequest.builder()
+                .coreDeviceThingName(Coerce.toString(deviceConfiguration.getThingName()))
+                .nextToken(nextToken.get()).build();
+        when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
+        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
+
+        when(client.listThingGroupsForCoreDevice(request))
+                .thenThrow(GreengrassV2DataException.builder().statusCode(500).build());
+        assertThrows(RetryableServerErrorException.class, () ->
+                helper.listThingGroupsForDevice(3));
+
+        verify(clientFactory, times(CLIENT_RETRY_COUNT)).fetchGreengrassV2DataClient();
+    }
+}


### PR DESCRIPTION
**Description of changes:**
1. Add simple util for checking 500 errors
2. Add new exception type to catch 500 erros
3. Throw new exception type to retry
**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
