### PR TITLE
ci: set AWS_REGION in flaky test finder

### DIFF
--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -19,6 +19,8 @@ jobs:
           pip3 -q install agithub &&
           python3 .github/scripts/flake.py --cmd "mvn -ntp -U verify" -i 10 -ff --token "${{ github.token }}"
           --out-dir "failed_tests/"
+        env:
+          AWS_REGION: us-west-2
       - name: Upload Errors
         uses: actions/upload-artifact@v1.0.0
         with:

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LogManagerHelperTest.java
@@ -165,7 +165,7 @@ class LogManagerHelperTest {
         logRandomMessages(greengrassLogger, 525, LogFormat.TEXT);
         // Rollover is guarded by ch.qos.logback.core.util.SimpleInvocationGate so that it's not invoked too soon/often
         // This is the minimum delay since startup for it to allow log rollover.
-        Thread.sleep(SimpleInvocationGate.DEFAULT_INCREMENT);
+        Thread.sleep(SimpleInvocationGate.DEFAULT_INCREMENT.getMilliseconds());
         componentLogger.atInfo().log();  // log once more to trigger roll over
         greengrassLogger.atInfo().log();  // log once more to trigger roll over
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set AWS_REGION in flake finder so that tests can pass which would fail due to the unexpected missing region.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
