### PR TITLE
feat(fss): update fss trigger type when component status change

### DIFF
--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -312,7 +312,8 @@ public class FleetStatusService extends GreengrassService {
                 overAllStatus.set(getOverallStatusBasedOnServiceState(overAllStatus.get(), service));
             });
 
-            uploadFleetStatusServiceData(erroredComponentSet, overAllStatus.get(), null, Trigger.ERRORED_COMPONENT);
+            uploadFleetStatusServiceData(erroredComponentSet, overAllStatus.get(), null,
+                    Trigger.COMPONENT_STATUS_CHANGE);
             return;
         }
 
@@ -324,7 +325,7 @@ public class FleetStatusService extends GreengrassService {
         if (!isDeploymentInProgress.get() && newState.equals(State.BROKEN)) {
             synchronized (updatedGreengrassServiceSet) {
                 uploadFleetStatusServiceData(updatedGreengrassServiceSet, OverallStatus.UNHEALTHY,
-                        null, Trigger.BROKEN_COMPONENT);
+                        null, Trigger.COMPONENT_STATUS_CHANGE);
             }
         }
     }

--- a/src/main/java/com/aws/greengrass/status/model/MessageType.java
+++ b/src/main/java/com/aws/greengrass/status/model/MessageType.java
@@ -22,8 +22,7 @@ public enum MessageType {
             case LOCAL_DEPLOYMENT:
             case THING_DEPLOYMENT:
             case THING_GROUP_DEPLOYMENT:
-            case ERRORED_COMPONENT:
-            case BROKEN_COMPONENT:
+            case COMPONENT_STATUS_CHANGE:
             case RECONNECT:
                 return PARTIAL;
             case CADENCE:

--- a/src/main/java/com/aws/greengrass/status/model/Trigger.java
+++ b/src/main/java/com/aws/greengrass/status/model/Trigger.java
@@ -11,8 +11,7 @@ public enum Trigger {
     LOCAL_DEPLOYMENT,
     THING_DEPLOYMENT,
     THING_GROUP_DEPLOYMENT,
-    ERRORED_COMPONENT,
-    BROKEN_COMPONENT,
+    COMPONENT_STATUS_CHANGE,
     // when mqtt connection resumes
     RECONNECT,
     // when nucleus initially connects IoT Core, a complete FSS update is sent

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -650,7 +650,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         assertEquals("testThing", fleetStatusDetails.getThing());
         assertEquals(OverallStatus.UNHEALTHY, fleetStatusDetails.getOverallStatus());
         assertEquals(MessageType.PARTIAL, fleetStatusDetails.getMessageType());
-        assertEquals(Trigger.BROKEN_COMPONENT, fleetStatusDetails.getTrigger());
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
         assertNull(fleetStatusDetails.getChunkInfo());
         assertEquals(1, fleetStatusDetails.getComponentDetails().size());
         assertEquals("MockService", fleetStatusDetails.getComponentDetails().get(0).getComponentName());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Combining the fss trigger type `ERRORED_COMPONENT` and `BROKEN_COMPONENT` to one type: `COMPONENT_STATUS_CHANGE` 
**Why is this change necessary:**
We currently only have ERROED and BROKEN trigger types, and it's not enough to cover all component lifecycle. 
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
