### PR TITLE
feat: execute sync when called by disk spooler implementation

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -273,6 +273,10 @@ public class Spool {
         int numMessages = 0;
         int queueOfMessageIdInitSize = queueOfMessageId.size();
         for (long currentId : diskQueueOfIds) {
+            // Check if Queue of message IDs already contains this ID
+            if (queueOfMessageId.contains(currentId)) {
+                continue;
+            }
             numMessages++;
             //Check for queue space and remove if necessary
             SpoolMessage message = persistenceSpool.getMessageById(currentId);

--- a/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
@@ -176,7 +176,7 @@ class InMemorySpoolTest {
     }
 
     @Test
-    void GIVEN_spooler_config_disk_WHEN_setup_spooler_THEN_persistent_queue_synced() throws ServiceLoadException, IOException {
+    void GIVEN_spooler_config_disk_WHEN_execute_sync_called_THEN_persistent_queue_synced() throws ServiceLoadException, IOException {
         List<Long> messageIds = Arrays.asList(1L, 2L, 3L);
         GreengrassService persistenceSpoolService = Mockito.mock(GreengrassService.class, withSettings().extraInterfaces(CloudMessageSpool.class));
         CloudMessageSpool persistenceSpool = (CloudMessageSpool) persistenceSpoolService;
@@ -196,6 +196,7 @@ class InMemorySpoolTest {
         lenient().when(persistenceSpool.getMessageById(3L)).thenReturn(message3);
 
         spool = new Spool(deviceConfiguration, kernel);
+        spool.executeQueueSync(persistenceSpool);
         assertEquals(3, spool.getCurrentMessageCount());
     }
 
@@ -240,8 +241,11 @@ class InMemorySpoolTest {
                 when(persistenceSpool).add(anyLong(), any(SpoolMessage.class));
 
         spool = new Spool(deviceConfiguration, kernel);
-
+        // sync 3 messages
+        spool.executeQueueSync(persistenceSpool);
         assertEquals(3, spool.getCurrentMessageCount());
+
+        // try to add 4th message
         spool.addMessage(request);
         // Should be able to add to InMemory spooler even if Disk Spooler Add failed
         assertEquals(4, spool.getCurrentMessageCount());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Modify Spool to only perform a sync of message IDs when called by the Disk Spooler implementation. This is because we don't know if the database for the Disk Spooler implementation would be ready by the time we start with the sync in our initialization. 
Corresponding change needs to be made in aws-greengrass-DiskSpooler to call `executeSync` in it's `startup()`.
**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
