### PR TITLE
revert: "chore: device sdk version bump (#1469)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.12.2-CLI-SNAPSHOT</version>
+            <version>1.12.1-CLI-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This reverts commit f54ba804e66ab712e7adc4c8f0722a358ecdc477.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
https://github.com/aws-greengrass/aws-greengrass-cli/pull/172
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
