### PR TITLE
chore: update generated code from smithy-iot-device-sdk-greengrass-ipc targeting 1.19.1

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -33,6 +33,7 @@ To begin developing with Greengrass you will need to clone the repositories.
 - Then open the Nucleus or any other module and import it as a Maven project
 - Once that's imported, go to File -> New -> Module from Existing Sources for each of the remaining modules you want to
   develop on. For each one, import it as a Maven project again.
+- Go to File -> Project Structure -> Project -> SDK ; and confirm you have the correct Java version (see prerequisites) selected.
 - You should now have all the projects properly configured to begin working
 - Once all projects are in, go to the Maven pane (usually on the right-hand side) and run `install` target for each of
   the projects

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
-            <version>1.18.1</version>
+            <version>1.19.1-C2CUC-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractCancelLocalDeploymentOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractCancelLocalDeploymentOperationHandler.java
@@ -5,6 +5,7 @@
 
 package software.amazon.awssdk.aws.greengrass;
 
+import java.lang.Override;
 import software.amazon.awssdk.aws.greengrass.model.CancelLocalDeploymentRequest;
 import software.amazon.awssdk.aws.greengrass.model.CancelLocalDeploymentResponse;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
@@ -12,16 +13,15 @@ import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext
 import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
-public abstract class GeneratedAbstractCancelLocalDeploymentOperationHandler extends
-        OperationContinuationHandler<CancelLocalDeploymentRequest, CancelLocalDeploymentResponse,
-                EventStreamJsonMessage, EventStreamJsonMessage> {
-    protected GeneratedAbstractCancelLocalDeploymentOperationHandler(OperationContinuationHandlerContext context) {
-        super(context);
-    }
+public abstract class GeneratedAbstractCancelLocalDeploymentOperationHandler extends OperationContinuationHandler<CancelLocalDeploymentRequest, CancelLocalDeploymentResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractCancelLocalDeploymentOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
 
-    @Override
-    public OperationModelContext<CancelLocalDeploymentRequest, CancelLocalDeploymentResponse, EventStreamJsonMessage,
-            EventStreamJsonMessage> getOperationModelContext() {
-        return GreengrassCoreIPCServiceModel.getCancelLocalDeploymentModelContext();
-    }
+  @Override
+  public OperationModelContext<CancelLocalDeploymentRequest, CancelLocalDeploymentResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getCancelLocalDeploymentModelContext();
+  }
 }

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPutComponentMetricOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractPutComponentMetricOperationHandler.java
@@ -15,13 +15,13 @@ import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
 public abstract class GeneratedAbstractPutComponentMetricOperationHandler extends OperationContinuationHandler<PutComponentMetricRequest, PutComponentMetricResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
   protected GeneratedAbstractPutComponentMetricOperationHandler(
-          OperationContinuationHandlerContext context) {
+      OperationContinuationHandlerContext context) {
     super(context);
   }
 
   @Override
   public OperationModelContext<PutComponentMetricRequest, PutComponentMetricResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
-  ) {
+      ) {
     return GreengrassCoreIPCServiceModel.getPutComponentMetricModelContext();
   }
 }

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler.java
@@ -15,14 +15,14 @@ import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
 public abstract class GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler extends OperationContinuationHandler<SubscribeToCertificateUpdatesRequest, SubscribeToCertificateUpdatesResponse, EventStreamJsonMessage, CertificateUpdateEvent> {
-    protected GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler(
-            OperationContinuationHandlerContext context) {
-        super(context);
-    }
+  protected GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
 
-    @Override
-    public OperationModelContext<SubscribeToCertificateUpdatesRequest, SubscribeToCertificateUpdatesResponse, EventStreamJsonMessage, CertificateUpdateEvent> getOperationModelContext(
-    ) {
-        return GreengrassCoreIPCServiceModel.getSubscribeToCertificateUpdatesModelContext();
-    }
+  @Override
+  public OperationModelContext<SubscribeToCertificateUpdatesRequest, SubscribeToCertificateUpdatesResponse, EventStreamJsonMessage, CertificateUpdateEvent> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getSubscribeToCertificateUpdatesModelContext();
+  }
 }

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -5,16 +5,17 @@
 
 package software.amazon.awssdk.aws.greengrass;
 
