### PR TITLE
perf: create manual partition metadata provider

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -487,7 +487,7 @@ public class DeviceProvisioningHelper {
     }
 
     private Optional<String> getPolicyArn(String policyName, Region awsRegion) {
-        String partition = awsRegion.metadata().partition().id();
+        String partition = RegionUtils.getPartitionId(awsRegion.id());
         try {
             // Check if a managed policy exists with the name
             return Optional.of(iamClient.getPolicy(software.amazon.awssdk.services.iam.model.GetPolicyRequest.builder()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change should save ~10MB of heap space at runtime, particularly during a deployment (when memory is the most tight).

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
