### PR TITLE
chore: bump oshi version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <dependency>
              <groupId>com.github.oshi</groupId>
              <artifactId>oshi-core</artifactId>
-             <version>6.3.2</version>
+             <version>6.4.4</version>
         </dependency>
 
         <!-- zeroturnaround brings in an older version jna which tries to load msvcr100.dll. msvcr100.dll is not shipped


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump OSHI lib to 6.4.4 which includes the fix for [process group name queries](https://github.com/oshi/oshi/pull/2407)

**Why is this change necessary:**
In LDAP file systems with large number of users, Nucleus was unable to stop component processes due to a bug in the OSHI lib. OSHI was internally calling `getent passwd` when Nucleus queries [getDescendantProcesses](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/b5bcec9b1c045da4566b1ae5bbb0cca89f342dc6/src/main/java/com/aws/greengrass/util/platforms/unix/UnixPlatform.java#L544).

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
