### PR TITLE
chore: do not validate device config for custom domain endpoints

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -141,6 +141,7 @@ public class DeviceConfiguration {
     public static final String NUCLEUS_BUILD_METADATA_DIRECTORY = "conf";
     public static final String NUCLEUS_RECIPE_FILENAME = "recipe.yaml";
     public static final String FALLBACK_DEFAULT_REGION = "us-east-1";
+    public static final String AMAZON_DOMAIN_SEQUENCE = ".amazonaws.";
     protected static final String FALLBACK_VERSION = "0.0.0";
     private final Kernel kernel;
 
@@ -861,12 +862,14 @@ public class DeviceConfiguration {
             throw new ComponentConfigurationValidationException(
                     String.format("Error looking up AWS region %s", awsRegion), DeploymentErrorCode.UNSUPPORTED_REGION);
         }
-        if (Utils.isNotEmpty(iotCredEndpoint) && !iotCredEndpoint.contains(awsRegion)) {
+        if (Utils.isNotEmpty(iotCredEndpoint) && iotCredEndpoint.contains(AMAZON_DOMAIN_SEQUENCE)
+                && !iotCredEndpoint.contains(awsRegion)) {
             throw new ComponentConfigurationValidationException(
                     String.format("IoT credential endpoint region %s does not match the AWS region %s of the device",
                             iotCredEndpoint, awsRegion), DeploymentErrorCode.IOT_CRED_ENDPOINT_FORMAT_NOT_VALID);
         }
-        if (Utils.isNotEmpty(iotDataEndpoint) && !iotDataEndpoint.contains(awsRegion)) {
+        if (Utils.isNotEmpty(iotDataEndpoint) && iotDataEndpoint.contains(AMAZON_DOMAIN_SEQUENCE)
+                && !iotDataEndpoint.contains(awsRegion)) {
             throw new ComponentConfigurationValidationException(
                     String.format("IoT data endpoint region %s does not match the AWS region %s of the device",
                             iotDataEndpoint, awsRegion), DeploymentErrorCode.IOT_DATA_ENDPOINT_FORMAT_NOT_VALID);

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -123,6 +123,13 @@ class DeviceConfigurationTest {
     }
 
     @Test
+    void GIVEN_good_custom_config_WHEN_validate_THEN_succeeds() {
+        deviceConfiguration = new DeviceConfiguration(mockKernel);
+        assertDoesNotThrow(() -> deviceConfiguration.validateEndpoints("us-east-1", "xxxxxx.custom-cred-endpoint.com",
+                "xxxxxx.custom-data-endpoint.com"));
+    }
+
+    @Test
     void GIVEN_bad_cred_endpoint_config_WHEN_validate_THEN_fails() {
         deviceConfiguration = new DeviceConfiguration(mockKernel);
         ComponentConfigurationValidationException ex = assertThrows(ComponentConfigurationValidationException.class,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:** Do not validate credential and data endpoints if domain is not an Amazon domain

**Why is this change necessary:** Currently, if a customer wants to configure device with custom domain (not amazonaws.com) endpoints then Nucleus throws a device configuration exception

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
