### PR TITLE
fix: do not bootloop if bootstrap fails and deployment metadata is corrupted

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -137,11 +137,13 @@ public class DeploymentDirectoryManager {
         }
         Path filePath = getDeploymentMetadataFilePath();
         logger.atInfo().kv(FILE_LOG_KEY, filePath).kv(DEPLOYMENT_ID_LOG_KEY,
-                deployment.getGreengrassDeploymentId()).log("Persist deployment metadata");
+                deployment.getGreengrassDeploymentId()).log("Saving deployment metadata to file");
         writeDeploymentMetadata(filePath, deployment);
     }
 
     private void writeDeploymentMetadata(Path filePath, Deployment deployment) throws IOException {
+        Files.deleteIfExists(filePath);
+        Files.createFile(filePath);
         try (CommitableWriter out = CommitableWriter.commitOnClose(filePath)) {
             SerializerFactory.getFailSafeJsonObjectMapper().writeValue(out, deployment);
         }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -551,7 +551,7 @@ class KernelTest {
         }
 
         verify(kernelAlternatives).prepareRollback();
-        verify(kernelLifecycle).shutdown(eq(30), eq(REQUEST_RESTART));
+        verify(kernelLifecycle).launch();
     }
 
     static class TestClass extends GreengrassService {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. If a bootstrap task fails, prepare rollback irrespective if deployment metadata is readable/writable or not
2. If rollback preparation fails, launch Nucleus as default
3. Safe delete deployment metadata from file system before modification

**Why is this change necessary:**
After a restart, if
1. deployment stage is determined to be bootstrap,
2. a pending bootstrap task fails, and
3. persisted deployment metadata file is either missing or corrupted

then Nucleus will end up being stuck in a bootloop, effectively bricking the core device.
Note that simply taking out the rollback preparation step from try block at
https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/main/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java#L222
is not enough, as rollback preparation may fail causing a similar bootloop as explained above. Here, the deployment should proceed as default and complete. This way the core device can receive deployments later.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
