### PR TITLE
chore: upgrade greengrass logging to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>logging</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Bump Greengrass Logging to 2.3.0-SNAPSHOT

**Why is this change necessary:**
- Update to logback clean up behavior to delete old log files by last modified date instead of the expected file name

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
