### PR TITLE
fix: check if qos0 message check is required

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -14,6 +14,7 @@ import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.QOS;
 import com.aws.greengrass.util.Coerce;
 
 import java.io.IOException;
@@ -324,7 +325,9 @@ public class Spool {
             queueCapacityCheck(request, false);
 
             queueOfMessageId.putLast(currentId);
-            qos0MessageCheckRequired.set(true);
+            if (request.getQos().equals(QOS.AT_MOST_ONCE)) {
+                qos0MessageCheckRequired.set(true);
+            }
             if (currentId > highestId) {
                 highestId = currentId;
             }

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -263,8 +263,10 @@ public class Spool {
         removeMessagesWithQosZero(false);
     }
 
-    private synchronized void removeMessagesWithQosZero(boolean needToCheckCurSpoolerSize) {
-        if (!qos0MessageCheckRequired.get()) {
+    private void removeMessagesWithQosZero(boolean needToCheckCurSpoolerSize) {
+        // Don't proceed if we are doing removal to make space (not due to being offline) and qos0 message check
+        // is not required
+        if (needToCheckCurSpoolerSize && !qos0MessageCheckRequired.get()) {
             return;
         }
         Iterator<Long> messageIdIterator = queueOfMessageId.iterator();

--- a/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/Spool.java
@@ -264,9 +264,7 @@ public class Spool {
     }
 
     private void removeMessagesWithQosZero(boolean needToCheckCurSpoolerSize) {
-        // Don't proceed if we are doing removal to make space (not due to being offline) and qos0 message check
-        // is not required
-        if (needToCheckCurSpoolerSize && !qos0MessageCheckRequired.get()) {
+        if (!qos0MessageCheckRequired.get()) {
             return;
         }
         Iterator<Long> messageIdIterator = queueOfMessageId.iterator();


### PR DESCRIPTION
**Issue #, if available:**
When GG is offline, or when spool storage is full, we check through all messages to see if i we can remove any QOS 0 message to accommodate the incoming message. This loop reads through all messages in spooler and is heavy as it reads through database, in case its a disk spooler. This was discovered as we saw high CPU usage in the Disk spooler performance tests which ran spooler tests with QOS 1 messages and at 100 TPS in an unstable network (online <-> offline every 5 mins)

**Description of changes:**
1. Have a flag to see if we need to check for QOS 0 messages or not, when the removal method is called. We set the flag to true every time a new message is added to spooler queue, and set it to false at the end of removal method. Basically, a flag saying "do we need to check for qos 0 message because the queue has been added to"

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
