### PR TITLE
fix: stop mqtt5 IoT core client with normal disconnection

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -248,7 +248,9 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
             logger.atDebug().log("Disconnecting from AWS IoT Core");
             CompletableFuture<Void> f = new CompletableFuture<>();
             stopFuture.set(f);
-            client.stop(null);
+            client.stop(new DisconnectPacket.DisconnectPacketBuilder()
+                    .withReasonCode(DisconnectPacket.DisconnectReasonCode.NORMAL_DISCONNECTION)
+                    .build());
             connectionCleanup();
             return f;
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When stopping Nucleus' MQTT5 client, use `NORMAL_DISCONNECTION` as disconnect reason.  

**Why is this change necessary:**
Without providing a disconnect reason, CRT will inform IoT Core that disconnect was due to `CONNECTION_LOST`.  This will also prevent onDisconnect callbacks from running during shutdown.

**How was this change tested:**
Manually deployed to my AWS account, stopped nucleus, and verified in IoT Core CloudWatch logs (AWSIotLogsV2) via the following query that Nucleus MQTT5 client disconnected with `CLIENT_INITIATED_DISCONNECT`. Also confirmed that without the fix, query returns `CONNECTION_LOST` instead.
```
filter @message like "disconnect"
| fields @timestamp, disconnectReason
```

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
