### PR TITLE
fix: properly recreate PATH environment

### DIFF
--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -22,15 +22,18 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -61,7 +64,7 @@ public abstract class Exec implements Closeable {
     // default directory relative paths are resolved against (i.e. current working directory)
     private static final File userdir = new File(System.getProperty("user.dir"));
 
-    protected static final ConcurrentLinkedDeque<Path> paths = new ConcurrentLinkedDeque<>();
+    protected static final List<Path> paths = Collections.synchronizedList(new ArrayList<>());
     protected static final Map<String, String> defaultEnvironment = new ConcurrentHashMap<>();
     protected Map<String, String> environment;
 
@@ -158,14 +161,7 @@ public abstract class Exec implements Closeable {
     }
 
     protected static void computeDefaultPathString() {
-        StringBuilder sb = new StringBuilder();
-        paths.forEach(p -> {
-            if (sb.length() > 5) {
-                sb.append(PATH_SEP);
-            }
-            sb.append(p.toString());
-        });
-        setDefaultEnv(PATH_ENVVAR, sb.toString());
+        setDefaultEnv(PATH_ENVVAR, paths.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator)));
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/util/Exec.java
+++ b/src/main/java/com/aws/greengrass/util/Exec.java
@@ -55,7 +55,7 @@ import javax.annotation.Nullable;
  */
 public abstract class Exec implements Closeable {
     private static final char PATH_SEP = File.pathSeparatorChar;
-    private static final String PATH_ENVVAR = "PATH";
+    public static final String PATH_ENVVAR = "PATH";
     private static final Logger staticLogger = LogManager.getLogger(Exec.class);
     protected Logger logger = staticLogger;
     private static final Consumer<CharSequence> NOP = s -> {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
In `Exec` we read `PATH`, split it up, possibly modify it, then combine it again to pass into subprocesses. In this process we were checking for length>5 before adding the path separator character for some reason... this is not correct and results in the first path entry getting munged if it is less than 5 characters. This change simply starts adding the path separator after the first entry.

**Why is this change necessary:**

**How was this change tested:**
Added new test which fails without the change and passes with the change.
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
