### PR TITLE
revert: #1445 environment variable override in loader script

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -7,12 +7,12 @@ PWD=$(dirname "$0")
 
 sigterm_received=0
 # Assuming loader is launched from "$GG_ROOT/alts/current/distro/bin/loader"
-GG_ROOT:=$(cd $PWD/../../../..; pwd)
+GG_ROOT=$(cd $PWD/../../../..; pwd)
 
 echo "Greengrass root: "${GG_ROOT}
 
-LAUNCH_DIR:="$GG_ROOT/alts/current"
-CONFIG_FILE:=""
+LAUNCH_DIR="$GG_ROOT/alts/current"
+CONFIG_FILE=""
 
 is_directory_link() {
   [ -L "$1" ] && [ -d "$1" ]


### PR DESCRIPTION
…loader (#1445)"

This reverts commit 75a5fa27b6b860bfc572d7fd44ac344341fd4c23.

**Issue #, if available:**

**Description of changes:**
#1445 breaks the loader, reverting it.
```
/home/ec2-user/testResults/fdf350aad81d92b9d9014347357a459392c1dcb7/alts/current/distro/bin/loader: line 10: GG_ROOT:=/home/ec2-user/testResults/fdf350aad81d92b9d9014347357a459392c1dcb7: No such file or directory
/home/ec2-user/testResults/fdf350aad81d92b9d9014347357a459392c1dcb7/alts/current/distro/bin/loader: line 14: LAUNCH_DIR:=/alts/current: No such file or directory
/home/ec2-user/testResults/fdf350aad81d92b9d9014347357a459392c1dcb7/alts/current/distro/bin/loader: line 15: CONFIG_FILE:=: command not found
```

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
