### PR TITLE
fix(authZ): do not check for duplicate authZ policy IDs

### DIFF
--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -414,15 +414,6 @@ public class AuthorizationHandler  {
         if (policies.stream().anyMatch(p -> Utils.isEmpty(p.getPolicyId()))) {
             throw new AuthorizationException("Malformed policy with empty/null policy IDs");
         }
-        // check for duplicates
-        Set<String> duplicates = new HashSet<>();
-        for (AuthorizationPolicy policy : policies) {
-            if (!duplicates.add(policy.getPolicyId())) {
-                throw new AuthorizationException(
-                        String.format("Duplicate policy ID \"%s\" for principal \"%s\"",
-                                policy.getPolicyId(), policy.getPrincipals()));
-            }
-        }
     }
 
     private void validatePrincipals(AuthorizationPolicy policy) throws AuthorizationException {

--- a/src/test/java/com/aws/greengrass/authorization/AuthorizationHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/AuthorizationHandlerTest.java
@@ -275,8 +275,10 @@ class AuthorizationHandlerTest {
         Set<String> serviceOpsB = new HashSet<>(Arrays.asList("OpD", "OpE"));
         authorizationHandler.registerComponent("ServiceB", serviceOpsB);
 
+        // Duplicate IDs are fine
         authorizationHandler.loadAuthorizationPolicies("ServiceA",
-                Collections.singletonList(getAuthZPolicy()), false);
+                getAuthZPolicyWithDuplicateId(), false);
+        // Non-duplicate policy also works
         authorizationHandler.loadAuthorizationPolicies("ServiceB",
                 Collections.singletonList(getAuthZPolicyB()), false);
 
@@ -509,7 +511,7 @@ class AuthorizationHandlerTest {
                 Collections.singletonList(getAuthZPolicy()), false);
         assertTrue(logReceived.await(5, TimeUnit.SECONDS));
 
-//        // register the component
+        // register the component
         authorizationHandler.registerComponent("ServiceA", new HashSet<>(Arrays.asList("Op")));
 
         // Empty principal should fail to load now
@@ -533,12 +535,6 @@ class AuthorizationHandlerTest {
         authorizationHandler.loadAuthorizationPolicies(
                 "ServiceA",
                 Collections.singletonList(getAuthZPolicyWithEmptyOp()), false);
-        assertTrue(logReceived.await(5, TimeUnit.SECONDS));
-
-        // duplicate policyId should fails
-        setupLogListener("load-authorization-config-invalid-policy");
-        authorizationHandler.loadAuthorizationPolicies("ServiceA",
-                getAuthZPolicyWithDuplicateId(), false);
         assertTrue(logReceived.await(5, TimeUnit.SECONDS));
 
         // empty policy Id should fail


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The authorization policy ID is currently required to be unique within the device. This constraint has no purpose (we don't use the policy ID for anything at all except for logging), and it causes significant customer pain. Simply removing the duplicate check is safe and will positively impact the usability of Greengrass.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
