### PR TITLE
perf(fss): decrease wait time to 3s and only wait for component status change

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.integrationtests.status;
 
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
@@ -42,7 +43,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
-public class ComponentStatusChangeFleetStatusServiceTest {
+public class ComponentStatusChangeFleetStatusServiceTest extends BaseITCase {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static DeviceConfiguration deviceConfiguration;
@@ -134,7 +135,7 @@ public class ComponentStatusChangeFleetStatusServiceTest {
         FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
         fss.setWaitBetweenPublishDisabled(true);
         //Increase this for windows testing
-        assertTrue(statusChange.await(60, TimeUnit.SECONDS));
+        assertTrue(statusChange.await(30, TimeUnit.SECONDS));
         // we expect a total of 4 messages, 1 Nucleus launch, 3 component status change includes:
         // 1 Errored from A, 1 Errored B, 1 recovery message for both
         assertEquals(4, fleetStatusDetailsList.get().size());
@@ -174,7 +175,7 @@ public class ComponentStatusChangeFleetStatusServiceTest {
         FleetStatusService fss = (FleetStatusService) kernel.locateIgnoreError(FLEET_STATUS_SERVICE_TOPICS);
         fss.setWaitBetweenPublishDisabled(true);
         //Increase this for windows testing
-        assertTrue(statusChange.await(60, TimeUnit.SECONDS));
+        assertTrue(statusChange.await(30, TimeUnit.SECONDS));
         // we expect a total of 5 messages, 1 Nucleus launch, 4 component status change includes:
         // 1 Errored from A with B reovered, 1 Errored B, 1 Errored C, 1 recovery message for the rest of non recovery ones
         assertEquals(5, fleetStatusDetailsList.get().size());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/FleetStatusServiceSetupTest.java
@@ -89,7 +89,7 @@ class FleetStatusServiceSetupTest extends BaseITCase {
     }
 
     @Test
-    void GIVEN_kernel_launches_THEN_thing_details_and_components_terminal_states_uploaded_to_cloud_10s_after_launch_message()
+    void GIVEN_kernel_launches_THEN_thing_details_and_components_terminal_states_uploaded_to_cloud_3s_after_launch_message()
             throws Exception {
         deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
                 "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
@@ -100,8 +100,9 @@ class FleetStatusServiceSetupTest extends BaseITCase {
         assertThat(kernel.locate(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS)::getState, eventuallyEval(is(State.RUNNING)));
         assertEquals("ThingName", Coerce.toString(deviceConfiguration.getThingName()));
 
-        // we should send two status updates within 11 seconds; 1 nucleus launch  and 1 component status change
+        // we should send two status updates within 4 seconds; 1 nucleus launch  and 1 component status change
         assertTrue(statusChange.await(FLEET_STATUS_MESSAGE_PUBLISH_MIN_WAIT_TIME_SEC + 1L, TimeUnit.SECONDS));
+        fleetStatusDetailsList.get().removeIf(f -> Trigger.NETWORK_RECONFIGURE.equals(f.getTrigger()));
         assertEquals(2, fleetStatusDetailsList.get().size());
         // first message is nucleus launch
         FleetStatusDetails fssDetails = fleetStatusDetailsList.get().get(0);

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -82,7 +82,7 @@ public class FleetStatusService extends GreengrassService {
     public static final String FLEET_STATUS_TEST_PERIODIC_UPDATE_INTERVAL_SEC = "fssPeriodicUpdateIntervalSec";
     public static final int DEFAULT_PERIODIC_PUBLISH_INTERVAL_SEC = 86_400;
     public static final int MINIMAL_RECONNECT_PUBLISH_INTERVAL_SEC = 60;
-    public static final int FLEET_STATUS_MESSAGE_PUBLISH_MIN_WAIT_TIME_SEC = 10;
+    public static final int FLEET_STATUS_MESSAGE_PUBLISH_MIN_WAIT_TIME_SEC = 3;
     public static final String FLEET_STATUS_PERIODIC_PUBLISH_INTERVAL_SEC = "periodicStatusPublishIntervalSeconds";
     static final String FLEET_STATUS_SEQUENCE_NUMBER_TOPIC = "sequenceNumber";
     static final String FLEET_STATUS_LAST_PERIODIC_UPDATE_TIME_TOPIC = "lastPeriodicUpdateTime";
@@ -637,7 +637,7 @@ public class FleetStatusService extends GreengrassService {
             }
             lastFSSPublishTime.set(expectedPublishTime);
         }
-        if (delay == 0) {
+        if (delay == 0 || !Trigger.COMPONENT_STATUS_CHANGE.equals(trigger)) {
             // Publish immediately
             publisher.publish(fleetStatusDetails, components);
             logger.atInfo().event("fss-status-update-published").kv("trigger", trigger)


### PR DESCRIPTION
…s change message

**Issue #, if available:**

**Description of changes:**
1. Decrease the wait time to 3s between messages
2. Only wait on component status change messages

**Why is this change necessary:**
Improve synchronization on component status between device and console
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
