### PR TITLE
fix: validate mqtt topic is not empty

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -683,6 +683,9 @@ public class MqttClient implements Closeable {
     }
 
     protected void isValidRequestTopic(String topic) throws MqttRequestException {
+        if (Utils.isEmpty(topic)) {
+            throw new MqttRequestException("Topic must not be empty");
+        }
         if (Pattern.matches(reservedTopicTemplate, topic.toLowerCase())) {
             // remove the prefix of "$aws/rules/rule-name/"
             topic = topic.toLowerCase().split(prefixOfReservedTopic, 2)[1];


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
MQTT topic must not be empty.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
