### PR TITLE
chore: add opens for PCKS11 plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -640,7 +640,8 @@
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.aws.greengrass.easysetup.GreengrassSetup</mainClass>
                                     <manifestEntries>
-                                        <Add-Opens>java.base/java.io</Add-Opens>
+                                        <Add-Opens>java.base/java.io java.base/sun.security.jca</Add-Opens>
+                                        <!-- sun.security.jca for pkcs11 GetInstance !-->
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Addresses

```
java.lang.IllegalAccessError: class com.aws.greengrass.security.provider.pkcs11.SingleKeyStore (in unnamed module @0x493ca8) cannot access class sun.security.jca.GetInstance (in module java.base) because module java.base does not export sun.security.jca to unnamed module @0x493ca8
```

**Why is this change necessary:**

**How was this change tested:**
Rebuilt nucleus and ran using java 17, observed error occurs without the change and error does not occur with the change.

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
