### PR TITLE
fix: do not move terminated service to desired state on kernel shutdown

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/services_startup_with_hard_dep.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/services_startup_with_hard_dep.yaml
@@ -1,0 +1,45 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+
+  component_with_depender:
+    lifecycle:
+      posix:
+        startup: |-
+          while true; do
+          date; echo component_with_depender_running; sleep 5
+          done
+      windows:
+        startup: |-
+          powershell -command "& { while(1) { echo component_with_depender_running; sleep 5 } }"
+
+  component_with_hard_dependency:
+    dependencies:
+      - component_with_depender:HARD
+    lifecycle:
+      posix:
+        startup: |-
+          while true; do
+          date; echo component_with_hard_dependency_running; sleep 5
+          done
+      windows:
+        startup: |-
+          powershell -command "& { while(1) { echo component_with_hard_dependency_running; sleep 5 } }"
+
+  main:
+    dependencies:
+      - component_with_hard_dependency
+      - component_with_depender
+    lifecycle:
+      posix:
+        run: |-
+          while true; do
+          sleep 5
+          done
+      windows:
+        run: |-
+          powershell -command while(1) { sleep 5 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -578,7 +578,8 @@ public class GenericExternalService extends GreengrassService {
         resetRunWith(); // reset runWith - a deployment can change user info
     }
 
-    private synchronized void stopAllLifecycleProcesses() {
+    // public for integ test use only
+    public synchronized void stopAllLifecycleProcesses() {
         stopProcesses(lifecycleProcesses);
     }
 

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -118,7 +118,8 @@ public class KernelLifecycle {
     @Getter
     private ConfigurationWriter tlog;
     private GreengrassService mainService;
-    private final AtomicBoolean isShutdownInitiated = new AtomicBoolean(false);
+    @Getter
+    private final AtomicBoolean shutdownInitiated = new AtomicBoolean(false);
 
     /**
      * Constructor.
@@ -545,7 +546,7 @@ public class KernelLifecycle {
      */
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
     public void shutdown(int timeoutSeconds) {
-        if (!isShutdownInitiated.compareAndSet(false, true)) {
+        if (!shutdownInitiated.compareAndSet(false, true)) {
             logger.info("Shutdown already initiated, returning...");
             return;
         }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -709,7 +709,9 @@ public class Lifecycle {
      */
     @SuppressWarnings("PMD.MissingBreakInSwitch")
     private void serviceTerminatedMoveToDesiredState(@Nonnull State desiredState) {
-        if (isClosed.get()) {
+        KernelLifecycle kernelLifecycle = greengrassService.getContext().get(KernelLifecycle.class);
+        // if kernel is shutting down already, do not move back to NEW/INSTALLED/RUNNING
+        if (isClosed.get() || kernelLifecycle.getShutdownInitiated().get()) {
             internalReportState(State.FINISHED);
             return;
         }


### PR DESCRIPTION
**Description of changes:**
- Fixes a race condition between component error and kernel shutdown
- Adds integ test


**Why is this change necessary:**
If component error and kernel shutdown happen at the same time (e.g. SIGKILL is sent to both component process and nucleus process), there is a chance that component restarts during kernel shutdown.

Specifically, if the component has a hard depender, it waits for the depender to close first during kernel shutdown and allows other state transitions.

After this change, while it still waits for the depender to close, it does not restart.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
