### PR TITLE
fix(mqtt5): keep old reference of connectFuture on reconnect

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -292,7 +292,9 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
         if (client != null) {
             return;
         }
-        connectFuture = new CompletableFuture<>();
+        if (connectFuture == null || connectFuture.isDone()) {
+            connectFuture = new CompletableFuture<>();
+        }
         try (AwsIotMqtt5ClientBuilder builder = this.builderProvider.get()) {
             long minReconnectSeconds = Coerce.toLong(mqttTopics.find("minimumReconnectDelaySeconds"));
             long maxReconnectSeconds = Coerce.toLong(mqttTopics.find("maximumReconnectDelaySeconds"));


### PR DESCRIPTION
**Description of changes:**
1. when mqtt5 client reconnect, reuse the old future if it's not completed.

**Why is this change necessary:**
We are observing cloud deployments not reaching test devices on multiple test reports, especially slower device such as rpi3. This is because test device has a configuration change in private key path during initial installation, which triggers a reconnection/reconfiguration of mqtt client. It seems that upon successful reconfiguration of mqtt5 client, the spooler is still blocked waiting for an old/discarded future to complete.

**How was this change tested:**
Tested with a local e2e test
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
