### PR TITLE
feat: allow local deployment cancellation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.12.0-CLI-SNAPSHOT</version>
+            <version>1.12.1-CLI-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -509,7 +509,8 @@ public class DeploymentService extends GreengrassService {
                                 .getGreengrassDeploymentId());
                 if (canCancelDeployment) {
                     currentDeploymentTaskMetadata.getDeploymentResultFuture().cancel(true);
-                    if (DeploymentType.SHADOW.equals(currentDeploymentTaskMetadata.getDeploymentType())) {
+                    DeploymentType deploymentType = currentDeploymentTaskMetadata.getDeploymentType();
+                    if (DeploymentType.SHADOW.equals(deploymentType) || DeploymentType.LOCAL.equals(deploymentType)) {
                         deploymentStatusKeeper.persistAndPublishDeploymentStatus(
                                 currentDeploymentTaskMetadata.getDeploymentId(),
                                 currentDeploymentTaskMetadata.getGreengrassDeploymentId(),

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractCancelLocalDeploymentOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractCancelLocalDeploymentOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import software.amazon.awssdk.aws.greengrass.model.CancelLocalDeploymentRequest;
+import software.amazon.awssdk.aws.greengrass.model.CancelLocalDeploymentResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractCancelLocalDeploymentOperationHandler extends
+        OperationContinuationHandler<CancelLocalDeploymentRequest, CancelLocalDeploymentResponse,
+                EventStreamJsonMessage, EventStreamJsonMessage> {
+    protected GeneratedAbstractCancelLocalDeploymentOperationHandler(OperationContinuationHandlerContext context) {
+        super(context);
+    }
+
+    @Override
+    public OperationModelContext<CancelLocalDeploymentRequest, CancelLocalDeploymentResponse, EventStreamJsonMessage,
+            EventStreamJsonMessage> getOperationModelContext() {
+        return GreengrassCoreIPCServiceModel.getCancelLocalDeploymentModelContext();
+    }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -5,17 +5,16 @@
 
 package software.amazon.awssdk.aws.greengrass;
 
-import java.lang.Override;
-import java.lang.String;
+import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceHandler;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceModel;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
-import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceHandler;
-import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceModel;
-import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
 public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler {
   public static final String SERVICE_NAMESPACE = "aws.greengrass";
@@ -87,6 +86,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public static final String PAUSE_COMPONENT = SERVICE_NAMESPACE + "#PauseComponent";
 
   public static final String CREATE_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CreateLocalDeployment";
+
+  public static final String CANCEL_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CancelLocalDeployment";
 
   static {
     SERVICE_OPERATION_SET = new HashSet();
@@ -299,6 +300,11 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setCreateLocalDeploymentHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractCreateLocalDeploymentOperationHandler> handler) {
     operationSupplierMap.put(CREATE_LOCAL_DEPLOYMENT, handler);
+  }
+
+  public void setCancelLocalDeploymentHandler(
+          Function<OperationContinuationHandlerContext, GeneratedAbstractCancelLocalDeploymentOperationHandler> handler) {
+    operationSupplierMap.put(CANCEL_LOCAL_DEPLOYMENT, handler);
   }
 
   @Override


### PR DESCRIPTION
**Description of changes:**
- necessary nucleus changes to support local deployment cancellation.
- update device sdk snapshot

**Why is this change necessary:**

**How was this change tested:**
Will be covered by tests in CLI repo. Nucleus changes here are minimal and do not require additional testings.
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
CLI will offer a deployment object with `isCancelled = true`. When DeploymentService processes the deployment it calls `cancelCurrentDeployment` which handles deployment cancellation regardless of deployment type. The only change required is making sure the deployment status is persisted after cancellation takes effect.

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
