### PR TITLE
fix(config): childOf needs to use equalsIgnoreCase as config is supposed to be case-insensitive

### DIFF
--- a/src/main/java/com/aws/greengrass/config/Node.java
+++ b/src/main/java/com/aws/greengrass/config/Node.java
@@ -171,7 +171,7 @@ public abstract class Node {
      * @return true if this node is a child of a node named n
      */
     public boolean childOf(String n) {
-        return n.equals(name) || parent != null && parent.childOf(n);
+        return n.equalsIgnoreCase(name) || parent != null && parent.childOf(n);
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Config is supposed to be case insensitive, but childOf was using equals which will care about the case.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
