### PR TITLE
fix: restart on spooler config chage

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
@@ -196,7 +196,9 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
         String currentSpoolerStorageType = Coerce.toString(
                 currentDeviceConfiguration.getSpoolerNamespace().findOrDefault(DEFAULT_SPOOL_STORAGE_TYPE,
                         SPOOL_STORAGE_TYPE_KEY));
-        Map<String, Object> newSpooler = (Map<String, Object>) newNucleusParameters.get(DEVICE_SPOOLER_NAMESPACE);
+        Map<String, Object> newMqtt = (Map<String, Object>) newNucleusParameters.get(DEVICE_MQTT_NAMESPACE);
+        Map<String, Object> newSpooler = newMqtt == null ? null
+                : (Map<String, Object>) newMqtt.get(DEVICE_SPOOLER_NAMESPACE);
         Object newStorageType = newSpooler == null ? null : newSpooler.get(SPOOL_STORAGE_TYPE_KEY);
         if (newStorageType == null
                 && !(DEFAULT_SPOOL_STORAGE_TYPE.toString().equalsIgnoreCase(currentSpoolerStorageType))

--- a/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
@@ -534,8 +534,10 @@ class BootstrapManagerTest {
                         put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
                             put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
                             put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
-                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
-                                    put(SPOOL_STORAGE_TYPE_KEY, "Disk");
+                                put(DeviceConfiguration.DEVICE_MQTT_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
+                                        put(SPOOL_STORAGE_TYPE_KEY, "Disk");
+                                    }});
                                 }});
                                 put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
                             }});
@@ -554,8 +556,10 @@ class BootstrapManagerTest {
                         put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
                             put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
                             put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
-                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
-                                    put(SPOOL_STORAGE_TYPE_KEY, "Memory");
+                                put(DeviceConfiguration.DEVICE_MQTT_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
+                                        put(SPOOL_STORAGE_TYPE_KEY, "Memory");
+                                    }});
                                 }});
                                 put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
                             }});
@@ -573,7 +577,9 @@ class BootstrapManagerTest {
                         put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
                             put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
                             put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
-                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, Collections.emptyMap());
+                                put(DeviceConfiguration.DEVICE_MQTT_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, Collections.emptyMap());
+                                }});
                                 put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
                             }});
                         }});
@@ -608,8 +614,10 @@ class BootstrapManagerTest {
                         put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
                             put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
                             put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
-                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
-                                    put(SPOOL_STORAGE_TYPE_KEY, "Disk");
+                                put(DeviceConfiguration.DEVICE_MQTT_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, new HashMap<String, Object>() {{
+                                        put(SPOOL_STORAGE_TYPE_KEY, "Disk");
+                                    }});
                                 }});
                                 put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
                             }});
@@ -627,7 +635,9 @@ class BootstrapManagerTest {
                         put(DEFAULT_NUCLEUS_COMPONENT_NAME, new HashMap<String, Object>() {{
                             put(SERVICE_TYPE_TOPIC_KEY, ComponentType.NUCLEUS.toString());
                             put(CONFIGURATION_CONFIG_KEY, new HashMap<String, Object>() {{
-                                put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, Collections.emptyMap());
+                                put(DeviceConfiguration.DEVICE_MQTT_NAMESPACE, new HashMap<String, Object>() {{
+                                    put(DeviceConfiguration.DEVICE_SPOOLER_NAMESPACE, Collections.emptyMap());
+                                }});
                                 put(DeviceConfiguration.RUN_WITH_TOPIC, runWith);
                             }});
                         }});


### PR DESCRIPTION
**Issue #, if available:**
We were checking Spooler namespace directly which will always give value null as Spooler Namespace is an object inside MQTT Namespace. This would fail to restart whenever there's a change in Spooler `StorageType`
**Description of changes:**
Get Spooler StorageType from Spooler Namespace inside MQTT Namespace
**Why is this change necessary:**

**How was this change tested:**
Tested the behavior via manual deployment
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
