### PR TITLE
fix: properly close S3 client

### DIFF
--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -79,7 +79,6 @@ public class S3SdkClientFactory {
         if (configValidationError != null) {
             throw configValidationError;
         }
-        setS3EndpointType(Coerce.toString(deviceConfiguration.gets3EndpointType()));
         return getClientForRegion(region);
     }
 
@@ -90,6 +89,7 @@ public class S3SdkClientFactory {
      * @return s3client
      */
     public S3Client getClientForRegion(Region r) {
+        setS3EndpointType(Coerce.toString(deviceConfiguration.gets3EndpointType()));
         return clientCache.computeIfAbsent(r, (region) -> S3Client.builder()
                 .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
                 .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build())
@@ -118,7 +118,15 @@ public class S3SdkClientFactory {
         }
     }
 
+    /**
+     * Remove the cached client and close it.
+     *
+     */
+    @SuppressWarnings({"PMD.CloseResource"})
     private void refreshClientCache() {
-        clientCache.remove(region);
+        S3Client clientToRemove = clientCache.remove(region);
+        if (clientToRemove != null) {
+            clientToRemove.close();
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Close S3 client properly
**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
