### PR TITLE
fix(fss): windows flaky integration test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -161,7 +159,6 @@ public class ComponentStatusChangeFleetStatusServiceTest extends BaseITCase {
         componentStatusAssertion(fleetStatusDetails, SERVICE_B, State.RUNNING);
     }
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void GIVEN_three_components_errored_and_recovered_THEN_fss_should_send_only_one_recovery_message_and_one_errored_message_should_contain_recovery_message() throws Exception {
         statusChange  = new CountDownLatch(4);
         deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_10s_recovery.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_10s_recovery.yaml
@@ -32,8 +32,10 @@ services:
           script: echo NUL > ErrorIndicator
         startup:
           requiresPrivilege: true
-          script: |-
-            powershell -command "& { if (Test-Path ErrorIndicator) {  ping -n 7 127.0.0.1 > NUL; echo "Startup Failed"; exit 1; } }"
+          script:
+            if exist "ErrorIndicator" (
+              ping 127.0.0.1 -n 7 > NUL && echo Startup Failed && exit /b 1
+            )
         recover:
           requiresPrivilege: true
           script: echo Fixing ServiceA && del ErrorIndicator
@@ -65,11 +67,13 @@ services:
           script: echo NUL > ErrorIndicator
         startup:
           requiresPrivilege: true
-          script: |-
-            powershell -command "& {if (Test-Path ErrorIndicator) { ping -n 3 127.0.0.1 > NUL; echo "Startup Failed"; exit 1; } }"
+          script:
+            if exist "ErrorIndicator" (
+              ping 127.0.0.1 -n 3 > NUL && echo Startup Failed && exit /b 1
+            )
         recover:
           requiresPrivilege: true
-          script: del ErrorIndicator && ping -n 2 127.0.0.1 > NUL
+          script: del ErrorIndicator && echo Fixing ServiceB
   ServiceC:
     lifecycle:
       posix:
@@ -96,8 +100,10 @@ services:
           script: echo NUL > ErrorIndicator
         startup:
           requiresPrivilege: true
-          script: |-
-            powershell -command "& { if (Test-Path ErrorIndicator) { echo "Startup Failed"; exit 1; } }"
+          script:
+            if exist "ErrorIndicator" (
+            echo Startup Failed && exit /b 1
+            )
         recover:
           requiresPrivilege: true
           script: ping -n 10 127.0.0.1 > NUL && del ErrorIndicator

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_5s_recovery.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/fss_service_5s_recovery.yaml
@@ -32,8 +32,10 @@ services:
           script: echo NUL > ErrorIndicator
         startup:
           requiresPrivilege: true
-          script: |-
-            powershell -command "& {if (Test-Path ErrorIndicator) {  ping -n 3 127.0.0.1 > NUL; echo "Startup Failed"; exit 1; } }"
+          script:
+            if exist "ErrorIndicator" (
+              ping 127.0.0.1 -n 3 > NUL && echo Startup Failed && exit /b 1
+            )
         recover:
           requiresPrivilege: true
           script: echo Fixing ServiceA && del ErrorIndicator
@@ -64,8 +66,10 @@ services:
           script: echo NUL > ErrorIndicator
         startup:
           requiresPrivilege: true
-          script: |-
-            powershell -command "& { if (Test-Path ErrorIndicator) { echo "Startup Failed"; exit 1; } }"
+          script:
+            if exist "ErrorIndicator" (
+              echo Startup Failed && exit /b 1
+            )
         recover:
           requiresPrivilege: true
           script: ping -n 5 127.0.0.1 > NUL && del ErrorIndicator


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change ping method to Start-Sleep for power shell for sleeping
**Why is this change necessary:**
Fix flaky windows integration tests
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
