### PR TITLE
fix: remove extra config during deployment rollback

### DIFF
--- a/src/main/java/com/aws/greengrass/config/Configuration.java
+++ b/src/main/java/com/aws/greengrass/config/Configuration.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -201,6 +202,10 @@ public class Configuration {
 
     public void deepForEachTopic(Consumer<Topic> f) {
         root.deepForEachTopic(f);
+    }
+
+    public void deepForEach(BiConsumer<Node, UpdateBehaviorTree.UpdateBehavior> f, UpdateBehaviorTree tree) {
+        root.deepForEach(f, tree);
     }
 
     public void forEachChildlessTopics(Consumer<Topics> f) {

--- a/src/main/java/com/aws/greengrass/config/Node.java
+++ b/src/main/java/com/aws/greengrass/config/Node.java
@@ -11,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public abstract class Node {
@@ -159,6 +160,9 @@ public abstract class Node {
     }
 
     public abstract void deepForEachTopic(Consumer<Topic> f);
+
+    public abstract void deepForEach(BiConsumer<Node, UpdateBehaviorTree.UpdateBehavior> f,
+                                     UpdateBehaviorTree tree);
 
     /**
      * Check if this node is a child of a node with the given name.

--- a/src/main/java/com/aws/greengrass/config/Topic.java
+++ b/src/main/java/com/aws/greengrass/config/Topic.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class Topic extends Node {
@@ -324,6 +325,11 @@ public class Topic extends Node {
     @Override
     public void deepForEachTopic(Consumer<Topic> f) {
         f.accept(this);
+    }
+
+    @Override
+    public void deepForEach(BiConsumer<Node, UpdateBehaviorTree.UpdateBehavior> f, UpdateBehaviorTree tree) {
+        f.accept(this, tree.getBehavior());
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/config/Topics.java
+++ b/src/main/java/com/aws/greengrass/config/Topics.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 
@@ -393,6 +394,12 @@ public class Topics extends Node implements Iterable<Node> {
     @Override
     public void deepForEachTopic(Consumer<Topic> f) {
         children.values().forEach((t) -> t.deepForEachTopic(f));
+    }
+
+    @Override
+    public void deepForEach(BiConsumer<Node, UpdateBehaviorTree.UpdateBehavior> f, UpdateBehaviorTree tree) {
+        children.values().forEach((t) -> t.deepForEach(f, tree.getChildBehavior(t.getName())));
+        f.accept(this, tree.getBehavior());
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
@@ -23,6 +23,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.MERGE_ERROR_LOG_EVENT_KEY;
@@ -59,23 +60,28 @@ public abstract class DeploymentActivator {
     }
 
     protected long rollbackConfig(CompletableFuture<DeploymentResult> totallyCompleteFuture, Throwable failureCause) {
-        long mergeTime;
-        try {
-            mergeTime = System.currentTimeMillis();
-            ConfigurationReader.mergeTLogInto(kernel.getConfig(),
-                    deploymentDirectoryManager.getSnapshotFilePath(), true, null);
-            // Immediately truncate the tlog such that the config.tlog file only contains the correct rolled back
-            // information. Without this step, a nucleus reboot could cause the configuration to contain "newer" values
-            // even though we wanted those values to be rolled back.
-            kernel.getContext().get(KernelLifecycle.class).getTlog().truncateNow();
-            return mergeTime;
-        } catch (IOException e) {
-            // Could not merge old snapshot transaction log, rollback failed
-            logger.atError().setEventType(MERGE_ERROR_LOG_EVENT_KEY).setCause(e).log("Failed to rollback deployment");
-            totallyCompleteFuture.complete(new DeploymentResult(
-                    DeploymentResult.DeploymentStatus.FAILED_UNABLE_TO_ROLLBACK, failureCause));
-            return -1;
-        }
+        AtomicLong mergeTime = new AtomicLong(-1);
+        // Run on publish thread to ensure lifecycle listeners only run once all config changes go through
+        kernel.getContext().runOnPublishQueueAndWait(() -> {
+            try {
+                mergeTime.set(System.currentTimeMillis());
+                ConfigurationReader.updateFromTLog(kernel.getConfig(), deploymentDirectoryManager.getSnapshotFilePath(),
+                        true, null, createRollbackMergeBehavior());
+                // Immediately truncate the tlog such that the config.tlog file only contains the correct rolled back
+                // information. Without this step, a nucleus reboot could cause the configuration to contain "newer"
+                // values even though we wanted those values to be rolled back.
+                kernel.getContext().get(KernelLifecycle.class).getTlog().truncateNow();
+            } catch (IOException e) {
+                mergeTime.set(-1);
+                // Could not merge old snapshot transaction log, rollback failed
+                logger.atError().setEventType(MERGE_ERROR_LOG_EVENT_KEY).setCause(e)
+                        .log("Failed to rollback deployment");
+                totallyCompleteFuture.complete(
+                        new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_UNABLE_TO_ROLLBACK,
+                                failureCause));
+            }
+        });
+        return mergeTime.get();
     }
 
     /*
@@ -138,4 +144,42 @@ public abstract class DeploymentActivator {
 
         return rootMergeBehavior;
     }
+
+    private UpdateBehaviorTree createRollbackMergeBehavior() {
+        // root: MERGE
+        //   services: MERGE
+        //     *: REPLACE
+        //       runtime: MERGE
+        //       _private: MERGE
+        //       configuration: REPLACE
+        //     AUTH_TOKEN: MERGE
+
+        // For rollback the timestamp from the snapshot will be used and not this timestamp
+        long now = System.currentTimeMillis();
+        UpdateBehaviorTree rootMergeBehavior = new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, now);
+        UpdateBehaviorTree servicesMergeBehavior = new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, now);
+        UpdateBehaviorTree insideServiceMergeBehavior =
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now);
+        UpdateBehaviorTree serviceRuntimeMergeBehavior =
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, now);
+        UpdateBehaviorTree servicePrivateMergeBehavior =
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, now);
+
+        rootMergeBehavior.getChildOverride().put(SERVICES_NAMESPACE_TOPIC, servicesMergeBehavior);
+        servicesMergeBehavior.getChildOverride().put(UpdateBehaviorTree.WILDCARD, insideServiceMergeBehavior);
+        servicesMergeBehavior.getChildOverride().put(AUTHENTICATION_TOKEN_LOOKUP_KEY,
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, now));
+
+        insideServiceMergeBehavior.getChildOverride().put(
+                GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC, serviceRuntimeMergeBehavior);
+        insideServiceMergeBehavior.getChildOverride().put(
+                GreengrassService.PRIVATE_STORE_NAMESPACE_TOPIC, servicePrivateMergeBehavior);
+        UpdateBehaviorTree serviceConfigurationMergeBehavior =
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now);
+        insideServiceMergeBehavior.getChildOverride().put(
+                CONFIGURATION_CONFIG_KEY, serviceConfigurationMergeBehavior);
+
+        return rootMergeBehavior;
+    }
+
 }

--- a/src/test/resources/com/aws/greengrass/config/testSkeleton.tlog
+++ b/src/test/resources/com/aws/greengrass/config/testSkeleton.tlog
@@ -1,0 +1,10 @@
+{"TS":1,"TP":["test","firstline"],"W":"changed","V":"firstline"}
+{"TS":1,"TP":["system","rootpath"],"W":"changed","V":"/tmp"}
+{"TS":1588872930086,"TP":["setenv","AWS_GG_KERNEL_URI"],"W":"changed","V":"tcp://127.0.0.1:37743"}
+{"TS":1,"TP":["services","servicediscovery","dependencies"],"W":"changed","V":[]}
+{"TS":1588872925144,"TP":["services","main","lifecycle","install"],"W":"changed","V":"echo All installed"}
+{"TS":1588872925144,"TP":["services","main","lifecycle","run"],"W":"changed","V":"echo $PATH\npwd\nprintenv\nwhile true; do\ndate; sleep 5; echo RUNNING\ndone"}
+{"TS":1588872928102,"TP":["services","_AUTH_TOKENS","FakeToken"],"W":"changed","V":"main"}
+{"TS":1588872930080,"TP":["services","_AUTH_TOKENS","FakeToken2"],"W":"changed","V":"YellowSignal"}
+{"TS":15888729311200,"TP":["services","YellowSignal","lifecycle","shutdown"],"W":"removed"}
+{"TS":1,"TP":["test","lastline"],"W":"changed","V":"lastline"}

--- a/src/test/resources/com/aws/greengrass/config/updateFromTlogTest.tlog
+++ b/src/test/resources/com/aws/greengrass/config/updateFromTlogTest.tlog
@@ -1,0 +1,3 @@
+{"TS":6,"TP":["first","second","toUpdate"],"W":"changed","V":"v2"}
+{"TS":10,"TP":["first","second","toAdd"],"W":"changed","V":"v3"}
+{"TS":10,"TP":["first","sixth","leaf6"],"W":"changed","V":"value6"}


### PR DESCRIPTION
**Issue #, if available:**
-
**Description of changes:**
If deployment added configuration that is expected to follow the 'Replace' behavior, upon rollback it should be removed, but since rollback is done by performing a merge of the old snapshot, nothing gets removed. This change removes everything from the current Configuration object that is not in the rollback snapshot but its parent node has 'Replace' behavior 

**Why is this change necessary:**
To ensure rollbacks don't leave behind nodes that were newly added by the deployment and prevent scenarios like a faulty lifecycle script left behind still executes after rollback and produces erroneous results 

**How was this change tested:**
Tested with unit and user acceptance tests

- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
