### PR TITLE
fix: add mqtt change subscribe from publish queue

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -288,76 +288,80 @@ public class MqttClient implements Closeable {
         deviceConfiguration.getSpoolerNamespace();
         deviceConfiguration.getAWSRegion();
 
-        // If anything in the device configuration changes, then we will need to reconnect to the cloud
-        // using the new settings. We do this by calling reconnect() on all of our connections
-        this.deviceConfiguration.onAnyChange(new BatchedSubscriber((what, node) -> {
-            // Skip events that don't change anything
-            if (WhatHappened.timestampUpdated.equals(what) || WhatHappened.interiorAdded.equals(what) || node == null) {
-                return true;
-            }
-
-            // List of configuration nodes that we need to reconfigure for if they change
-            if (!(node.childOf(DEVICE_MQTT_NAMESPACE) || node.childOf(DEVICE_PARAM_THING_NAME) || node.childOf(
-                    DEVICE_PARAM_IOT_DATA_ENDPOINT) || node.childOf(DEVICE_PARAM_PRIVATE_KEY_PATH) || node.childOf(
-                    DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node.childOf(DEVICE_PARAM_ROOT_CA_PATH) || node.childOf(
-                    DEVICE_PARAM_AWS_REGION))) {
-                return true;
-            }
-
-            // Only reconnect when the region changed if the proxy exists
-            if (node.childOf(DEVICE_PARAM_AWS_REGION) && !ProxyUtils.isProxyConfigured(deviceConfiguration)) {
-                return true;
-            }
-
-            logger.atDebug().kv("modifiedNode", node.getFullName()).kv("changeType", what)
-                    .log("Reconfiguring MQTT clients");
-            return false;
-        }, (what) -> {
-            validateAndSetMqttPublishConfiguration();
-
-            // Reconnect in separate thread to not block publish thread
-            // Schedule the reconnection for slightly in the future to de-dupe multiple changes
-            Future<?> oldFuture = reconfigureFuture.getAndSet(ses.schedule(() -> {
-                // If the rootCa path changed, then we need to update the TLS options
-                String newRootCaPath = Coerce.toString(deviceConfiguration.getRootCAFilePath());
-                synchronized (httpProxyLock) {
-                    if (!Objects.equals(rootCaPath, newRootCaPath)) {
-                        if (proxyTlsOptions != null) {
-                            proxyTlsOptions.close();
-                        }
-                        if (proxyTlsContext != null) {
-                            proxyTlsContext.close();
-                        }
-                        rootCaPath = newRootCaPath;
-                        proxyTlsOptions = getTlsContextOptions(rootCaPath);
-                        proxyTlsContext = new ClientTlsContext(proxyTlsOptions);
-                    }
+        // Setup change subscriber from the publish queue so that all pending events are cleared before we subscribe
+        mqttTopics.context.runOnPublishQueue(() -> {
+            // If anything in the device configuration changes, then we will need to reconnect to the cloud
+            // using the new settings. We do this by calling reconnect() on all of our connections
+            this.deviceConfiguration.onAnyChange(new BatchedSubscriber((what, node) -> {
+                // Skip events that don't change anything
+                if (WhatHappened.timestampUpdated.equals(what) || WhatHappened.interiorAdded.equals(what)
+                        || node == null) {
+                    return true;
                 }
 
-                // Continually try to reconnect until all the connections are reconnected
-                Set<IndividualMqttClient> brokenConnections = new CopyOnWriteArraySet<>(connections);
-                do {
-                    for (IndividualMqttClient connection : brokenConnections) {
-                        if (Thread.currentThread().isInterrupted()) {
-                            return;
-                        }
+                // List of configuration nodes that we need to reconfigure for if they change
+                if (!(node.childOf(DEVICE_MQTT_NAMESPACE) || node.childOf(DEVICE_PARAM_THING_NAME) || node.childOf(
+                        DEVICE_PARAM_IOT_DATA_ENDPOINT) || node.childOf(DEVICE_PARAM_PRIVATE_KEY_PATH) || node.childOf(
+                        DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node.childOf(DEVICE_PARAM_ROOT_CA_PATH) || node.childOf(
+                        DEVICE_PARAM_AWS_REGION))) {
+                    return true;
+                }
 
-                        try {
-                            connection.reconnect(getMqttOperationTimeoutMillis());
-                            brokenConnections.remove(connection);
-                        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                            logger.atError().setCause(e).kv(CLIENT_ID_KEY, connection.getClientId())
-                                    .log("Error while reconnecting MQTT client");
+                // Only reconnect when the region changed if the proxy exists
+                if (node.childOf(DEVICE_PARAM_AWS_REGION) && !ProxyUtils.isProxyConfigured(deviceConfiguration)) {
+                    return true;
+                }
+
+                logger.atDebug().kv("modifiedNode", node.getFullName()).kv("changeType", what)
+                        .log("Reconfiguring MQTT clients");
+                return false;
+            }, (what) -> {
+                validateAndSetMqttPublishConfiguration();
+
+                // Reconnect in separate thread to not block publish thread
+                // Schedule the reconnection for slightly in the future to de-dupe multiple changes
+                Future<?> oldFuture = reconfigureFuture.getAndSet(ses.schedule(() -> {
+                    // If the rootCa path changed, then we need to update the TLS options
+                    String newRootCaPath = Coerce.toString(deviceConfiguration.getRootCAFilePath());
+                    synchronized (httpProxyLock) {
+                        if (!Objects.equals(rootCaPath, newRootCaPath)) {
+                            if (proxyTlsOptions != null) {
+                                proxyTlsOptions.close();
+                            }
+                            if (proxyTlsContext != null) {
+                                proxyTlsContext.close();
+                            }
+                            rootCaPath = newRootCaPath;
+                            proxyTlsOptions = getTlsContextOptions(rootCaPath);
+                            proxyTlsContext = new ClientTlsContext(proxyTlsOptions);
                         }
                     }
-                } while (!brokenConnections.isEmpty());
-            }, 1, TimeUnit.SECONDS));
 
-            // If a reconfiguration task already existed, then kill it and create a new one
-            if (oldFuture != null) {
-                oldFuture.cancel(true);
-            }
-        }));
+                    // Continually try to reconnect until all the connections are reconnected
+                    Set<IndividualMqttClient> brokenConnections = new CopyOnWriteArraySet<>(connections);
+                    do {
+                        for (IndividualMqttClient connection : brokenConnections) {
+                            if (Thread.currentThread().isInterrupted()) {
+                                return;
+                            }
+
+                            try {
+                                connection.reconnect(getMqttOperationTimeoutMillis());
+                                brokenConnections.remove(connection);
+                            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                                logger.atError().setCause(e).kv(CLIENT_ID_KEY, connection.getClientId())
+                                        .log("Error while reconnecting MQTT client");
+                            }
+                        }
+                    } while (!brokenConnections.isEmpty());
+                }, 1, TimeUnit.SECONDS));
+
+                // If a reconfiguration task already existed, then kill it and create a new one
+                if (oldFuture != null) {
+                    oldFuture.cancel(true);
+                }
+            }));
+        });
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -303,6 +303,7 @@ class MqttClientTest {
         ArgumentCaptor<ChildChanged> cc = ArgumentCaptor.forClass(ChildChanged.class);
         doNothing().when(deviceConfiguration).onAnyChange(cc.capture());
         MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        mqttNamespace.context.waitForPublishQueueToClear();
 
         AwsIotMqttClient iClient1 = mock(AwsIotMqttClient.class);
         when(iClient1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Setup change subscriber from the publish queue so that all pending events are cleared before we subscribe

**Why is this change necessary:**
We add validators which turn the paths (example private key path) from relative to absolute paths. This changes the value immediately but it fires a change notification asynchronously. This notification forces a reconfigure which is not required.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
