### PR TITLE
fix: bootstrap on rollback when component breaks

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelAlternatives.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelAlternatives.java
@@ -435,7 +435,7 @@ public class KernelAlternatives {
             logger.atError().log("Failed to read rollback snapshot config", exc);
             return false;
         }
-        boolean bootstrapOnRollbackRequired = false;
+        boolean bootstrapOnRollbackRequired;
         try {
             // Check if we need to execute component bootstrap steps during the rollback deployment.
             final Set<String> componentsToExclude =


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Determine if bootstrap on rollback is required when a component errors 3 times and transitions to broken state when activating kernel.
Tested using a UAT which makes 2 deployments
1. Deploys 3 components, all with working bootstrap steps. This deployment completes with success.
2. Deploys 2 components, one with a bootstrap step and the other with a broken startup lifecycle. The second component breaks during the kernel activation stage and triggers a rollback. Before rolling back, `KernelAlternatives` determines if bootstrap rollback is needed and persists rollback bootstrap file if necessary.

With this test setup, Nucleus enters rollback bootstrap deployment stage after preparing rollback and executes bootstrap steps of the components deployment in the first deployment.

**Why is this change necessary:**
It looks like we are not bootstrapping when rollback is triggered due to a broken component when activating kernel.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
