### PR TITLE
fix: always remove message from memory spooler

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -102,6 +102,7 @@ public class Spool {
                         .cause(e).log("Persistence spool set up failed, defaulting to InMemory Spooler");
             }
         }
+        logger.atInfo().log("Memory Spooler has been set up");
         return inMemorySpooler;
     }
 
@@ -122,12 +123,14 @@ public class Spool {
             } catch (SpoolerStoreException e) {
                 logger.atWarn()
                         .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
-                        .cause(e).log("Persistence spool queue sync was not completed");
+                        .cause(e).log("Persistence spool queue sync was not completed, continuing with"
+                                + " Persistent Spooler anyways");
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.atWarn()
                         .kv(PERSISTENCE_SPOOL_SERVICE_NAME_KEY, config.getPersistenceSpoolServiceName())
-                        .cause(e).log("Persistence spool queue sync was not completed");
+                        .log("Persistence spool queue sync was interrupted, continuing with"
+                                + " Persistent Spooler anyways");
             }
             logger.atInfo().log("Persistent Spooler has been set up");
             return persistenceSpool;

--- a/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/InMemorySpoolTest.java
@@ -200,39 +200,6 @@ class InMemorySpoolTest {
     }
 
     @Test
-    void GIVEN_spooler_config_disk_WHEN_persistent_queue_sync_THEN_sync_only_adds_new_messageIDs() throws ServiceLoadException, IOException, SpoolerStoreException, InterruptedException {
-        List<Long> messageIds = Arrays.asList(0L, 1L, 2L);
-        GreengrassService persistenceSpoolService = Mockito.mock(GreengrassService.class, withSettings().extraInterfaces(CloudMessageSpool.class));
-        CloudMessageSpool persistenceSpool = (CloudMessageSpool) persistenceSpoolService;
-
-        Publish request = PublishRequest.builder().topic("spool").payload(ByteBuffer.allocate(1).array())
-                .qos(QualityOfService.AT_LEAST_ONCE).build().toPublish();
-
-        SpoolMessage message0 = SpoolMessage.builder().id(0L).request(request).build();
-        SpoolMessage message1 = SpoolMessage.builder().id(1L).request(request).build();
-        SpoolMessage message2 = SpoolMessage.builder().id(2L).request(request).build();
-
-        config.lookup("spooler", SPOOL_STORAGE_TYPE_KEY).withValue("Disk");
-        lenient().when(kernel.locate(anyString())).thenReturn(persistenceSpoolService);
-        lenient().when(persistenceSpool.getMessageById(0L)).thenReturn(message0);
-        lenient().when(persistenceSpool.getMessageById(1L)).thenReturn(message1);
-        lenient().when(persistenceSpool.getMessageById(2L)).thenReturn(message2);
-
-        spool = new Spool(deviceConfiguration, kernel);
-        // Add 3 messages
-        spool.addMessage(request);
-        spool.addMessage(request);
-        spool.addMessage(request);
-        assertEquals(3, spool.getCurrentMessageCount());
-
-        // Sync messages from Database (mocked to give out 3 messages with IDs 0,1,2)
-        lenient().when(persistenceSpool.getAllMessageIds()).thenReturn(messageIds);
-        spool.persistentQueueSync(persistenceSpool.getAllMessageIds(), persistenceSpool);
-        // Validate Message IDs Queue size is still same as these IDs are already present in the Queue
-        assertEquals(3, spool.getCurrentMessageCount());
-    }
-
-    @Test
     void GIVEN_spooler_config_disk_WHEN_setup_spooler_failed_THEN_use_in_memory_spooler(ExtensionContext context) throws ServiceLoadException, IOException, SpoolerStoreException, InterruptedException {
         ignoreExceptionOfType(context, IOException.class);
         GreengrassService persistenceSpoolService = Mockito.mock(GreengrassService.class, withSettings().extraInterfaces(CloudMessageSpool.class));


### PR DESCRIPTION
**Issue #, if available:**
Given spooler storageType "Disk", and `addMessage` fails for some reason, we add the message to Memory spooler as a fallback. When we call `removeMessageById` it will try to remove message from DiskSpooler with the given ID but message was never added to persistent spooler and instead added to Memory. Due to this, the message will actually never be removed from the memory spooler , which is bad. 
**Description of changes:**
- Always remove message from Memory Spooler.
- Removed a check in `persistentQueueSync` which is never possible now that we moved `persistentQueueSync` back to spooler initialization. Earlier the check was added as we were calling queue sync from Disk Spooler implementation, in that case the condition would have occurred when we restarted the disk Spooler component.
**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
