### PR TITLE
feat(mqtt5): resume session on reconnect

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -71,7 +71,7 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
     private static final String RESUB_LOG_EVENT = "resubscribe";
     private final Provider<AwsIotMqtt5ClientBuilder> builderProvider;
 
-    @Getter // for testing
+    @Getter(AccessLevel.PACKAGE) // for testing
     private Mqtt5Client client = null;
 
     private static final Random RANDOM = new Random();

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -73,10 +73,6 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
 
     private Mqtt5Client client = null;
 
-    synchronized Mqtt5Client getClient() { // for testing
-        return client;
-    }
-
     private static final Random RANDOM = new Random();
     private final Logger logger = LogManager.getLogger(AwsIotMqtt5Client.class).createChild()
             .dfltKv(MqttClient.CLIENT_ID_KEY, (Supplier<String>) this::getClientId);
@@ -198,6 +194,10 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
         this.executorService = executorService;
         this.ses = ses;
         this.builderProvider = builderProvider;
+    }
+
+    synchronized Mqtt5Client getClient() { // for testing
+        return client;
     }
 
     void disableRateLimiting() {

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -71,8 +71,11 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
     private static final String RESUB_LOG_EVENT = "resubscribe";
     private final Provider<AwsIotMqtt5ClientBuilder> builderProvider;
 
-    @Getter(AccessLevel.PACKAGE) // for testing
     private Mqtt5Client client = null;
+
+    synchronized Mqtt5Client getClient() { // for testing
+        return client;
+    }
 
     private static final Random RANDOM = new Random();
     private final Logger logger = LogManager.getLogger(AwsIotMqtt5Client.class).createChild()

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqtt5ClientTest.java
@@ -24,16 +24,12 @@ import software.amazon.awssdk.crt.mqtt5.packets.ConnAckPacket;
 import software.amazon.awssdk.iot.AwsIotMqtt5ClientBuilder;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
-import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/AwsIotMqtt5ClientTest.java
@@ -5,33 +5,42 @@
 
 package com.aws.greengrass.mqttclient;
 
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
+import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
 import software.amazon.awssdk.crt.mqtt5.OnDisconnectionReturn;
 import software.amazon.awssdk.iot.AwsIotMqtt5ClientBuilder;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeoutException;
 
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("PMD.CloseResource")
 @ExtendWith({GGExtension.class, MockitoExtension.class})
-public class AwsIotMqtt5ClientTest {
+class AwsIotMqtt5ClientTest {
     @Mock
     AwsIotMqtt5ClientBuilder builder;
 
@@ -41,29 +50,34 @@ public class AwsIotMqtt5ClientTest {
     @Mock
     MqttClientConnectionEvents mockCallback2;
 
+    @Spy
     CallbackEventManager callbackEventManager;
-    Topics mockTopic;
 
-    // same as what we use in Kernel
-    private ExecutorService executorService;
-    private ScheduledExecutorService ses;
+    Topics topics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+    @Mock
+    ScheduledExecutorService ses;
 
     @BeforeEach
     void beforeEach() {
-        callbackEventManager = spy(new CallbackEventManager());
         callbackEventManager.addToCallbackEvents(mockCallback1);
         callbackEventManager.addToCallbackEvents(mockCallback2);
-        mockTopic = mock(Topics.class);
-        executorService = Executors.newCachedThreadPool();
-        ses = new ScheduledThreadPoolExecutor(4);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        executorService.shutdownNow();
+        topics.getContext().close();
     }
 
     @Test
     void GIVEN_multiple_callbacks_in_callbackEventManager_WHEN_connections_are_interrupted_purposely_THEN_no_callbacks_are_called() {
-        AwsIotMqtt5Client client1 = new AwsIotMqtt5Client(() -> builder, (x) -> null, "A", 0, mockTopic,
+        AwsIotMqtt5Client client1 = new AwsIotMqtt5Client(() -> builder, (x) -> null, "A", 0, topics,
                 callbackEventManager, executorService, ses);
         client1.disableRateLimiting();
-        AwsIotMqtt5Client client2 = new AwsIotMqtt5Client(() -> builder, (x) -> null, "B", 0, mockTopic,
+        AwsIotMqtt5Client client2 = new AwsIotMqtt5Client(() -> builder, (x) -> null, "B", 0, topics,
                 callbackEventManager, executorService, ses);
         client2.disableRateLimiting();
         callbackEventManager.runOnConnectionResumed(false);
@@ -83,5 +97,23 @@ public class AwsIotMqtt5ClientTest {
         verify(mockCallback2, never()).onConnectionInterrupted(anyInt());
 
         assertTrue(callbackEventManager.hasCallbacked());
+    }
+
+    @Test
+    void GIVEN_connected_client_WHEN_reconnect_THEN_client_configured_to_resume_session() {
+        try (AwsIotMqtt5ClientBuilder builder = AwsIotMqtt5ClientBuilder.newMqttBuilder("localhost");
+             AwsIotMqtt5Client client = new AwsIotMqtt5Client(() -> builder, (x) -> null, "A", 0, topics,
+                     callbackEventManager, executorService, ses)) {
+            // running async because reconnect will never complete,
+            // but it will trigger the code path that sets client session behavior
+            executorService.submit(() -> {
+                try {
+                    client.reconnect(0L);
+                } catch (TimeoutException | ExecutionException | InterruptedException ignore) {
+                }
+            });
+            assertThat("session behavior is rejoin always", () -> client.getClient().getClientOptions().getSessionBehavior(),
+                    eventuallyEval(is(Mqtt5ClientOptions.ClientSessionBehavior.REJOIN_ALWAYS)));
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When MQTT5 client purposefully reconnects, do so with cleanSession=false

**Why is this change necessary:**
To match behavior of MQTT3 client, and improve performance when reconnecting (subscriptions don't need to be made again).

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
