### PR TITLE
fix: s3 client re-validate on change

### DIFF
--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -37,7 +37,7 @@ public class S3SdkClientFactory {
     public S3SdkClientFactory(DeviceConfiguration deviceConfiguration, LazyCredentialProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
         this.deviceConfiguration = deviceConfiguration;
-        this.deviceConfiguration.getAWSRegion().subscribe((what, node) -> handleRegionUpdate());
+        this.deviceConfiguration.onAnyChange((what, node) -> handleRegionUpdate());
     }
 
     protected void handleRegionUpdate() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If the region is changed before iot data endpoint, then validation will fail and the S3 client will cache that failure forever because the region won't be changed again. To fix this, just subscribe to all changes.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
