### PR TITLE
feat: remove docker image when component deleted

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -526,8 +526,8 @@ public class ComponentManager implements InjectionActions {
                 try {
                     ComponentIdentifier identifier = new ComponentIdentifier(compName, new Semver(compVersion));
                     removeRecipeDigestIfExists(identifier);
-                    componentStore.deleteComponent(identifier);
-                } catch (SemverException | PackageLoadingException e) {
+                    componentStore.deleteComponent(identifier, artifactDownloaderFactory);
+                } catch (SemverException | PackageLoadingException | InvalidArtifactUriException e) {
                     // Log a warn here. This shouldn't cause a deployment to fail.
                     logger.atWarn().kv(COMPONENT_NAME, compName).kv("version", compVersion).setCause(e)
                             .log("Failed to clean up component");

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentStore.java
@@ -5,10 +5,14 @@
 
 package com.aws.greengrass.componentmanager;
 
+import com.aws.greengrass.componentmanager.builtins.ArtifactDownloader;
+import com.aws.greengrass.componentmanager.builtins.ArtifactDownloaderFactory;
 import com.aws.greengrass.componentmanager.converter.RecipeLoader;
 import com.aws.greengrass.componentmanager.exceptions.HashingAlgorithmUnavailableException;
+import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriException;
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.exceptions.PackagingException;
+import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.ComponentMetadata;
 import com.aws.greengrass.componentmanager.models.ComponentRecipe;
@@ -206,7 +210,7 @@ public class ComponentStore {
      * @return retrieved package recipe.
      * @throws PackageLoadingException if fails to find the target package recipe or fails to parse the recipe file.
      */
-    ComponentRecipe getPackageRecipe(@NonNull ComponentIdentifier pkgId) throws PackageLoadingException {
+    public ComponentRecipe getPackageRecipe(@NonNull ComponentIdentifier pkgId) throws PackageLoadingException {
         Optional<ComponentRecipe> optionalPackage = findPackageRecipe(pkgId);
 
         if (!optionalPackage.isPresent()) {
@@ -226,15 +230,42 @@ public class ComponentStore {
      * @param compId component identifier
      * @throws PackageLoadingException if deletion of the component failed
      */
-    void deleteComponent(@NonNull ComponentIdentifier compId) throws PackageLoadingException {
+    void deleteComponent(@NonNull ComponentIdentifier compId,
+                         @NonNull ArtifactDownloaderFactory artifactDownloaderFactory)
+            throws PackageLoadingException, InvalidArtifactUriException {
         logger.atDebug("delete-component-start").kv("componentIdentifier", compId).log();
         IOException exception = null;
+        // issues #1111
+        // delete docker image before removing the recipe file
+        Optional<String> componentRecipeContent = findComponentRecipeContent(compId);
+        if (componentRecipeContent.isPresent()) {
+            // get recipe, all recipes are saved as yml files
+            ComponentRecipe recipe = getPackageRecipe(compId);
+            Path packageArtifactDirectory = resolveArtifactDirectoryPath(compId);
+            for (ComponentArtifact artifact : recipe.getArtifacts()) {
+                ArtifactDownloader downloader = artifactDownloaderFactory
+                        .getArtifactDownloader(compId, artifact, packageArtifactDirectory);
+                try {
+                    downloader.cleanup();
+                } catch (IOException e) {
+                    if (exception == null) {
+                        exception = e;
+                    } else {
+                        exception.addSuppressed(e);
+                    }
+                }
+            }
+        }
         // delete recipe
         try {
             Path recipePath = resolveRecipePath(compId);
             Files.deleteIfExists(recipePath);
         } catch (IOException e) {
-            exception = e;
+            if (exception == null) {
+                exception = e;
+            } else {
+                exception.addSuppressed(e);
+            }
         }
         // delete recipeMetadata
         try {

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloader.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.componentmanager.builtins;
 
+import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.exceptions.ArtifactChecksumMismatchException;
 import com.aws.greengrass.componentmanager.exceptions.HashingAlgorithmUnavailableException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
@@ -48,6 +49,7 @@ public abstract class ArtifactDownloader {
     protected final ComponentIdentifier identifier;
     protected final ComponentArtifact artifact;
     protected final Path artifactDir;
+    protected final ComponentStore componentStore;
 
     @Setter(AccessLevel.PACKAGE)
     private RetryUtils.RetryConfig checksumMismatchRetryConfig =
@@ -56,10 +58,12 @@ public abstract class ArtifactDownloader {
                     .retryableExceptions(Arrays.asList(ArtifactChecksumMismatchException.class)).build();
     private Path saveToPath;
 
-    protected ArtifactDownloader(ComponentIdentifier identifier, ComponentArtifact artifact, Path artifactDir) {
+    protected ArtifactDownloader(ComponentIdentifier identifier, ComponentArtifact artifact,
+                                 Path artifactDir, ComponentStore componentStore) {
         this.identifier = identifier;
         this.artifact = artifact;
         this.artifactDir = artifactDir;
+        this.componentStore = componentStore;
         this.logger = LogManager.getLogger(this.getClass()).createChild();
         this.logger.addDefaultKeyValue(ARTIFACT_URI_LOG_KEY, artifact.getArtifactUri())
                 .addDefaultKeyValue(COMPONENT_IDENTIFIER_LOG_KEY, identifier.getName());
@@ -300,5 +304,12 @@ public abstract class ArtifactDownloader {
     public boolean canUnarchiveArtifact() {
         return true;
     }
+
+    /**
+     * Cleanup artifacts.
+     *
+     * @throws IOException if error encountered
+     */
+    public abstract void cleanup() throws IOException;
 }
 

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
@@ -87,12 +87,12 @@ public class ArtifactDownloaderFactory {
             return new GreengrassRepositoryDownloader(clientFactory, identifier, artifact, artifactDir, componentStore);
         }
         if (S3_SCHEME.equals(scheme)) {
-            return new S3Downloader(s3ClientFactory, identifier, artifact, artifactDir);
+            return new S3Downloader(s3ClientFactory, identifier, artifact, artifactDir, componentStore);
         }
         // TODO : Needs to be moved out into a different mechanism where when loaded via a plugin,
         //  an artifact downloader can register itself and be discoverable here.
         if (DOCKER_SCHEME.equals(scheme)) {
-            return new DockerImageDownloader(identifier, artifact, artifactDir, context);
+            return new DockerImageDownloader(identifier, artifact, artifactDir, context, componentStore);
         }
         throw new PackageLoadingException(String.format("artifact URI scheme %s is not supported yet", scheme),
                 DeploymentErrorCode.UNSUPPORTED_ARTIFACT_SCHEME);

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloader.java
@@ -63,7 +63,7 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     protected GreengrassRepositoryDownloader(GreengrassServiceClientFactory clientFactory,
                                              ComponentIdentifier identifier, ComponentArtifact artifact,
                                              Path artifactDir, ComponentStore componentStore) {
-        super(identifier, artifact, artifactDir);
+        super(identifier, artifact, artifactDir, componentStore);
         this.clientFactory = clientFactory;
         this.componentStore = componentStore;
     }
@@ -76,6 +76,11 @@ public class GreengrassRepositoryDownloader extends ArtifactDownloader {
     @Override
     protected String getArtifactFilename() {
         return getArtifactFilename(artifact);
+    }
+
+    @Override
+    public void cleanup() throws IOException {
+
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.componentmanager.builtins;
 
+import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
@@ -58,8 +59,8 @@ public class S3Downloader extends ArtifactDownloader {
      * @param clientFactory S3 client factory
      */
     protected S3Downloader(S3SdkClientFactory clientFactory, ComponentIdentifier identifier, ComponentArtifact artifact,
-                           Path artifactDir) throws InvalidArtifactUriException {
-        super(identifier, artifact, artifactDir);
+                           Path artifactDir, ComponentStore componentStore) throws InvalidArtifactUriException {
+        super(identifier, artifact, artifactDir, componentStore);
         this.s3ClientFactory = clientFactory;
         this.s3ObjectPath = getS3PathForURI(artifact.getArtifactUri());
     }
@@ -69,6 +70,11 @@ public class S3Downloader extends ArtifactDownloader {
         String objectKey = s3ObjectPath.key;
         String[] pathStrings = objectKey.split("/");
         return pathStrings[pathStrings.length - 1];
+    }
+
+    @Override
+    public void cleanup() throws IOException {
+
     }
 
     @SuppressWarnings(

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.componentmanager.plugins.docker;
 
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.ConnectionException;
+import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerImageDeleteException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerLoginException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerPullException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerServiceUnavailableException;
@@ -185,6 +186,23 @@ public class DefaultDockerClient {
                     + "and redo the deployment");
         }
         return Optional.ofNullable(error);
+    }
+
+    /**
+     * Use docker command to delete the docker image.
+     *
+     * @param image docker image to delete
+     * @throws DockerImageDeleteException if error is encountered
+     */
+    public void deleteImage(Image image) throws DockerImageDeleteException {
+        CliResponse response = runDockerCmd(String.format("docker rmi %s", image.getImageFullName()));
+        if (response.exit.isPresent() && response.exit.get() == 0) {
+            return;
+        } else {
+            throw new DockerImageDeleteException(
+                    String.format("Unexpected error while trying to perform docker rmi - %s", response.err),
+                    response.failureCause);
+        }
     }
 
     @Getter

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -324,7 +324,7 @@ public class DockerImageDownloader extends ArtifactDownloader {
                 try {
                     ComponentIdentifier identifier = new ComponentIdentifier(compName, new Semver(compVersion));
                     // this.identifier is to be deleted identifier
-                    if (identifier.compareTo(this.identifier) == 0) {
+                    if (identifier.equals(this.identifier)) {
                         ComponentRecipe recipe = componentStore.getPackageRecipe(identifier);
                         if (recipe.getArtifacts().stream().anyMatch(
                                 i -> i.getArtifactUri().equals(artifact.getArtifactUri()))) {

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -5,11 +5,14 @@
 
 package com.aws.greengrass.componentmanager.plugins.docker;
 
+import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.builtins.ArtifactDownloader;
 import com.aws.greengrass.componentmanager.exceptions.InvalidArtifactUriException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
+import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.componentmanager.models.ComponentRecipe;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.ConnectionException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerLoginException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerServiceUnavailableException;
@@ -18,6 +21,8 @@ import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.util.CrashableSupplier;
 import com.aws.greengrass.util.RetryUtils;
 import com.aws.greengrass.util.Utils;
+import com.vdurmont.semver4j.Semver;
+import com.vdurmont.semver4j.SemverException;
 import lombok.AccessLevel;
 import lombok.Setter;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -29,7 +34,10 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.AvoidCatchingGenericException",
@@ -61,18 +69,20 @@ public class DockerImageDownloader extends ArtifactDownloader {
      * @param artifact    artifact to download
      * @param artifactDir artifact store path
      * @param context     context
+     * @param componentStore componentStore
      */
     public DockerImageDownloader(ComponentIdentifier identifier, ComponentArtifact artifact, Path artifactDir,
-                                 Context context) {
-        super(identifier, artifact, artifactDir);
+                                 Context context, ComponentStore componentStore) {
+        super(identifier, artifact, artifactDir, componentStore);
         ecrAccessor = context.get(EcrAccessor.class);
         dockerClient = context.get(DefaultDockerClient.class);
         mqttClient = context.get(MqttClient.class);
     }
 
     DockerImageDownloader(ComponentIdentifier identifier, ComponentArtifact artifact, Path artifactDir,
-                          DefaultDockerClient dockerClient, EcrAccessor ecrAccessor, MqttClient mqttClient) {
-        super(identifier, artifact, artifactDir);
+                          DefaultDockerClient dockerClient, EcrAccessor ecrAccessor, MqttClient mqttClient,
+                          ComponentStore componentStore) {
+        super(identifier, artifact, artifactDir, componentStore);
         this.dockerClient = dockerClient;
         this.ecrAccessor = ecrAccessor;
         this.mqttClient = mqttClient;
@@ -278,5 +288,55 @@ public class DockerImageDownloader extends ArtifactDownloader {
             }
             throw e;
         }
+    }
+
+    /**
+     * Cleanup component, delete docker image when component being removed.
+     * @throws IOException exception
+     */
+    @Override
+    public void cleanup() throws IOException {
+        // this docker image not only used by itself
+        try {
+            if (!ifImageUsedByOther(componentStore)) {
+                Image image = DockerImageArtifactParser
+                        .getImage(ComponentArtifact.builder().artifactUri(artifact.getArtifactUri()).build());
+                dockerClient.deleteImage(image);
+            }
+        } catch (PackageLoadingException | InvalidArtifactUriException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Judge if the docker image used by other artifacts.
+     *
+     * @param componentStore componentStore
+     * @return true: this image used by other; false: not used.
+     * @throws PackageLoadingException from getPackageRecipe
+     */
+    public boolean ifImageUsedByOther(ComponentStore componentStore) throws PackageLoadingException {
+        Map<String, Set<String>> allVersions = componentStore.listAvailableComponentVersions();
+        for (Map.Entry<String, Set<String>> versions : allVersions.entrySet()) {
+            String compName = versions.getKey();
+            Set<String> localVersions = new HashSet<>(versions.getValue());
+            for (String compVersion : localVersions) {
+                try {
+                    ComponentIdentifier identifier = new ComponentIdentifier(compName, new Semver(compVersion));
+                    // this.identifier is to be deleted identifier
+                    if (identifier.compareTo(this.identifier) == 0) {
+                        ComponentRecipe recipe = componentStore.getPackageRecipe(identifier);
+                        if (recipe.getArtifacts().stream().anyMatch(
+                                i -> i.getArtifactUri().equals(artifact.getArtifactUri()))) {
+                            return true;
+                        }
+                    }
+                } catch (SemverException e) {
+                    logger.atWarn().kv("identifier", identifier.getName()).kv("compVersion", compVersion)
+                            .setCause(e).log("Error happened when semver being created");
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/exceptions/DockerImageDeleteException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/exceptions/DockerImageDeleteException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins.docker.exceptions;
+
+import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
+
+@SuppressWarnings("checkstyle:MissingJavadocMethod")
+public class DockerImageDeleteException extends PackageLoadingException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public DockerImageDeleteException(String message) {
+        super(message);
+    }
+
+    public DockerImageDeleteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
@@ -627,9 +627,9 @@ class ComponentManagerTest {
 
         // THEN
         verify(componentStore, times(1))
-                .deleteComponent(new ComponentIdentifier(MONITORING_SERVICE_PKG_NAME, new Semver("3.0.0")));
-        verify(componentStore, times(1)).deleteComponent(new ComponentIdentifier(anotherCompName, new Semver("1.0.0")));
-        verify(componentStore, times(1)).deleteComponent(new ComponentIdentifier(anotherCompName, new Semver("2.0.0")));
+                .deleteComponent(new ComponentIdentifier(MONITORING_SERVICE_PKG_NAME, new Semver("3.0.0")), artifactDownloaderFactory);
+        verify(componentStore, times(1)).deleteComponent(new ComponentIdentifier(anotherCompName, new Semver("1.0.0")), artifactDownloaderFactory);
+        verify(componentStore, times(1)).deleteComponent(new ComponentIdentifier(anotherCompName, new Semver("2.0.0")), artifactDownloaderFactory);
 
         // verify digest was cleaned up
         verify(digestTopic, times(3)).remove();

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.componentmanager.builtins;
 
+import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.exceptions.ArtifactChecksumMismatchException;
 import com.aws.greengrass.componentmanager.exceptions.HashingAlgorithmUnavailableException;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
@@ -55,6 +57,8 @@ import static org.mockito.Mockito.verify;
 class ArtifactDownloaderTest {
 
     private static final String LOCAL_FILE_NAME = "artifact.txt";
+    @Mock
+    ComponentStore componentStore;
 
     @TempDir
     Path tempDir;
@@ -78,7 +82,7 @@ class ArtifactDownloaderTest {
                 .algorithm("SHA-256").checksum(checksum)
                 .artifactUri(new URI("s3://eg-artifacts/ComponentWithS3Artifacts-1.0.0/artifact.txt")).build();
 
-        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content);
+        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore);
         assertThat(downloader.downloadRequired(), is(true));
 
         File file = downloader.download();
@@ -95,7 +99,7 @@ class ArtifactDownloaderTest {
         String content = "Sample artifact content";
         ComponentArtifact artifact = createTestArtifact("SHA-256", "invalidChecksum");
 
-        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content);
+        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore);
         downloader.setChecksumMismatchRetryConfig(RetryUtils.RetryConfig.builder().maxAttempt(2)
                 .retryableExceptions(Arrays.asList(ArtifactChecksumMismatchException.class)).build());
         assertThrows(PackageDownloadException.class, downloader::download);
@@ -106,7 +110,7 @@ class ArtifactDownloaderTest {
         String content = "Sample artifact content";
         ComponentArtifact artifact = createTestArtifact("invalidAlgorithm", "invalidChecksum");
 
-        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content);
+        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore);
         Exception e = assertThrows(HashingAlgorithmUnavailableException.class, downloader::download);
         assertThat(e.getMessage(), containsString("checksum is not supported"));
     }
@@ -119,7 +123,7 @@ class ArtifactDownloaderTest {
                 .encodeToString(MessageDigest.getInstance("SHA-256").digest(content.getBytes()));
         ComponentArtifact artifact = createTestArtifact("SHA-256", checksum);
 
-        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content);
+        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore);
 
         File localPartialFile = downloader.getArtifactFile();
         Files.write(localPartialFile.toPath(), "Sample".getBytes());
@@ -142,7 +146,7 @@ class ArtifactDownloaderTest {
                 Base64.getEncoder().encodeToString(MessageDigest.getInstance("SHA-256").digest(content.getBytes()));
         ComponentArtifact artifact = createTestArtifact("SHA-256", checksum);
 
-        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content));
+        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore));
 
         File localPartialFile = downloader.getArtifactFile();
         Files.write(localPartialFile.toPath(), "Foo".getBytes());
@@ -174,7 +178,7 @@ class ArtifactDownloaderTest {
             return invocationOnMock.callRealMethod();
         }).when(mockBrokenInputStream).read(any());
 
-        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content));
+        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore));
         downloader.overridingInputStream = mockBrokenInputStream;
 
         File file = downloader.download();
@@ -192,7 +196,7 @@ class ArtifactDownloaderTest {
                 .encodeToString(MessageDigest.getInstance("SHA-256").digest(content.getBytes()));
         ComponentArtifact artifact = createTestArtifact("SHA-256", checksum);
 
-        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content));
+        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore));
         AtomicInteger invocationTimes = new AtomicInteger(0);
         doAnswer(invocationOnMock -> {
             invocationTimes.incrementAndGet();
@@ -217,7 +221,7 @@ class ArtifactDownloaderTest {
                 .encodeToString(MessageDigest.getInstance("SHA-256").digest(content.getBytes()));
         ComponentArtifact artifact = createTestArtifact("SHA-256", checksum);
 
-        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content));
+        MockDownloader downloader = spy(new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore));
         doAnswer(invocationOnMock -> {
             throw new PackageDownloadException("Fail to download");
         }).when(downloader).download(anyLong(), anyLong(), any());
@@ -234,7 +238,7 @@ class ArtifactDownloaderTest {
                 .algorithm("SHA-256").checksum(checksum)
                 .artifactUri(new URI("s3://eg-artifacts/ComponentWithS3Artifacts-1.0.0/artifact.txt")).build();
 
-        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content);
+        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore);
 
         File file = downloader.getArtifactFile();
         Files.write(file.toPath(), content.getBytes());
@@ -246,7 +250,7 @@ class ArtifactDownloaderTest {
         String content = "Sample artifact content";
         ComponentArtifact artifact = createTestArtifact("SHA-256", null);
 
-        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content);
+        MockDownloader downloader = new MockDownloader(createTestIdentifier(), artifact, artifactDir, content, componentStore);
         Files.write(downloader.getArtifactFile().toPath(), "Sample local artifact content".getBytes());
 
         assertThat(downloader.downloadRequired(), is(false));
@@ -267,14 +271,19 @@ class ArtifactDownloaderTest {
         InputStream overridingInputStream = null;
 
         MockDownloader(ComponentIdentifier identifier, ComponentArtifact artifact, Path artifactDir,
-                       String inputContent) {
-            super(identifier, artifact, artifactDir);
+                       String inputContent, ComponentStore componentStore) {
+            super(identifier, artifact, artifactDir, componentStore);
             this.input = inputContent;
         }
 
         @Override
         protected String getArtifactFilename() {
             return localFileName;
+        }
+
+        @Override
+        public void cleanup() throws IOException {
+
         }
 
         @Override

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
@@ -5,9 +5,12 @@
 
 package com.aws.greengrass.componentmanager.plugins.docker;
 
+import com.amazon.aws.iot.greengrass.component.common.RecipeFormatVersion;
+import com.aws.greengrass.componentmanager.ComponentStore;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.componentmanager.models.ComponentRecipe;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.ConnectionException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerLoginException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerPullException;
@@ -34,7 +37,13 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.aws.greengrass.componentmanager.plugins.docker.DockerImageDownloader.DOCKER_NOT_INSTALLED_ERROR_MESSAGE;
@@ -48,9 +57,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,6 +71,7 @@ import static org.mockito.Mockito.when;
 public class DockerImageDownloaderTest {
     private static ComponentIdentifier TEST_COMPONENT_ID =
             new ComponentIdentifier("test.container.component", new Semver("1.0.0"));
+
     // Using retry config with much smaller interval and count
     private final RetryUtils.RetryConfig infiniteAttemptsRetryConfig =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(50L))
@@ -78,6 +91,8 @@ public class DockerImageDownloaderTest {
     private MqttClient mqttClient;
     @Mock
     private Path artifactDir;
+    @Mock
+    private ComponentStore componentStore;
 
     @BeforeEach
     public void setup() throws Exception {
@@ -501,6 +516,46 @@ public class DockerImageDownloaderTest {
     }
 
     @Test
+    void GIVEN_a_artifact_with_private_ecr_image_THEN_check_if_image_used_by_others()
+            throws Exception {
+        URI artifactUri = new URI("450817829141.dkr.ecr.us-east-1.amazonaws.com/integrationdockerimage:latest");
+        DockerImageDownloader downloader = spy(getDownloader(artifactUri));
+
+        Map<String, Set<String>> allVersions = new HashMap<>();
+        Set<String> versions = new HashSet<>();
+        versions.add("1.0.0");
+        allVersions.put("com.example.HelloWorld", versions);
+        when(componentStore.listAvailableComponentVersions()).thenReturn(allVersions);
+
+        assertFalse(downloader.ifImageUsedByOther(componentStore));
+
+        Set<String> versions_test = new HashSet<>();
+        versions_test.add(TEST_COMPONENT_ID.getVersion().getValue());
+        allVersions.put(TEST_COMPONENT_ID.getName(), versions_test);
+        ComponentRecipe recipe = new ComponentRecipe(RecipeFormatVersion.JAN_25_2020, "com.example.HelloWorld",
+                new Semver("2.0.0", Semver.SemverType.NPM), "", "", null, new HashMap<String, Object>() {{
+            put("LIFECYCLE_RUN_KEY", "java -jar {artifacts:path}/test.jar -x arg");
+        }}, new ArrayList<ComponentArtifact>() {{ add(ComponentArtifact.builder().artifactUri(artifactUri).build());}}, Collections.emptyMap(), null);
+        when(componentStore.getPackageRecipe(any())).thenReturn(recipe);
+
+        assertTrue(downloader.ifImageUsedByOther(componentStore));
+    }
+
+    @Test
+    void GIVEN_a_artifact_with_private_ecr_image_WHEN_image_not_used_by_others_THEN_remove_image()
+            throws Exception {
+        URI artifactUri = new URI("450817829141.dkr.ecr.us-east-1.amazonaws.com/integrationdockerimage:latest");
+        DockerImageDownloader downloader = spy(getDownloader(artifactUri));
+
+        doReturn(false).when(downloader).ifImageUsedByOther(any());
+        doNothing().when(dockerClient).deleteImage(any());
+
+        downloader.cleanup();
+
+        verify(dockerClient, times(1)).deleteImage(any());
+    }
+
+    @Test
     void GIVEN_network_error_WHEN_download_docker_image_THEN_retry_download_image_until_succeed(
             ExtensionContext extensionContext) throws Exception {
         ignoreExceptionOfType(extensionContext, ConnectionException.class);
@@ -520,7 +575,7 @@ public class DockerImageDownloaderTest {
     private DockerImageDownloader getDownloader(URI artifactUri) {
         DockerImageDownloader downloader = new DockerImageDownloader(TEST_COMPONENT_ID,
                 ComponentArtifact.builder().artifactUri(artifactUri).build(), artifactDir, dockerClient, ecrAccessor,
-                mqttClient);
+                mqttClient, componentStore);
         downloader.setInfiniteAttemptsRetryConfig(infiniteAttemptsRetryConfig);
         downloader.setFiniteAttemptsRetryConfig(finiteAttemptsRetryConfig);
         return downloader;

--- a/src/test/resources/com/aws/greengrass/componentmanager/recipes/Component_recipe_content.yaml
+++ b/src/test/resources/com/aws/greengrass/componentmanager/recipes/Component_recipe_content.yaml
@@ -15,9 +15,7 @@ Manifests:
   - Platform:
       os: all
     Lifecycle:
-      Run: >-
-        docker run
-        450817829141.dkr.ecr.us-east-1.amazonaws.com/integrationdockerimage:latest
+      Run: echo com.srm01.MyPrivateDockerComponent-1.0.0
     Artifacts:
       - Uri: >-
           docker:450817829141.dkr.ecr.us-east-1.amazonaws.com/integrationdockerimage:latest

--- a/src/test/resources/com/aws/greengrass/componentmanager/recipes/Component_recipe_content.yaml
+++ b/src/test/resources/com/aws/greengrass/componentmanager/recipes/Component_recipe_content.yaml
@@ -1,0 +1,28 @@
+RecipeFormatVersion: '2020-01-25'
+ComponentName: com.srm01.MyPrivateDockerComponent
+ComponentVersion: 1.0.0
+ComponentType: aws.greengrass.generic
+ComponentDescription: A component that runs a Docker container from a private Amazon ECR image.
+ComponentPublisher: Amazon
+ComponentDependencies:
+  aws.greengrass.DockerApplicationManager:
+    VersionRequirement: '>=2.0.0 <2.3.0'
+    DependencyType: SOFT
+  aws.greengrass.TokenExchangeService:
+    VersionRequirement: '>=2.0.0 <2.3.0'
+    DependencyType: SOFT
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      Run: >-
+        docker run
+        450817829141.dkr.ecr.us-east-1.amazonaws.com/integrationdockerimage:latest
+    Artifacts:
+      - Uri: >-
+          docker:450817829141.dkr.ecr.us-east-1.amazonaws.com/integrationdockerimage:latest
+        Unarchive: NONE
+        Permission:
+          Read: OWNER
+          Execute: NONE
+Lifecycle: {}


### PR DESCRIPTION
Copied from PR #1352:

**Description of changes:**
When a component which use docker image has been removed, check whether this image being used by other running components，if not, delete this image with docker cli commend rmi.

**Why is this change necessary:**
Before this change, unused images would be left and take lots of space.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Manual test.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
