### PR TITLE
fix: sync spool message queue during initialization

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
@@ -20,7 +20,6 @@ import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.mqttclient.spool.SpoolerStorageType;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.CommitableReader;
 import com.aws.greengrass.util.CommitableWriter;
@@ -202,9 +201,7 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
         if (newStorageType == null
                 && !(DEFAULT_SPOOL_STORAGE_TYPE.toString().equalsIgnoreCase(currentSpoolerStorageType))
                 || newStorageType instanceof String
-                && !currentSpoolerStorageType.equalsIgnoreCase((String) newStorageType)
-                || newStorageType instanceof SpoolerStorageType
-                && !currentSpoolerStorageType.equalsIgnoreCase(newStorageType.toString())) {
+                && !currentSpoolerStorageType.equalsIgnoreCase((String) newStorageType)) {
             logger.atInfo().kv(DEVICE_SPOOLER_NAMESPACE, newSpooler).log(RESTART_REQUIRED_MESSAGE);
             return true;
         }

--- a/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.mqttclient.spool.SpoolerStorageType;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.CommitableReader;
 import com.aws.greengrass.util.CommitableWriter;
@@ -58,6 +59,7 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PRO
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PROXY_URL;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PROXY_USERNAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PROXY_NAMESPACE;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE;
 import static com.aws.greengrass.deployment.DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_SHELL;
 import static com.aws.greengrass.deployment.DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_SHELL_VALUE;
 import static com.aws.greengrass.deployment.DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_USER;
@@ -73,6 +75,8 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFE
 import static com.aws.greengrass.lifecyclemanager.Kernel.SERVICE_TYPE_TOPIC_KEY;
 import static com.aws.greengrass.lifecyclemanager.Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC;
 import static com.aws.greengrass.mqttclient.MqttClient.DEFAULT_MQTT_VERSION;
