### PR TITLE
ci: flake finder use sudo and ubuntu 20

### DIFF
--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   flake:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8

--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: '*'
-
 jobs:
   flake:
     runs-on: ubuntu-20.04

--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: '*'
 
 jobs:
   flake:
@@ -17,7 +19,7 @@ jobs:
       - name: Analyze Test Run
         run: >-
           pip3 -q install agithub &&
-          python3 .github/scripts/flake.py --cmd "mvn -ntp -U verify" -i 10 -ff --token "${{ github.token }}"
+          python3 .github/scripts/flake.py --cmd "sudo -E mvn -ntp -U verify" -i 10 -ff --token "${{ github.token }}"
           --out-dir "failed_tests/"
         env:
           AWS_REGION: us-west-2


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix flake finder to use ubuntu 20 and run with sudo which should fix the failure on cgroups. Flake finder is not passing, but this is improved.

https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/8011866632/job/21886519075?pr=1579
> Running iteration 1 of 10
> Succeeded with no failure

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
