### PR TITLE
feat(s3Endpoint): enable configurable s3 endpoint as global or regional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.295</version>
+                <version>2.20.138</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>greengrassv2-data</artifactId>
-            <version>2.17.x-SNAPSHOT</version>
+            <version>2.20.x-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactory.java
@@ -14,6 +14,7 @@ import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.plugins.docker.DockerImageDownloader;
 import com.aws.greengrass.componentmanager.plugins.docker.Image;
 import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.S3SdkClientFactory;
@@ -50,6 +51,8 @@ public class ArtifactDownloaderFactory {
 
     private final Context context;
 
+    private final DeviceConfiguration deviceConfiguration;
+
     /**
      * ArtifactDownloaderFactory constructor.
      *
@@ -57,16 +60,19 @@ public class ArtifactDownloaderFactory {
      * @param greengrassServiceClientFactory greengrassComponentServiceClientFactory
      * @param componentStore                          componentStore
      * @param context                                 context
+     * @param deviceConfiguration                     deviceConfiguration
      */
     @Inject
     public ArtifactDownloaderFactory(S3SdkClientFactory s3SdkClientFactory,
                                      GreengrassServiceClientFactory greengrassServiceClientFactory,
                                      ComponentStore componentStore,
-                                     Context context) {
+                                     Context context,
+                                     DeviceConfiguration deviceConfiguration) {
         this.s3ClientFactory = s3SdkClientFactory;
         this.clientFactory = greengrassServiceClientFactory;
         this.componentStore = componentStore;
         this.context = context;
+        this.deviceConfiguration = deviceConfiguration;
     }
 
     /**
@@ -84,7 +90,8 @@ public class ArtifactDownloaderFactory {
         URI artifactUri = artifact.getArtifactUri();
         String scheme = artifactUri.getScheme() == null ? null : artifactUri.getScheme().toUpperCase();
         if (GREENGRASS_SCHEME.equals(scheme)) {
-            return new GreengrassRepositoryDownloader(clientFactory, identifier, artifact, artifactDir, componentStore);
+            return new GreengrassRepositoryDownloader(clientFactory, identifier, artifact, artifactDir, componentStore,
+                    deviceConfiguration);
         }
         if (S3_SCHEME.equals(scheme)) {
             return new S3Downloader(s3ClientFactory, identifier, artifact, artifactDir, componentStore);

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -172,7 +172,7 @@ public class DeploymentDocumentDownloader {
         String thingName = Coerce.toString(deviceConfiguration.getThingName());
         GetDeploymentConfigurationRequest getDeploymentConfigurationRequest =
                 GetDeploymentConfigurationRequest.builder().deploymentId(deploymentId).coreDeviceThingName(thingName)
-                        .build();
+                        .s3EndpointType(Coerce.toString(deviceConfiguration.gets3EndpointType())).build();
 
         GetDeploymentConfigurationResponse deploymentConfiguration;
 

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -24,6 +24,7 @@ import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
 import com.aws.greengrass.deployment.exceptions.ComponentConfigurationValidationException;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.deployment.model.S3EndpointType;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
@@ -43,6 +44,7 @@ import com.aws.greengrass.util.platforms.Platform;
 import com.vdurmont.semver4j.Semver;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.event.Level;
+import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
@@ -122,6 +124,8 @@ public class DeviceConfiguration {
     public static final String NUCLEUS_CONFIG_LOGGING_TOPICS = "logging";
     public static final String TELEMETRY_CONFIG_LOGGING_TOPICS = "telemetry";
 
+    public static final String S3_ENDPOINT_TYPE = "s3EndpointType";
+    public static final String S3_ENDPOINT_PROP_NAME = SdkSystemSetting.AWS_S3_US_EAST_1_REGIONAL_ENDPOINT.property();
     public static final String DEVICE_NETWORK_PROXY_NAMESPACE = "networkProxy";
     public static final String DEVICE_PROXY_NAMESPACE = "proxy";
     public static final String DEVICE_PARAM_NO_PROXY_ADDRESSES = "noProxyAddresses";
@@ -198,6 +202,10 @@ public class DeviceConfiguration {
         getAWSRegion().withValue(awsRegion);
         getIotRoleAlias().withValue(tesRoleAliasName);
 
+        if (System.getProperty(S3_ENDPOINT_PROP_NAME) != null
+                && System.getProperty(S3_ENDPOINT_PROP_NAME).equalsIgnoreCase(S3EndpointType.REGIONAL.name())) {
+            gets3EndpointType().withValue(S3EndpointType.REGIONAL.name());
+        }
         validate();
     }
 
@@ -677,6 +685,15 @@ public class DeviceConfiguration {
 
     public Topic getDeploymentPollingFrequencySeconds() {
         return getTopic(DEPLOYMENT_POLLING_FREQUENCY_SECONDS);
+    }
+
+    /**
+     * Get s3 endpoint topic.
+     *
+     * @return s3 endpoint topic
+     */
+    public Topic gets3EndpointType() {
+        return getTopic(S3_ENDPOINT_TYPE).dflt(S3EndpointType.GLOBAL.name());
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/model/S3EndpointType.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/S3EndpointType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.model;
+
+public enum S3EndpointType {
+    GLOBAL,REGIONAL
+}

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -7,7 +7,11 @@ package com.aws.greengrass.util;
 
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.deployment.model.S3EndpointType;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.tes.LazyCredentialProvider;
+import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -23,7 +27,9 @@ public class S3SdkClientFactory {
     static final Map<Region, S3Client> clientCache = new ConcurrentHashMap<>();
     private final LazyCredentialProvider credentialsProvider;
     private final DeviceConfiguration deviceConfiguration;
-
+    private static final Logger logger = LogManager.getLogger(S3SdkClientFactory.class);
+    private static final String S3_ENDPOINT_PROP_NAME = SdkSystemSetting.AWS_S3_US_EAST_1_REGIONAL_ENDPOINT.property();
+    private static final String S3_REGIONAL_ENDPOINT_VALUE = "regional";
     private DeviceConfigurationException configValidationError;
     private Region region;
 
@@ -73,6 +79,7 @@ public class S3SdkClientFactory {
         if (configValidationError != null) {
             throw configValidationError;
         }
+        setS3EndpointType(Coerce.toString(deviceConfiguration.gets3EndpointType()));
         return getClientForRegion(region);
     }
 
@@ -87,5 +94,31 @@ public class S3SdkClientFactory {
                 .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
                 .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build())
                 .credentialsProvider(credentialsProvider).region(r).build());
+    }
+
+    /**
+     * Set s3 endpoint type.
+     *
+     * @param type s3EndpointType
+     */
+    private void setS3EndpointType(String type) {
+        //Check if system property and device config are consistent
+        //If not consistent, set system property according to device config value
+        String s3EndpointSystemProp = System.getProperty(S3_ENDPOINT_PROP_NAME);
+        boolean isGlobal = S3EndpointType.GLOBAL.name().equals(type);
+
+        if (isGlobal && S3_REGIONAL_ENDPOINT_VALUE.equals(s3EndpointSystemProp)) {
+            System.clearProperty(S3_ENDPOINT_PROP_NAME);
+            refreshClientCache();
+            logger.atDebug().log("s3 endpoint set to global");
+        } else if (!isGlobal && !S3_REGIONAL_ENDPOINT_VALUE.equals(s3EndpointSystemProp)) {
+            System.setProperty(S3_ENDPOINT_PROP_NAME, S3_REGIONAL_ENDPOINT_VALUE);
+            refreshClientCache();
+            logger.atDebug().log("s3 endpoint set to regional");
+        }
+    }
+
+    private void refreshClientCache() {
+        clientCache.remove(region);
     }
 }

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.componentmanager.exceptions.MissingRequiredComponentsE
 import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentArtifact;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
