### PR TITLE
chore: change cluster component name

### DIFF
--- a/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
+++ b/src/main/java/com/aws/greengrass/authorization/AuthorizationHandler.java
@@ -91,7 +91,7 @@ public class AuthorizationHandler  {
     public static final String SHADOW_MANAGER_SERVICE_NAME = "aws.greengrass.ShadowManager";
     public static final String CLIENT_DEVICE_AUTH_SERVICE_NAME = "aws.greengrass.clientdevices.Auth";
     private static final String CLI_SERVICE_NAME = "aws.greengrass.Cli";
-    public static final String HA_CONTROLLER_SERVICE_NAME = "aws.greengrass.HAController";
+    public static final String CLUSTER_MANAGER_SERVICE_NAME = "aws.greengrass.ClusterManager";
 
     public enum ResourceLookupPolicy {
         STANDARD,
@@ -146,7 +146,7 @@ public class AuthorizationHandler  {
         componentToOperationsMap.put(PUT_COMPONENT_METRIC_SERVICE_NAME,
                 new HashSet<>(Arrays.asList(PUT_COMPONENT_METRIC, ANY_REGEX)));
 
-        componentToOperationsMap.put(HA_CONTROLLER_SERVICE_NAME, new HashSet<>(Arrays.asList(
+        componentToOperationsMap.put(CLUSTER_MANAGER_SERVICE_NAME, new HashSet<>(Arrays.asList(
                 UPDATE_CLUSTER_STATE, SUBSCRIBE_TO_CLUSTER_STATE_EVENTS,
                 RETRIEVE_SHARED_LOCK, CREATE_SHARED_LOCK, EXTEND_SHARED_LOCK, QUERY_SHARED_PROPERTIES,
                 RETRIEVE_SHARED_PROPERTY, DELETE_SHARED_PROPERTY, PUBLISH_SHARED_PROPERTY, UNLOCK_SHARED_PROPERTY,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change Cluster component name to `aws.greengrass.ClusterManager`

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