+import static com.aws.greengrass.mqttclient.spool.Spool.DEFAULT_SPOOL_STORAGE_TYPE;
+import static com.aws.greengrass.mqttclient.spool.Spool.SPOOL_STORAGE_TYPE_KEY;
 
 /**
  * Generates a list of bootstrap tasks from deployments, manages the execution and persists status.
@@ -188,6 +192,25 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
         return false;
     }
 
+    private boolean spoolerStorageTypeHasChanged(Map<String, Object> newNucleusParameters,
+                                          DeviceConfiguration currentDeviceConfiguration) {
+        String currentSpoolerStorageType = Coerce.toString(
+                currentDeviceConfiguration.getSpoolerNamespace().findOrDefault(DEFAULT_SPOOL_STORAGE_TYPE,
+                        SPOOL_STORAGE_TYPE_KEY));
+        Map<String, Object> newSpooler = (Map<String, Object>) newNucleusParameters.get(DEVICE_SPOOLER_NAMESPACE);
+        Object newStorageType = newSpooler == null ? null : newSpooler.get(SPOOL_STORAGE_TYPE_KEY);
+        if (newStorageType == null
+                && !(DEFAULT_SPOOL_STORAGE_TYPE.toString().equalsIgnoreCase(currentSpoolerStorageType))
+                || newStorageType instanceof String
+                && !currentSpoolerStorageType.equalsIgnoreCase((String) newStorageType)
+                || newStorageType instanceof SpoolerStorageType
+                && !currentSpoolerStorageType.equalsIgnoreCase(newStorageType.toString())) {
+            logger.atInfo().kv(DEVICE_SPOOLER_NAMESPACE, newSpooler).log(RESTART_REQUIRED_MESSAGE);
+            return true;
+        }
+        return false;
+    }
+
     private boolean networkProxyHasChanged(Map<String, Object> newNucleusParameters,
                                            DeviceConfiguration currentDeviceConfiguration) {
         Map<String, Object> newNetworkProxy =
@@ -283,8 +306,10 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
         boolean proxyChanged =  networkProxyHasChanged(newNucleusParameters, currentDeviceConfiguration);
         boolean runWithChanged = defaultRunWithChanged(newNucleusParameters, currentDeviceConfiguration);
         boolean mqttVersionChanged = mqttVersionHasChanged(newNucleusParameters, currentDeviceConfiguration);
+        boolean spoolerStorageTypeChanged = spoolerStorageTypeHasChanged(newNucleusParameters,
+                currentDeviceConfiguration);
 
-        return proxyChanged || runWithChanged || mqttVersionChanged;
+        return proxyChanged || runWithChanged || mqttVersionChanged || spoolerStorageTypeChanged;
     }
 
     private boolean nucleusConfigValidAndNeedsRestart(Map<String, Object> deploymentConfig)

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/CloudMessageSpool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/CloudMessageSpool.java
@@ -16,4 +16,6 @@ public interface CloudMessageSpool {
     void add(long id, SpoolMessage message) throws IOException;
 
     Iterable<Long> getAllMessageIds() throws IOException;
+
+    void initializeSpooler() throws IOException;
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/InMemorySpool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/InMemorySpool.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.mqttclient.spool;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,10 @@ public class InMemorySpool implements CloudMessageSpool {
     @Override
     public List<Long> getAllMessageIds() {
         return new ArrayList<>(messages.keySet());
+    }
+
+    @Override
+    public void initializeSpooler() throws IOException {
     }
 
 }

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -49,11 +49,11 @@ public class Spool {
      * @param kernel              a kernel instance
      */
     public Spool(DeviceConfiguration deviceConfiguration, Kernel kernel) {
+        inMemorySpooler = new InMemorySpool();
         this.deviceConfiguration = deviceConfiguration;
         Topics topics = this.deviceConfiguration.getSpoolerNamespace();
         this.kernel = kernel;
         setSpoolerConfigFromDeviceConfig(topics);
-        inMemorySpooler = new InMemorySpool();
         spooler = setupSpooler();
         // To subscribe to the topics of spooler configuration
         topics.subscribe((what, node) -> {
@@ -116,6 +116,7 @@ public class Spool {
         GreengrassService locatedService = kernel.locate(config.getPersistenceSpoolServiceName());
         if (locatedService instanceof CloudMessageSpool) {
             CloudMessageSpool persistenceSpool = (CloudMessageSpool) locatedService;
+            persistenceSpool.initializeSpooler();
             try {
                 persistentQueueSync(persistenceSpool.getAllMessageIds(), persistenceSpool);
             } catch (SpoolerStoreException e) {

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -27,14 +27,14 @@ public class Spool {
     private static final Logger logger = LogManager.getLogger(Spool.class);
     private static final String DEFAULT_GG_PERSISTENCE_SPOOL_SERVICE_NAME = "aws.greengrass.DiskSpooler";
     private static final String PERSISTENCE_SPOOL_SERVICE_NAME_KEY = "pluginName";
-    private static final String SPOOL_STORAGE_TYPE_KEY = "storageType";
+    public static final String SPOOL_STORAGE_TYPE_KEY = "storageType";
     private static final String SPOOL_MAX_SIZE_IN_BYTES_KEY = "maxSizeInBytes";
     private static final String SPOOL_KEEP_QOS_0_WHEN_OFFLINE_KEY = "keepQos0WhenOffline";
     private static final boolean DEFAULT_KEEP_Q0S_0_WHEN_OFFLINE = false;
-    private static final SpoolerStorageType DEFAULT_SPOOL_STORAGE_TYPE = SpoolerStorageType.Memory;
+    public static final SpoolerStorageType DEFAULT_SPOOL_STORAGE_TYPE = SpoolerStorageType.Memory;
     private static final int DEFAULT_SPOOL_MAX_MESSAGE_QUEUE_SIZE_IN_BYTES = (int) (2.5 * 1024 * 1024); // 2.5MB
     private final DeviceConfiguration deviceConfiguration;
-    private CloudMessageSpool spooler;
+    private final CloudMessageSpool spooler;
     private final InMemorySpool inMemorySpooler;
     private final Kernel kernel;
     private final AtomicLong nextId = new AtomicLong(0);
@@ -59,7 +59,6 @@ public class Spool {
         topics.subscribe((what, node) -> {
             if (WhatHappened.childChanged.equals(what) && node != null) {
                 setSpoolerConfigFromDeviceConfig(topics);
-                spooler = setupSpooler();
             }
         });
     }

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -22,7 +22,6 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 
 public class Spool {
     private static final Logger logger = LogManager.getLogger(Spool.class);
@@ -49,7 +48,6 @@ public class Spool {
      * @param deviceConfiguration the device configuration
      * @param kernel              a kernel instance
      */
-    @Inject
     public Spool(DeviceConfiguration deviceConfiguration, Kernel kernel) {
         this.deviceConfiguration = deviceConfiguration;
         Topics topics = this.deviceConfiguration.getSpoolerNamespace();
@@ -61,6 +59,7 @@ public class Spool {
         topics.subscribe((what, node) -> {
             if (WhatHappened.childChanged.equals(what) && node != null) {
                 setSpoolerConfigFromDeviceConfig(topics);
+                spooler = setupSpooler();
             }
         });
     }
@@ -97,7 +96,7 @@ public class Spool {
         if (config.getStorageType() == SpoolerStorageType.Disk) {
             try {
                 return getPersistenceSpoolGGService();
-            } catch (ServiceLoadException e) {
+            } catch (ServiceLoadException | IOException e) {
                 //log and use InMemorySpool
                 logger.atWarn()
                         .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
@@ -114,10 +113,24 @@ public class Spool {
      * @throws ServiceLoadException thrown if the service cannot be located
      */
     private CloudMessageSpool getPersistenceSpoolGGService()
-            throws ServiceLoadException {
+            throws ServiceLoadException, IOException {
         GreengrassService locatedService = kernel.locate(config.getPersistenceSpoolServiceName());
         if (locatedService instanceof CloudMessageSpool) {
-            return (CloudMessageSpool) locatedService;
+            CloudMessageSpool persistenceSpool = (CloudMessageSpool) locatedService;
+            try {
+                persistentQueueSync(persistenceSpool.getAllMessageIds(), persistenceSpool);
+            } catch (SpoolerStoreException e) {
+                logger.atWarn()
+                        .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
+                        .cause(e).log("Persistence spool queue sync was not completed");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.atWarn()
+                        .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
+                        .cause(e).log("Persistence spool queue sync was not completed");
+            }
+            logger.atInfo().log("Persistent Spooler has been set up");
+            return persistenceSpool;
         } else {
             throw new ServiceLoadException(
                     "The Greengrass service located was not an instance of CloudMessageSpool"
@@ -264,7 +277,18 @@ public class Spool {
         return config;
     }
 
-    private void persistentQueueSync(Iterable<Long> diskQueueOfIds, CloudMessageSpool persistenceSpool)
+    /**
+     * Extract message ids from the persistenceSpool plugin's disk database and insert the message
+     * ids into queueOfMessageId, this function is only used in Disk storage mode. If Sync fails midway,
+     * we continue anyway with that DiskSpooler. If we fail to get all Message IDs from Disk Spooler Database,
+     * we default to InMemory spooler.
+     *
+     * @param diskQueueOfIds   list of messageIds to sync
+     * @param persistenceSpool instance of CloudMessageSpool
+     * @throws InterruptedException  If interrupted
+     * @throws SpoolerStoreException thrown if message too large or spooler capacity exceeded
+     */
+    public void persistentQueueSync(Iterable<Long> diskQueueOfIds, CloudMessageSpool persistenceSpool)
             throws InterruptedException, SpoolerStoreException {
         if (!diskQueueOfIds.iterator().hasNext()) {
             return;
@@ -292,39 +316,7 @@ public class Spool {
                 .kv("numSpoolerMessages", numMessages)
                 .kv("numMessagesAdded", queueOfMessageId.size() - queueOfMessageIdInitSize)
                 .log("Messages added to spool runtime queue");
-        nextId.set(highestId + 1);
-    }
-
-    /**
-     * Extract message ids from the persistenceSpool plugin's disk database and insert the message
-     * ids into queueOfMessageId, this function is only used in Disk storage mode. If Sync fails midway,
-     * we continue anyway with that DiskSpooler. If we fail to get all Message IDs from Disk Spooler Database,
-     * we default to InMemory spooler.
-     *
-     * @param diskSpooler   the disk spooler instance for syncing messages
-     */
-    public void executeQueueSync(CloudMessageSpool diskSpooler) {
-        try {
-            persistentQueueSync(diskSpooler.getAllMessageIds(), diskSpooler);
-            logger.atInfo().log("Persistent Spooler has been set up");
-        } catch (SpoolerStoreException e) {
-            logger.atWarn()
-                    .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
-                    .cause(e).log("Persistence spool queue sync was not completed");
-            logger.atInfo().log("Persistent Spooler has been set up");
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            logger.atWarn()
-                    .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
-                    .cause(e).log("Persistence spool queue sync was not completed");
-            logger.atInfo().log("Persistent Spooler has been set up");
-        } catch (IOException e) {
-            //log and use InMemorySpool
-            logger.atWarn()
-                    .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
-                    .cause(e).log("Persistence spool set up failed, defaulting to InMemory Spooler");
-            spooler = inMemorySpooler;
-        }
+        nextId.set(Math.max(nextId.get(), highestId + 1));
     }
 
 

--- a/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.mqttclient.spool.SpoolerStorageType;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.CommitableWriter;
 import com.aws.greengrass.util.platforms.Platform;
@@ -48,6 +49,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_LIFE
 import static com.aws.greengrass.lifecyclemanager.Kernel.SERVICE_TYPE_TOPIC_KEY;
 import static com.aws.greengrass.lifecyclemanager.Lifecycle.LIFECYCLE_BOOTSTRAP_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.Lifecycle.LIFECYCLE_INSTALL_NAMESPACE_TOPIC;
+import static com.aws.greengrass.mqttclient.spool.Spool.SPOOL_STORAGE_TYPE_KEY;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -86,6 +88,11 @@ class BootstrapManagerTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     Platform platform;
 
+    Map<String, Object> mockRunWith = new HashMap<String, Object>() {{
+        put(DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_USER, "foo:bar");
+        put(DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_SHELL, "sh");
+    }};
+
     @Test
     void GIVEN_new_config_without_service_change_WHEN_check_isBootstrapRequired_THEN_return_false() throws Exception {
         BootstrapManager bootstrapManager = new BootstrapManager(kernel);
@@ -100,6 +107,9 @@ class BootstrapManagerTest {
         Topics mockMqttTopics = mock(Topics.class);
         when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
         when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
+        Topics mockSpoolerTopics = mock(Topics.class);
+        when(mockSpoolerTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getSpoolerNamespace()).thenReturn(mockSpoolerTopics);
 
         BootstrapManager bootstrapManager = spy(new BootstrapManager(kernel));
         doReturn(false).when(bootstrapManager).serviceBootstrapRequired(any(), any());
@@ -187,16 +197,16 @@ class BootstrapManagerTest {
 
     @Test
     void GIVEN_deployment_config_WHEN_check_boostrap_required_THEN_boostrap_only_if_plugin_is_removed() throws Exception {
-        Map<String, Object> runWith = new HashMap<String, Object>() {{
-            put(DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_USER, "foo:bar");
-            put(DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_SHELL, "sh");
-        }};
+        Map<String, Object> runWith = mockRunWith;
         when(kernel.getContext()).thenReturn(context);
         when(context.get(DeviceConfiguration.class)).thenReturn(deviceConfiguration);
         when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(runWith);
         Topics mockMqttTopics = mock(Topics.class);
         when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
         when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
+        Topics mockSpoolerTopics = mock(Topics.class);
+        when(mockSpoolerTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getSpoolerNamespace()).thenReturn(mockSpoolerTopics);
 
         GenericExternalService nucleus = mock(GenericExternalService.class);
         doReturn(false).when(nucleus).isBootstrapRequired(anyMap());
@@ -406,15 +416,15 @@ class BootstrapManagerTest {
         Topics mockMqttTopics = mock(Topics.class);
         when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
         when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
+        Topics mockSpoolerTopics = mock(Topics.class);
+        when(mockSpoolerTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getSpoolerNamespace()).thenReturn(mockSpoolerTopics);
 
         GenericExternalService service = mock(GenericExternalService.class);
         doReturn(false).when(service).isBootstrapRequired(anyMap());
         when(kernel.locate(DEFAULT_NUCLEUS_COMPONENT_NAME)).thenReturn(service);
 
-        Map<String, Object> runWith = new HashMap<String, Object>() {{
-            put(DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_USER, "foo:bar");
-            put(DeviceConfiguration.RUN_WITH_DEFAULT_POSIX_SHELL, "sh");
-        }};
+        Map<String, Object> runWith = mockRunWith;
         when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(runWith);
 
         BootstrapManager bootstrapManager = new BootstrapManager(kernel, platform);
@@ -498,5 +508,127 @@ class BootstrapManagerTest {
 
         assertThrows(ComponentConfigurationValidationException.class, () ->
                 bootstrapManager.isBootstrapRequired(config));
+    }
+
+    @Test
+    void GIVEN_spooler_storage_type_changes_WHEN_isBootstrapRequired_THEN_return_true()
+            throws ServiceUpdateException, ComponentConfigurationValidationException, ServiceLoadException {
+        when(context.get(DeviceConfiguration.class)).thenReturn(deviceConfiguration);
+        when(kernel.getContext()).thenReturn(context);
+
+        GenericExternalService service = mock(GenericExternalService.class);
+        doReturn(false).when(service).isBootstrapRequired(anyMap());
+        when(kernel.locate(DEFAULT_NUCLEUS_COMPONENT_NAME)).thenReturn(service);
+        when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Memory);
+        Topics mockMqttTopics = mock(Topics.class);
+        when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
+        Map<String, Object> runWith = mockRunWith;
+        when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(runWith);
+
+        BootstrapManager bootstrapManager = new BootstrapManager(kernel, platform);
+        Map<String, Object> config =
+                new HashMap<String, Object>() {{
+                    put(SERVICES_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                        put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
+                            put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
+                            put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
+                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(SPOOL_STORAGE_TYPE_KEY, "Disk");
+                                }});
+                                put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
+                            }});
+                        }});
+                    }});
+                }};
+        boolean actual = bootstrapManager.isBootstrapRequired(config);
+        assertThat("restart required", actual, is(true));
+
+        when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Disk);
+        bootstrapManager = new BootstrapManager(kernel, platform);
+        config =
+                new HashMap<String, Object>() {{
+                    put(SERVICES_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                        put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
+                            put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
+                            put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
+                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(SPOOL_STORAGE_TYPE_KEY, SpoolerStorageType.Memory);
+                                }});
+                                put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
+                            }});
+                        }});
+                    }});
+                }};
+        actual = bootstrapManager.isBootstrapRequired(config);
+        assertThat("restart required", actual, is(true));
+
+        when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Disk);
+        bootstrapManager = new BootstrapManager(kernel, platform);
+        config =
+                new HashMap<String, Object>() {{
+                    put(SERVICES_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                        put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
+                            put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
+                            put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
+                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, Collections.emptyMap());
+                                put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
+                            }});
+                        }});
+                    }});
+                }};
+        actual = bootstrapManager.isBootstrapRequired(config);
+        assertThat("restart required", actual, is(true));
+    }
+
+    @Test
+    void GIVEN_spooler_storage_type_same_WHEN_isBootstrapRequired_THEN_return_false()
+            throws ServiceUpdateException, ComponentConfigurationValidationException, ServiceLoadException {
+        when(kernel.getContext()).thenReturn(context);
+        when(context.get(DeviceConfiguration.class)).thenReturn(deviceConfiguration);
+        Topics mockMqttTopics = mock(Topics.class);
+        when(mockMqttTopics.findOrDefault(any(), any())).thenAnswer((c) -> c.getArgument(0));
+        when(deviceConfiguration.getMQTTNamespace()).thenReturn(mockMqttTopics);
+        when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Disk);
+
+        GenericExternalService service = mock(GenericExternalService.class);
+        doReturn(false).when(service).isBootstrapRequired(anyMap());
+        when(kernel.locate(DEFAULT_NUCLEUS_COMPONENT_NAME)).thenReturn(service);
+
+        Map<String, Object> runWith = mockRunWith;
+        when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(runWith);
+
+        BootstrapManager bootstrapManager = new BootstrapManager(kernel, platform);
+        Map<String, Object> config =
+                new HashMap<String, Object>() {{
+                    put(SERVICES_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                        put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
+                            put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
+                            put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
+                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(SPOOL_STORAGE_TYPE_KEY, "Disk");
+                                }});
+                                put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
+                            }});
+                        }});
+                    }});
+                }};
+        assertThat("restart required", bootstrapManager.isBootstrapRequired(config), is(false));
+
+        when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Memory);
+        bootstrapManager = new BootstrapManager(kernel, platform);
+        config =
+                new HashMap<String, Object>() {{
+                    put(SERVICES_NAMESPACE_TOPIC, new HashMap<String, Object>() {{
+                        put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
+                            put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
+                            put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
+                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, Collections.emptyMap());
+                                put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
+                            }});
+                        }});
+                    }});
+                }};
+        assertThat("restart required", bootstrapManager.isBootstrapRequired(config), is(false));
     }
 }

