### PR TITLE
fix: parameter hyphens for --tes-role-name option

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -78,7 +78,7 @@ public class GreengrassSetup {
             + "\t\t\t\t\tOtherwise a policy called GreengrassV2IoTThingPolicy is used instead. If the policy with\n"
             + "\t\t\t\t\tthis name doesn't exist in your AWS account, the AWS IoT Greengrass Core software creates it\n"
             + "\t\t\t\t\twith a default policy document.\n"
-            + "\t—tes-role-name, -trn\t\t(Optional) The name of the IAM role to use to acquire AWS credentials that "
+            + "\t--tes-role-name, -trn\t\t(Optional) The name of the IAM role to use to acquire AWS credentials that "
             + "let the device\n"
             + "\t\t\t\t\tinteract with AWS services. If the role with this name doesn't exist in your AWS account, "
             + "the AWS\n"

--- a/src/main/java/com/aws/greengrass/easysetup/README.md
+++ b/src/main/java/com/aws/greengrass/easysetup/README.md
@@ -39,7 +39,7 @@ OPTIONS
                                 Otherwise a policy called GreengrassV2IoTThingPolicy is used instead. If the policy with
                                 this name doesn't exist in your AWS account, the AWS IoT Greengrass Core software creates it
                                 with a default policy document.
-—-tes-role-name, -trn           (Optional) The name of the IAM role to use to acquire AWS credentials that let the device interact
+--tes-role-name, -trn           (Optional) The name of the IAM role to use to acquire AWS credentials that let the device interact
                                 with AWS services. If the role with this name doesn't exist in your AWS account, then the AWS IoT
                                 Greengrass Core software creates it with the GreengrassV2TokenExchangeRoleAccess policy. This role
                                 DOES NOT have access to your S3 buckets where you host component artifacts. This means that you


### PR DESCRIPTION
…instead of em dash

**Issue #, if available:**

**Description of changes:**
replaced em dash in `—tes-role-name` with `--tes-role-name`

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
