### PR TITLE
fix(docker): correct is image used by others check

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -337,13 +337,14 @@ public class DockerImageDownloader extends ArtifactDownloader {
             for (String compVersion : localVersions) {
                 try {
                     ComponentIdentifier identifier = new ComponentIdentifier(compName, new Semver(compVersion));
-                    // this.identifier is to be deleted identifier
+                    // this.identifier is to be deleted identifier. Skip checking ourselves.
                     if (identifier.equals(this.identifier)) {
-                        ComponentRecipe recipe = componentStore.getPackageRecipe(identifier);
-                        if (recipe.getArtifacts().stream().anyMatch(
-                                i -> i.getArtifactUri().equals(artifact.getArtifactUri()))) {
-                            return true;
-                        }
+                        continue;
+                    }
+                    ComponentRecipe recipe = componentStore.getPackageRecipe(identifier);
+                    if (recipe.getArtifacts().stream().anyMatch(
+                            i -> i.getArtifactUri().equals(artifact.getArtifactUri()))) {
+                        return true;
                     }
                 } catch (SemverException e) {
                     logger.atWarn().kv("identifier", identifier.getName()).kv("compVersion", compVersion)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix the check in `ifImageUsedByOther` so that it _skips_ checking itself rather than _only_ checking itself (which would always be true).

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Manually tested as well to ensure it works properly by @yitingb.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
