### PR TITLE
chore: switch to gamma for e2e test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
@@ -127,7 +127,8 @@ public class BaseE2ETestCase implements AutoCloseable {
 
     protected static final String testComponentSuffix = "_" + UUID.randomUUID().toString();
     protected static Optional<String> tesRolePolicyArn;
-    public static final IotSdkClientFactory.EnvironmentStage E2ETEST_ENV_STAGE = IotSdkClientFactory.EnvironmentStage.PROD;
+    public static final IotSdkClientFactory.EnvironmentStage E2ETEST_ENV_STAGE =
+            IotSdkClientFactory.EnvironmentStage.GAMMA;
 
     protected final Set<CancelDeploymentRequest> createdDeployments = new HashSet<>();
     protected final Set<String> createdThingGroups = new HashSet<>();


### PR DESCRIPTION
**Description of changes:**
1. Run E2E Tests in gamma instead of prod.

**Why is this change necessary:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/commit/63f26abe6e7a15c00fc7ec018ad3bfc423d508a2 is currently only available in gamma.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
