### PR TITLE
chore: update logging for bootstrap on rollback

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/bootstrap/BootstrapManager.java
@@ -177,6 +177,7 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
             }
         });
         if (componentsRequiresBootstrapTask.isEmpty()) {
+            logger.atInfo().log("No component found with a pending bootstrap task");
             // Force restart if
             // 1. any nucleus config change requires restart or
             // 2. if any plugin will be removed in the deployment to ensure plugin cleanup
@@ -369,6 +370,9 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
             }
         }
 
+        if (needsRestart) {
+            logger.atInfo().log("Bootstrap required as some component configs changed");
+        }
         return needsRestart;
     }
 
@@ -478,8 +482,9 @@ public class BootstrapManager implements Iterator<BootstrapTaskStatus>  {
             logger.atError().log("No bootstrap task list to delete: the provided file path was null");
             return;
         }
-        logger.atInfo().kv("filePath", persistedTaskFilePath).log("Deleting bootstrap task list");
-        Files.deleteIfExists(persistedTaskFilePath);
+        if (Files.deleteIfExists(persistedTaskFilePath)) {
+            logger.atInfo().kv("filePath", persistedTaskFilePath).log("Deleted bootstrap task list");
+        }
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelAlternatives.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelAlternatives.java
@@ -462,6 +462,8 @@ public class KernelAlternatives {
                 return false;
             }
         } else {
+            logger.atInfo().log("No component with a pending rollback bootstrap task found: "
+                    + "No rollback deployment exists or rollback deployment has no bootstrap tasks");
             // Bootstrap-on-rollback is not required, so ensure that the task file is deleted.
             try {
                 bootstrapManager.deleteBootstrapTaskList(rollbackBootstrapTaskFilePath);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Improves the logging in the bootstrap workflow. We should log the reason behind Nucleus determining if bootstrap is required for current/rollback deployment.

**Why is this change necessary:**
Current logging can be misleading.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
