### PR TITLE
fix(spool): remove message when retries run out

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -623,6 +623,7 @@ public class MqttClient implements Closeable {
                                 logger.atError().log("Failed to publish the message via Spooler"
                                                 + " after retried {} times and will drop the message",
                                         maxPublishRetryCount, throwable);
+                                spool.removeMessageById(finalId);
                             }
 
                         }

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -719,7 +719,7 @@ class MqttClientTest {
         client.publishSingleSpoolerMessage(awsIotMqttClient);
 
         verify(awsIotMqttClient).publish(any(), any(), anyBoolean());
-        verify(spool, never()).removeMessageById(anyLong());
+        verify(spool, times(1)).removeMessageById(anyLong());
         verify(spool, never()).addId(anyLong());
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove the mqtt message from the spooler when we run out of retries.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
