### PR TITLE
fix(mqtt5): pass in keepalive to mqtt 5 client

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -61,6 +61,8 @@ import java.util.stream.Collectors;
 import javax.inject.Provider;
 
 import static com.aws.greengrass.mqttclient.AwsIotMqttClient.QOS_KEY;
+import static com.aws.greengrass.mqttclient.MqttClient.DEFAULT_MQTT_KEEP_ALIVE_TIMEOUT;
+import static com.aws.greengrass.mqttclient.MqttClient.MQTT_KEEP_ALIVE_TIMEOUT_KEY;
 
 class AwsIotMqtt5Client implements IndividualMqttClient {
 
@@ -307,7 +309,9 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                             minConnectTimeSeconds == 0 ? null : minConnectTimeSeconds * 1000)
                     .withConnectProperties(new ConnectPacket.ConnectPacketBuilder()
                         .withRequestProblemInformation(true)
-                        .withClientId(clientId)
+                        .withClientId(clientId).withKeepAliveIntervalSeconds(Coerce.toLong(
+                                    mqttTopics.findOrDefault(DEFAULT_MQTT_KEEP_ALIVE_TIMEOUT,
+                                            MQTT_KEEP_ALIVE_TIMEOUT_KEY)) / 1000)
                         .withReceiveMaximum(Coerce.toLong(mqttTopics.findOrDefault(100L, "receiveMaximum")))
                         .withSessionExpiryIntervalSeconds(Coerce.toLong(mqttTopics.findOrDefault(10_080L,
                                 "sessionExpirySeconds")))

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -92,8 +92,8 @@ import static com.aws.greengrass.mqttclient.AwsIotMqttClient.TOPIC_KEY;
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals"})
 public class MqttClient implements Closeable {
     private static final Logger logger = LogManager.getLogger(MqttClient.class);
-    private static final String MQTT_KEEP_ALIVE_TIMEOUT_KEY = "keepAliveTimeoutMs";
-    private static final int DEFAULT_MQTT_KEEP_ALIVE_TIMEOUT = (int) Duration.ofSeconds(60).toMillis();
+    static final String MQTT_KEEP_ALIVE_TIMEOUT_KEY = "keepAliveTimeoutMs";
+    static final int DEFAULT_MQTT_KEEP_ALIVE_TIMEOUT = (int) Duration.ofSeconds(60).toMillis();
     private static final String MQTT_PING_TIMEOUT_KEY = "pingTimeoutMs";
     private static final int DEFAULT_MQTT_PING_TIMEOUT = (int) Duration.ofSeconds(30).toMillis();
     private static final String MQTT_THREAD_POOL_SIZE_KEY = "threadPoolSize";


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Pass in the customer keepalive value to the MQTT 5 client which was missed earlier. Without this, we're getting disconnected from IoT Core every 20 minutes; this seems like an issue with either the CRT or IoT Core.

**Why is this change necessary:**

**How was this change tested:**
Ran connected for more than 20 minutes without getting disconnected.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
