### PR TITLE
fix: close stdin on launched processes to prevent interactive questions

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -315,6 +315,8 @@ public abstract class Exec implements Closeable {
         }
         process = createProcess();
         logger.debug("Created process with pid {}", getPid());
+        // Close stdin, no one can write anything to stdin.
+        process.getOutputStream().close();
 
         stderrc = new Copier(process.getErrorStream(), stderr);
         stdoutc = new Copier(process.getInputStream(), stdout);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
docker compose may ask interactive questions, the only way to prevent this is to close stdin. Closing stdin for all processes since we do not need it and it will avoid interactivity issues in future.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
