### PR TITLE
fix: use URI builder for proxy, test for @ in username

### DIFF
--- a/src/test/java/com/aws/greengrass/util/ProxyUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/ProxyUtilsTest.java
@@ -61,7 +61,7 @@ class ProxyUtilsTest {
 
     @Test
     void testGetProxyUsername() {
-        assertEquals("user", ProxyUtils.getProxyUsername("https://user:password@localhost:8080", "test-user"));
+        assertEquals("user@aws", ProxyUtils.getProxyUsername("https://user%40aws:password@localhost:8080", "test-user"));
         assertEquals("usernameOnly", ProxyUtils.getProxyUsername("https://usernameOnly@localhost:8080", "test-user"));
         assertEquals("test-user", ProxyUtils.getProxyUsername("https://myproxy:8080", "test-user"));
         assertNull(ProxyUtils.getProxyUsername("https://myproxy:8080", ""));
@@ -93,8 +93,9 @@ class ProxyUtilsTest {
 
     @Test
     void testGetProxyEnvVarValue_passthroughWithAuth() {
-        when(deviceConfiguration.getProxyUrl()).thenReturn("https://test-user:itsasecret@myproxy:8080");
-        assertEquals("https://test-user:itsasecret@myproxy:8080", ProxyUtils.getProxyEnvVarValue(deviceConfiguration));
+        when(deviceConfiguration.getProxyUrl()).thenReturn("https://test-user%40aws:itsasecret@myproxy:8080");
+        assertEquals("https://test-user%40aws:itsasecret@myproxy:8080",
+                ProxyUtils.getProxyEnvVarValue(deviceConfiguration));
     }
 
     @Test
@@ -106,9 +107,14 @@ class ProxyUtilsTest {
     @Test
     void testGetProxyEnvVarValue_authInfoAddedToUrl() {
         when(deviceConfiguration.getProxyUrl()).thenReturn("https://myproxy:8080");
-        when(deviceConfiguration.getProxyUsername()).thenReturn("test-user");
+        when(deviceConfiguration.getProxyUsername()).thenReturn("test-user@aws");
         when(deviceConfiguration.getProxyPassword()).thenReturn("itsasecret");
-        assertEquals("https://test-user:itsasecret@myproxy:8080", ProxyUtils.getProxyEnvVarValue(deviceConfiguration));
+        assertEquals("https://test-user%40aws:itsasecret@myproxy:8080",
+                ProxyUtils.getProxyEnvVarValue(deviceConfiguration));
+
+        when(deviceConfiguration.getProxyPassword()).thenReturn(null);
+        assertEquals("https://test-user%40aws@myproxy:8080",
+                ProxyUtils.getProxyEnvVarValue(deviceConfiguration));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use URIBuilder instead of manual string manipulation in order to properly encode the userinfo in the proxy environment variable. Add tests for the same, verifying we properly pass down usernames including `@`

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