-import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
-import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceHandler;
-import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceModel;
-import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
-
+import java.lang.Override;
+import java.lang.String;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceHandler;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCServiceModel;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
 public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler {
   public static final String SERVICE_NAMESPACE = "aws.greengrass";
@@ -75,6 +76,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String UPDATE_STATE = SERVICE_NAMESPACE + "#UpdateState";
 
+  public static final String CANCEL_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CancelLocalDeployment";
+
   public static final String LIST_NAMED_SHADOWS_FOR_THING = SERVICE_NAMESPACE + "#ListNamedShadowsForThing";
 
   public static final String SUBSCRIBE_TO_COMPONENT_UPDATES = SERVICE_NAMESPACE + "#SubscribeToComponentUpdates";
@@ -86,8 +89,6 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public static final String PAUSE_COMPONENT = SERVICE_NAMESPACE + "#PauseComponent";
 
   public static final String CREATE_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CreateLocalDeployment";
-
-  public static final String CANCEL_LOCAL_DEPLOYMENT = SERVICE_NAMESPACE + "#CancelLocalDeployment";
 
   static {
     SERVICE_OPERATION_SET = new HashSet();
@@ -118,6 +119,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(GET_LOCAL_DEPLOYMENT_STATUS);
     SERVICE_OPERATION_SET.add(GET_SECRET_VALUE);
     SERVICE_OPERATION_SET.add(UPDATE_STATE);
+    SERVICE_OPERATION_SET.add(CANCEL_LOCAL_DEPLOYMENT);
     SERVICE_OPERATION_SET.add(LIST_NAMED_SHADOWS_FOR_THING);
     SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_COMPONENT_UPDATES);
     SERVICE_OPERATION_SET.add(LIST_LOCAL_DEPLOYMENTS);
@@ -272,6 +274,11 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     operationSupplierMap.put(UPDATE_STATE, handler);
   }
 
+  public void setCancelLocalDeploymentHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractCancelLocalDeploymentOperationHandler> handler) {
+    operationSupplierMap.put(CANCEL_LOCAL_DEPLOYMENT, handler);
+  }
+
   public void setListNamedShadowsForThingHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractListNamedShadowsForThingOperationHandler> handler) {
     operationSupplierMap.put(LIST_NAMED_SHADOWS_FOR_THING, handler);
@@ -300,11 +307,6 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setCreateLocalDeploymentHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractCreateLocalDeploymentOperationHandler> handler) {
     operationSupplierMap.put(CREATE_LOCAL_DEPLOYMENT, handler);
-  }
-
-  public void setCancelLocalDeploymentHandler(
-          Function<OperationContinuationHandlerContext, GeneratedAbstractCancelLocalDeploymentOperationHandler> handler) {
-    operationSupplierMap.put(CANCEL_LOCAL_DEPLOYMENT, handler);
   }
 
   @Override

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
@@ -15,7 +15,7 @@ public interface AuthenticationData {
      * string must be appropriate for audit logs and enable tracing specific callers/clients
      * to relevant decision and operations executed
      *
-     * @return
+     * @return A human readable string for who the identity of the client/caller is
      */
     public String getIdentityLabel();
 }

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
@@ -8,7 +8,6 @@ package software.amazon.awssdk.eventstreamrpc;
 /**
  * Authorization decision object contains the decision in general
  * and the authentication data along with it.
- *
  */
 public enum Authorization {
     ACCEPT,

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
@@ -20,6 +20,11 @@ public class DebugLoggingOperationHandler extends OperationContinuationHandler
     private static Logger LOGGER = LoggerFactory.getLogger(DebugLoggingOperationHandler.class);
     private final OperationModelContext operationModelContext;
 
+    /**
+     * Constructs a new DebugLoggingOperationHandler from the given model and continuation handler contexts
+     * @param modelContext The model context
+     * @param context The continuation handler model context
+     */
     public DebugLoggingOperationHandler(final OperationModelContext modelContext, final OperationContinuationHandlerContext context) {
         super(context);
         this.operationModelContext = modelContext;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
@@ -7,10 +7,16 @@ package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.Collection;
 
+/**
+ * The EventStream RPC Service Handler
+ */
 public abstract class EventStreamRPCServiceHandler implements OperationContinuationHandlerFactory {
     private AuthenticationHandler authenticationHandler;
     private AuthorizationHandler authorizationHandler;
 
+    /**
+     * Constructs a new EventStreamRPCServiceHandler
+     */
     public EventStreamRPCServiceHandler() {
         authorizationHandler = null;
     }
@@ -27,7 +33,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * TODO: How may we want to protect this from being re-assigned after service creation?
-     * @param handler
+     * @param handler Sets the authorization handler
      */
     public void setAuthorizationHandler(final AuthorizationHandler handler) {
         this.authorizationHandler = handler;
@@ -35,8 +41,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * Use this to determine if the connection should be accepted or rejected for this service
-     *
-     * @return
+     * @return Returns the authorization handler
      */
     public AuthorizationHandler getAuthorizationHandler() {
         return authorizationHandler;
@@ -49,7 +54,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * Pulls caller/client identity when server connection occurs
-     * @return
+     * @return Returns the authentication handler
      */
     public AuthenticationHandler getAuthenticationHandler() {
         return authenticationHandler;
@@ -57,7 +62,7 @@ public abstract class EventStreamRPCServiceHandler implements OperationContinuat
 
     /**
      * TODO: How may we want to protect this from being re-assigned after service creation?
-     * @param authenticationHandler
+     * @param authenticationHandler Sets the authentication handler
      */
     public void setAuthenticationHandler(AuthenticationHandler authenticationHandler) {
         this.authenticationHandler = authenticationHandler;

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
@@ -5,15 +5,31 @@
 
 package software.amazon.awssdk.eventstreamrpc;
 
+/**
+ * Thrown when a invalid service configuration exception occurs
+ */
 public class InvalidServiceConfigurationException extends RuntimeException {
+    /**
+     * Constructs a new InvalidServiceConfigurationException with the given message
+     * @param msg The message to associate with the exception
+     */
     public InvalidServiceConfigurationException(String msg) {
         super(msg);
     }
 
+    /**
+     * Constructs a new InvalidServiceConfigurationException with the given message and cause
+     * @param msg The message to associate with the exception
+     * @param cause The cause to associate with the exception
+     */
     public InvalidServiceConfigurationException(String msg, Throwable cause) {
         super(msg, cause);
     }
 
+    /**
+     * Constructs a new InvalidServiceConfigurationException with the given cause
+     * @param cause The cause to associate with the exception
+     */
     public InvalidServiceConfigurationException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
@@ -21,6 +21,12 @@ public class OperationContinuationHandlerContext {
     private final ServerConnectionContinuation continuation;
     private final AuthenticationData authenticationData;
 
+    /**
+     * Creates a new OperationContinuationHandlerContext
+     * @param connection The connection to associate with the OperationContinuationHandlerContext
+     * @param continuation The continuation to associate with the OperationContinuationHandlerContext
+     * @param authenticationData The authentication data to associate with the OperationContinuationHandlerContext
+     */
     public OperationContinuationHandlerContext(final ServerConnection connection,
            final ServerConnectionContinuation continuation,
            final AuthenticationData authenticationData) {
@@ -29,14 +35,26 @@ public class OperationContinuationHandlerContext {
         this.authenticationData = authenticationData;
     }
 
+    /**
+     * Returns the connection associated with the OperationContinuationHandlerContext
+     * @return the connection associated with the OperationContinuationHandlerContext
+     */
     public ServerConnection getServerConnection() {
         return serverConnection;
     }
 
+    /**
+     * Returns the continuation associated with the OperationContinuationHandlerContext
+     * @return the continuation associated with the OperationContinuationHandlerContext
+     */
     public ServerConnectionContinuation getContinuation() {
         return continuation;
     }
 
+    /**
+     * Returns the authentication data associated with the OperationContinuationHandlerContext
+     * @return the authentication data associated with the OperationContinuationHandlerContext
+     */
     public AuthenticationData getAuthenticationData() {
         return authenticationData;
     }

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
@@ -5,11 +5,11 @@
 
 package software.amazon.awssdk.eventstreamrpc;
 
+import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
+
 import java.util.Collection;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
 
 /**
  * This is really the entire service interface base class
@@ -19,8 +19,10 @@ public interface OperationContinuationHandlerFactory {
     Collection<String> getAllOperations();
     boolean hasHandlerForOperation(String operation);
 
-    //this may not be a good use of a default method impl as implementers can override it
-    //also InvalidServiceConfigurationException is a needed exception to be thrown from IpcServer
+    /**
+     * this may not be a good use of a default method impl as implementers can override it
+     * also InvalidServiceConfigurationException is a needed exception to be thrown from IpcServer
+     */
     default void validateAllOperationsSet() {
         if (!getAllOperations().stream().allMatch(op -> hasHandlerForOperation(op))) {
             String unmappedOperations = getAllOperations().stream()

--- a/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
+++ b/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
@@ -5,6 +5,17 @@
 
 package software.amazon.awssdk.eventstreamrpc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.crt.eventstream.Header;
+import software.amazon.awssdk.crt.eventstream.HeaderType;
+import software.amazon.awssdk.crt.eventstream.MessageFlags;
+import software.amazon.awssdk.crt.eventstream.MessageType;
+import software.amazon.awssdk.crt.eventstream.ServerConnection;
+import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
+import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;
+import software.amazon.awssdk.crt.eventstream.ServerConnectionHandler;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,15 +24,19 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.crt.eventstream.*;
-
+/**
+ * Handler for Service Operation Continuation Mapping
+ */
 public class ServiceOperationMappingContinuationHandler extends ServerConnectionHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceOperationMappingContinuationHandler.class);
     private final EventStreamRPCServiceHandler serviceHandler;
     private AuthenticationData authenticationData;  //should only be set once after AuthN
 
+    /**
+     * Constructs a new ServiceOperationMappingContinuationHandler
+     * @param serverConnection The ServerConnection to use
+     * @param handler The EventStreamRPCServiceHandler to use
+     */
     public ServiceOperationMappingContinuationHandler(final ServerConnection serverConnection, final EventStreamRPCServiceHandler handler) {
         super(serverConnection);
         this.serviceHandler = handler;
@@ -55,8 +70,8 @@ public class ServiceOperationMappingContinuationHandler extends ServerConnection
 
     /**
      * Post: authenticationData should not be null
-     * @param headers
-     * @param payload
+     * @param headers The connection request headers
+     * @param payload The connection request payload
      */
     protected void onConnectRequest(List<Header> headers, byte[] payload) {
         final int[] responseMessageFlag = { 0 };
@@ -75,12 +90,12 @@ public class ServiceOperationMappingContinuationHandler extends ServerConnection
                     Version.fromString(versionHeader.get()).equals(Version.getInstance())) {
                 //version matches
                 if (authentication == null) {
-                    throw new IllegalStateException(String.format("%s has null authentication handler!",
-                            serviceHandler.getServiceName()));
+                    throw new IllegalStateException(
+                            String.format("%s has null authentication handler!", serviceHandler.getServiceName()));
                 }
                 if (authorization == null) {
-                    throw new IllegalStateException(String.format("%s has null authorization handler!",
-                            serviceHandler.getServiceName()));
+                    throw new IllegalStateException(
+                            String.format("%s has null authorization handler!", serviceHandler.getServiceName()));
                 }
 
                 LOGGER.trace(String.format("%s running authentication handler", serviceHandler.getServiceName()));


### PR DESCRIPTION
**Issue #, if available:**
GG-44743

**Description of changes:**
Update the generated code from smithy-iot-device-sdk-greengrass-ipc, targeting aws-iot-device-sdk 1.19.1.

(I'm posting this PR early to get some help with the unit test issues I'm seeing, see below)

(This should not actually be merged to main because the pom contains a snapshot version of aws-iot-device-sdk)

-----------------------------------------

**Unit test issues:**

I'm seeing 7 errors such as this
```
Strict stubbing argument mismatch. Please check:

 - this invocation of 'retrieveWithDefault' method:
    DEFAULT_HANDLER.retrieveWithDefault(
    class java.lang.Double,
    "fssPeriodicUpdateIntervalSec",
    86400
);
    -> at com.aws.greengrass.testing.TestFeatureParameters.retrieveWithDefault(TestFeatureParameters.java:59)

 - has following stubbing(s) with different arguments:
    1. DEFAULT_HANDLER.retrieveWithDefault(
    null,
    null,
    null
);
      -> at com.aws.greengrass.componentmanager.ComponentServiceHelperTest.beforeEach(ComponentServiceHelperTest.java:74)
```
Since this method is used in a lot of different contexts (wrapping different things during the same test), maybe it's a false negative?

I'm not sure why the changes are causing such behavior though
