### PR TITLE
fix: retry docker on dial tcp failure

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
@@ -45,6 +45,7 @@ public class DefaultDockerClient {
     private static final String REQUEST_CANCELED = "request canceled";
     private static final String DOCKER_PULL_TIMEOUT = "timeout";
     private static final String NO_SUCH_HOST = "no such host";
+    private static final String DIAL_TCP = "dial tcp";
 
     /**
      * Sanity check for installation.
@@ -139,7 +140,8 @@ public class DefaultDockerClient {
                         || response.err.toLowerCase().contains(NET_HTTP_TIMEOUT)
                         || response.err.toLowerCase().contains(REQUEST_CANCELED)
                         || response.err.toLowerCase().contains(DOCKER_PULL_TIMEOUT)
-                        || response.err.toLowerCase().contains(NO_SUCH_HOST)) {
+                        || response.err.toLowerCase().contains(NO_SUCH_HOST)
+                        || response.err.toLowerCase().contains(DIAL_TCP)) {
                     throw new ConnectionException(String.format("Network issue when docker pull - %s", response.err));
                 }
                 throw new DockerPullException(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
https://repost.aws/questions/QUsff-SxHZTLe0RWRn1x6nvA

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