+import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
@@ -54,13 +55,16 @@ class ArtifactDownloaderFactoryTest {
     @Mock
     Context context;
 
+    @Mock
+    DeviceConfiguration deviceConfiguration;
+
     ArtifactDownloaderFactory artifactDownloaderFactory;
 
     @BeforeEach
     public void setup() {
         artifactDownloaderFactory =
                 new ArtifactDownloaderFactory(s3SdkClientFactory, greengrassServiceClientFactory,
-                        componentStore, context);
+                        componentStore, context, deviceConfiguration);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,6 +57,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -66,7 +69,8 @@ class DeploymentDocumentDownloaderTest {
 
     private final Context context = new Context();
     private final Topic thingNameTopic = Topic.of(context, "thingName", THING_NAME);
-
+    @Captor
+    ArgumentCaptor<GetDeploymentConfigurationRequest> getDeploymentConfigurationRequestArgumentCaptor;
     @Mock
     private GreengrassServiceClientFactory greengrassServiceClientFactory;
 
@@ -419,5 +423,48 @@ class DeploymentDocumentDownloaderTest {
         // verify
         verify(greengrassV2DataClient, times(2)).getDeploymentConfiguration(GetDeploymentConfigurationRequest.builder().deploymentId(DEPLOYMENT_ID).coreDeviceThingName(THING_NAME)
                 .build());
+    }
+    @Test
+    void GIVEN_regional_s3_endpoint_in_device_config_WHEN_download_THEN_request_uses_regional_endpoint()
+            throws Exception {
+        when(httpClientProvider.getSdkHttpClient()).thenReturn(httpClient);
+
+        Path testFcsDeploymentJsonPath =
+                Paths.get(this.getClass().getResource("converter").toURI()).resolve("FcsDeploymentConfig_Full.json");
+
+        String expectedDeployConfigStr = IoUtils.toUtf8String(Files.newInputStream(testFcsDeploymentJsonPath));
+        String expectedDigest = Digest.calculate(expectedDeployConfigStr);
+
+        String url = "https://www.presigned.com/a.json";
+
+        Topic s3Endpoint = Topic.of(context, DeviceConfiguration.S3_ENDPOINT_TYPE,
+                "REGIONAL");
+        lenient().when(deviceConfiguration.gets3EndpointType()).thenReturn(s3Endpoint);
+        // mock gg client
+
+        GetDeploymentConfigurationResponse result = GetDeploymentConfigurationResponse.builder().preSignedUrl(url)
+                .integrityCheck(IntegrityCheck.builder().algorithm("SHA-256").digest(expectedDigest).build())
+                .build();
+
+        when(greengrassV2DataClient.getDeploymentConfiguration(getDeploymentConfigurationRequestArgumentCaptor.capture()))
+                .thenReturn(result);
+        // mock http client to return the file content
+        when(httpClient.prepareRequest(any())).thenReturn(request);
+
+        when(request.call()).thenReturn(
+                HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(HTTP_OK).build())
+                        .responseBody(AbortableInputStream.create(Files.newInputStream(testFcsDeploymentJsonPath)))
+                        .build());
+
+        DeploymentDocument deploymentDocumentOptional = downloader.download(DEPLOYMENT_ID);
+
+        DeploymentDocument expectedDeploymentDoc = DeploymentDocumentConverter.convertFromDeploymentConfiguration(
+                SerializerFactory.getFailSafeJsonObjectMapper()
+                        .readValue(expectedDeployConfigStr, Configuration.class));
+        GetDeploymentConfigurationRequest generatedRequest =
+                getDeploymentConfigurationRequestArgumentCaptor.getValue();
+        assertEquals("REGIONAL", generatedRequest.s3EndpointTypeAsString());
+        assertThat(deploymentDocumentOptional, equalTo(expectedDeploymentDoc));
+
     }
 }

