### PR TITLE
fix: avoid publish until fss is set up

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/SubGroupDeploymentIntegrationTest.java
@@ -205,6 +205,7 @@ public class SubGroupDeploymentIntegrationTest extends BaseITCase {
         // setup fss such that it could send mqtt messages to the mock listener
         FleetStatusService fleetStatusService = (FleetStatusService) kernel.locate(FLEET_STATUS_SERVICE_TOPICS);
         fleetStatusService.setDeviceConfiguration(deviceConfiguration);
+        fleetStatusService.getIsLaunchMessageSent().set(true);
         fleetStatusService.postInject();
 
         // setup jobs helper such that it could send mqtt messages to the mock listener

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/ComponentStatusChangeFleetStatusServiceTest.java
@@ -174,7 +174,7 @@ public class ComponentStatusChangeFleetStatusServiceTest extends BaseITCase {
         //Increase this for windows testing
         assertTrue(statusChange.await(30, TimeUnit.SECONDS));
         // we expect a total of 5 messages, 1 Nucleus launch, 4 component status change includes:
-        // 1 Errored from A with B reovered, 1 Errored B, 1 Errored C, 1 recovery message for the rest of non recovery ones
+        // 1 Errored from A with B recovered, 1 Errored B, 1 Errored C, 1 recovery message for the rest of non recovery ones
         assertEquals(5, fleetStatusDetailsList.get().size());
 
         // the first message should be nucleus launch

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -1044,6 +1044,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
                 mockKernelLifecycle, ses);
         fleetStatusService.postInject();
         fleetStatusService.setWaitBetweenPublishDisabled(true);
+        fleetStatusService.getIsLaunchMessageSent().set(true);
         return fleetStatusService;
     }
 
@@ -1054,6 +1055,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
                 mockKernelLifecycle, mockSes);
         fleetStatusService.postInject();
         fleetStatusService.setWaitBetweenPublishDisabled(true);
+        fleetStatusService.getIsLaunchMessageSent().set(true);
         return fleetStatusService;
     }
 
@@ -1064,6 +1066,7 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
                 ses, periodicUpdateIntervalSec);
         fleetStatusService.postInject();
         fleetStatusService.setWaitBetweenPublishDisabled(true);
+        fleetStatusService.getIsLaunchMessageSent().set(true);
         return fleetStatusService;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Avoid publishing component status change message until FSS is set up and Nucleus launch message is published.

**Why is this change necessary:**
A deadlock situation can arise if FSS is being set up while a component status change wants to be published during Nucleus startup.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
