### PR TITLE
chore: switch back to prod for e2e test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/e2e/BaseE2ETestCase.java
@@ -127,8 +127,7 @@ public class BaseE2ETestCase implements AutoCloseable {
 
     protected static final String testComponentSuffix = "_" + UUID.randomUUID().toString();
     protected static Optional<String> tesRolePolicyArn;
-    public static final IotSdkClientFactory.EnvironmentStage E2ETEST_ENV_STAGE =
-            IotSdkClientFactory.EnvironmentStage.GAMMA;
+    public static final IotSdkClientFactory.EnvironmentStage E2ETEST_ENV_STAGE = IotSdkClientFactory.EnvironmentStage.PROD;
 
     protected final Set<CancelDeploymentRequest> createdDeployments = new HashSet<>();
     protected final Set<String> createdThingGroups = new HashSet<>();


### PR DESCRIPTION
This reverts commit 07502bdbbcb6848b83581895ec3d8b0451576e34.

**Description of changes:**
Since the S3 endpoint SDK change is available in prod, we no longer need to test in gamma.

**Why is this change necessary:**
Improve E2E test reliability.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
Tested locally.

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
