### PR TITLE
fix: allow new services to wait for nucleus restart before install

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
@@ -21,8 +21,10 @@ import com.aws.greengrass.util.Utils;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 
@@ -31,6 +33,7 @@ import static com.aws.greengrass.deployment.DeploymentConfigMerger.MERGE_CONFIG_
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_REBOOT;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.KERNEL_ROLLBACK;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 
 /**
  * Activation and rollback of Kernel update deployments.
@@ -70,9 +73,12 @@ public class KernelUpdateActivator extends DeploymentActivator {
 
         DeploymentDocument deploymentDocument = deployment.getDeploymentDocumentObj();
         KernelLifecycle lifecycle = kernel.getContext().get(KernelLifecycle.class);
+
+        Set<String> servicesConfig = newConfig.get(SERVICES_NAMESPACE_TOPIC) == null ? Collections.emptySet() :
+                ((Map<String, Object>)newConfig.get(SERVICES_NAMESPACE_TOPIC)).keySet();
         // Preserve tlog state before launch directory is updated to reflect ongoing deployment.
         // Wait for all services to close.
-        lifecycle.softShutdown(30);
+        lifecycle.softShutdown(30, servicesConfig);
 
         updateConfiguration(deploymentDocument.getTimestamp(), newConfig);
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
@@ -561,7 +561,7 @@ class KernelLifecycleTest {
         kernelLifecycle.shutdown();
         kernelLifecycle.shutdown();
 
-        verify(mockKernel).orderedDependencies();
+        verify(mockKernel, times(2)).orderedDependencies();
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
While soft shutdown of Nucleus, create new services added to the deployment config and close them before nucleus restart. This prevents nucleus restart (in case of ota deployment/bootstrap steps) to interrupt service lifecycles. As Nucleus resumes default deployment (after all pending bootstrap steps are completed), all services in deployment config will request re-installation.

**Why is this change necessary:**
Nucleus restart was causing component lifecycles to interrupt

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
