### PR TITLE
feat: split startable services

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -111,7 +111,9 @@ public class KernelLifecycle {
     @Setter(AccessLevel.PACKAGE)
     private List<Class<? extends Startable>> startables = Arrays.asList(IPCEventStreamService.class,
             AuthorizationService.class, ConfigStoreIPCService.class, LifecycleIPCService.class,
-            PubSubIPCService.class, MqttProxyIPCService.class, ComponentMetricIPCService.class);
+            PubSubIPCService.class, ComponentMetricIPCService.class);
+    @Setter(AccessLevel.PACKAGE)
+    private List<Class<? extends Startable>> mqttStartable = Collections.singletonList(MqttProxyIPCService.class);
     @Getter
     private ConfigurationWriter tlog;
     private GreengrassService mainService;
@@ -152,6 +154,11 @@ public class KernelLifecycle {
         // referenced by main/dependencies of main
         final Queue<String> autostart = findBuiltInServicesAndPlugins(); //NOPMD
         loadPlugins();
+
+        for (Class<? extends Startable> c : mqttStartable) {
+            kernel.getContext().get(c).startup();
+        }
+
         // run the provisioning if device is not provisioned
         if (!kernel.getContext().get(DeviceConfiguration.class).isDeviceConfiguredToTalkToCloud()
                 && !provisioningPlugins.isEmpty()) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -113,7 +113,8 @@ public class KernelLifecycle {
             AuthorizationService.class, ConfigStoreIPCService.class, LifecycleIPCService.class,
             PubSubIPCService.class, ComponentMetricIPCService.class);
     @Setter(AccessLevel.PACKAGE)
-    private List<Class<? extends Startable>> mqttStartable = Collections.singletonList(MqttProxyIPCService.class);
+    private List<Class<? extends Startable>> postPluginStartables =
+            Collections.singletonList(MqttProxyIPCService.class);
     @Getter
     private ConfigurationWriter tlog;
     private GreengrassService mainService;
@@ -155,7 +156,10 @@ public class KernelLifecycle {
         final Queue<String> autostart = findBuiltInServicesAndPlugins(); //NOPMD
         loadPlugins();
 
-        for (Class<? extends Startable> c : mqttStartable) {
+        // Start MqttProxyIPCService after plugins are loaded, as it requires
+        // DiskSpooler Implementation Plugin. This behavior is only needed in testing
+        // as we scan our own classpath to find the @ImplementsService
+        for (Class<? extends Startable> c : postPluginStartables) {
             kernel.getContext().get(c).startup();
         }
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
@@ -194,7 +194,7 @@ class KernelLifecycleTest {
         // Mock out EZPlugins so I can return a deterministic set of services to be added as auto-start
         EZPlugins pluginMock = mock(EZPlugins.class);
         kernelLifecycle.setStartables(new ArrayList<>());
-        kernelLifecycle.setMqttStartable(new ArrayList<>());
+        kernelLifecycle.setPostPluginStartables(new ArrayList<>());
         when(mockContext.get(EZPlugins.class)).thenReturn(pluginMock);
         doAnswer((i) -> {
             ClassAnnotationMatchProcessor func = i.getArgument(1);
@@ -216,7 +216,7 @@ class KernelLifecycleTest {
         when(mockDeviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(false);
 
         kernelLifecycle.setStartables(new ArrayList<>());
-        kernelLifecycle.setMqttStartable(new ArrayList<>());
+        kernelLifecycle.setPostPluginStartables(new ArrayList<>());
         EZPlugins pluginMock = mock(EZPlugins.class);
         when(mockContext.get(EZPlugins.class)).thenReturn(pluginMock);
         doAnswer((i) -> null).when(pluginMock).implementing(eq(DeviceIdentityInterface.class), any());
@@ -398,7 +398,7 @@ class KernelLifecycleTest {
         when(mockServicesConfig.lookupTopics(any())).thenReturn(mock(Topics.class));
 
         kernelLifecycle.setStartables(new ArrayList<>());
-        kernelLifecycle.setMqttStartable(new ArrayList<>());
+        kernelLifecycle.setPostPluginStartables(new ArrayList<>());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
@@ -194,6 +194,7 @@ class KernelLifecycleTest {
         // Mock out EZPlugins so I can return a deterministic set of services to be added as auto-start
         EZPlugins pluginMock = mock(EZPlugins.class);
         kernelLifecycle.setStartables(new ArrayList<>());
+        kernelLifecycle.setMqttStartable(new ArrayList<>());
         when(mockContext.get(EZPlugins.class)).thenReturn(pluginMock);
         doAnswer((i) -> {
             ClassAnnotationMatchProcessor func = i.getArgument(1);
@@ -215,6 +216,7 @@ class KernelLifecycleTest {
         when(mockDeviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(false);
 
         kernelLifecycle.setStartables(new ArrayList<>());
+        kernelLifecycle.setMqttStartable(new ArrayList<>());
         EZPlugins pluginMock = mock(EZPlugins.class);
         when(mockContext.get(EZPlugins.class)).thenReturn(pluginMock);
         doAnswer((i) -> null).when(pluginMock).implementing(eq(DeviceIdentityInterface.class), any());
@@ -396,6 +398,7 @@ class KernelLifecycleTest {
         when(mockServicesConfig.lookupTopics(any())).thenReturn(mock(Topics.class));
 
         kernelLifecycle.setStartables(new ArrayList<>());
+        kernelLifecycle.setMqttStartable(new ArrayList<>());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -296,7 +296,7 @@ class KernelTest {
         } catch (RuntimeException ignored) {
         }
         GreengrassService service = kernel.locate("testSpooler");
-        assertEquals("testSpoolerName", service.getName());
+        assertEquals("testSpooler", service.getName());
         assertTrue(service instanceof CloudMessageSpool);
     }
 
@@ -574,7 +574,7 @@ class KernelTest {
         }
     }
 
-    @ImplementsService(name = "testSpooler", autostart = true)
+    @ImplementsService(name = "testSpooler")
     static class TestSpooler extends PluginService implements CloudMessageSpool {
         public TestSpooler(Topics topics) {
             super(topics);
@@ -582,7 +582,7 @@ class KernelTest {
 
         @Override
         public String getName() {
-            return "testSpoolerName";
+            return "testSpooler";
         }
 
         @Override

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -20,6 +20,8 @@ import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.mqttclient.spool.CloudMessageSpool;
+import com.aws.greengrass.mqttclient.spool.SpoolMessage;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.NucleusPaths;
 import org.junit.jupiter.api.AfterEach;
@@ -62,6 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -280,6 +283,21 @@ class KernelTest {
         kernel.getContext().get(EZPlugins.class).scanSelfClasspath();
         GreengrassService service2 = kernel.locate("testImpl");
         assertEquals("testImpl", service2.getName());
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @Test
+    void GIVEN_kernel_with_disk_spooler_config_WHEN_locate_spooler_impl_THEN_create_test_spooler_service()
+            throws Exception {
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+        try {
+            kernel.parseArgs("-i",
+                    getClass().getResource("spooler_config.yaml").toString()).launch();
+        } catch (RuntimeException ignored) {
+        }
+        GreengrassService service = kernel.locate("testSpooler");
+        assertEquals("testSpoolerName", service.getName());
+        assertTrue(service instanceof CloudMessageSpool);
     }
 
     @Test
@@ -553,6 +571,38 @@ class KernelTest {
         @Override
         public String getName() {
             return "testImpl";
+        }
+    }
+
+    @ImplementsService(name = "testSpooler", autostart = true)
+    static class TestSpooler extends PluginService implements CloudMessageSpool {
+        public TestSpooler(Topics topics) {
+            super(topics);
+        }
+
+        @Override
+        public String getName() {
+            return "testSpoolerName";
+        }
+
+        @Override
+        public SpoolMessage getMessageById(long id) {
+            return null;
+        }
+
+        @Override
+        public void removeMessageById(long id) {
+
+        }
+
+        @Override
+        public void add(long id, SpoolMessage message) throws IOException {
+
+        }
+
+        @Override
+        public Iterable<Long> getAllMessageIds() throws IOException {
+            return null;
         }
     }
 }

--- a/src/test/resources/com/aws/greengrass/lifecyclemanager/spooler_config.yaml
+++ b/src/test/resources/com/aws/greengrass/lifecyclemanager/spooler_config.yaml
@@ -1,0 +1,20 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      logging:
+        level: "INFO"
+      mqtt:
+        spooler:
+          storageType: Disk
+          maxSizeInBytes: 25
+          pluginName: "testSpooler"
+  testSpooler:
+    configuration:
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+      - testSpooler
+      - aws.greengrass.Nucleus


### PR DESCRIPTION
**Issue #, if available:**
MQTT Spool fails to locate the specified DiskSpooler Implementation as a Plugin Service, as the logic to find and load Plugins is after we start all the startable services. Startables include the MqttProxyIPCService which needs the Spooler implementation plugin. This behavior is only observed in Integration testing as we look for plugin service in Class path.
**Description of changes:**
Split the startable services and start everything except MqttProxyIPCService before plugins and start MQTT service after the plugins.
**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
