### PR TITLE
fix: maven assembly plugin error

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -4,6 +4,7 @@
     <formats>
         <format>zip</format>
     </formats>
+    <id>zip</id>
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -808,8 +808,10 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <finalName>aws.greengrass.nucleus</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>${basedir}/assembly.xml</descriptor>
                     </descriptors>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix assembly plugin error complaining that there's no id.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
