### PR TITLE
fix(log): bump ALPN old Java log up to warning

### DIFF
--- a/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
+++ b/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
@@ -50,7 +50,9 @@ public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
             params.setApplicationProtocols(new String[]{"x-amzn-http-ca", "http/1.1"});
             socket.setSSLParameters(params);
         } catch (NoSuchMethodError e) {
-            log.debug(() -> "Unable to configure socket for ALPN. Ports other than 443 may still work.");
+            log.warn(() -> "Unable to configure socket for ALPN. Ports other than 443 may still work."
+                    + " Your Java version is more than 3 years outdated, "
+                    + "update it to a version newer than Java 8u252.");
             // Java 8 did not launch with ALPN support, but it was backported in April 2020 with JDK8u252.
             // Catching the error here so that we can continue to work with older JDKs since the user may not
             // even require ALPN to work.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
