### PR TITLE
fix: create default user+group before provisioning

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/docker/DockerImageArtifactDownload01Test.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/docker/DockerImageArtifactDownload01Test.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class DockerImageArtifactDownload01Test extends BaseITCase {
 
     private final PlatformResolver platformResolver = new PlatformResolver(null);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/docker/DockerImageArtifactDownloadTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/componentmanager/plugins/docker/DockerImageArtifactDownloadTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class DockerImageArtifactDownloadTest extends BaseITCase {
 
     private final PlatformResolver platformResolver = new PlatformResolver(null);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.NOTIFY_COMPONENTS;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ServiceDependencyLifecycleTest extends BaseITCase {
     private static final String CustomerApp = "CustomerApp";
     private static final String HardDependency = "HardDependency";

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/UnloadableServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/UnloadableServiceIntegTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class UnloadableServiceIntegTest extends BaseITCase {
 
     private Kernel kernel;

--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -311,6 +311,7 @@ public class GreengrassSetup {
         }
 
         DeviceConfiguration deviceConfiguration = kernel.getContext().get(DeviceConfiguration.class);
+        setComponentDefaultUserAndGroup(deviceConfiguration);
         if (needProvisioning) {
             if (Utils.isEmpty(awsRegion)) {
                 awsRegion = Coerce.toString(deviceConfiguration.getAWSRegion());
@@ -323,9 +324,6 @@ public class GreengrassSetup {
             this.deviceProvisioningHelper = new DeviceProvisioningHelper(awsRegion, environmentStage, this.outStream);
             provision(kernel);
         }
-
-        // Attempt this only after config file and Nucleus args have been parsed
-        setComponentDefaultUserAndGroup(deviceConfiguration);
 
         if (setupSystemService) {
             kernel.getContext().get(KernelLifecycle.class).softShutdown(30);

--- a/src/test/java/com/aws/greengrass/authorization/AuthorizationHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/AuthorizationHandlerTest.java
@@ -46,7 +46,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class AuthorizationHandlerTest {
 
     @Mock

--- a/src/test/java/com/aws/greengrass/authorization/AuthorizationIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/AuthorizationIPCAgentTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class AuthorizationIPCAgentTest {
     private static final String TEST_TOKEN = "token";
     @Mock

--- a/src/test/java/com/aws/greengrass/authorization/AuthorizationPolicyParserTest.java
+++ b/src/test/java/com/aws/greengrass/authorization/AuthorizationPolicyParserTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class AuthorizationPolicyParserTest {
 
     private final static String TEST_COMPONENT = "testComponent";

--- a/src/test/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgentTest.java
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 @SuppressWarnings("PMD.CloseResource")
 class ConfigStoreIPCEventStreamAgentTest {
     private static final String TEST_COMPONENT_A = "Component_A";

--- a/src/test/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgentTest.java
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class LifecycleIPCEventStreamAgentTest {
 
     private static final String TEST_SERVICE = "TestService";

--- a/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class MqttProxyIPCAgentTest {
     private static final String TEST_SERVICE = "TestService";
     private static final String TEST_TOPIC = "TestTopic";

--- a/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/pubsub/PubSubIPCEventStreamAgentTest.java
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class PubSubIPCEventStreamAgentTest {
     private static final String TEST_SERVICE = "TestService";
     private static final String TEST_TOPIC = "TestTopic";

--- a/src/test/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgentTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class ComponentMetricIPCEventStreamAgentTest {
     private static final String VALID_TEST_COMPONENT = "aws.greengrass.testcomponent";
     private static final String STREAM_MANAGER_COMPONENT = "aws.greengrass.StreamManager";

--- a/src/test/java/com/aws/greengrass/componentmanager/ClientConfigurationUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ClientConfigurationUtilsTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ClientConfigurationUtilsTest {
     @Mock
     private SecurityService securityService;

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentManagerTest.java
@@ -99,7 +99,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ComponentManagerTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentServiceHelperTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ComponentServiceHelperTest {
 
     private static final Semver v1_0_0 = new Semver("1.0.0");

--- a/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/ComponentStoreTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.when;
  * files from its test resource folder if it needs to mock some recipe/artifact. It doesn't and shouldn't use or assume
  * any static folder directly as package store. The package store folder is deleted after each test.
  */
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ComponentStoreTest {
     private static final String MONITORING_SERVICE_PKG_NAME = "MonitoringService";
     private static final Semver MONITORING_SERVICE_PKG_VERSION = new Semver("1.0.0", Semver.SemverType.NPM);

--- a/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/DependencyResolverTest.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.NOTIFY_COMPONENTS;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DependencyResolverTest {
 
     private static final Semver v1_5_0 = new Semver("1.5.0");

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -77,7 +77,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 @SuppressWarnings("PMD.ExcessiveClassLength")
 class KernelConfigResolverTest {
     private static final String LIFECYCLE_INSTALL_KEY = "install";

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderFactoryTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ArtifactDownloaderFactoryTest {
 
     Path testDir = Paths.get("foo");

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/ArtifactDownloaderTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ArtifactDownloaderTest {
 
     private static final String LOCAL_FILE_NAME = "artifact.txt";

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/GreengrassRepositoryDownloaderTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class GreengrassRepositoryDownloaderTest {
     private static final String SHA256 = "SHA-256";
     private static final String TEST_ARN = "arn";

--- a/src/test/java/com/aws/greengrass/componentmanager/builtins/S3DownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/builtins/S3DownloaderTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class S3DownloaderTest {
 
     private static final String VALID_ARTIFACT_URI = "s3://eg-artifacts/ComponentWithS3Artifacts-1.0.0/artifact.txt";

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageArtifactParserTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageArtifactParserTest.java
@@ -17,7 +17,7 @@ import java.net.URI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class DockerImageArtifactParserTest {
 
     @Test

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
@@ -68,7 +68,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class DockerImageDownloaderTest {
     private static ComponentIdentifier TEST_COMPONENT_ID =
             new ComponentIdentifier("test.container.component", new Semver("1.0.0"));

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class EcrAccessorTest {
     @Mock
     private EcrClient ecrClient;

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -78,7 +78,7 @@ import static software.amazon.awssdk.services.greengrassv2.model.DeploymentCompo
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.SKIP_NOTIFY_COMPONENTS;
 
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentConfigMergerTest {
 
     private final Logger logger = LogManager.getLogger(this.getClass());

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentDirectoryManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentDirectoryManagerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentDirectoryManagerTest {
     private static final String mockArn = "arn:aws:greengrass:us-east-1:12345678910:configuration:thinggroup/group1:1";
     private static final String expectedDirectoryName =

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
@@ -62,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentDocumentDownloaderTest {
     private static final String THING_NAME = "myThing";
     private static final String DEPLOYMENT_ID = "deploymentId";

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentQueueTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class DeploymentQueueTest {
     private static final DeploymentDocument TEST_DEPLOYMENT_DOCUMENT = new DeploymentDocument();
     private static final String TEST_DEPLOYMENT_ID_1 = "deployment-1";

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -92,7 +92,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings({"PMD.LooseCoupling", "PMD.TestClassWithoutTestCases"})
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentServiceTest extends GGServiceTestUtil {
 
     private static final String TEST_JOB_ID_1 = "TEST_JOB_1";

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentTaskTest {
 
     private static final String COMPONENT_2_ROOT_PACKAGE_NAME = "component2";

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeviceConfigurationTest {
     @Mock
     Kernel mockKernel;

--- a/src/test/java/com/aws/greengrass/deployment/DynamicComponentConfigurationValidatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DynamicComponentConfigurationValidatorTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DynamicComponentConfigurationValidatorTest {
     private static final String DEFAULT_EXISTING_SERVICE_VERSION = "1.0.0";
     private static final long DEFAULT_EXISTING_NODE_MOD_TIME = 10;

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class IotJobsHelperTest {
 
     private static final String TEST_THING_NAME = "TEST_THING";

--- a/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class KernelUpdateDeploymentTaskTest {
     private static final Logger logger = LogManager.getLogger(KernelUpdateDeploymentTaskTest.class);
 

--- a/src/test/java/com/aws/greengrass/deployment/ThingGroupHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ThingGroupHelperTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class ThingGroupHelperTest {
     @Mock
     private DeviceConfiguration deviceConfiguration;

--- a/src/test/java/com/aws/greengrass/deployment/activator/DeploymentActivatorFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/DeploymentActivatorFactoryTest.java
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentActivatorFactoryTest {
     @Mock
     Kernel kernel;

--- a/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class KernelUpdateActivatorTest {
     @Mock
     Kernel kernel;

--- a/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/bootstrap/BootstrapManagerTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class BootstrapManagerTest {
     private static final String componentA = "componentA";
     private static final String componentB = "componentB";

--- a/src/test/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeUtilsTest.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentErrorCodeUtilsTest {
 
     @Mock

--- a/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
@@ -79,7 +79,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("PMD.CouplingBetweenObjects")
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeviceProvisioningHelperTest {
     private static final String TEST_REGION = "us-east-1";
 

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class GreengrassSetupTest {
     @Mock
     private DeviceProvisioningHelper deviceProvisioningHelper;

--- a/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/IPCEventStreamServiceTest.java
@@ -47,7 +47,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class IPCEventStreamServiceTest {
     private IPCEventStreamService ipcEventStreamService;
 

--- a/src/test/java/com/aws/greengrass/ipc/modules/LifecycleIPCServiceTest.java
+++ b/src/test/java/com/aws/greengrass/ipc/modules/LifecycleIPCServiceTest.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class LifecycleIPCServiceTest {
 
     LifecycleIPCService lifecycleIPCService;

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelAlternativesTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelAlternativesTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class KernelAlternativesTest {
     @TempDir
     Path altsDir;

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -76,7 +76,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class KernelTest {
     private static final String EXPECTED_CONFIG_OUTPUT =
             "  main:\n"

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -67,7 +67,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class LifecycleTest {
 
     @Mock

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class LogManagerHelperTest {
     private static final int TEXT_LOG_MIN_LEN = 46;
     private static final int JSON_LOG_MIN_LEN = 132;

--- a/src/test/java/com/aws/greengrass/provisioning/ProvisioningConfigUpdateHelperTest.java
+++ b/src/test/java/com/aws/greengrass/provisioning/ProvisioningConfigUpdateHelperTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class ProvisioningConfigUpdateHelperTest {
     private static final String MOCK_CERTIFICATE_PATH = "MOCK_CERTIFICATE_PATH";
     private static final String MOCK_PRIVATE_KEY_PATH = "MOCK_PRIVATE_KEY_PATH";

--- a/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
+++ b/src/test/java/com/aws/greengrass/security/SecurityServiceTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class SecurityServiceTest {
 
     @InjectMocks

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -91,7 +91,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class FleetStatusServiceTest extends GGServiceTestUtil {
     @Mock
     private MqttClient mockMqttClient;

--- a/src/test/java/com/aws/greengrass/telemetry/MetricsAggregatorTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/MetricsAggregatorTest.java
@@ -39,7 +39,7 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class MetricsAggregatorTest {
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final String GREENGRASS_COMPONENTS_NS = "GreengrassComponents";

--- a/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/TelemetryAgentTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class TelemetryAgentTest extends GGServiceTestUtil {
     @TempDir
     protected Path tempRootDir;

--- a/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class CredentialRequestHandlerTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String REQUEST_METHOD = "GET";

--- a/src/test/java/com/aws/greengrass/tes/HttpServerImplTest.java
+++ b/src/test/java/com/aws/greengrass/tes/HttpServerImplTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class HttpServerImplTest {
     private static final String mockResponse = "Hello World";
 

--- a/src/test/java/com/aws/greengrass/tes/IotCloudHelperTest.java
+++ b/src/test/java/com/aws/greengrass/tes/IotCloudHelperTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class IotCloudHelperTest {
     private static final byte[] CLOUD_RESPONSE = "HELLO WORLD".getBytes(StandardCharsets.UTF_8);
     private static final int STATUS_CODE = 200;

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -68,7 +68,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class TokenExchangeServiceTest extends GGServiceTestUtil {
     private static final String MOCK_ROLE_ALIAS = "ROLE_ALIAS";
     static ExecutorService executorService = Executors.newFixedThreadPool(1);

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/GGServiceTestUtil.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/GGServiceTestUtil.java
@@ -30,7 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 public class GGServiceTestUtil {
 
     protected String serviceFullName = "GreengrassServiceFullName";

--- a/src/test/java/com/aws/greengrass/testing/TestFeatureParametersTest.java
+++ b/src/test/java/com/aws/greengrass/testing/TestFeatureParametersTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class TestFeatureParametersTest {
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/util/BaseRetryableAccessorTest.java
+++ b/src/test/java/com/aws/greengrass/util/BaseRetryableAccessorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class BaseRetryableAccessorTest {
     private static final String MOCK_RESPONSE = "MockResponse";
     private static final int RETRY_COUNT = 3;

--- a/src/test/java/com/aws/greengrass/util/CommitableTest.java
+++ b/src/test/java/com/aws/greengrass/util/CommitableTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class CommitableTest {
     @TempDir
     Path temp;

--- a/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
+++ b/src/test/java/com/aws/greengrass/util/MqttChunkedPayloadPublisherTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class MqttChunkedPayloadPublisherTest {
     static final ObjectMapper MAPPER = new ObjectMapper();
     MqttChunkedPayloadPublisher<String> publisher;

--- a/src/test/java/com/aws/greengrass/util/OrderedExecutorServiceTest.java
+++ b/src/test/java/com/aws/greengrass/util/OrderedExecutorServiceTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class OrderedExecutorServiceTest {
     private static OrderedExecutorService orderedExecutorService;
     private volatile static Throwable lastThrownException = null;

--- a/src/test/java/com/aws/greengrass/util/UtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/UtilsTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings({"PMD.AvoidUsingOctalValues", "PMD.MethodNamingConventions"})
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 class UtilsTest {
 
     @Mock

--- a/src/test/java/com/aws/greengrass/util/platforms/unix/UnixRunWithGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/util/platforms/unix/UnixRunWithGeneratorTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doReturn;
 
-@ExtendWith({MockitoExtension.class, GGExtension.class})
+@ExtendWith({GGExtension.class, MockitoExtension.class})
 @DisabledOnOs(OS.WINDOWS)
 class UnixRunWithGeneratorTest {
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, we call `provision` before creating the default user. This will cause an error if the user does not exist and the default user configuration does not contain a group (eg: ggc_user instead of ggc_user:ggc_group).

**Why is this change necessary:**

**How was this change tested:**
Manually tested on a system without ggc_user and ggc_group with `--component-default-user ggc_user`, `--component-default-user ggc_user:ggc_user` and no default provided, cleaning up user and groups after each test.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
