### PR TITLE
fix(systemd): use killmode=mixed to signal nucleus first on shutdown

### DIFF
--- a/scripts/greengrass.service.template
+++ b/scripts/greengrass.service.template
@@ -9,6 +9,7 @@ RemainAfterExit=no
 Restart=on-failure
 RestartSec=10
 ExecStart=/bin/sh REPLACE_WITH_GG_LOADER_FILE
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Setting [KillMode=mixed](https://www.freedesktop.org/software/systemd/man/systemd.kill.html#:~:text=If%20set%20to%20mixed%2C%20the%20SIGTERM%20signal%20(see%20below)%20is%20sent%20to%20the%20main%20process%20while%20the%20subsequent%20SIGKILL%20signal%20(see%20below)%20is%20sent%20to%20all%20remaining%20processes%20of%20the%20unit%27s%20control%20group.) to first signal the main Nucleus process to shutdown before killing all children. All child processes will still be killed if they are running, but this gives Nucleus a chance to better control the child lifecycles.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
