### PR TITLE
fix(mqtt5): catch mqtt builder fails with mqtt exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.12.2-CLI-SNAPSHOT</version>
+            <version>1.13.2-CLI-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -20,6 +20,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.mqtt.MqttException;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5Client;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
 import software.amazon.awssdk.crt.mqtt5.OnAttemptingConnectReturn;
@@ -319,6 +320,9 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                                 "sessionExpirySeconds")))
                     );
             client = builder.build();
+        } catch (MqttException e) {
+            connectFuture.completeExceptionally(e);
+            return;
         }
         client.start();
     }

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -975,7 +975,7 @@ public class MqttClient implements Closeable {
         return 0;
     }
 
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
     protected IndividualMqttClient getNewMqttClient() {
         int clientIdNum = getNextClientIdNumber();
         // Name client by thingName#<number> except for the first connection which will just be thingName
@@ -988,6 +988,8 @@ public class MqttClient implements Closeable {
             return new AwsIotMqtt5Client(() -> {
                 try {
                     return builderProvider.apply(clientBootstrap).toAwsIotMqtt5ClientBuilder();
+                } catch (RuntimeException e) {
+                    throw e;
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -197,7 +197,7 @@ class MqttClientTest {
         mqttNamespace.lookup(MqttClient.MQTT_PING_TIMEOUT_KEY).withValue(pingTimeout);
         MqttClient mqttClient = new MqttClient(deviceConfiguration, ses, executorService,
                 mock(SecurityService.class), kernel);
-        RuntimeException e = assertThrows(RuntimeException.class, () -> mqttClient.getNewMqttClient().connect().get());
+        ExecutionException e = assertThrows(ExecutionException.class, () -> mqttClient.getNewMqttClient().connect().get());
         assertEquals(MqttException.class, e.getCause().getClass());
     }
 

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
@@ -147,6 +147,8 @@ public class ExceptionLogProtector implements BeforeEachCallback, AfterEachCallb
         ignoreExceptionOfType(context, ClosedByInterruptException.class);
         ignoreExceptionWithStackTraceContaining(context, IllegalAccessException.class,
                 ProvisioningPluginFactory.class.getName());
+        ignoreExceptionWithStackTraceContaining(context, NullPointerException.class,
+                "subscribeToGetNextJobDescription");
     }
 
     @Override


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Builderprovider.get() can fail with MqttException which is a runtime exception. This was missed previously and means that it is possible for Greengrass to be in a state where it isn't subscribed to the jobs/shadow topics.

Validated with Kyle that this fully fixes the issue and Greengrass can now retry appropriately.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
