### PR TITLE
chore(deps): bump JNA version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,13 +216,13 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.12.1</version>
+            <version>5.13.0</version>
         </dependency>
         <!-- jna-platform adds support for calling Windows system DLLs -->
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
-            <version>5.12.1</version>
+            <version>5.13.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The new version of OSHI that we took has a dependency on 5.13 for JNA, thus bumping our version to be compatible. This doesn't impact us negatively right now, but I want to avoid any future issues.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
