### PR TITLE
fix: set auth token using override to avoid any timing issues

### DIFF
--- a/src/main/java/com/aws/greengrass/ipc/AuthenticationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthenticationHandler.java
@@ -38,7 +38,7 @@ public class AuthenticationHandler implements InjectionActions {
     public static void registerAuthenticationToken(GreengrassService s) {
         Topic uid = s.getPrivateConfig().createLeafChild(SERVICE_UNIQUE_ID_KEY).withParentNeedsToKnow(false);
         String authenticationToken = Utils.generateRandomString(16).toUpperCase();
-        uid.withValue(authenticationToken);
+        uid.overrideValue(authenticationToken);
         Topics tokenTopics = s.getServiceConfig().parent.lookupTopics(AUTHENTICATION_TOKEN_LOOKUP_KEY);
         tokenTopics.withParentNeedsToKnow(false);
 
@@ -47,7 +47,7 @@ public class AuthenticationHandler implements InjectionActions {
         // If the authentication token was already registered, that's an issue, so we will retry
         // generating a new token in that case
         if (tokenTopic.getOnce() == null) {
-            tokenTopic.withValue(s.getServiceName());
+            tokenTopic.overrideValue(s.getServiceName());
         } else {
             registerAuthenticationToken(s);
         }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -445,26 +445,26 @@ class LifecycleTest {
         // So, validate that it has actually set the state to be running before reporting
         // the next error. Otherwise, it may register an error from STARTING instead of from RUNNING
         assertThat(greengrassService::getState, eventuallyEval(is(State.RUNNING)));
-        assertThat(lifecycle.getStatusDetails(), is(STATUS_DETAIL_HEALTHY));
+        assertThat(lifecycle::getStatusDetails, eventuallyEval(is(STATUS_DETAIL_HEALTHY)));
 
         // Report 1st error
         lifecycle.reportState(State.ERRORED);
         assertTrue(reachedRunning2.await(5, TimeUnit.SECONDS));
         verify(lifecycle, timeout(2000).times(2)).setState(any(), eq(STATE_TRANSITION_RUNNING));
         assertThat(greengrassService::getState, eventuallyEval(is(State.RUNNING)));
-        assertThat(lifecycle.getStatusDetails(), is(STATUS_DETAIL_HEALTHY));
+        assertThat(lifecycle::getStatusDetails, eventuallyEval(is(STATUS_DETAIL_HEALTHY)));
 
         // Report 2nd error
         lifecycle.reportState(State.ERRORED);
         assertTrue(reachedRunning3.await(5, TimeUnit.SECONDS));
         verify(lifecycle, timeout(2000).times(3)).setState(any(), eq(STATE_TRANSITION_RUNNING));
         assertThat(greengrassService::getState, eventuallyEval(is(State.RUNNING)));
-        assertThat(lifecycle.getStatusDetails(), is(STATUS_DETAIL_HEALTHY));
+        assertThat(lifecycle::getStatusDetails, eventuallyEval(is(STATUS_DETAIL_HEALTHY)));
 
         // Report 3rd error
         lifecycle.reportState(State.ERRORED);
         verify(lifecycle, timeout(10_000)).setState(any(), eq(STATE_TRANSITION_BROKEN_RUN_ERRORED));
-        assertThat(lifecycle.getStatusDetails(), is(STATUS_DETAIL_RUN_ERRORED));
+        assertThat(lifecycle::getStatusDetails, eventuallyEval(is(STATUS_DETAIL_RUN_ERRORED)));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use overrideValue just to avoid any possibility that the token is somehow outdated.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
