### PR TITLE
fix(s3): always get a new S3 client for retries

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/builtins/S3Downloader.java
@@ -90,7 +90,6 @@ public class S3Downloader extends ArtifactDownloader {
         String bucket = s3ObjectPath.bucket;
         String key = s3ObjectPath.key;
 
-        S3Client regionClient = getRegionClientForBucket(bucket);
         GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucket).key(key)
                 .range(String.format(HTTP_RANGE_HEADER_FORMAT, rangeStart, rangeEnd)).build();
         logger.atDebug().kv("bucket", getObjectRequest.bucket()).kv("s3-key", getObjectRequest.key())
@@ -99,6 +98,7 @@ public class S3Downloader extends ArtifactDownloader {
         try {
             return RetryUtils.runWithRetry(s3ClientExceptionRetryConfig, () -> {
                 long downloaded = 0;
+                S3Client regionClient = getRegionClientForBucket(bucket);
                 try (InputStream inputStream = regionClient.getObject(getObjectRequest)) {
                     downloaded = download(inputStream, messageDigest);
                     if (downloaded == 0) {
@@ -148,11 +148,11 @@ public class S3Downloader extends ArtifactDownloader {
         // Parse artifact path
         String key = s3ObjectPath.key;
         String bucket = s3ObjectPath.bucket;
-        S3Client regionClient = getRegionClientForBucket(bucket);
         try {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder().bucket(bucket).key(key).build();
             return RetryUtils.runWithRetry(s3ClientExceptionRetryConfig, () -> {
                 try {
+                    S3Client regionClient = getRegionClientForBucket(bucket);
                     HeadObjectResponse headObjectResponse = regionClient.headObject(headObjectRequest);
                     return headObjectResponse.contentLength();
                 } catch (S3Exception e) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Get a new S3 client during retries to prevent issues from using a possibly closed client.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
