### PR TITLE
feat(fss): update component status when recovered from error state

### DIFF
--- a/src/main/java/com/aws/greengrass/status/model/MessageType.java
+++ b/src/main/java/com/aws/greengrass/status/model/MessageType.java
@@ -22,8 +22,7 @@ public enum MessageType {
             case LOCAL_DEPLOYMENT:
             case THING_DEPLOYMENT:
             case THING_GROUP_DEPLOYMENT:
-            case ERRORED_COMPONENT:
-            case BROKEN_COMPONENT:
+            case COMPONENT_STATUS_CHANGE:
             case RECONNECT:
                 return PARTIAL;
             case CADENCE:

--- a/src/main/java/com/aws/greengrass/status/model/Trigger.java
+++ b/src/main/java/com/aws/greengrass/status/model/Trigger.java
@@ -11,8 +11,7 @@ public enum Trigger {
     LOCAL_DEPLOYMENT,
     THING_DEPLOYMENT,
     THING_GROUP_DEPLOYMENT,
-    ERRORED_COMPONENT,
-    BROKEN_COMPONENT,
+    COMPONENT_STATUS_CHANGE,
     // when mqtt connection resumes
     RECONNECT,
     // when nucleus initially connects IoT Core, a complete FSS update is sent


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We made 2 changes in this pr:
1. We send one more fss message on component status change when the component encountered an error, completes retry and recovered. 
2. We consolidated the trigger type for component errors and broken into a single component status change event.
**Why is this change necessary:**
We enhance customer usability and aim to synchronize the component status across devices and consoles, thereby streamlining operations and providing a seamless experience.
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