--- a/src/test/java/com/aws/greengrass/util/S3SdkClientFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/util/S3SdkClientFactoryTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.util;
 
 import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.tes.LazyCredentialProvider;
@@ -25,13 +26,17 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
+import static com.aws.greengrass.deployment.DeviceConfiguration.S3_ENDPOINT_PROP_NAME;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 public class S3SdkClientFactoryTest {
+    private final Context context = new Context();
+    private S3Client cachedClient;
 
     @Mock
     DeviceConfiguration deviceConfig;
@@ -53,6 +58,9 @@ public class S3SdkClientFactoryTest {
     @AfterEach
     void clearCache() {
         S3SdkClientFactory.clientCache.clear();
+        if(cachedClient != null) {
+            cachedClient.close();
+        }
     }
 
     @Test
@@ -120,6 +128,67 @@ public class S3SdkClientFactoryTest {
                     assertThat(S3SdkClientFactory.clientCache, hasEntry(is(Region.EU_CENTRAL_1), is(client2)));
                 }
             }
+        }
+    }
+
+    @Test
+    void GIVEN_regional_device_configuration_WHEN_get_client_for_region_THEN_client_uses_regional_endpoint()
+            throws DeviceConfigurationException {
+        S3SdkClientFactory factory = new S3SdkClientFactory(deviceConfig, credentialProvider);
+        factory.handleRegionUpdate();
+        assertEquals(null, System.getProperty(S3_ENDPOINT_PROP_NAME));
+        Topic s3Endpoint = Topic.of(context, DeviceConfiguration.S3_ENDPOINT_TYPE,
+                "REGIONAL");
+        when(deviceConfig.gets3EndpointType()).thenReturn(s3Endpoint);
+        try (S3Client client = factory.getS3Client()) {
+            assertThat("has client", client, is(notNullValue()));
+            assertEquals("regional", System.getProperty(S3_ENDPOINT_PROP_NAME));
+        }
+    }
+
+    @Test
+    void GIVEN_global_device_config_WHEN_get_client_THEN_clients_change_to_global_endpoint_and_update_cache()
+            throws DeviceConfigurationException {
+        S3SdkClientFactory factory = new S3SdkClientFactory(deviceConfig, credentialProvider);
+        factory.handleRegionUpdate();
+
+        Topic s3Endpoint = Topic.of(context, DeviceConfiguration.S3_ENDPOINT_TYPE,
+                "REGIONAL");
+        when(deviceConfig.gets3EndpointType()).thenReturn(s3Endpoint);
+        try (S3Client client = factory.getS3Client()) {
+            cachedClient = client;
+            assertThat("has client", client, is(notNullValue()));
+            assertEquals("regional", System.getProperty(S3_ENDPOINT_PROP_NAME));
+        }
+
+        s3Endpoint = Topic.of(context, DeviceConfiguration.S3_ENDPOINT_TYPE,
+                "GLOBAL");
+        when(deviceConfig.gets3EndpointType()).thenReturn(s3Endpoint);
+
+        try (S3Client client = factory.getS3Client()) {
+            assertThat("has client", client, is(notNullValue()));
+            assertThat(client, is(not(cachedClient)));
+            assertEquals(null, System.getProperty(S3_ENDPOINT_PROP_NAME));
+        }
+    }
+
+    @Test
+    void GIVEN_regional_device_config_and_regional_system_property_WHEN_get_client_THEN_client_does_not_update()
+            throws DeviceConfigurationException {
+        S3SdkClientFactory factory = new S3SdkClientFactory(deviceConfig, credentialProvider);
+        factory.handleRegionUpdate();
+        System.setProperty(S3_ENDPOINT_PROP_NAME, "regional");
+        Topic s3Endpoint = Topic.of(context, DeviceConfiguration.S3_ENDPOINT_TYPE,
+                "REGIONAL");
+        when(deviceConfig.gets3EndpointType()).thenReturn(s3Endpoint);
+        try (S3Client client = factory.getS3Client()) {
+            cachedClient = client;
+            assertThat("has client", client, is(notNullValue()));
+            assertEquals("regional", System.getProperty(S3_ENDPOINT_PROP_NAME));
+        }
+        try (S3Client client = factory.getS3Client()) {
+            assertEquals(client, cachedClient);
+            assertEquals("regional", System.getProperty(S3_ENDPOINT_PROP_NAME));
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Enable s3 endpoint to be configurable, users could merge the s3 endpoint type from configuration to use"REGIONAL" or "GLOBAL". 
**Why is this change necessary:**
This change unblocks VPC users who can only use regional endpoints.
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
