### PR TITLE
fix: report untriggered on-demand lambdas in fss deployment message

### DIFF
--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -447,7 +447,7 @@ public class FleetStatusService extends GreengrassService {
                 // (e.g. on-demand lambdas), include them in the updated gg service set because they should be also
                 // installed by this deployment
                 kernel.orderedDependencies().forEach(greengrassService -> {
-                    if (greengrassService.inState(State.NEW) && !isSystemLevelService(greengrassService)) {
+                    if (greengrassService.inState(State.NEW)) {
                         updatedGreengrassServiceSet.add(greengrassService);
                     }
                 });

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -442,8 +442,16 @@ public class FleetStatusService extends GreengrassService {
                 return;
             }
 
-            // remove any component from unchanged status component list if it's in updatedGreengrassServiceSet
             if (deploymentInformation != null && deploymentInformation.getUnchangedRootComponents() != null) {
+                // for a deployment-triggered FSS update, if any component is NEW state when deployment finishes
+                // (e.g. on-demand lambdas), include them in the updated gg service set because they should be also
+                // installed by this deployment
+                kernel.orderedDependencies().forEach(greengrassService -> {
+                    if (greengrassService.inState(State.NEW) && !isSystemLevelService(greengrassService)) {
+                        updatedGreengrassServiceSet.add(greengrassService);
+                    }
+                });
+                // remove any component from unchanged status component list if it's in updatedGreengrassServiceSet
                 deploymentInformation.getUnchangedRootComponents().removeIf(
                         componentName -> updatedGreengrassServiceSet.stream()
                                 .anyMatch(service -> service.getName().equals(componentName)));


### PR DESCRIPTION
**Description of changes:**
- Include New-state components in FSS deployment updates.

**Why is this change necessary:**
If an on-demand lambda component is deployed but not triggered during a deployment, it is kept at NEW state throughout the deployment. Before this change, FSS ignores this component in deployment status update and the component does not show up on console.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
