### PR TITLE
chore(deps): update device sdk to 1.12.1-MQTT-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.12.0-CLI-SNAPSHOT</version>
+            <version>1.12.1-MQTT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/aws/greengrass/deployment/model/LocalOverrideRequest.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/LocalOverrideRequest.java
@@ -14,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import software.amazon.awssdk.aws.greengrass.model.FailureHandlingPolicy;
 import software.amazon.awssdk.aws.greengrass.model.RunWithInfo;
 
 import java.util.List;
@@ -43,6 +42,4 @@ public class LocalOverrideRequest {
     String recipeDirectoryPath;
 
     String artifactsDirectoryPath;
-
-    FailureHandlingPolicy failureHandlingPolicy;
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Reverts #1439 from release branch. Update SDK to 1.12.1-MQTT-SNAPSHOT which fixes the maxReconnectDelay setting (https://github.com/aws/aws-iot-device-sdk-java-v2/pull/417).

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
