### PR TITLE
 fix: improvements to lifecycle transition and shutdown

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/services_startup_with_hard_dep.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/services_startup_with_hard_dep.yaml
@@ -1,0 +1,45 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+
+  component_with_depender:
+    lifecycle:
+      posix:
+        startup: |-
+          while true; do
+          date; echo component_with_depender_running; sleep 5
+          done
+      windows:
+        startup: |-
+          powershell -command "& { while(1) { echo component_with_depender_running; sleep 5 } }"
+
+  component_with_hard_dependency:
+    dependencies:
+      - component_with_depender:HARD
+    lifecycle:
+      posix:
+        startup: |-
+          while true; do
+          date; echo component_with_hard_dependency_running; sleep 5
+          done
+      windows:
+        startup: |-
+          powershell -command "& { while(1) { echo component_with_hard_dependency_running; sleep 5 } }"
+
+  main:
+    dependencies:
+      - component_with_hard_dependency
+      - component_with_depender
+    lifecycle:
+      posix:
+        run: |-
+          while true; do
+          sleep 5
+          done
+      windows:
+        run: |-
+          powershell -command while(1) { sleep 5 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -578,7 +578,8 @@ public class GenericExternalService extends GreengrassService {
         resetRunWith(); // reset runWith - a deployment can change user info
     }
 
-    private synchronized void stopAllLifecycleProcesses() {
+    // public for integ test use only
+    public synchronized void stopAllLifecycleProcesses() {
         stopProcesses(lifecycleProcesses);
     }
 


### PR DESCRIPTION
**Description of changes:**
1. Do not mark dependency ready if it's stopping and previously it errored
2. Improvements to the order of lifecycle close
3. Added integ test.


**Why is this change necessary:**
To improve the accuracy of dependency waiting logic and kernel shutdown order


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
