### PR TITLE
fix: do not close stdin except with system property

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -315,8 +315,12 @@ public abstract class Exec implements Closeable {
         }
         process = createProcess();
         logger.debug("Created process with pid {}", getPid());
-        // Close stdin, no one can write anything to stdin.
-        process.getOutputStream().close();
+
+        // By default, do not close stdin.
+        if ("true".equalsIgnoreCase(System.getProperty("gg.closeStdIn", "false"))) {
+            // Close stdin, no one can write anything to stdin.
+            process.getOutputStream().close();
+        }
 
         stderrc = new Copier(process.getErrorStream(), stderr);
         stdoutc = new Copier(process.getInputStream(), stdout);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Nucleus 2.10 closes stdin by default, unfortunately this turns out to be backward incompatible for run scripts which require stdin to stay open but with no data.

This change makes us keep stdin open by default, but it can be closed by setting the java system property `gg.closeStdIn`

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
