### PR TITLE
fix(tes): read role alias and thing name directly

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -114,13 +114,12 @@ public class CredentialRequestHandler implements HttpHandler {
         this.authZHandler = authZHandler;
 
         deviceConfiguration.getIotRoleAlias().subscribe((why, newv) -> {
-            String iotRoleAlias = Coerce.toString(newv);
             clearCache();
-            setIotCredentialsPath(iotRoleAlias);
+            setIotCredentialsPath(Coerce.toString(deviceConfiguration.getIotRoleAlias()));
         });
         deviceConfiguration.getThingName().subscribe((why, newv) -> {
             clearCache();
-            setThingName(Coerce.toString(newv));
+            setThingName(Coerce.toString(deviceConfiguration.getThingName()));
         });
         deviceConfiguration.getCertificateFilePath().subscribe((why, newv) -> clearCache());
         deviceConfiguration.getRootCAFilePath().subscribe((why, newv) -> clearCache());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Read the role alias and thing name directly from config instead of getting it from the on-change event.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
