### PR TITLE
fix(retry-util): do not sleep after final retry attempt

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -191,11 +191,11 @@ public class DefaultDeploymentTask implements DeploymentTask {
         // retries by default similar/to all other cloud interactions.
         boolean isLocalDeployment = Deployment.DeploymentType.LOCAL.equals(deployment.getDeploymentType());
         // SDK already retries with RetryMode.STANDARD. For local deployment we don't retry on top of that
-        int retryCount = isLocalDeployment ? 1 : INFINITE_RETRY_COUNT;
+        int maxAttemptCount = isLocalDeployment ? 1 : INFINITE_RETRY_COUNT;
 
         Optional<Set<String>> groupsForDeviceOpt;
         try {
-            groupsForDeviceOpt = thingGroupHelper.listThingGroupsForDevice(retryCount);
+            groupsForDeviceOpt = thingGroupHelper.listThingGroupsForDevice(maxAttemptCount);
         } catch (GreengrassV2DataException e) {
             if (e.statusCode() == HttpStatusCode.FORBIDDEN) {
                 // Getting group hierarchy requires permission to call the ListThingGroupsForCoreDevice API which

--- a/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
@@ -30,7 +30,6 @@ public class ThingGroupHelper {
     protected static final Logger logger = LogManager.getLogger(ThingGroupHelper.class);
     public static final String THING_GROUP_RESOURCE_TYPE = "thinggroup";
     public static final String THING_GROUP_RESOURCE_TYPE_PREFIX = THING_GROUP_RESOURCE_TYPE + "/";
-    private static final int DEFAULT_RETRY_COUNT = Integer.MAX_VALUE;
 
     // Retry on internal service errors as well as offline indicative exceptions
     static final List<Class> RETRYABLE_EXCEPTIONS = Arrays.asList(SdkClientException.class,

--- a/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/ThingGroupHelper.java
@@ -48,23 +48,12 @@ public class ThingGroupHelper {
     /**
      * Retrieve the thing group names the device belongs to.
      *
+     * @param maxAttemptCount desired max num of attempts
      * @return list of thing group names
      * @throws Exception when not able to fetch thing group names
      */
     @SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.AvoidRethrowingException"})
-    public Optional<Set<String>> listThingGroupsForDevice() throws Exception {
-        return listThingGroupsForDevice(DEFAULT_RETRY_COUNT);
-    }
-
-    /**
-     * Retrieve the thing group names the device belongs to.
-     *
-     * @param retryCount desired retry count
-     * @return list of thing group names
-     * @throws Exception when not able to fetch thing group names
-     */
-    @SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.AvoidRethrowingException"})
-    public Optional<Set<String>> listThingGroupsForDevice(int retryCount) throws Exception {
+    public Optional<Set<String>> listThingGroupsForDevice(int maxAttemptCount) throws Exception {
 
         if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
             return Optional.empty();
@@ -74,7 +63,7 @@ public class ThingGroupHelper {
 
         RetryUtils.RetryConfig clientExceptionRetryConfig =
                 RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1))
-                        .maxRetryInterval(Duration.ofMinutes(1)).maxAttempt(retryCount)
+                        .maxRetryInterval(Duration.ofMinutes(1)).maxAttempt(maxAttemptCount)
                         .retryableExceptions(RETRYABLE_EXCEPTIONS).build();
 
         return RetryUtils.runWithRetry(clientExceptionRetryConfig, () -> {

--- a/src/main/java/com/aws/greengrass/util/RetryUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RetryUtils.java
@@ -41,8 +41,8 @@ public class RetryUtils {
             String taskDescription, Logger logger) throws Exception {
         long retryInterval = retryConfig.getInitialRetryInterval().toMillis();
         int attempt = 1;
-        Exception lastException = null;
-        while (attempt <= retryConfig.maxAttempt) {
+        // if it's not the final attempt, execute and backoff on retryable exceptions
+        while (attempt < retryConfig.maxAttempt) {
             if (Thread.currentThread().isInterrupted()) {
                 throw new InterruptedException(taskDescription + " task is interrupted");
             }
@@ -62,7 +62,6 @@ public class RetryUtils {
                     }
                     logBuild.kv("task-attempt", attempt).setCause(e)
                             .log("task failed and will be retried");
-                    lastException = e;
                     // Backoff with jitter strategy from EqualJitterBackoffStrategy in AWS SDK
                     Thread.sleep(retryInterval / 2 + RANDOM.nextInt((int) (retryInterval / 2 + 1)));
                     if (retryInterval < retryConfig.getMaxRetryInterval().toMillis()) {
@@ -76,7 +75,11 @@ public class RetryUtils {
                 }
             }
         }
-        throw lastException;
+        // if it's the final attempt, return directly
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException(taskDescription + " task is interrupted");
+        }
+        return task.apply();
     }
 
     @Builder
@@ -98,6 +101,6 @@ public class RetryUtils {
      * @return boolean
      */
     public static boolean retryErrorCodes(int errorCode) {
-        return errorCode >= 500 || errorCode == 429 ? true : false;
+        return errorCode >= 500 || errorCode == 429;
     }
 }


### PR DESCRIPTION
**Description of changes:**
1. In `runWithRetry`, remove unnecessary sleep after final retry attempt if it throws a retryable exception.
2. Rename `retryCount` to `maxAttemptCount` in ThingGroupHelper to be more accurate and remove unused function.

**Why is this change necessary:**
Remove unnecessary sleeps in retry util.  
Specifically, if a local deployment is offline, it's always unnecessarily waiting 1 min for listThingGroupsForDevice.


**How was this change tested:**
Tested manually.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