--- a/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
@@ -526,6 +526,7 @@ class BootstrapManagerTest {
         Map<String, Object> runWith = mockRunWith;
         when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(runWith);
 
+        // Change SpoolerStorageType from "Memory" to "Disk"
         BootstrapManager bootstrapManager = new BootstrapManager(kernel, platform);
         Map<String, Object> config =
                 new HashMap<String, Object>() {{
@@ -544,6 +545,7 @@ class BootstrapManagerTest {
         boolean actual = bootstrapManager.isBootstrapRequired(config);
         assertThat("restart required", actual, is(true));
 
+        // Change SpoolerStorageType from "Disk" to "Memory"
         when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Disk);
         bootstrapManager = new BootstrapManager(kernel, platform);
         config =
@@ -553,7 +555,7 @@ class BootstrapManagerTest {
                             put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
                             put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
                                 put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
-                                    put(SPOOL_STORAGE_TYPE_KEY, SpoolerStorageType.Memory);
+                                    put(SPOOL_STORAGE_TYPE_KEY, "Memory");
                                 }});
                                 put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
                             }});
@@ -563,7 +565,7 @@ class BootstrapManagerTest {
         actual = bootstrapManager.isBootstrapRequired(config);
         assertThat("restart required", actual, is(true));
 
-        when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Disk);
+        // Change SpoolerStorageType from "Disk" to "Memory" (without specifying any value)
         bootstrapManager = new BootstrapManager(kernel, platform);
         config =
                 new HashMap<String, Object>() {{
@@ -598,6 +600,7 @@ class BootstrapManagerTest {
         Map<String, Object> runWith = mockRunWith;
         when(deviceConfiguration.getRunWithTopic().toPOJO()).thenReturn(runWith);
 
+        // Change SpoolerStorageType from "Disk" to "Disk"
         BootstrapManager bootstrapManager = new BootstrapManager(kernel, platform);
         Map<String, Object> config =
                 new HashMap<String, Object>() {{
@@ -615,6 +618,7 @@ class BootstrapManagerTest {
                 }};
         assertThat("restart required", bootstrapManager.isBootstrapRequired(config), is(false));
 
+        // Change SpoolerStorageType from "Memory" to "Memory" (without specifying any value)
         when(deviceConfiguration.getSpoolerNamespace().findOrDefault(any(), any())).thenReturn(SpoolerStorageType.Memory);
         bootstrapManager = new BootstrapManager(kernel, platform);
         config =

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -607,5 +607,10 @@ class KernelTest {
         public Iterable<Long> getAllMessageIds() throws IOException {
             return null;
         }
+
+        @Override
+        public void initializeSpooler() throws IOException {
+
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
1. Having the sync queue run from Persistent spooler can cause some edge cases which would result in some unwanted scenarios like adding 2 same message IDs into the queue, or failure to add message in DB. These are difficult to debug and would cause unnecessary complexity. Already saw a couple instances while running UATs, like the FSS message is added to spooler when kernel is launched, and this happens even before we complete the sync. This results in failure to add a message with message ID 0, as there's already a message in DB with that ID which was not synced. We can remove this complexity by doing the sync during initialization before any spool message is added/removed from queue. 
2. We need to restart nucleus if Spooler configuration changes include a change in `SpoolStorageType`. Changing storage from Disk to Memory will result in losing messages and could break Nucleus and our ability to do deployments, if we don't restart Nucleus.

**Description of changes:**
1. Basically revert this commit (https://github.com/aws-greengrass/aws-greengrass-nucleus/commit/9d0d18e9ff0f929a5108e5f93d5df13ba30fc134) and keep some of the changes that are required. 
2. Add check for `SpoolStorageType` change in `BootstrapManager`

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
