### PR TITLE
fix: set private key permission on provisioning

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Permissions.java
+++ b/src/main/java/com/aws/greengrass/util/Permissions.java
@@ -21,6 +21,8 @@ public final class Permissions {
 
     static final FileSystemPermission OWNER_RWX_ONLY =  FileSystemPermission.builder()
             .ownerRead(true).ownerWrite(true).ownerExecute(true).build();
+    static final FileSystemPermission OWNER_RW_ONLY =  FileSystemPermission.builder()
+            .ownerRead(true).ownerWrite(true).build();
     public static final FileSystemPermission OWNER_RWX_EVERYONE_RX = FileSystemPermission.builder()
             .ownerRead(true).ownerWrite(true).ownerExecute(true)
             .groupRead(true).groupExecute(true)
@@ -123,6 +125,10 @@ public final class Permissions {
 
     public static void setBinPermission(Path p) throws IOException {
         platform.setPermissions(OWNER_RWX_EVERYONE_RX, p);
+    }
+
+    public static void setPrivateKeyPermission(Path p) throws IOException {
+        platform.setPermissions(OWNER_RW_ONLY, p);
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set permission on the private key when we create it to be 600. Remove usage of CommitableFile which isn't necessary and creates a "backup" file that we do not want.

**Why is this change necessary:**

**How was this change tested:**
Ran provisioning steps to create the key and validated permission on disk is set to 600.
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
