### PR TITLE
fix: timeout http server connections when unable to retrieve credentials

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
@@ -151,7 +153,7 @@ public class CredentialRequestHandler implements HttpHandler {
                 return;
             }
             doAuth(exchange);
-            final byte[] credentials = getCredentials();
+            final byte[] credentials = getCredentialsWithTimeout(30, TimeUnit.SECONDS);
             exchange.sendResponseHeaders(tesCache.get(iotCredentialsPath).responseCode, credentials.length);
             exchange.getResponseBody().write(credentials);
         } catch (AuthorizationException e) {
@@ -160,6 +162,9 @@ public class CredentialRequestHandler implements HttpHandler {
         } catch (UnauthenticatedException e) {
             LOGGER.atInfo().log("Request denied due to invalid token");
             generateError(exchange, HttpURLConnection.HTTP_FORBIDDEN);
+        } catch (TimeoutException e) {
+            LOGGER.atDebug().log("Client credential request timed out");
+            generateError(exchange, HttpURLConnection.HTTP_GATEWAY_TIMEOUT);
         } catch (Throwable e) {
             // Broken pipe is ignorable; it just means that the client went away
             if ("Broken pipe".equalsIgnoreCase(e.getMessage())) {
@@ -172,6 +177,44 @@ public class CredentialRequestHandler implements HttpHandler {
         } finally {
             exchange.close();
         }
+    }
+
+    private byte[] getCredentialsWithTimeout(int timeout, TimeUnit timeUnit) throws TimeoutException {
+        TESCache cacheEntry = tesCache.get(iotCredentialsPath);
+        CompletableFuture<Void> future = null;
+        synchronized (cacheEntry) {
+            if (areCredentialsValid(cacheEntry)) {
+                return cacheEntry.credentials;
+            }
+            CompletableFuture<Void> newFut = new CompletableFuture<>();
+            // "take the lock" by immediately setting the future non-null while inside the sync block
+            if (!cacheEntry.future.compareAndSet(null, newFut)) {
+                future = cacheEntry.future.get();
+            }
+        }
+        if (future != null) {
+            LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
+                    .log("IAM credentials not found in cache or already expired. A request to fetch new credentials "
+                            + "is already ongoing, waiting for it to complete.");
+            try {
+                // block along with any other threads so we don't send multiple requests
+                if (timeout == 0) {
+                    future.get();
+                } else {
+                    future.get(timeout, timeUnit);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException ignore) {
+                // We never complete the future exceptionally
+            }
+            return tesCache.get(iotCredentialsPath).credentials;
+        }
+
+        // Get new credentials from cloud
+        LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
+                .log("IAM credentials not found in cache or already expired. Fetching new ones from TES");
+        return getCredentialsBypassCache();
     }
 
     private void generateError(HttpExchange exchange, int statusCode) throws IOException {
@@ -295,36 +338,12 @@ public class CredentialRequestHandler implements HttpHandler {
      * @return AWS credentials from cloud.
      */
     public byte[] getCredentials() {
-        TESCache cacheEntry = tesCache.get(iotCredentialsPath);
-        CompletableFuture<Void> future = null;
-        synchronized (cacheEntry) {
-            if (areCredentialsValid(cacheEntry)) {
-                return cacheEntry.credentials;
-            }
-            CompletableFuture<Void> newFut = new CompletableFuture<>();
-            // "take the lock" by immediately setting the future non-null while inside the sync block
-            if (!cacheEntry.future.compareAndSet(null, newFut)) {
-                future = cacheEntry.future.get();
-            }
+        try {
+            return getCredentialsWithTimeout(0, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            // Not possible
+            return new byte[0];
         }
-        if (future != null) {
-            LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
-                    .log("IAM credentials not found in cache or already expired. A request to fetch new credentials "
-                            + "is already ongoing, waiting for it to complete.");
-            try {
-                future.get(); // block along with any other threads so we don't send multiple requests
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (ExecutionException ignore) {
-                // We never complete the future exceptionally
-            }
-            return tesCache.get(iotCredentialsPath).credentials;
-        }
-
-        // Get new credentials from cloud
-        LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
-                .log("IAM credentials not found in cache or already expired. Fetching new ones from TES");
-        return getCredentialsBypassCache();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/tes/HttpServerImpl.java
+++ b/src/main/java/com/aws/greengrass/tes/HttpServerImpl.java
@@ -10,37 +10,31 @@ import com.sun.net.httpserver.HttpServer;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.concurrent.ExecutorService;
-import javax.inject.Inject;
 
 public class HttpServerImpl implements Server {
     public static final String URL = "/2016-11-01/credentialprovider/";
     private static final int TIME_TO_WAIT_BEFORE_SHUTDOWN_IN_SECONDS = 1;
     private final HttpServer httpImpl;
 
-    @Inject
     private final HttpHandler credentialRequestHandler;
-
-    @Inject
-    private final ExecutorService executorService;
 
     /**
      * Constructor.
      * @param port Http server port
      * @param credentialRequestHandler request handler for server requests
-     * @param executorService executor service instance
      * @throws IOException When server creation fails
      */
-    HttpServerImpl(int port, HttpHandler credentialRequestHandler, ExecutorService executorService) throws IOException {
+    HttpServerImpl(int port, HttpHandler credentialRequestHandler) throws IOException {
         httpImpl = HttpServer.create(new InetSocketAddress("localhost", port), 0);
         this.credentialRequestHandler = credentialRequestHandler;
-        this.executorService = executorService;
     }
 
     @Override
     public void start() {
         httpImpl.createContext(URL, credentialRequestHandler);
-        httpImpl.setExecutor(executorService);
+        // Use the default single thread (only one connection at a time will be processed, other connections will
+        // backlog at TCP level).
+        httpImpl.setExecutor(null);
         httpImpl.start();
     }
 

--- a/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
+++ b/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
@@ -21,7 +21,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.concurrent.ExecutorService;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
@@ -44,21 +43,18 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
 
     private final AuthorizationHandler authZHandler;
     private final CredentialRequestHandler credentialRequestHandler;
-    private final ExecutorService executor;
 
     /**
      * Constructor.
      * @param topics the configuration coming from kernel
      * @param credentialRequestHandler {@link CredentialRequestHandler}
      * @param authZHandler {@link AuthorizationHandler}
-     * @param executor executor service shared with kernel
      * @param deviceConfiguration device's system configuration
      */
     @Inject
     public TokenExchangeService(Topics topics,
                                 CredentialRequestHandler credentialRequestHandler,
-                                AuthorizationHandler authZHandler,
-                                ExecutorService executor, DeviceConfiguration deviceConfiguration) {
+                                AuthorizationHandler authZHandler, DeviceConfiguration deviceConfiguration) {
         super(topics);
         // Port change should not be allowed
         topics.lookup(CONFIGURATION_CONFIG_KEY, PORT_TOPIC).dflt(DEFAULT_PORT)
@@ -70,7 +66,6 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
 
         this.authZHandler = authZHandler;
         this.credentialRequestHandler = credentialRequestHandler;
-        this.executor = executor;
     }
 
     @Override
@@ -90,7 +85,7 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
                 .log("Attempting to start server at configured port {}", port);
         try {
             validateConfig();
-            server = new HttpServerImpl(port, credentialRequestHandler, executor);
+            server = new HttpServerImpl(port, credentialRequestHandler);
             server.start();
             logger.atInfo().log("Started server at port {}", server.getServerPort());
             // Get port from the server, in case no port was specified and server started on a random port

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -19,7 +19,6 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeviceConfiguration.COMPONENT_STORE_MAX_SIZE_BYTES;
@@ -71,7 +68,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 class TokenExchangeServiceTest extends GGServiceTestUtil {
     private static final String MOCK_ROLE_ALIAS = "ROLE_ALIAS";
-    static ExecutorService executorService = Executors.newFixedThreadPool(1);
     @Mock
     AuthorizationHandler mockAuthZHandler;
 
@@ -132,11 +128,6 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         context.close();
     }
 
-    @AfterAll
-    static void tearDown() {
-        executorService.shutdownNow();
-    }
-
     @ParameterizedTest
     @ValueSource(ints = {0, 3000})
     void GIVEN_token_exchange_service_WHEN_started_THEN_correct_env_set(int port) throws Exception {
@@ -168,8 +159,7 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
 
         TokenExchangeService tes = new TokenExchangeService(config,
                 mockCredentialHandler,
-                mockAuthZHandler,
-                executorService, deviceConfigurationWithRoleAlias(MOCK_ROLE_ALIAS));
+                mockAuthZHandler, deviceConfigurationWithRoleAlias(MOCK_ROLE_ALIAS));
         tes.postInject();
         tes.startup();
         Thread.sleep(5000L);
@@ -225,8 +215,7 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
 
         TokenExchangeService tes = spy(new TokenExchangeService(config,
                 mockCredentialHandler,
-                mockAuthZHandler,
-                executorService, deviceConfigurationWithRoleAlias(roleAlias)));
+                mockAuthZHandler, deviceConfigurationWithRoleAlias(roleAlias)));
         ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
         doNothing().when(tes).reportState(stateArgumentCaptor.capture());
         tes.startup();
@@ -262,8 +251,7 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
 
         TokenExchangeService tes = spy(new TokenExchangeService(config,
                 mockCredentialHandler,
-                mockAuthZHandler,
-                executorService, deviceConfigurationWithRoleAlias("TEST")));
+                mockAuthZHandler, deviceConfigurationWithRoleAlias("TEST")));
         ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
         doNothing().when(tes).reportState(stateArgumentCaptor.capture());
         tes.postInject();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Timeout credential requests after 30 seconds. Without this, we can end up with tons of threads all waiting for credentials since a new thread is created for each incoming request and those threads are not interrupted even if the client disconnects (due to a client disconnect).

Also avoiding thread creation entirely by using a single thread for all requests, if we do not have credentials to vend out anyway then blocking additional requests should be fine.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [x] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
