### PR TITLE
feat(fss): update component status for terminal states

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
@@ -294,6 +294,8 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
     @Test
     void GIVEN_root_deployment_success_WHEN_nested_subgroups_deploy_with_different_component_versions_and_deploy_received_not_in_order_THEN_stale_deployment_rejected(
             ExtensionContext context) throws Exception {
+        FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
+        fss.setWaitBetweenPublishDisabled(true);
         // expect a rejection exception
         ignoreExceptionOfType(context, DeploymentRejectedException.class);
 
@@ -384,7 +386,7 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
 
             // verify fleet status update
             assertThat(() -> fleetStatusUpdates.get(groupName),
-                    eventuallyEval(notNullValue(AtomicReference.class), Duration.ofSeconds(20)));
+                    eventuallyEval(notNullValue(AtomicReference.class), Duration.ofSeconds(30)));
             FleetStatusDetails statusUpdate = fleetStatusUpdates.get(groupName).get();
             DeploymentInformation deploymentInfo = statusUpdate.getDeploymentInformation();
             assertEquals("REJECTED", deploymentInfo.getStatus());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.status;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.PublishRequest;
+import com.aws.greengrass.status.FleetStatusService;
+import com.aws.greengrass.status.model.FleetStatusDetails;
+import com.aws.greengrass.status.model.OverallStatus;
+import com.aws.greengrass.status.model.Trigger;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.NoOpPathOwnershipHandler;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_SERVICE_TOPICS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+public class ComponentStatusChangeFleetStatusServiceTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static DeviceConfiguration deviceConfiguration;
+    private static Kernel kernel;
+    @Mock
+    private MqttClient mqttClient;
+
+    private AtomicReference<List<FleetStatusDetails>> fleetStatusDetailsList;
+
+    private CountDownLatch statusChange;
+
+    private final static String SERVICE_A = "ServiceA";
+    private final static String SERVICE_B = "ServiceB";
+    private final static String SERVICE_C = "ServiceC";
+
+    @BeforeEach
+    void setupKernel() throws Exception {
+        fleetStatusDetailsList = new AtomicReference<>(new ArrayList<>());
+        kernel = new Kernel();
+        NoOpPathOwnershipHandler.register(kernel);
+        kernel.getContext().put(MqttClient.class, mqttClient);
+
+        when(mqttClient.publish(any(PublishRequest.class))).thenAnswer(i -> {
+            Object argument = i.getArgument(0);
+            PublishRequest publishRequest = (PublishRequest) argument;
+            try {
+                FleetStatusDetails fleetStatusDetails = OBJECT_MAPPER.readValue(publishRequest.getPayload(), FleetStatusDetails.class);
+                if (fleetStatusDetails.getTrigger().equals(Trigger.COMPONENT_STATUS_CHANGE)) {
+                    statusChange.countDown();
+                }
+                fleetStatusDetailsList.get().add(fleetStatusDetails);
+            } catch (JsonMappingException ignored) {
+            }
+            return CompletableFuture.completedFuture(0);
+        });
+    }
+    @AfterEach
+    void afterEach() {
+        if (kernel != null) {
+            kernel.shutdown();
+        }
+    }
+    @Test
+    void GIVEN_one_component_errored_and_recovered_THEN_fss_should_send_recovery_message() throws Exception {
+        statusChange = new CountDownLatch(2);
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
+                "us-east-1", "roleAliasName");
+        kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                ComponentStatusChangeFleetStatusServiceTest.class.getResource("fss_service_recovery.yaml"));
+        kernel.launch();
+
+        FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
+        fss.setWaitBetweenPublishDisabled(true);
+
+        assertTrue(statusChange.await(20, TimeUnit.SECONDS));
+
+        // we expect a total of 3 messages; 1 nucleus launch and 2 component status change (error + recovery)
+        assertEquals(3, fleetStatusDetailsList.get().size());
+
+        // the first message should be nucleus launch
+        FleetStatusDetails fleetStatusDetails = fleetStatusDetailsList.get().get(0);
+        assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(Trigger.NUCLEUS_LAUNCH, fleetStatusDetails.getTrigger());
+
+        // the second message should be errored component
+        fleetStatusDetails = fleetStatusDetailsList.get().get(1);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_A, State.ERRORED);
+
+        // the third message should be component recovery
+        fleetStatusDetails = fleetStatusDetailsList.get().get(2);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_A, State.RUNNING);
+    }
+
+    @Test
+    void GIVEN_two_components_errored_and_recovered_THEN_fss_should_send_only_one_recovery_message() throws Exception {
+        statusChange  = new CountDownLatch(3);
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
+                "us-east-1", "roleAliasName");
+        kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                ComponentStatusChangeFleetStatusServiceTest.class.getResource("fss_service_5s_recovery.yaml"));
+        kernel.launch();
+
+        FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
+        fss.setWaitBetweenPublishDisabled(true);
+        //Increase this for windows testing
+        assertTrue(statusChange.await(60, TimeUnit.SECONDS));
+        // we expect a total of 4 messages, 1 Nucleus launch, 3 component status change includes:
+        // 1 Errored from A, 1 Errored B, 1 recovery message for both
+        assertEquals(4, fleetStatusDetailsList.get().size());
+
+        // the first message should be nucleus launch
+        FleetStatusDetails fleetStatusDetails = fleetStatusDetailsList.get().get(0);
+        assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(Trigger.NUCLEUS_LAUNCH, fleetStatusDetails.getTrigger());
+
+        // the second and third message should be errored component
+        fleetStatusDetails = fleetStatusDetailsList.get().get(1);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_B, State.ERRORED);
+
+        fleetStatusDetails = fleetStatusDetailsList.get().get(2);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_A, State.ERRORED);
+
+        // the fourth message should be component recovery
+        fleetStatusDetails = fleetStatusDetailsList.get().get(3);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_A, State.RUNNING);
+        componentStatusAssertion(fleetStatusDetails, SERVICE_B, State.RUNNING);
+    }
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void GIVEN_three_components_errored_and_recovered_THEN_fss_should_send_only_one_recovery_message_and_one_errored_message_should_contain_recovery_message() throws Exception {
+        statusChange  = new CountDownLatch(4);
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
+                "us-east-1", "roleAliasName");
+        kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                ComponentStatusChangeFleetStatusServiceTest.class.getResource("fss_service_10s_recovery.yaml"));
+        kernel.launch();
+
+        FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
+        fss.setWaitBetweenPublishDisabled(true);
+        //Increase this for windows testing
+        assertTrue(statusChange.await(60, TimeUnit.SECONDS));
+        // we expect a total of 5 messages, 1 Nucleus launch, 4 component status change includes:
+        // 1 Errored from A with B reovered, 1 Errored B, 1 Errored C, 1 recovery message for the rest of non recovery ones
+        assertEquals(5, fleetStatusDetailsList.get().size());
+
+        // the first message should be nucleus launch
+        FleetStatusDetails fleetStatusDetails = fleetStatusDetailsList.get().get(0);
+        assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
+        assertEquals(Trigger.NUCLEUS_LAUNCH, fleetStatusDetails.getTrigger());
+
+        // the second should be errored component C
+        fleetStatusDetails = fleetStatusDetailsList.get().get(1);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_C, State.ERRORED);
+
+        // the 3rd message should be errored component B
+        fleetStatusDetails = fleetStatusDetailsList.get().get(2);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_B, State.ERRORED);
+
+        // the 4th message should be errrored component A with recovery of B
+        fleetStatusDetails = fleetStatusDetailsList.get().get(3);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_A, State.ERRORED);
+        assertTrue(fleetStatusDetails.getComponentDetails().stream()
+                .anyMatch(c -> "ServiceB".equals(c.getComponentName()) && !State.ERRORED.equals(c.getState())));
+
+        // the 5th message should be rest component recovery
+        fleetStatusDetails = fleetStatusDetailsList.get().get(4);
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fleetStatusDetails.getTrigger());
+        componentStatusAssertion(fleetStatusDetails, SERVICE_C, State.RUNNING);
+        componentStatusAssertion(fleetStatusDetails, SERVICE_A, State.RUNNING);
+    }
+    private void componentStatusAssertion(FleetStatusDetails fleetStatusDetails, String componentName, State state) {
+        assertTrue(fleetStatusDetails.getComponentDetails().stream()
+                .anyMatch(c -> componentName.equals(c.getComponentName()) && state.equals(c.getState())));
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -29,14 +29,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_MESSAGE_PUBLISH_MIN_WAIT_TIME_SEC;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -50,12 +54,15 @@ class FleetStatusServiceSetupTest extends BaseITCase {
     private static DeviceConfiguration deviceConfiguration;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private AtomicReference<FleetStatusDetails> fleetStatusDetails;
+    private AtomicReference<List<FleetStatusDetails>> fleetStatusDetailsList;
+    private final CountDownLatch statusChange = new CountDownLatch(1);
     @Mock
     private MqttClient mqttClient;
 
     @BeforeEach
     void setupKernel() throws Exception {
         fleetStatusDetails = new AtomicReference<>();
+        fleetStatusDetailsList = new AtomicReference<>(new ArrayList<>());
         kernel = new Kernel();
         ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
                 FleetStatusServiceSetupTest.class.getResource("onlyMain.yaml"));
@@ -66,6 +73,10 @@ class FleetStatusServiceSetupTest extends BaseITCase {
             PublishRequest publishRequest = (PublishRequest) argument;
             try {
                 fleetStatusDetails.set(OBJECT_MAPPER.readValue(publishRequest.getPayload(), FleetStatusDetails.class));
+                fleetStatusDetailsList.get().add(fleetStatusDetails.get());
+                if (fleetStatusDetails.get().getTrigger().equals(Trigger.COMPONENT_STATUS_CHANGE)) {
+                    statusChange.countDown();
+                }
             } catch (JsonMappingException ignored) {
             }
             return CompletableFuture.completedFuture(0);
@@ -78,9 +89,8 @@ class FleetStatusServiceSetupTest extends BaseITCase {
     }
 
     @Test
-    void GIVEN_kernel_deployment_WHEN_device_provisioning_completes_before_kernel_launches_and_is_changed_after_THEN_thing_details_uploaded_to_cloud_exactly_once()
+    void GIVEN_kernel_launches_THEN_thing_details_and_components_terminal_states_uploaded_to_cloud_10s_after_launch_message()
             throws Exception {
-
         deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
                 "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
                 "us-east-1", "roleAliasName");
@@ -89,10 +99,23 @@ class FleetStatusServiceSetupTest extends BaseITCase {
 
         assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState, eventuallyEval(is(State.RUNNING)));
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
-        assertThat(()-> fleetStatusDetails.get(), eventuallyEval(notNullValue(), Duration.ofSeconds(30)));
-        assertEquals("ThingName", fleetStatusDetails.get().getThing());
-        assertEquals(MessageType.COMPLETE, fleetStatusDetails.get().getMessageType());
-        assertEquals(Trigger.NUCLEUS_LAUNCH, fleetStatusDetails.get().getTrigger());
+
+        // we should send two status updates within 11 seconds; 1 nucleus launch  and 1 component status change
+        assertTrue(statusChange.await(FLEET_STATUS_MESSAGE_PUBLISH_MIN_WAIT_TIME_SEC + 1L, TimeUnit.SECONDS));
+        assertEquals(2, fleetStatusDetailsList.get().size());
+        // first message is nucleus launch
+        FleetStatusDetails fssDetails = fleetStatusDetailsList.get().get(0);
+        assertEquals("ThingName", fssDetails.getThing());
+        assertEquals(MessageType.COMPLETE, fssDetails.getMessageType());
+        assertEquals(Trigger.NUCLEUS_LAUNCH, fssDetails.getTrigger());
+        Instant launchTimestamp = Instant.ofEpochMilli(fssDetails.getTimestamp());
+        // second message is component status change
+        fssDetails = fleetStatusDetailsList.get().get(1);
+        assertEquals(MessageType.PARTIAL, fssDetails.getMessageType());
+        assertEquals(Trigger.COMPONENT_STATUS_CHANGE, fssDetails.getTrigger());
+        Instant terminalTimestamp = Instant.ofEpochMilli(fssDetails.getTimestamp());
+        assertEquals(FLEET_STATUS_MESSAGE_PUBLISH_MIN_WAIT_TIME_SEC, Duration.between(launchTimestamp, terminalTimestamp).getSeconds());
+
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/PeriodicFleetStatusServiceTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_SERVICE_TOPICS;
 import static com.aws.greengrass.status.FleetStatusService.FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.DEFAULT_PERIODIC_AGGREGATE_INTERVAL_SEC;
 import static com.aws.greengrass.telemetry.TelemetryAgent.DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC;
@@ -99,7 +100,8 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
                 if (mainServiceFinished.get() && kernel.orderedDependencies().size() == publishedFleetStatusDetails
                         .getComponentDetails().size() && publishedFleetStatusDetails
                         .getTrigger() != Trigger.NUCLEUS_LAUNCH && publishedFleetStatusDetails
-                        .getTrigger() != Trigger.NETWORK_RECONFIGURE) {
+                        .getTrigger() != Trigger.NETWORK_RECONFIGURE && publishedFleetStatusDetails
+                        .getTrigger() != Trigger.COMPONENT_STATUS_CHANGE) {
                     fleetStatusDetails.set(publishedFleetStatusDetails);
                     allComponentsInFssPeriodicUpdate.countDown();
                 }
@@ -108,7 +110,7 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
         });
 
         kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
-            if (service.getName().equals(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)) {
+            if (service.getName().equals(FLEET_STATUS_SERVICE_TOPICS)) {
                 if (newState.equals(State.RUNNING)) {
                     fssRunning.countDown();
                 }
@@ -130,6 +132,8 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
                         "certFilePath", "caFilePath", "us-east-1", "roleAliasName");
         kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
         kernel.launch();
+        FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
+        fss.setWaitBetweenPublishDisabled(true);
         assertTrue(deploymentServiceRunning.await(10, TimeUnit.SECONDS));
         assertTrue(fssRunning.await(10, TimeUnit.SECONDS));
     }
@@ -142,6 +146,8 @@ class PeriodicFleetStatusServiceTest extends BaseITCase {
     @Test
     void GIVEN_config_with_small_periodic_interval_WHEN_interval_elapses_THEN_status_is_uploaded_to_cloud()
             throws Exception {
+        FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
+        fss.setWaitBetweenPublishDisabled(true);
         ((Map) kernel.getContext().getvIfExists(Kernel.SERVICE_TYPE_TO_CLASS_MAP_KEY).get()).put("plugin",
                 GreengrassService.class.getName());
         assertNotNull(deviceConfiguration.getThingName());

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_10s_recovery.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_10s_recovery.yaml
@@ -1,0 +1,108 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+
+  ServiceA:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: |-
+            touch ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            sleep 7
+            if [ -f "ErrorIndicator" ]; then
+              echo Startup Failed
+              exit 1
+            fi
+        recover:
+          requiresPrivilege: true
+          script: |-
+            echo Fixing ServiceA
+            rm ErrorIndicator
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& { if (Test-Path ErrorIndicator) {  ping -n 7 127.0.0.1 > NUL; echo "Startup Failed"; exit 1; } }"
+        recover:
+          requiresPrivilege: true
+          script: echo Fixing ServiceA && del ErrorIndicator
+
+  ServiceB:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: |-
+            touch ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            sleep 3
+            if [ -f "ErrorIndicator" ]; then
+              echo Startup Failed
+              exit 1
+            fi
+        recover:
+          requiresPrivilege: true
+          script: |-
+            echo Fixing ServiceB
+            rm ErrorIndicator
+            sleep 2
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& {if (Test-Path ErrorIndicator) { ping -n 3 127.0.0.1 > NUL; echo "Startup Failed"; exit 1; } }"
+        recover:
+          requiresPrivilege: true
+          script: del ErrorIndicator && ping -n 2 127.0.0.1 > NUL
+  ServiceC:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: |-
+            touch ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            if [ -f "ErrorIndicator" ]; then
+              echo Startup Failed
+              exit 1
+            fi
+        recover:
+          requiresPrivilege: true
+          script: |-
+            echo Fixing ServiceB
+            rm ErrorIndicator
+            sleep 10
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& { if (Test-Path ErrorIndicator) { echo "Startup Failed"; exit 1; } }"
+        recover:
+          requiresPrivilege: true
+          script: ping -n 10 127.0.0.1 > NUL && del ErrorIndicator
+  main:
+    dependencies:
+      - ServiceA
+      - ServiceB
+      - ServiceC

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_5s_recovery.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_5s_recovery.yaml
@@ -1,0 +1,76 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+
+  ServiceA:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: |-
+            touch ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            sleep 3
+            if [ -f "ErrorIndicator" ]; then
+              echo Startup Failed
+              exit 1
+            fi
+        recover:
+          requiresPrivilege: true
+          script: |-
+            echo Fixing ServiceA
+            rm ErrorIndicator
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& {if (Test-Path ErrorIndicator) {  ping -n 3 127.0.0.1 > NUL; echo "Startup Failed"; exit 1; } }"
+        recover:
+          requiresPrivilege: true
+          script: echo Fixing ServiceA && del ErrorIndicator
+
+  ServiceB:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: |-
+            touch ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            if [ -f "ErrorIndicator" ]; then
+              echo Startup Failed
+              exit 1
+            fi
+        recover:
+          requiresPrivilege: true
+          script: |-
+            echo Fixing ServiceB
+            rm ErrorIndicator
+            sleep 5
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& { if (Test-Path ErrorIndicator) { echo "Startup Failed"; exit 1; } }"
+        recover:
+          requiresPrivilege: true
+          script: ping -n 5 127.0.0.1 > NUL && del ErrorIndicator
+
+  main:
+    dependencies:
+      - ServiceA
+      - ServiceB

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_recovery.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_recovery.yaml
@@ -1,0 +1,42 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+
+  ServiceA:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: |-
+            touch ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            if [ -f "ErrorIndicator" ]; then
+              echo Startup Failed
+              exit 1
+            fi
+        recover:
+          requiresPrivilege: true
+          script: |-
+            echo Fixing ServiceA
+            rm ErrorIndicator
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > ErrorIndicator
+        startup:
+          requiresPrivilege: true
+          script: |-
+            powershell -command "& { if (Test-Path ErrorIndicator) { echo "Startup Failed"; exit 1; } }"
+        recover:
+          requiresPrivilege: true
+          script: echo Fixing ServiceA && del ErrorIndicator
+
+  main:
+    dependencies:
+      - ServiceA


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Once Nucleus finished restarting process and all components are up and running, Nucleus sends an additional fss message to console with all components status
2. Once a component being recovered, Nucleus waits for all other components being recovered and send an additional message notifying all components has been recovered.

**Why is this change necessary:**
We would like to improve our customer experience on sending extra messages indicating when all components in Nucleus are up and running
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
