### PR TITLE
Revert "Revert "chore: upgrade to greengrass logging 2.2.0 (#1509)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>logging</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -663,9 +663,12 @@
                                     </excludes>
                                 </filter>
                                 <filter>
+                                    <!--
+                                        We implement our own SLF4J provider, so exclude the default provider from logback-classic.
+                                    -->
                                     <artifact>ch.qos.logback:logback-classic:jar:*</artifact>
                                     <excludes>
-                                        <exclude>org/slf4j/impl/StaticLoggerBinder.class</exclude>
+                                        <exclude>META-INF/services/org.slf4j.spi.SLF4JServiceProvider</exclude>
                                     </excludes>
                                 </filter>
                                 <!-- We provide our own SdkTlsSocketFactory to support ALPN, so make sure not to

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.lifecyclemanager;
 
+import ch.qos.logback.core.util.SimpleInvocationGate;
 import com.aws.greengrass.config.ChildChanged;
 import com.aws.greengrass.config.Configuration;
 import com.aws.greengrass.config.Topic;
@@ -162,9 +163,9 @@ class LogManagerHelperTest {
         // Should rotate this time
         logRandomMessages(componentLogger, 525, LogFormat.TEXT);
         logRandomMessages(greengrassLogger, 525, LogFormat.TEXT);
-        // Rollover is guarded by ch.qos.logback.core.util.DefaultInvocationGate so that it's not invoked too soon/often
+        // Rollover is guarded by ch.qos.logback.core.util.SimpleInvocationGate so that it's not invoked too soon/often
         // This is the minimum delay since startup for it to allow log rollover.
-        Thread.sleep(850);
+        Thread.sleep(SimpleInvocationGate.DEFAULT_INCREMENT);
         componentLogger.atInfo().log();  // log once more to trigger roll over
         greengrassLogger.atInfo().log();  // log once more to trigger roll over
 


### PR DESCRIPTION

This reverts commit ea517c64a7f96ea75085dd1a896abaf0bf005ed1.

**Issue #, if available:**

**Description of changes:**
We found that the new version of the logger was not causing log rotation problems on windows; rather it was our perf test log reader on windows which prevented the file from closing and thus rotating. That has now been remedied, so adding this back in.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
