### PR TITLE
fix(mqtt3/5): deduplicate subscription callbacks using deprecated API

### DIFF
--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -212,21 +212,19 @@ public class MqttProxyIPCAgent {
                                 .log("Unable to subscribe to topic");
                         throw new ServiceError(String.format("Subscribe to topic %s failed with error %s", topic, t));
                     }).thenApply((i) -> {
-                        if (i != null) {
-                            int rc = i.getReasonCode();
-                            if (rc > 2) {
-                                String rcString = SubAckPacket.SubAckReasonCode.UNSPECIFIED_ERROR.name();
-                                try {
-                                    rcString = SubAckPacket.SubAckReasonCode.getEnumValueFromInteger(rc).name();
-                                } catch (RuntimeException ignored) {
-                                }
-
-                                throw new ServiceError(
-                                        String.format("Subscribe to topic %s failed with error %s", topic,
-                                                rcString))
-                                        .withContext(Utils.immutableMap("reasonString", i.getReasonString(),
-                                                "reasonCode", i.getReasonCode()));
+                        if (i != null && !i.isSuccessful()) {
+                            String rcString = SubAckPacket.SubAckReasonCode.UNSPECIFIED_ERROR.name();
+                            try {
+                                rcString =
+                                        SubAckPacket.SubAckReasonCode.getEnumValueFromInteger(i.getReasonCode()).name();
+                            } catch (RuntimeException ignored) {
                             }
+
+                            throw new ServiceError(
+                                    String.format("Subscribe to topic %s failed with error %s", topic,
+                                            rcString))
+                                    .withContext(Utils.immutableMap("reasonString", i.getReasonString(),
+                                            "reasonCode", i.getReasonCode()));
                         }
                         return new SubscribeToIoTCoreResponse();
                     });

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -144,7 +144,7 @@ public class IotJobsHelper implements InjectionActions {
     @Setter // For tests
     private IotJobsClientWrapper iotJobsClientWrapper;
 
-    private AtomicBoolean isSubscribedToIotJobsTopics = new AtomicBoolean(false);
+    private final AtomicBoolean isSubscribedToIotJobsTopics = new AtomicBoolean(false);
     private Future<?> subscriptionFuture;
     private volatile String thingName;
 
@@ -179,7 +179,7 @@ public class IotJobsHelper implements InjectionActions {
     /**
      * Handler that gets invoked when a job description is received.
      * Next pending job description is requested when an mqtt message
-     * is published using {@Code requestNextPendingJobDocument} in {@link IotJobsHelper}
+     * is published using {@code requestNextPendingJobDocument} in {@link IotJobsHelper}
      */
     private final Consumer<DescribeJobExecutionResponse> describeJobExecutionResponseConsumer = response -> {
         if (response.execution == null) {

--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -432,7 +432,7 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                 List<CompletableFuture<SubscribeResponse>> subFutures = new ArrayList<>();
                 for (Subscribe sub : droppedSubscriptionTopics) {
                     subFutures.add(subscribe(sub).whenComplete((result, error) -> {
-                        if (error == null) {
+                        if (error == null && (result == null || result.isSuccessful())) {
                             droppedSubscriptionTopics.remove(sub);
                         } else {
                             logger.atError().event(RESUB_LOG_EVENT).cause(error).kv(TOPIC_KEY, sub.getTopic())

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -516,10 +516,14 @@ public class MqttClient implements Closeable {
                         if (v == null || v.isSuccessful()) {
                             return v;
                         }
+                        String rcString = SubAckPacket.SubAckReasonCode.UNSPECIFIED_ERROR.name();
+                        try {
+                            rcString = SubAckPacket.SubAckReasonCode.getEnumValueFromInteger(v.getReasonCode()).name();
+                        } catch (RuntimeException ignored) {
+                        }
                         // Consumers of this deprecated API expect to receive an MqttException if subscribing fails
                         throw new MqttException(
-                                "Error subscribing. Reason: " + SubAckPacket.SubAckReasonCode.getEnumValueFromInteger(
-                                        v.getReasonCode()).name());
+                                "Error subscribing. Reason: " + rcString);
                     })
                     .get(getMqttOperationTimeoutMillis(), TimeUnit.MILLISECONDS);
         } catch (MqttRequestException e) {

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -497,6 +497,7 @@ public class MqttClient implements Closeable {
      * @deprecated Use {@code subscribe(Subscribe request)} instead
      */
     @Deprecated
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void subscribe(SubscribeRequest request)
             throws ExecutionException, InterruptedException, TimeoutException {
         try {

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.crt.mqtt.MqttException;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.crt.mqtt5.packets.PubAckPacket;
+import software.amazon.awssdk.crt.mqtt5.packets.SubAckPacket;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 import java.io.Closeable;
@@ -471,11 +472,13 @@ public class MqttClient implements Closeable {
             IndividualMqttClient finalConnection = connection;
             return connection.subscribe(request).whenComplete((i, t) -> {
                 try (LockScope scope = LockScope.lock(connectionLock.readLock())) {
-                    if (t == null) {
+                    if (t == null && (i == null || i.isSuccessful())) {
                         subscriptionTopics.put(new MqttTopic(request.getTopic()), finalConnection);
                     } else {
                         subscriptions.remove(request);
-                        logger.atError().kv(TOPIC_KEY, request.getTopic()).log("Error subscribing", t);
+                        if (t != null) {
+                            logger.atError().kv(TOPIC_KEY, request.getTopic()).log("Error subscribing", t);
+                        }
                     }
                 }
             });
@@ -490,18 +493,34 @@ public class MqttClient implements Closeable {
      * @throws ExecutionException   if an error occurs
      * @throws InterruptedException if the thread is interrupted while subscribing
      * @throws TimeoutException     if the request times out
+     * @throws MqttException        if the request fails
+     * @deprecated Use {@code subscribe(Subscribe request)} instead
      */
+    @Deprecated
     public void subscribe(SubscribeRequest request)
             throws ExecutionException, InterruptedException, TimeoutException {
         try {
-            Consumer<Publish> cb = (Publish m) -> request.getCallback()
-                    .accept(new MqttMessage(m.getTopic(), m.getPayload(),
-                            QualityOfService.getEnumValueFromInteger(m.getQos().getValue()), m.isRetain()));
-            Subscribe newReq =
-                    Subscribe.builder().qos(QOS.fromInt(request.getQos().getValue())).topic(request.getTopic())
-                            .callback(cb).build();
+            // Deduplicate subscription callbacks so that retries do not result in getting called multiple times
+            Subscribe newReq = cbMapping.computeIfAbsent(new Pair<>(request.getTopic(), request.getCallback()), (p) -> {
+                Consumer<Publish> cb = (Publish m) -> request.getCallback()
+                        .accept(new MqttMessage(m.getTopic(), m.getPayload(),
+                                QualityOfService.getEnumValueFromInteger(m.getQos().getValue()), m.isRetain()));
+
+                return Subscribe.builder().qos(QOS.fromInt(request.getQos().getValue())).topic(request.getTopic())
+                        .callback(cb).build();
+            });
+
             subscribe(newReq)
-                    .thenAccept((v) -> cbMapping.put(new Pair<>(request.getTopic(), request.getCallback()), newReq))
+                    .thenApply((v) -> {
+                        // null is a success because subscribe returns null if the subscription already existed
+                        if (v == null || v.isSuccessful()) {
+                            return v;
+                        }
+                        // Consumers of this deprecated API expect to receive an MqttException if subscribing fails
+                        throw new MqttException(
+                                "Error subscribing. Reason: " + SubAckPacket.SubAckReasonCode.getEnumValueFromInteger(
+                                        v.getReasonCode()).name());
+                    })
                     .get(getMqttOperationTimeoutMillis(), TimeUnit.MILLISECONDS);
         } catch (MqttRequestException e) {
             throw new ExecutionException(e);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
In our upgrade from MQTT 3 to MQTT 5, we changed the interface to support MQTT 5 features. This required a layer of indirection and translation which resulted in making a wrapper lambda to translate message types. This wrapper lambda is not deduplicated even if the consumer is the same, a new wrapper would be created each time. This means that the consumer can end up getting called more than once if it calls subscribe more than once. As a solution, we will now deduplicate these wrappers so that only one callback exists for each subscription.

Manually tested by turning off internet while starting GG and observing that the hashcodes for lambdas are the same and that when back online, the consumer is only called one time.

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
