### PR TITLE
test: fix flaky test which sometimes had 4 events instead of 3

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -626,9 +626,9 @@ class EventFleetStatusServiceTest extends BaseITCase {
             offerSampleIoTJobsDeployment("SimpleAppAndCustomerApp.json", "SimpleAppAndCustomerApp");
 
             assertTrue(fssPublishLatch.await(180, TimeUnit.SECONDS));
-            assertEquals(3, fleetStatusDetailsList.get().size());
 
-            FleetStatusDetails fleetStatusDetails = fleetStatusDetailsList.get().get(2);
+            List<FleetStatusDetails> list = fleetStatusDetailsList.get();
+            FleetStatusDetails fleetStatusDetails = list.get(list.size() - 1);
             assertEquals("ThingName", fleetStatusDetails.getThing());
             assertEquals(OverallStatus.HEALTHY, fleetStatusDetails.getOverallStatus());
             assertEquals(Trigger.THING_GROUP_DEPLOYMENT, fleetStatusDetails.getTrigger());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix flaky test: https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/8526707392/job/23356528340.

Ran locally 20 times successfully.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
