### PR TITLE
test: use guava CycleDetectingLockFactory to detect possible deadlocks

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/status/EventFleetStatusServiceTest.java
@@ -220,7 +220,7 @@ class EventFleetStatusServiceTest extends BaseITCase {
         assertTrue(fssRunning.await(10, TimeUnit.SECONDS));
         assertTrue(deploymentServiceRunning.await(10, TimeUnit.SECONDS));
         assertTrue(mainFinished.await(10, TimeUnit.SECONDS));
-        assertTrue(componentStatusChange.await(35, TimeUnit.SECONDS));
+        assertTrue(componentStatusChange.await(10, TimeUnit.SECONDS));
         //components with their status already updated will be removed from the set
         fleetStatusDetailsList.get().forEach(fleetStatusDetails -> fleetStatusDetails.getComponentDetails().
                 forEach(componentStatusDetails -> {

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/onlyMain.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/status/onlyMain.yaml
@@ -10,3 +10,4 @@ services:
   main:
     dependencies:
       - aws.greengrass.Nucleus
+      - FleetStatusService

--- a/src/main/java/com/aws/greengrass/config/Topic.java
+++ b/src/main/java/com/aws/greengrass/config/Topic.java
@@ -8,10 +8,13 @@ package com.aws.greengrass.config;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.locks.Lock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -21,6 +24,7 @@ public class Topic extends Node {
     private Object value;
 
     private static final Logger logger = LogManager.getLogger(Topic.class);
+    private final Lock lock = LockFactory.newReentrantLock(this);
 
     Topic(Context c, String n, Topics p) {
         super(c, n, p);
@@ -216,47 +220,49 @@ public class Topic extends Node {
      *                                                      proposed value is the same as the current value
      * @return this.
      */
-    synchronized Topic withNewerValue(long proposedModtime, final Object proposed, boolean allowTimestampToDecrease,
+    Topic withNewerValue(long proposedModtime, final Object proposed, boolean allowTimestampToDecrease,
                                       boolean allowTimestampToIncreaseWhenValueHasntChanged) {
-        final Object currentValue = value;
-        final long currentModTime = modtime;
-        boolean timestampWouldIncrease =
-                allowTimestampToIncreaseWhenValueHasntChanged && proposedModtime > currentModTime;
+        try (LockScope ls = LockScope.lock(lock)) {
+            final Object currentValue = value;
+            final long currentModTime = modtime;
+            boolean timestampWouldIncrease =
+                    allowTimestampToIncreaseWhenValueHasntChanged && proposedModtime > currentModTime;
 
-        // If the value hasn't changed, or if the proposed timestamp is in the past AND we don't want to
-        // decrease the timestamp
-        // AND the timestamp would not increase
-        // THEN, return immediately and do nothing.
-        if ((Objects.equals(proposed, currentValue)
-                || !allowTimestampToDecrease && (proposedModtime < currentModTime))
-                && !timestampWouldIncrease) {
-            return this;
-        }
-        final Object validated = validate(proposed, currentValue);
-        boolean changed = true;
-        if (Objects.equals(validated, currentValue)) {
-            changed = false;
-            if (!timestampWouldIncrease) {
+            // If the value hasn't changed, or if the proposed timestamp is in the past AND we don't want to
+            // decrease the timestamp
+            // AND the timestamp would not increase
+            // THEN, return immediately and do nothing.
+            if ((Objects.equals(proposed, currentValue) || !allowTimestampToDecrease && (proposedModtime
+                    < currentModTime)) && !timestampWouldIncrease) {
                 return this;
             }
-        }
+            final Object validated = validate(proposed, currentValue);
+            boolean changed = true;
+            if (Objects.equals(validated, currentValue)) {
+                changed = false;
+                if (!timestampWouldIncrease) {
+                    return this;
+                }
+            }
 
-        if (validated != null && !(validated instanceof String) && !(validated instanceof Number)
-                && !(validated instanceof Boolean) && !(validated instanceof List) && !(validated instanceof Enum)) {
-            // Log with cause if it is an invalid type. This will trip our test protection without actually causing an
-            // exception and failing the write
-            logger.atError().cause(new UnsupportedInputTypeException(proposed.getClass()))
-                    .kv("path", path()).kv("value", validated).log();
-        }
+            if (validated != null && !(validated instanceof String) && !(validated instanceof Number)
+                    && !(validated instanceof Boolean) && !(validated instanceof List)
+                    && !(validated instanceof Enum)) {
+                // Log with cause if it is an invalid type. This will trip our test protection without
+                // actually causing an exception and failing the write
+                logger.atError().cause(new UnsupportedInputTypeException(proposed.getClass())).kv("path", path())
+                        .kv("value", validated).log();
+            }
 
-        value = validated;
-        modtime = proposedModtime;
-        if (changed) {
-            context.runOnPublishQueue(() -> this.fire(WhatHappened.changed));
-        } else {
-            context.runOnPublishQueue(() -> this.fire(WhatHappened.timestampUpdated));
+            value = validated;
+            modtime = proposedModtime;
+            if (changed) {
+                context.runOnPublishQueue(() -> this.fire(WhatHappened.changed));
+            } else {
+                context.runOnPublishQueue(() -> this.fire(WhatHappened.timestampUpdated));
+            }
+            return this;
         }
-        return this;
     }
 
     @Override
@@ -301,11 +307,13 @@ public class Topic extends Node {
      * @param dflt the default value
      * @return this
      */
-    public synchronized Topic dflt(Object dflt) {
-        if (value == null) {
-            withNewerValue(DEFAULT_VALUE_TIMESTAMP, dflt, true); // defaults come from the dawn of time
+    public Topic dflt(Object dflt) {
+        try (LockScope ls = LockScope.lock(lock)) {
+            if (value == null) {
+                withNewerValue(DEFAULT_VALUE_TIMESTAMP, dflt, true); // defaults come from the dawn of time
+            }
+            return this;
         }
-        return this;
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentQueue.java
@@ -8,12 +8,15 @@ package com.aws.greengrass.deployment;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 /**
  * <p>DeploymentQueue is a thread-safe deployment queue that automatically de-duplicates by deployment id, and
@@ -55,6 +58,7 @@ public class DeploymentQueue {
      * Map of internal queue id -> deployment instance.
      */
     private final Map<String, Deployment> deploymentMap = new LinkedHashMap<>();
+    private final Lock lock = LockFactory.newReentrantLock(this);
 
     /**
      * <p>If the offered deployment id is unique, then insert the offered deployment at the tail of the queue.</p>
@@ -80,37 +84,39 @@ public class DeploymentQueue {
      * @throws NullPointerException if the offered deployment is null.
      */
     @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
-    public synchronized boolean offer(Deployment offeredDeployment) {
+    public boolean offer(Deployment offeredDeployment) {
         if (offeredDeployment == null) {
             throw new NullPointerException("Offered deployment must not be null");
         }
-        final String offeredDeploymentInternalId; // the id to employ in the internal queue
-        if (Deployment.DeploymentType.SHADOW.equals(offeredDeployment.getDeploymentType())) {
-            offeredDeploymentInternalId = SHADOW_DEPLOYMENT_QUEUE_ID;
-        } else {
-            offeredDeploymentInternalId = offeredDeployment.getId();
-        }
-
-        if (deploymentMap.containsKey(offeredDeploymentInternalId)) {
-            // internal queue id is already in use; check the replacement criteria
-            final Deployment enqueuedDeployment = deploymentMap.get(offeredDeploymentInternalId);
-            if (checkReplacementCriteria(enqueuedDeployment, offeredDeployment)) {
-                logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, offeredDeployment.getId())
-                        .kv(DISCARDED_DEPLOYMENT_ID_LOG_KEY,
-                                deploymentMap.get(offeredDeploymentInternalId) == null ? null
-                                : deploymentMap.get(offeredDeploymentInternalId).getId())
-                        .log("New deployment replacing enqueued deployment");
-                deploymentMap.put(offeredDeploymentInternalId, offeredDeployment);
-                return true;
+        try (LockScope ls = LockScope.lock(lock)) {
+            final String offeredDeploymentInternalId; // the id to employ in the internal queue
+            if (Deployment.DeploymentType.SHADOW.equals(offeredDeployment.getDeploymentType())) {
+                offeredDeploymentInternalId = SHADOW_DEPLOYMENT_QUEUE_ID;
+            } else {
+                offeredDeploymentInternalId = offeredDeployment.getId();
             }
-            logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, offeredDeployment.getId())
-                    .log("New deployment ignored as duplicate");
-            return false;
-        }
 
-        // internal queue id is not in use; enqueue deployment normally
-        deploymentMap.put(offeredDeploymentInternalId, offeredDeployment);
-        return true;
+            if (deploymentMap.containsKey(offeredDeploymentInternalId)) {
+                // internal queue id is already in use; check the replacement criteria
+                final Deployment enqueuedDeployment = deploymentMap.get(offeredDeploymentInternalId);
+                if (checkReplacementCriteria(enqueuedDeployment, offeredDeployment)) {
+                    logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, offeredDeployment.getId())
+                            .kv(DISCARDED_DEPLOYMENT_ID_LOG_KEY,
+                                    deploymentMap.get(offeredDeploymentInternalId) == null ? null
+                                            : deploymentMap.get(offeredDeploymentInternalId).getId())
+                            .log("New deployment replacing enqueued deployment");
+                    deploymentMap.put(offeredDeploymentInternalId, offeredDeployment);
+                    return true;
+                }
+                logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY, offeredDeployment.getId())
+                        .log("New deployment ignored as duplicate");
+                return false;
+            }
+
+            // internal queue id is not in use; enqueue deployment normally
+            deploymentMap.put(offeredDeploymentInternalId, offeredDeployment);
+            return true;
+        }
     }
 
     private boolean checkReplacementCriteria(Deployment enqueued, Deployment offered) {
@@ -132,12 +138,14 @@ public class DeploymentQueue {
      *
      * @return the deployment retrieved from the head of the queue, or null if the queue is empty.
      */
-    public synchronized Deployment poll() {
-        final Iterator<String> deploymentMapIterator = deploymentMap.keySet().iterator();
-        if (deploymentMapIterator.hasNext()) {
-            return deploymentMap.remove(deploymentMapIterator.next());
+    public Deployment poll() {
+        try (LockScope ls = LockScope.lock(lock)) {
+            final Iterator<String> deploymentMapIterator = deploymentMap.keySet().iterator();
+            if (deploymentMapIterator.hasNext()) {
+                return deploymentMap.remove(deploymentMapIterator.next());
+            }
+            return null; // queue is empty
         }
-        return null; // queue is empty
     }
 
     /**
@@ -145,8 +153,10 @@ public class DeploymentQueue {
      *
      * @return true if the queue contains no elements, otherwise false.
      */
-    public synchronized boolean isEmpty() {
-        return deploymentMap.isEmpty();
+    public boolean isEmpty() {
+        try (LockScope ls = LockScope.lock(lock)) {
+            return deploymentMap.isEmpty();
+        }
     }
 
     /**
@@ -154,11 +164,13 @@ public class DeploymentQueue {
      *
      * @return the contents of the queue as a list of deployments.
      */
-    public synchronized List<Deployment> toArray() {
-        final List<Deployment> result = new ArrayList<>();
-        deploymentMap.forEach((key, value) -> {
-            result.add(value);
-        });
-        return result;
+    public List<Deployment> toArray() {
+        try (LockScope ls = LockScope.lock(lock)) {
+            final List<Deployment> result = new ArrayList<>();
+            deploymentMap.forEach((key, value) -> {
+                result.add(value);
+            });
+            return result;
+        }
     }
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -586,6 +586,7 @@ public class GenericExternalService extends GreengrassService {
                 }
             } catch (InterruptedException ex) {
                 logger.atWarn("generic-service-shutdown").log("Thread interrupted while shutting down service");
+                Thread.currentThread().interrupt();
             } finally {
                 stopAllLifecycleProcesses();
 

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
@@ -23,6 +23,8 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.status.model.ComponentStatusDetails;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 import com.aws.greengrass.util.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
@@ -42,6 +44,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -91,6 +94,7 @@ public class GreengrassService implements InjectionActions {
     protected final ConcurrentHashMap<GreengrassService, DependencyInfo> dependencies = new ConcurrentHashMap<>();
     // Service logger instance
     protected final Logger logger;
+    protected final Lock dependenciesLock = LockFactory.newReentrantLock("dependenciesLock");
 
     /**
      * Constructor.
@@ -197,7 +201,7 @@ public class GreengrassService implements InjectionActions {
     }
 
     private void initDependenciesTopic() {
-        synchronized (dependencies) {
+        try (LockScope ls = LockScope.lock(dependenciesLock)) {
             externalDependenciesTopicWatcher = (what, node) -> {
                 if (!WhatHappened.changed.equals(what)) {
                     return;
@@ -489,7 +493,7 @@ public class GreengrassService implements InjectionActions {
             throw new InputValidationException("One or more parameters was null");
         }
 
-        synchronized (dependencies) {
+        try (LockScope ls = LockScope.lock(dependenciesLock)) {
             dependencies.compute(dependencyService, (dependentService, dependencyInfo) -> {
                 // If the dependency already exists, we should first remove the subscriber before creating the
                 // new subscriber with updated input.
@@ -705,7 +709,7 @@ public class GreengrassService implements InjectionActions {
 
     private void setupDependencies(Collection<String> dependencyList)
             throws ServiceLoadException, InputValidationException {
-        synchronized (dependencies) {
+        try (LockScope ls = LockScope.lock(dependenciesLock)) {
             Map<GreengrassService, DependencyType> oldDependencies = new HashMap<>(getDependencies());
             Map<GreengrassService, DependencyType> keptDependencies = getDependencyTypeMap(dependencyList);
 

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -788,7 +788,7 @@ public class Lifecycle {
                             return;
                         } catch (RejectedExecutionException e) {
                             logger.atWarn("service-state-transition-error", e)
-                                    .log("Service lifecycle thread had RejectedExecutionException."
+                                    .log("Service lifecycle thread had RejectedExecutionException. "
                                             + "Since no more tasks can be run, thread will exit now");
                             return;
                         } catch (InterruptedException i) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/ShellRunner.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/ShellRunner.java
@@ -40,7 +40,7 @@ public interface ShellRunner {
         DeviceConfiguration deviceConfiguration;
 
         @Override
-        public synchronized Exec setup(String note, String command, GreengrassService onBehalfOf) throws IOException {
+        public Exec setup(String note, String command, GreengrassService onBehalfOf) throws IOException {
             if (!isEmpty(command) && onBehalfOf != null) {
                 Path cwd = nucleusPaths.workPath(onBehalfOf.getServiceName());
                 Logger logger = getLoggerToUse(onBehalfOf);

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -34,6 +34,8 @@ import com.aws.greengrass.status.model.StatusDetails;
 import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testing.TestFeatureParameters;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 import com.aws.greengrass.util.MqttChunkedPayloadPublisher;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -56,6 +58,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import java.util.function.Function;
 import javax.inject.Inject;
 
@@ -115,7 +118,7 @@ public class FleetStatusService extends GreengrassService {
             Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final ConcurrentHashMap<GreengrassService, Instant> serviceFssTracksMap = new ConcurrentHashMap<>();
     private final AtomicBoolean isDeploymentInProgress = new AtomicBoolean(false);
-    private final Object periodicUpdateInProgressLock = new Object();
+    private final Lock periodicUpdateInProgressLock = LockFactory.newReentrantLock(this);
     @Setter // Needed for integration tests.
     @Getter(AccessLevel.PACKAGE) // Needed for unit tests.
     private int periodicPublishIntervalSec;
@@ -123,7 +126,7 @@ public class FleetStatusService extends GreengrassService {
     // default to zero so that first Reconnect update would go thru
     private Instant lastReconnectUpdateTime = Instant.EPOCH;
     private final AtomicReference<Instant> lastFSSPublishTime = new AtomicReference<>(Instant.EPOCH);
-    private final Object publishLock = new Object();
+    private final Lock publishLock = LockFactory.newReentrantLock("fssPublishLock");
     private final ScheduledExecutorService ses;
     // Used for unit test
     @Setter
@@ -154,6 +157,7 @@ public class FleetStatusService extends GreengrassService {
             schedulePeriodicFleetStatusDataUpdate(false);
         }
     };
+    private final Lock serviceSetLock = LockFactory.newReentrantLock("serviceSetLock");
 
     /**
      * Constructor for FleetStatusService.
@@ -295,7 +299,7 @@ public class FleetStatusService extends GreengrassService {
             periodicUpdateFuture.cancel(false);
         }
 
-        synchronized (periodicUpdateInProgressLock) {
+        try (LockScope ls = LockScope.lock(periodicUpdateInProgressLock)) {
             Instant lastPeriodicUpdateTime = Instant.ofEpochMilli(Coerce.toLong(getPeriodicUpdateTimeTopic()));
             if (lastPeriodicUpdateTime.plusSeconds(periodicPublishIntervalSec).isBefore(Instant.now())) {
                 updatePeriodicFleetStatusData();
@@ -318,7 +322,7 @@ public class FleetStatusService extends GreengrassService {
     @SuppressWarnings("PMD.UnusedFormalParameter")
     private void handleServiceStateChange(GreengrassService greengrassService, State oldState,
                                           State newState) {
-        synchronized (updatedGreengrassServiceSet) {
+        try (LockScope ls = LockScope.lock(serviceSetLock)) {
             updatedGreengrassServiceSet.add(greengrassService);
         }
         if (newState.equals(State.ERRORED)) {
@@ -335,7 +339,7 @@ public class FleetStatusService extends GreengrassService {
             }
             // Report status of other components, in case recovery duration takes too long and other components need
             // to wait until all components to reach terminal state to update status
-            synchronized (updatedGreengrassServiceSet) {
+            try (LockScope ls = LockScope.lock(serviceSetLock)) {
                 uploadFleetStatusServiceData(updatedGreengrassServiceSet, overallStatus, null,
                         Trigger.COMPONENT_STATUS_CHANGE);
             }
@@ -346,7 +350,7 @@ public class FleetStatusService extends GreengrassService {
             // if there is no ongoing deployment and we encounter a BROKEN component,
             // update the fleet status as UNHEALTHY.
             if (newState.equals(State.BROKEN)) {
-                synchronized (updatedGreengrassServiceSet) {
+                try (LockScope ls = LockScope.lock(serviceSetLock)) {
                     uploadFleetStatusServiceData(updatedGreengrassServiceSet, OverallStatus.UNHEALTHY,
                             null, Trigger.COMPONENT_STATUS_CHANGE);
                 }
@@ -355,7 +359,7 @@ public class FleetStatusService extends GreengrassService {
             // Send a status update
             if (greengrassService.reachedDesiredState() && !kernelLifecycle.getIsShutdownInitiated().get()
                     && kernelLifecycle.allServicesInTerminalState()) {
-                synchronized (updatedGreengrassServiceSet) {
+                try (LockScope ls = LockScope.lock(serviceSetLock)) {
                     uploadFleetStatusServiceData(updatedGreengrassServiceSet, getOverallStatus(), null,
                             Trigger.COMPONENT_STATUS_CHANGE);
                 }
@@ -384,7 +388,7 @@ public class FleetStatusService extends GreengrassService {
             return;
         }
         logger.atDebug().log("Updating FSS data on a periodic basis");
-        synchronized (periodicUpdateInProgressLock) {
+        try (LockScope ls = LockScope.lock(periodicUpdateInProgressLock)) {
             updateFleetStatusUpdateForAllComponents(Trigger.CADENCE);
             getPeriodicUpdateTimeTopic().withValue(Instant.now().toEpochMilli());
         }
@@ -458,7 +462,7 @@ public class FleetStatusService extends GreengrassService {
         AtomicReference<OverallStatus> overAllStatus = new AtomicReference<>(OverallStatus.HEALTHY);
 
         // if last event-triggered update is still ongoing, wait for it to finish
-        synchronized (updatedGreengrassServiceSet) {
+        try (LockScope ls = LockScope.lock(serviceSetLock)) {
             // Check if the removed dependency is still running (Probably as a dependant service to another service).
             // If so, then remove it from the removedDependencies collection.
             this.kernel.orderedDependencies().forEach(greengrassService -> {
@@ -631,7 +635,7 @@ public class FleetStatusService extends GreengrassService {
         long delay;
 
         // lock to avoid concurrent modifying of lastFSSPublishTime
-        synchronized (publishLock) {
+        try (LockScope ls = LockScope.lock(publishLock)) {
             // add a 10 sec gap between each publish request to avoid message receiving out of order in cloud
             Instant minimalAllowedPublishTime = lastFSSPublishTime.get()
                     .plusSeconds(FLEET_STATUS_MESSAGE_PUBLISH_MIN_WAIT_TIME_SEC);

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -313,7 +313,7 @@ public class FleetStatusService extends GreengrassService {
 
         // Add some jitter as an initial delay. If the fleet has a lot of devices associated to it,
         // we don't want all the devices to send the periodic update for fleet statuses at the same time.
-        long initialDelay = RandomUtils.nextLong(0, maxInitialDelay);
+        long initialDelay = RandomUtils.nextLong(0, maxInitialDelay + 1);
         this.periodicUpdateFuture = ses.scheduleWithFixedDelay(this::updatePeriodicFleetStatusData,
                 initialDelay, periodicPublishIntervalSec, TimeUnit.SECONDS);
     }

--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -309,6 +309,7 @@ public class FleetStatusService extends GreengrassService {
         // service starts up as well, which is not needed.
         if (isDuringConnectionResumed) {
             updateEventTriggeredFleetStatusData(null, Trigger.RECONNECT);
+            maxInitialDelay = periodicPublishIntervalSec;
         }
 
         // Add some jitter as an initial delay. If the fleet has a lot of devices associated to it,

--- a/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/aws/greengrass/telemetry/TelemetryAgent.java
@@ -14,6 +14,8 @@ import com.aws.greengrass.lifecyclemanager.KernelMetricsEmitter;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testing.TestFeatureParameters;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 import com.aws.greengrass.util.MqttChunkedPayloadPublisher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AccessLevel;
@@ -31,6 +33,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import javax.inject.Inject;
 
 @ImplementsService(name = TelemetryAgent.TELEMETRY_AGENT_SERVICE_TOPICS, autostart = true)
@@ -50,8 +53,8 @@ public class TelemetryAgent extends GreengrassService {
     private final MqttClient mqttClient;
     private final MetricsAggregator metricsAggregator;
     private final AtomicBoolean isConnected = new AtomicBoolean(true);
-    private final Object periodicPublishMetricsInProgressLock = new Object();
-    private final Object periodicAggregateMetricsInProgressLock = new Object();
+    private final Lock periodicPublishMetricsInProgressLock = LockFactory.newReentrantLock("publishInProgress");
+    private final Lock periodicAggregateMetricsInProgressLock = LockFactory.newReentrantLock("aggInProgress");
     private final MqttChunkedPayloadPublisher<AggregatedNamespaceData> publisher;
     private final ScheduledExecutorService ses;
     private final ExecutorService executorService;
@@ -172,7 +175,7 @@ public class TelemetryAgent extends GreengrassService {
             return;
         }
         if (isReconfigured) {
-            synchronized (periodicAggregateMetricsInProgressLock) {
+            try (LockScope ls = LockScope.lock(periodicAggregateMetricsInProgressLock)) {
                 Instant lastPeriodicAggTime = Instant.ofEpochMilli(Coerce.toLong(getPeriodicAggregateTimeTopic()));
                 if (lastPeriodicAggTime.plusSeconds(configuration.getPeriodicAggregateMetricsIntervalSeconds())
                         .isBefore(Instant.now())) {
@@ -184,7 +187,7 @@ public class TelemetryAgent extends GreengrassService {
             }
         }
         int periodicAggregateMetricsIntervalSec = configuration.getPeriodicAggregateMetricsIntervalSeconds();
-        synchronized (periodicAggregateMetricsInProgressLock) {
+        try (LockScope ls = LockScope.lock(periodicAggregateMetricsInProgressLock)) {
             for (PeriodicMetricsEmitter emitter : periodicMetricsEmitters) {
                 // Start emitting metrics with no delay. This is device specific where metrics are stored in files.
                 emitter.future = ses.scheduleWithFixedDelay(emitter::emitMetrics, 0,
@@ -215,7 +218,7 @@ public class TelemetryAgent extends GreengrassService {
             return;
         }
         if (isReconfigured) {
-            synchronized (periodicPublishMetricsInProgressLock) {
+            try (LockScope ls = LockScope.lock(periodicPublishMetricsInProgressLock)) {
                 Instant lastPeriodicPubTime = Instant.ofEpochMilli(Coerce.toLong(getPeriodicPublishTimeTopic()));
                 if (lastPeriodicPubTime.plusSeconds(configuration.getPeriodicPublishMetricsIntervalSeconds())
                         .isBefore(Instant.now())) {
@@ -227,7 +230,7 @@ public class TelemetryAgent extends GreengrassService {
         // Add some jitter as an initial delay. If the fleet has a lot of devices associated to it, we don't want
         // all the devices to publish metrics at the same time.
         long initialDelay = RandomUtils.nextLong(0, periodicPublishMetricsIntervalSec + 1);
-        synchronized (periodicPublishMetricsInProgressLock) {
+        try (LockScope ls = LockScope.lock(periodicPublishMetricsInProgressLock)) {
             periodicPublishMetricsFuture = ses.scheduleWithFixedDelay(this::publishPeriodicMetrics, initialDelay,
                     periodicPublishMetricsIntervalSec, TimeUnit.SECONDS);
         }
@@ -285,8 +288,8 @@ public class TelemetryAgent extends GreengrassService {
         }
     }
 
-    private void cancelJob(ScheduledFuture<?> future, Object lock, boolean immediately) {
-        synchronized (lock) {
+    private void cancelJob(ScheduledFuture<?> future, Lock lock, boolean immediately) {
+        try (LockScope ls = LockScope.lock(lock)) {
             if (future != null) {
                 future.cancel(immediately);
             }
@@ -353,7 +356,7 @@ public class TelemetryAgent extends GreengrassService {
                         .getPeriodicAggregateMetricsIntervalSeconds())
                 .enabled(telemetryConfiguration.isEnabled())
                 .build());
-        synchronized (periodicPublishMetricsInProgressLock) {
+        try (LockScope ls = LockScope.lock(periodicPublishMetricsInProgressLock)) {
             if (periodicPublishMetricsFuture != null && telemetryConfiguration.isEnabled()) {
                 schedulePeriodicPublishMetrics(true);
             }
@@ -371,7 +374,7 @@ public class TelemetryAgent extends GreengrassService {
                 .enabled(telemetryConfiguration.isEnabled())
                 .build());
 
-        synchronized (periodicAggregateMetricsInProgressLock) {
+        try (LockScope ls = LockScope.lock(periodicAggregateMetricsInProgressLock)) {
             if (periodicAggregateMetricsFuture != null && telemetryConfiguration.isEnabled()) {
                 schedulePeriodicAggregateMetrics(true);
             }

--- a/src/main/java/com/aws/greengrass/util/LockFactory.java
+++ b/src/main/java/com/aws/greengrass/util/LockFactory.java
@@ -10,9 +10,21 @@ import vendored.com.google.common.util.concurrent.CycleDetectingLockFactory;
 import java.util.concurrent.locks.Lock;
 
 public final class LockFactory {
+    private static CycleDetectingLockFactory.Policy policy;
+
+    // Setup factory to throw exceptions when we are testing.
+    // We detect that we are testing by checking for the JUnit @Test annotation in our classpath.
+    static {
+        try {
+            Class.forName("org.junit.jupiter.api.Test");
+            policy = CycleDetectingLockFactory.Policies.THROW;
+        } catch (ClassNotFoundException e) {
+            policy = CycleDetectingLockFactory.Policies.DISABLED;
+        }
+    }
 
     private static final CycleDetectingLockFactory factory =
-            CycleDetectingLockFactory.newInstance(CycleDetectingLockFactory.Policies.THROW);
+            CycleDetectingLockFactory.newInstance(policy);
 
     private LockFactory() {
     }

--- a/src/main/java/com/aws/greengrass/util/LockFactory.java
+++ b/src/main/java/com/aws/greengrass/util/LockFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import vendored.com.google.common.util.concurrent.CycleDetectingLockFactory;
+
+import java.util.concurrent.locks.Lock;
+
+public final class LockFactory {
+
+    private static final CycleDetectingLockFactory factory =
+            CycleDetectingLockFactory.newInstance(CycleDetectingLockFactory.Policies.THROW);
+
+    private LockFactory() {
+    }
+
+    public static Lock newReentrantLock(Object self) {
+        return newReentrantLock(self.getClass().getSimpleName());
+    }
+
+    public static Lock newReentrantLock(String name) {
+        return factory.newReentrantLock(name);
+    }
+}

--- a/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtilsFactory.java
+++ b/src/main/java/com/aws/greengrass/util/orchestration/SystemServiceUtilsFactory.java
@@ -9,6 +9,8 @@ import com.aws.greengrass.config.PlatformResolver;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 
@@ -16,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.concurrent.locks.Lock;
 import javax.inject.Inject;
 
 @AllArgsConstructor(onConstructor = @__(@Inject))
@@ -23,6 +26,7 @@ public class SystemServiceUtilsFactory {
     protected static final Logger logger = LogManager.getLogger(SystemServiceUtilsFactory.class);
 
     private final Context context;
+    private final Lock lock = LockFactory.newReentrantLock(this);
 
     /**
      * Get the appropriate instance of Platform for the current platform.
@@ -30,29 +34,31 @@ public class SystemServiceUtilsFactory {
      * @return Platform
      */
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-    public synchronized SystemServiceUtils getInstance() {
-        if (PlatformResolver.isWindows) {
-            return context.get(WinswUtils.class);
-        }
-
-        try {
-            String bootPath = Files.readSymbolicLink(Paths.get("/sbin/init")).toString();
-            if (bootPath.contains("systemd")) {
-                logger.atDebug().log("Detected systemd on the device");
-                return context.get(SystemdUtils.class);
+    public SystemServiceUtils getInstance() {
+        try (LockScope ls = LockScope.lock(lock)) {
+            if (PlatformResolver.isWindows) {
+                return context.get(WinswUtils.class);
             }
-        } catch (IOException e) {
-            logger.atDebug().log("Unable to determine init process type");
-        }
 
-        if (new File("/sbin/procd").isFile()) {
-            logger.atDebug().log("Detected procd on the device");
-            return context.get(ProcdUtils.class);
-        } else {
-            logger.atDebug().log("No procd is detected");
-        }
+            try {
+                String bootPath = Files.readSymbolicLink(Paths.get("/sbin/init")).toString();
+                if (bootPath.contains("systemd")) {
+                    logger.atDebug().log("Detected systemd on the device");
+                    return context.get(SystemdUtils.class);
+                }
+            } catch (IOException e) {
+                logger.atDebug().log("Unable to determine init process type");
+            }
 
-        logger.atError().log("Unable to determine system service type");
-        return context.get(InitUtils.class);
+            if (new File("/sbin/procd").isFile()) {
+                logger.atDebug().log("Detected procd on the device");
+                return context.get(ProcdUtils.class);
+            } else {
+                logger.atDebug().log("No procd is detected");
+            }
+
+            logger.atError().log("Unable to determine system service type");
+            return context.get(InitUtils.class);
+        }
     }
 }

--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixExec.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixExec.java
@@ -6,6 +6,8 @@
 package com.aws.greengrass.util.platforms.unix;
 
 import com.aws.greengrass.util.Exec;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 import com.aws.greengrass.util.platforms.Platform;
 import org.zeroturnaround.process.PidProcess;
 import org.zeroturnaround.process.Processes;
@@ -19,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -31,6 +34,8 @@ public class UnixExec extends Exec {
         ensurePresent("/bin", "/usr/bin", "/sbin", "/usr/sbin");
         computeDefaultPathString();
     }
+
+    private final Lock lock = LockFactory.newReentrantLock(this);
 
     UnixExec() {
         super();
@@ -92,51 +97,55 @@ public class UnixExec extends Exec {
     }
 
     @Override
-    public synchronized void close() throws IOException {
-        if (isClosed.get()) {
-            return;
-        }
-        Process p = process;
-        if (p == null || !p.isAlive()) {
-            return;
-        }
-
-        Platform platformInstance = Platform.getInstance();
-
-        Set<Integer> pids = Collections.emptySet();
-        try {
-            pids = platformInstance.killProcessAndChildren(p, false, pids, userDecorator);
-            // TODO: [P41214162] configurable timeout
-            // Wait for it to die, but ignore the outcome and just forcefully kill it and all its
-            // children anyway. This way, any misbehaving children or grandchildren will be killed
-            // whether or not the parent behaved appropriately.
-
-            // Wait up to 5 seconds for each child process to stop
-            List<PidProcess> pidProcesses = pids.stream().map(Processes::newPidProcess).collect(Collectors.toList());
-            for (PidProcess pp : pidProcesses) {
-                pp.waitFor(gracefulShutdownTimeout.getSeconds(), TimeUnit.SECONDS);
+    public void close() throws IOException {
+        try (LockScope ls = LockScope.lock(lock)) {
+            if (isClosed.get()) {
+                return;
             }
-            if (pidProcesses.stream().anyMatch(pidProcess -> {
-                try {
-                    return pidProcess.isAlive();
-                } catch (IOException ignored) {
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-                return false;
-            })) {
-                logger.atWarn()
-                        .log("Command {} did not respond to interruption within timeout. Going to kill it now", this);
+            Process p = process;
+            if (p == null || !p.isAlive()) {
+                return;
             }
-            platformInstance.killProcessAndChildren(p, true, pids, userDecorator);
-            if (!p.waitFor(5, TimeUnit.SECONDS) && !isClosed.get()) {
-                throw new IOException("Could not stop " + this);
-            }
-        } catch (InterruptedException e) {
-            // If we're interrupted make sure to kill the process before returning
+
+            Platform platformInstance = Platform.getInstance();
+
+            Set<Integer> pids = Collections.emptySet();
             try {
+                pids = platformInstance.killProcessAndChildren(p, false, pids, userDecorator);
+                // TODO: [P41214162] configurable timeout
+                // Wait for it to die, but ignore the outcome and just forcefully kill it and all its
+                // children anyway. This way, any misbehaving children or grandchildren will be killed
+                // whether or not the parent behaved appropriately.
+
+                // Wait up to 5 seconds for each child process to stop
+                List<PidProcess> pidProcesses =
+                        pids.stream().map(Processes::newPidProcess).collect(Collectors.toList());
+                for (PidProcess pp : pidProcesses) {
+                    pp.waitFor(gracefulShutdownTimeout.getSeconds(), TimeUnit.SECONDS);
+                }
+                if (pidProcesses.stream().anyMatch(pidProcess -> {
+                    try {
+                        return pidProcess.isAlive();
+                    } catch (IOException ignored) {
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return false;
+                })) {
+                    logger.atWarn()
+                            .log("Command {} did not respond to interruption within timeout. Going to kill it now",
+                                    this);
+                }
                 platformInstance.killProcessAndChildren(p, true, pids, userDecorator);
-            } catch (InterruptedException ignore) {
+                if (!p.waitFor(5, TimeUnit.SECONDS) && !isClosed.get()) {
+                    throw new IOException("Could not stop " + this);
+                }
+            } catch (InterruptedException e) {
+                // If we're interrupted make sure to kill the process before returning
+                try {
+                    platformInstance.killProcessAndChildren(p, true, pids, userDecorator);
+                } catch (InterruptedException ignore) {
+                }
             }
         }
     }

--- a/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/windows/WindowsPlatform.java
@@ -12,6 +12,8 @@ import com.aws.greengrass.lifecyclemanager.RunWith;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Exec;
 import com.aws.greengrass.util.FileSystemPermission;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
 import com.aws.greengrass.util.Utils;
 import com.aws.greengrass.util.platforms.Platform;
 import com.aws.greengrass.util.platforms.RunWithGenerator;
@@ -25,6 +27,7 @@ import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Kernel32Util;
 import com.sun.jna.platform.win32.Win32Exception;
 import com.sun.jna.platform.win32.WinBase;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.zeroturnaround.exec.InvalidExitValueException;
@@ -54,6 +57,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -84,6 +88,7 @@ public class WindowsPlatform extends Platform {
             WindowsUserAttributes.builder().superUser(true).superUserKnown(true)
                     .principalIdentifier(LOCAL_SYSTEM_SID).principalName(LOCAL_SYSTEM_USERNAME)
                     .build();
+    private static final Lock lock = LockFactory.newReentrantLock(WindowsPlatform.class.getSimpleName());
 
     private final SystemResourceController systemResourceController = new StubResourceController();
     private static WindowsUserAttributes CURRENT_USER;
@@ -511,43 +516,43 @@ public class WindowsPlatform extends Platform {
         return loadCurrentUser();
     }
 
-    private static synchronized WindowsUserAttributes loadCurrentUser() throws IOException {
-        if (CURRENT_USER != null) {
-            return CURRENT_USER;
-        }
-
-        String user = System.getProperty("user.name");
-        if (Utils.isEmpty(user)) {
-            throw new IOException("No user to lookup");
-        }
-
-        // Looking up "SYSTEM" will always fail, so short circuit with its well known attributes
-        if (user.equalsIgnoreCase(getComputerName() + "$") || user.equals(LOCAL_SYSTEM_USERNAME)) {
-            CURRENT_USER = LOCAL_SYSTEM_USER_ATTRIBUTES;
-            return CURRENT_USER;
-        }
-
-        Advapi32Util.Account account;
-        try {
-            account = Advapi32Util.getAccountByName(user);
-        } catch (Win32Exception e) {
-            throw new IOException("Unrecognized user: " + user, e);
-        }
-        boolean superUser = false;
-        for (Advapi32Util.Account group : Advapi32Util.getCurrentUserGroups()) {
-            if (ADMINISTRATORS_SID.equalsIgnoreCase(group.sidString)) {
-                superUser = true;
-                break;
+    @SuppressFBWarnings(value = "LI_LAZY_INIT_UPDATE_STATIC", justification = "We are properly locking")
+    private static WindowsUserAttributes loadCurrentUser() throws IOException {
+        try (LockScope ls = LockScope.lock(lock)) {
+            if (CURRENT_USER != null) {
+                return CURRENT_USER;
             }
-        }
 
-        CURRENT_USER = WindowsUserAttributes.builder()
-                .principalName(account.name)
-                .principalIdentifier(account.sidString)
-                .superUserKnown(true)
-                .superUser(superUser)
-                .build();
-        return CURRENT_USER;
+            String user = System.getProperty("user.name");
+            if (Utils.isEmpty(user)) {
+                throw new IOException("No user to lookup");
+            }
+
+            // Looking up "SYSTEM" will always fail, so short circuit with its well known attributes
+            if (user.equalsIgnoreCase(getComputerName() + "$") || user.equals(LOCAL_SYSTEM_USERNAME)) {
+                CURRENT_USER = LOCAL_SYSTEM_USER_ATTRIBUTES;
+                return CURRENT_USER;
+            }
+
+            Advapi32Util.Account account;
+            try {
+                account = Advapi32Util.getAccountByName(user);
+            } catch (Win32Exception e) {
+                throw new IOException("Unrecognized user: " + user, e);
+            }
+            boolean superUser = false;
+            for (Advapi32Util.Account group : Advapi32Util.getCurrentUserGroups()) {
+                if (ADMINISTRATORS_SID.equalsIgnoreCase(group.sidString)) {
+                    superUser = true;
+                    break;
+                }
+            }
+
+            CURRENT_USER =
+                    WindowsUserAttributes.builder().principalName(account.name).principalIdentifier(account.sidString)
+                            .superUserKnown(true).superUser(superUser).build();
+            return CURRENT_USER;
+        }
     }
 
     /**

--- a/src/main/java/vendored/com/google/common/util/concurrent/CycleDetectingLockFactory.java
+++ b/src/main/java/vendored/com/google/common/util/concurrent/CycleDetectingLockFactory.java
@@ -658,8 +658,11 @@ public class CycleDetectingLockFactory {
             if (found != null) {
                 return found; // Found a path ending at the node!
             }
+
+            // Copy to prevent concurrent modification while iterating
+            WeakHashMap<LockGraphNode, ExampleStackTrace> copyLocks = new WeakHashMap<>(allowedPriorLocks);
             // Recurse the edges.
-            for (Entry<LockGraphNode, ExampleStackTrace> entry : allowedPriorLocks.entrySet()) {
+            for (Entry<LockGraphNode, ExampleStackTrace> entry : copyLocks.entrySet()) {
                 LockGraphNode preAcquiredLock = entry.getKey();
                 found = preAcquiredLock.findPathTo(node, seen);
                 if (found != null) {

--- a/src/main/java/vendored/com/google/common/util/concurrent/CycleDetectingLockFactory.java
+++ b/src/main/java/vendored/com/google/common/util/concurrent/CycleDetectingLockFactory.java
@@ -14,6 +14,8 @@
 
 package vendored.com.google.common.util.concurrent;
 
+import com.aws.greengrass.logging.impl.LogManager;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -185,6 +187,7 @@ public class CycleDetectingLockFactory {
         THROW {
             @Override
             public void handlePotentialDeadlock(PotentialDeadlockException e) {
+                LogManager.getLogger(CycleDetectingLockFactory.class).atError().log("Possible deadlock", e);
                 throw e;
             }
         },

--- a/src/main/java/vendored/com/google/common/util/concurrent/CycleDetectingLockFactory.java
+++ b/src/main/java/vendored/com/google/common/util/concurrent/CycleDetectingLockFactory.java
@@ -1,0 +1,944 @@
+/*
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package vendored.com.google.common.util.concurrent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.CheckForNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The {@code CycleDetectingLockFactory} creates {@link ReentrantLock} instances and {@link
+ * ReentrantReadWriteLock} instances that detect potential deadlock by checking for cycles in lock
+ * acquisition order.
+ *
+ * <p>Potential deadlocks detected when calling the {@code lock()}, {@code lockInterruptibly()}, or
+ * {@code tryLock()} methods will result in the execution of the {@link Policy} specified when
+ * creating the factory. The currently available policies are:
+ *
+ * <ul>
+ *   <li>DISABLED
+ *   <li>WARN
+ *   <li>THROW
+ * </ul>
+ *
+ * <p>The locks created by a factory instance will detect lock acquisition cycles with locks created
+ * by other {@code CycleDetectingLockFactory} instances (except those with {@code Policy.DISABLED}).
+ * A lock's behavior when a cycle is detected, however, is defined by the {@code Policy} of the
+ * factory that created it. This allows detection of cycles across components while delegating
+ * control over lock behavior to individual components.
+ *
+ * <p>Applications are encouraged to use a {@code CycleDetectingLockFactory} to create any locks for
+ * which external/unmanaged code is executed while the lock is held. (See caveats under
+ * <strong>Performance</strong>).
+ *
+ * <p><strong>Cycle Detection</strong>
+ *
+ * <p>Deadlocks can arise when locks are acquired in an order that forms a cycle. In a simple
+ * example involving two locks and two threads, deadlock occurs when one thread acquires Lock A, and
+ * then Lock B, while another thread acquires Lock B, and then Lock A:
+ *
+ * <pre>
+ * Thread1: acquire(LockA) --X acquire(LockB)
+ * Thread2: acquire(LockB) --X acquire(LockA)
+ * </pre>
+ *
+ * <p>Neither thread will progress because each is waiting for the other. In more complex
+ * applications, cycles can arise from interactions among more than 2 locks:
+ *
+ * <pre>
+ * Thread1: acquire(LockA) --X acquire(LockB)
+ * Thread2: acquire(LockB) --X acquire(LockC)
+ * ...
+ * ThreadN: acquire(LockN) --X acquire(LockA)
+ * </pre>
+ *
+ * <p>The implementation detects cycles by constructing a directed graph in which each lock
+ * represents a node and each edge represents an acquisition ordering between two locks.
+ *
+ * <ul>
+ *   <li>Each lock adds (and removes) itself to/from a ThreadLocal Set of acquired locks when the
+ *       Thread acquires its first hold (and releases its last remaining hold).
+ *   <li>Before the lock is acquired, the lock is checked against the current set of acquired
+ *       locks---to each of the acquired locks, an edge from the soon-to-be-acquired lock is either
+ *       verified or created.
+ *   <li>If a new edge needs to be created, the outgoing edges of the acquired locks are traversed
+ *       to check for a cycle that reaches the lock to be acquired. If no cycle is detected, a new
+ *       "safe" edge is created.
+ *   <li>If a cycle is detected, an "unsafe" (cyclic) edge is created to represent a potential
+ *       deadlock situation, and the appropriate Policy is executed.
+ * </ul>
+ *
+ * <p>Note that detection of potential deadlock does not necessarily indicate that deadlock will
+ * happen, as it is possible that higher level application logic prevents the cyclic lock
+ * acquisition from occurring. One example of a false positive is:
+ *
+ * <pre>
+ * LockA -&gt; LockB -&gt; LockC
+ * LockA -&gt; LockC -&gt; LockB
+ * </pre>
+ *
+ * <p><strong>ReadWriteLocks</strong>
+ *
+ * <p>While {@code ReadWriteLock} instances have different properties and can form cycles without
+ * potential deadlock, this class treats {@code ReadWriteLock} instances as equivalent to
+ * traditional exclusive locks. Although this increases the false positives that the locks detect
+ * (i.e. cycles that will not actually result in deadlock), it simplifies the algorithm and
+ * implementation considerably. The assumption is that a user of this factory wishes to eliminate
+ * any cyclic acquisition ordering.
+ *
+ * <p><strong>Explicit Lock Acquisition Ordering</strong>
+ *
+ * <p>The {@link CycleDetectingLockFactory.WithExplicitOrdering} class can be used to enforce an
+ * application-specific ordering in addition to performing general cycle detection.
+ *
+ * <p><strong>Garbage Collection</strong>
+ *
+ * <p>In order to allow proper garbage collection of unused locks, the edges of the lock graph are
+ * weak references.
+ *
+ * <p><strong>Performance</strong>
+ *
+ * <p>The extra bookkeeping done by cycle detecting locks comes at some cost to performance.
+ * Benchmarks (as of December 2011) show that:
+ *
+ * <ul>
+ *   <li>for an unnested {@code lock()} and {@code unlock()}, a cycle detecting lock takes 38ns as
+ *       opposed to the 24ns taken by a plain lock.
+ *   <li>for nested locking, the cost increases with the depth of the nesting:
+ *       <ul>
+ *         <li>2 levels: average of 64ns per lock()/unlock()
+ *         <li>3 levels: average of 77ns per lock()/unlock()
+ *         <li>4 levels: average of 99ns per lock()/unlock()
+ *         <li>5 levels: average of 103ns per lock()/unlock()
+ *         <li>10 levels: average of 184ns per lock()/unlock()
+ *         <li>20 levels: average of 393ns per lock()/unlock()
+ *       </ul>
+ * </ul>
+ *
+ * <p>As such, the CycleDetectingLockFactory may not be suitable for performance-critical
+ * applications which involve tightly-looped or deeply-nested locking algorithms.
+ *
+ * @author Darick Tong
+ * @since 13.0
+ */
+public class CycleDetectingLockFactory {
+
+    /**
+     * Encapsulates the action to be taken when a potential deadlock is encountered. Clients can use
+     * one of the predefined {@link Policies} or specify a custom implementation. Implementations must
+     * be thread-safe.
+     *
+     * @since 13.0
+     */
+    public interface Policy {
+
+        /**
+         * Called when a potential deadlock is encountered. Implementations can throw the given {@code
+         * exception} and/or execute other desired logic.
+         *
+         * <p>Note that the method will be called even upon an invocation of {@code tryLock()}. Although
+         * {@code tryLock()} technically recovers from deadlock by eventually timing out, this behavior
+         * is chosen based on the assumption that it is the application's wish to prohibit any cyclical
+         * lock acquisitions.
+         */
+        void handlePotentialDeadlock(PotentialDeadlockException exception);
+    }
+
+    /**
+     * Pre-defined {@link Policy} implementations.
+     *
+     * @since 13.0
+     */
+    public enum Policies implements Policy {
+        /**
+         * When potential deadlock is detected, this policy results in the throwing of the {@code
+         * PotentialDeadlockException} indicating the potential deadlock, which includes stack traces
+         * illustrating the cycle in lock acquisition order.
+         */
+        THROW {
+            @Override
+            public void handlePotentialDeadlock(PotentialDeadlockException e) {
+                throw e;
+            }
+        },
+
+        /**
+         * Disables cycle detection. This option causes the factory to return unmodified lock
+         * implementations provided by the JDK, and is provided to allow applications to easily
+         * parameterize when cycle detection is enabled.
+         *
+         * <p>Note that locks created by a factory with this policy will <em>not</em> participate the
+         * cycle detection performed by locks created by other factories.
+         */
+        DISABLED {
+            @Override
+            public void handlePotentialDeadlock(PotentialDeadlockException e) {}
+        };
+    }
+
+    /** Creates a new factory with the specified policy. */
+    public static CycleDetectingLockFactory newInstance(Policy policy) {
+        return new CycleDetectingLockFactory(policy);
+    }
+
+    /** Equivalent to {@code newReentrantLock(lockName, false)}. */
+    public ReentrantLock newReentrantLock(String lockName) {
+        return newReentrantLock(lockName, false);
+    }
+
+    /**
+     * Creates a {@link ReentrantLock} with the given fairness policy. The {@code lockName} is used in
+     * the warning or exception output to help identify the locks involved in the detected deadlock.
+     */
+    public ReentrantLock newReentrantLock(String lockName, boolean fair) {
+        return policy == Policies.DISABLED
+                ? new ReentrantLock(fair)
+                : new CycleDetectingReentrantLock(new LockGraphNode(lockName), fair);
+    }
+
+    /** Equivalent to {@code newReentrantReadWriteLock(lockName, false)}. */
+    public ReentrantReadWriteLock newReentrantReadWriteLock(String lockName) {
+        return newReentrantReadWriteLock(lockName, false);
+    }
+
+    /**
+     * Creates a {@link ReentrantReadWriteLock} with the given fairness policy. The {@code lockName}
+     * is used in the warning or exception output to help identify the locks involved in the detected
+     * deadlock.
+     */
+    public ReentrantReadWriteLock newReentrantReadWriteLock(String lockName, boolean fair) {
+        return policy == Policies.DISABLED
+                ? new ReentrantReadWriteLock(fair)
+                : new CycleDetectingReentrantReadWriteLock(new LockGraphNode(lockName), fair);
+    }
+
+    // A static mapping from an Enum type to its set of LockGraphNodes.
+    private static final ConcurrentMap<
+            Class<? extends Enum<?>>, Map<? extends Enum<?>, LockGraphNode>>
+            lockGraphNodesPerType = new ConcurrentHashMap<>();
+
+    /** Creates a {@code CycleDetectingLockFactory.WithExplicitOrdering<E>}. */
+    public static <E extends Enum<E>> WithExplicitOrdering<E> newInstanceWithExplicitOrdering(
+            Class<E> enumClass, Policy policy) {
+        // createNodes maps each enumClass to a Map with the corresponding enum key
+        // type.
+        requireNonNull(enumClass);
+        requireNonNull(policy);
+        @SuppressWarnings("unchecked")
+        Map<E, LockGraphNode> lockGraphNodes = (Map<E, LockGraphNode>) getOrCreateNodes(enumClass);
+        return new WithExplicitOrdering<>(policy, lockGraphNodes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Enum<E>> Map<? extends E, LockGraphNode> getOrCreateNodes(
+            Class<E> clazz) {
+        Map<E, LockGraphNode> existing = (Map<E, LockGraphNode>) lockGraphNodesPerType.get(clazz);
+        if (existing != null) {
+            return existing;
+        }
+        Map<E, LockGraphNode> created = createNodes(clazz);
+        existing = (Map<E, LockGraphNode>) lockGraphNodesPerType.putIfAbsent(clazz, created);
+        return existing == null ? created : existing;
+    }
+
+    /**
+     * For a given Enum type, creates an immutable map from each of the Enum's values to a
+     * corresponding LockGraphNode, with the {@code allowedPriorLocks} and {@code
+     * disallowedPriorLocks} prepopulated with nodes according to the natural ordering of the
+     * associated Enum values.
+     */
+    static <E extends Enum<E>> Map<E, LockGraphNode> createNodes(Class<E> clazz) {
+        EnumMap<E, LockGraphNode> map = new EnumMap<>(clazz);
+        E[] keys = clazz.getEnumConstants();
+        int numKeys = keys.length;
+        ArrayList<LockGraphNode> nodes = new ArrayList<>(numKeys);
+        // Create a LockGraphNode for each enum value.
+        for (E key : keys) {
+            LockGraphNode node = new LockGraphNode(getLockName(key));
+            nodes.add(node);
+            map.put(key, node);
+        }
+        // Pre-populate all allowedPriorLocks with nodes of smaller ordinal.
+        for (int i = 1; i < numKeys; i++) {
+            nodes.get(i).checkAcquiredLocks(Policies.THROW, nodes.subList(0, i));
+        }
+        // Pre-populate all disallowedPriorLocks with nodes of larger ordinal.
+        for (int i = 0; i < numKeys - 1; i++) {
+            nodes.get(i).checkAcquiredLocks(Policies.DISABLED, nodes.subList(i + 1, numKeys));
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * For the given Enum value {@code rank}, returns the value's {@code "EnumClass.name"}, which is
+     * used in exception and warning output.
+     */
+    private static String getLockName(Enum<?> rank) {
+        return rank.getDeclaringClass().getSimpleName() + "." + rank.name();
+    }
+
+    /**
+     * A {@code CycleDetectingLockFactory.WithExplicitOrdering} provides the additional enforcement of
+     * an application-specified ordering of lock acquisitions. The application defines the allowed
+     * ordering with an {@code Enum} whose values each correspond to a lock type. The order in which
+     * the values are declared dictates the allowed order of lock acquisition. In other words, locks
+     * corresponding to smaller values of {@link Enum#ordinal()} should only be acquired before locks
+     * with larger ordinals. Example:
+     *
+     * <pre>{@code
+     * enum MyLockOrder {
+     *   FIRST, SECOND, THIRD;
+     * }
+     *
+     * CycleDetectingLockFactory.WithExplicitOrdering<MyLockOrder> factory =
+     *   CycleDetectingLockFactory.newInstanceWithExplicitOrdering(Policies.THROW);
+     *
+     * Lock lock1 = factory.newReentrantLock(MyLockOrder.FIRST);
+     * Lock lock2 = factory.newReentrantLock(MyLockOrder.SECOND);
+     * Lock lock3 = factory.newReentrantLock(MyLockOrder.THIRD);
+     *
+     * lock1.lock();
+     * lock3.lock();
+     * lock2.lock();  // will throw an IllegalStateException
+     * }</pre>
+     *
+     * <p>As with all locks created by instances of {@code CycleDetectingLockFactory} explicitly
+     * ordered locks participate in general cycle detection with all other cycle detecting locks, and
+     * a lock's behavior when detecting a cyclic lock acquisition is defined by the {@code Policy} of
+     * the factory that created it.
+     *
+     * <p>Note, however, that although multiple locks can be created for a given Enum value, whether
+     * it be through separate factory instances or through multiple calls to the same factory,
+     * attempting to acquire multiple locks with the same Enum value (within the same thread) will
+     * result in an IllegalStateException regardless of the factory's policy. For example:
+     *
+     * <pre>{@code
+     * CycleDetectingLockFactory.WithExplicitOrdering<MyLockOrder> factory1 =
+     *   CycleDetectingLockFactory.newInstanceWithExplicitOrdering(...);
+     * CycleDetectingLockFactory.WithExplicitOrdering<MyLockOrder> factory2 =
+     *   CycleDetectingLockFactory.newInstanceWithExplicitOrdering(...);
+     *
+     * Lock lockA = factory1.newReentrantLock(MyLockOrder.FIRST);
+     * Lock lockB = factory1.newReentrantLock(MyLockOrder.FIRST);
+     * Lock lockC = factory2.newReentrantLock(MyLockOrder.FIRST);
+     *
+     * lockA.lock();
+     *
+     * lockB.lock();  // will throw an IllegalStateException
+     * lockC.lock();  // will throw an IllegalStateException
+     *
+     * lockA.lock();  // reentrant acquisition is okay
+     * }</pre>
+     *
+     * <p>It is the responsibility of the application to ensure that multiple lock instances with the
+     * same rank are never acquired in the same thread.
+     *
+     * @param <E> The Enum type representing the explicit lock ordering.
+     * @since 13.0
+     */
+    public static final class WithExplicitOrdering<E extends Enum<E>>
+            extends CycleDetectingLockFactory {
+
+        private final Map<E, LockGraphNode> lockGraphNodes;
+
+        WithExplicitOrdering(Policy policy, Map<E, LockGraphNode> lockGraphNodes) {
+            super(policy);
+            this.lockGraphNodes = lockGraphNodes;
+        }
+
+        /** Equivalent to {@code newReentrantLock(rank, false)}. */
+        public ReentrantLock newReentrantLock(E rank) {
+            return newReentrantLock(rank, false);
+        }
+
+        /**
+         * Creates a {@link ReentrantLock} with the given fairness policy and rank. The values returned
+         * by {@link Enum#getDeclaringClass()} and {@link Enum#name()} are used to describe the lock in
+         * warning or exception output.
+         *
+         * @throws IllegalStateException If the factory has already created a {@code Lock} with the
+         *     specified rank.
+         */
+        public ReentrantLock newReentrantLock(E rank, boolean fair) {
+            return policy == Policies.DISABLED
+                    ? new ReentrantLock(fair)
+                    // requireNonNull is safe because createNodes inserts an entry for every E.
+                    // (If the caller passes `null` for the `rank` parameter, this will throw, but that's OK.)
+                    : new CycleDetectingReentrantLock(requireNonNull(lockGraphNodes.get(rank)), fair);
+        }
+
+        /** Equivalent to {@code newReentrantReadWriteLock(rank, false)}. */
+        public ReentrantReadWriteLock newReentrantReadWriteLock(E rank) {
+            return newReentrantReadWriteLock(rank, false);
+        }
+
+        /**
+         * Creates a {@link ReentrantReadWriteLock} with the given fairness policy and rank. The values
+         * returned by {@link Enum#getDeclaringClass()} and {@link Enum#name()} are used to describe the
+         * lock in warning or exception output.
+         *
+         * @throws IllegalStateException If the factory has already created a {@code Lock} with the
+         *     specified rank.
+         */
+        public ReentrantReadWriteLock newReentrantReadWriteLock(E rank, boolean fair) {
+            return policy == Policies.DISABLED
+                    ? new ReentrantReadWriteLock(fair)
+                    // requireNonNull is safe because createNodes inserts an entry for every E.
+                    // (If the caller passes `null` for the `rank` parameter, this will throw, but that's OK.)
+                    : new CycleDetectingReentrantReadWriteLock(
+                            requireNonNull(lockGraphNodes.get(rank)), fair);
+        }
+    }
+
+    //////// Implementation /////////
+
+    final Policy policy;
+
+    private CycleDetectingLockFactory(Policy policy) {
+        this.policy = requireNonNull(policy);
+    }
+
+    /**
+     * Tracks the currently acquired locks for each Thread, kept up to date by calls to {@link
+     * #aboutToAcquire(CycleDetectingLock)} and {@link #lockStateChanged(CycleDetectingLock)}.
+     */
+    // This is logically a Set, but an ArrayList is used to minimize the amount
+    // of allocation done on lock()/unlock().
+    private static final ThreadLocal<ArrayList<LockGraphNode>> acquiredLocks =
+            ThreadLocal.withInitial(() -> new ArrayList<>(3));
+
+    /**
+     * A Throwable used to record a stack trace that illustrates an example of a specific lock
+     * acquisition ordering. The top of the stack trace is truncated such that it starts with the
+     * acquisition of the lock in question, e.g.
+     *
+     * <pre>
+     * com...ExampleStackTrace: LockB -&gt; LockC
+     *   at com...CycleDetectingReentrantLock.lock(CycleDetectingLockFactory.java:443)
+     *   at ...
+     *   at ...
+     *   at com...MyClass.someMethodThatAcquiresLockB(MyClass.java:123)
+     * </pre>
+     */
+    private static class ExampleStackTrace extends IllegalStateException {
+
+        static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
+
+        static final Set<String> EXCLUDED_CLASS_NAMES =
+                Collections.unmodifiableSet(new HashSet<String>() {{
+                    this.add(CycleDetectingLockFactory.class.getName());
+                    this.add(ExampleStackTrace.class.getName());
+                    this.add(LockGraphNode.class.getName());
+                }});
+
+        ExampleStackTrace(LockGraphNode node1, LockGraphNode node2) {
+            super(node1.getLockName() + " -> " + node2.getLockName());
+            StackTraceElement[] origStackTrace = getStackTrace();
+            for (int i = 0, n = origStackTrace.length; i < n; i++) {
+                if (WithExplicitOrdering.class.getName().equals(origStackTrace[i].getClassName())) {
+                    // For pre-populated disallowedPriorLocks edges, omit the stack trace.
+                    setStackTrace(EMPTY_STACK_TRACE);
+                    break;
+                }
+                if (!EXCLUDED_CLASS_NAMES.contains(origStackTrace[i].getClassName())) {
+                    setStackTrace(Arrays.copyOfRange(origStackTrace, i, n));
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Represents a detected cycle in lock acquisition ordering. The exception includes a causal chain
+     * of {@code ExampleStackTrace} instances to illustrate the cycle, e.g.
+     *
+     * <pre>
+     * com....PotentialDeadlockException: Potential Deadlock from LockC -&gt; ReadWriteA
+     *   at ...
+     *   at ...
+     * Caused by: com...ExampleStackTrace: LockB -&gt; LockC
+     *   at ...
+     *   at ...
+     * Caused by: com...ExampleStackTrace: ReadWriteA -&gt; LockB
+     *   at ...
+     *   at ...
+     * </pre>
+     *
+     * <p>Instances are logged for the {@code Policies.WARN}, and thrown for {@code Policies.THROW}.
+     *
+     * @since 13.0
+     */
+    public static final class PotentialDeadlockException extends ExampleStackTrace {
+
+        private final ExampleStackTrace conflictingStackTrace;
+
+        private PotentialDeadlockException(
+                LockGraphNode node1, LockGraphNode node2, ExampleStackTrace conflictingStackTrace) {
+            super(node1, node2);
+            this.conflictingStackTrace = conflictingStackTrace;
+            initCause(conflictingStackTrace);
+        }
+
+        public ExampleStackTrace getConflictingStackTrace() {
+            return conflictingStackTrace;
+        }
+
+        /**
+         * Appends the chain of messages from the {@code conflictingStackTrace} to the original {@code
+         * message}.
+         */
+        @Override
+        public String getMessage() {
+            // requireNonNull is safe because ExampleStackTrace sets a non-null message.
+            StringBuilder message = new StringBuilder(requireNonNull(super.getMessage()));
+            for (Throwable t = conflictingStackTrace; t != null; t = t.getCause()) {
+                message.append(", ").append(t.getMessage());
+            }
+            return message.toString();
+        }
+    }
+
+    /**
+     * Internal Lock implementations implement the {@code CycleDetectingLock} interface, allowing the
+     * detection logic to treat all locks in the same manner.
+     */
+    private interface CycleDetectingLock {
+
+        /** @return the {@link LockGraphNode} associated with this lock. */
+        LockGraphNode getLockGraphNode();
+
+        /** @return {@code true} if the current thread has acquired this lock. */
+        boolean isAcquiredByCurrentThread();
+    }
+
+    /**
+     * A {@code LockGraphNode} associated with each lock instance keeps track of the directed edges in
+     * the lock acquisition graph.
+     */
+    private static class LockGraphNode {
+
+        /**
+         * The map tracking the locks that are known to be acquired before this lock, each associated
+         * with an example stack trace. Locks are weakly keyed to allow proper garbage collection when
+         * they are no longer referenced.
+         */
+        final Map<LockGraphNode, ExampleStackTrace> allowedPriorLocks =
+                Collections.synchronizedMap(new WeakHashMap<>());
+
+        /**
+         * The map tracking lock nodes that can cause a lock acquisition cycle if acquired before this
+         * node.
+         */
+        final Map<LockGraphNode, PotentialDeadlockException> disallowedPriorLocks =
+                Collections.synchronizedMap(new WeakHashMap<>());
+
+        final String lockName;
+
+        LockGraphNode(String lockName) {
+            this.lockName = requireNonNull(lockName);
+        }
+
+        String getLockName() {
+            return lockName;
+        }
+
+        void checkAcquiredLocks(Policy policy, List<LockGraphNode> acquiredLocks) {
+            for (LockGraphNode acquiredLock : acquiredLocks) {
+                checkAcquiredLock(policy, acquiredLock);
+            }
+        }
+
+        /**
+         * Checks the acquisition-ordering between {@code this}, which is about to be acquired, and the
+         * specified {@code acquiredLock}.
+         *
+         * <p>When this method returns, the {@code acquiredLock} should be in either the {@code
+         * preAcquireLocks} map, for the case in which it is safe to acquire {@code this} after the
+         * {@code acquiredLock}, or in the {@code disallowedPriorLocks} map, in which case it is not
+         * safe.
+         */
+        void checkAcquiredLock(Policy policy, LockGraphNode acquiredLock) {
+            // checkAcquiredLock() should never be invoked by a lock that has already
+            // been acquired. For unordered locks, aboutToAcquire() ensures this by
+            // checking isAcquiredByCurrentThread(). For ordered locks, however, this
+            // can happen because multiple locks may share the same LockGraphNode. In
+            // this situation, throw an IllegalStateException as defined by contract
+            // described in the documentation of WithExplicitOrdering.
+            if (this == acquiredLock) {
+                throw new IllegalStateException(
+                        String.format("Attempted to acquire multiple locks with the same rank %s",
+                                acquiredLock.getLockName()));
+            }
+
+            if (allowedPriorLocks.containsKey(acquiredLock)) {
+                // The acquisition ordering from "acquiredLock" to "this" has already
+                // been verified as safe. In a properly written application, this is
+                // the common case.
+                return;
+            }
+            PotentialDeadlockException previousDeadlockException = disallowedPriorLocks.get(acquiredLock);
+            if (previousDeadlockException != null) {
+                // Previously determined to be an unsafe lock acquisition.
+                // Create a new PotentialDeadlockException with the same causal chain
+                // (the example cycle) as that of the cached exception.
+                PotentialDeadlockException exception =
+                        new PotentialDeadlockException(
+                                acquiredLock, this, previousDeadlockException.getConflictingStackTrace());
+                policy.handlePotentialDeadlock(exception);
+                return;
+            }
+            // Otherwise, it's the first time seeing this lock relationship. Look for
+            // a path from the acquiredLock to this.
+            Set<LockGraphNode> seen = new HashSet<>();
+            ExampleStackTrace path = acquiredLock.findPathTo(this, seen);
+
+            if (path == null) {
+                // this can be safely acquired after the acquiredLock.
+                //
+                // Note that there is a race condition here which can result in missing
+                // a cyclic edge: it's possible for two threads to simultaneous find
+                // "safe" edges which together form a cycle. Preventing this race
+                // condition efficiently without _introducing_ deadlock is probably
+                // tricky. For now, just accept the race condition---missing a warning
+                // now and then is still better than having no deadlock detection.
+                allowedPriorLocks.put(acquiredLock, new ExampleStackTrace(acquiredLock, this));
+            } else {
+                // Unsafe acquisition order detected. Create and cache a
+                // PotentialDeadlockException.
+                PotentialDeadlockException exception =
+                        new PotentialDeadlockException(acquiredLock, this, path);
+                disallowedPriorLocks.put(acquiredLock, exception);
+                policy.handlePotentialDeadlock(exception);
+            }
+        }
+
+        /**
+         * Performs a depth-first traversal of the graph edges defined by each node's {@code
+         * allowedPriorLocks} to find a path between {@code this} and the specified {@code lock}.
+         *
+         * @return If a path was found, a chained {@link ExampleStackTrace} illustrating the path to the
+         *     {@code lock}, or {@code null} if no path was found.
+         */
+        @CheckForNull
+        private ExampleStackTrace findPathTo(LockGraphNode node, Set<LockGraphNode> seen) {
+            if (!seen.add(this)) {
+                return null; // Already traversed this node.
+            }
+            ExampleStackTrace found = allowedPriorLocks.get(node);
+            if (found != null) {
+                return found; // Found a path ending at the node!
+            }
+            // Recurse the edges.
+            for (Entry<LockGraphNode, ExampleStackTrace> entry : allowedPriorLocks.entrySet()) {
+                LockGraphNode preAcquiredLock = entry.getKey();
+                found = preAcquiredLock.findPathTo(node, seen);
+                if (found != null) {
+                    // One of this node's allowedPriorLocks found a path. Prepend an
+                    // ExampleStackTrace(preAcquiredLock, this) to the returned chain of
+                    // ExampleStackTraces.
+                    ExampleStackTrace path = new ExampleStackTrace(preAcquiredLock, this);
+                    path.setStackTrace(entry.getValue().getStackTrace());
+                    path.initCause(found);
+                    return path;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * CycleDetectingLock implementations must call this method before attempting to acquire the lock.
+     */
+    private void aboutToAcquire(CycleDetectingLock lock) {
+        if (!lock.isAcquiredByCurrentThread()) {
+            // requireNonNull accommodates Android's @RecentlyNullable annotation on ThreadLocal.get
+            ArrayList<LockGraphNode> acquiredLockList = requireNonNull(acquiredLocks.get());
+            LockGraphNode node = lock.getLockGraphNode();
+            node.checkAcquiredLocks(policy, acquiredLockList);
+            acquiredLockList.add(node);
+        }
+    }
+
+    /**
+     * CycleDetectingLock implementations must call this method in a {@code finally} clause after any
+     * attempt to change the lock state, including both lock and unlock attempts. Failure to do so can
+     * result in corrupting the acquireLocks set.
+     */
+    private static void lockStateChanged(CycleDetectingLock lock) {
+        if (!lock.isAcquiredByCurrentThread()) {
+            // requireNonNull accommodates Android's @RecentlyNullable annotation on ThreadLocal.get
+            ArrayList<LockGraphNode> acquiredLockList = requireNonNull(acquiredLocks.get());
+            LockGraphNode node = lock.getLockGraphNode();
+            // Iterate in reverse because locks are usually locked/unlocked in a
+            // LIFO order.
+            for (int i = acquiredLockList.size() - 1; i >= 0; i--) {
+                if (acquiredLockList.get(i) == node) {
+                    acquiredLockList.remove(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    final class CycleDetectingReentrantLock extends ReentrantLock implements CycleDetectingLock {
+
+        private final LockGraphNode lockGraphNode;
+
+        private CycleDetectingReentrantLock(LockGraphNode lockGraphNode, boolean fair) {
+            super(fair);
+            this.lockGraphNode = requireNonNull(lockGraphNode);
+        }
+
+        ///// CycleDetectingLock methods. /////
+
+        @Override
+        public LockGraphNode getLockGraphNode() {
+            return lockGraphNode;
+        }
+
+        @Override
+        public boolean isAcquiredByCurrentThread() {
+            return isHeldByCurrentThread();
+        }
+
+        ///// Overridden ReentrantLock methods. /////
+
+        @Override
+        public void lock() {
+            aboutToAcquire(this);
+            try {
+                super.lock();
+            } finally {
+                lockStateChanged(this);
+            }
+        }
+
+        @Override
+        public void lockInterruptibly() throws InterruptedException {
+            aboutToAcquire(this);
+            try {
+                super.lockInterruptibly();
+            } finally {
+                lockStateChanged(this);
+            }
+        }
+
+        @Override
+        public boolean tryLock() {
+            aboutToAcquire(this);
+            try {
+                return super.tryLock();
+            } finally {
+                lockStateChanged(this);
+            }
+        }
+
+        @Override
+        public boolean tryLock(long timeout, TimeUnit unit) throws InterruptedException {
+            aboutToAcquire(this);
+            try {
+                return super.tryLock(timeout, unit);
+            } finally {
+                lockStateChanged(this);
+            }
+        }
+
+        @Override
+        public void unlock() {
+            try {
+                super.unlock();
+            } finally {
+                lockStateChanged(this);
+            }
+        }
+    }
+
+    final class CycleDetectingReentrantReadWriteLock extends ReentrantReadWriteLock
+            implements CycleDetectingLock {
+
+        // These ReadLock/WriteLock implementations shadow those in the
+        // ReentrantReadWriteLock superclass. They are simply wrappers around the
+        // internal Sync object, so this is safe since the shadowed locks are never
+        // exposed or used.
+        private final CycleDetectingReentrantReadLock readLock;
+        private final CycleDetectingReentrantWriteLock writeLock;
+
+        private final LockGraphNode lockGraphNode;
+
+        private CycleDetectingReentrantReadWriteLock(LockGraphNode lockGraphNode, boolean fair) {
+            super(fair);
+            this.readLock = new CycleDetectingReentrantReadLock(this);
+            this.writeLock = new CycleDetectingReentrantWriteLock(this);
+            this.lockGraphNode = requireNonNull(lockGraphNode);
+        }
+
+        ///// Overridden ReentrantReadWriteLock methods. /////
+
+        @Override
+        public ReadLock readLock() {
+            return readLock;
+        }
+
+        @Override
+        public WriteLock writeLock() {
+            return writeLock;
+        }
+
+        ///// CycleDetectingLock methods. /////
+
+        @Override
+        public LockGraphNode getLockGraphNode() {
+            return lockGraphNode;
+        }
+
+        @Override
+        public boolean isAcquiredByCurrentThread() {
+            return isWriteLockedByCurrentThread() || getReadHoldCount() > 0;
+        }
+    }
+
+    private class CycleDetectingReentrantReadLock extends ReentrantReadWriteLock.ReadLock {
+
+        final CycleDetectingReentrantReadWriteLock readWriteLock;
+
+        CycleDetectingReentrantReadLock(CycleDetectingReentrantReadWriteLock readWriteLock) {
+            super(readWriteLock);
+            this.readWriteLock = readWriteLock;
+        }
+
+        @Override
+        public void lock() {
+            aboutToAcquire(readWriteLock);
+            try {
+                super.lock();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public void lockInterruptibly() throws InterruptedException {
+            aboutToAcquire(readWriteLock);
+            try {
+                super.lockInterruptibly();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public boolean tryLock() {
+            aboutToAcquire(readWriteLock);
+            try {
+                return super.tryLock();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public boolean tryLock(long timeout, TimeUnit unit) throws InterruptedException {
+            aboutToAcquire(readWriteLock);
+            try {
+                return super.tryLock(timeout, unit);
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public void unlock() {
+            try {
+                super.unlock();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+    }
+
+    private class CycleDetectingReentrantWriteLock extends ReentrantReadWriteLock.WriteLock {
+
+        final CycleDetectingReentrantReadWriteLock readWriteLock;
+
+        CycleDetectingReentrantWriteLock(CycleDetectingReentrantReadWriteLock readWriteLock) {
+            super(readWriteLock);
+            this.readWriteLock = readWriteLock;
+        }
+
+        @Override
+        public void lock() {
+            aboutToAcquire(readWriteLock);
+            try {
+                super.lock();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public void lockInterruptibly() throws InterruptedException {
+            aboutToAcquire(readWriteLock);
+            try {
+                super.lockInterruptibly();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public boolean tryLock() {
+            aboutToAcquire(readWriteLock);
+            try {
+                return super.tryLock();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public boolean tryLock(long timeout, TimeUnit unit) throws InterruptedException {
+            aboutToAcquire(readWriteLock);
+            try {
+                return super.tryLock(timeout, unit);
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+
+        @Override
+        public void unlock() {
+            try {
+                super.unlock();
+            } finally {
+                lockStateChanged(readWriteLock);
+            }
+        }
+    }
+}

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -89,6 +89,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -923,15 +924,11 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         fleetStatusService = createFSS(3);
         fleetStatusService.startup();
         mqttClientConnectionEventsArgumentCaptor.getValue().onConnectionInterrupted(500);
-
-        TimeUnit.SECONDS.sleep(4);
-
         mqttClientConnectionEventsArgumentCaptor.getValue().onConnectionResumed(false);
 
-        TimeUnit.SECONDS.sleep(5);
-
+        verify(mockMqttClient, timeout(5_000).atLeast(1)).publish(any(PublishRequest.class));
         // Verify that an MQTT message with the components' status is uploaded.
-        verify(mockMqttClient, atLeast(1)).publish(publishRequestArgumentCaptor.capture());
+        verify(mockMqttClient, timeout(5_000).atLeast(2)).publish(publishRequestArgumentCaptor.capture());
 
         PublishRequest publishRequest = publishRequestArgumentCaptor.getValue();
         assertEquals(QualityOfService.AT_LEAST_ONCE, publishRequest.getQos());

--- a/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
+++ b/src/test/java/com/aws/greengrass/status/FleetStatusServiceTest.java
@@ -436,10 +436,8 @@ class FleetStatusServiceTest extends GGServiceTestUtil {
         fleetStatusService = createFSS(3);
         fleetStatusService.startup();
 
-        TimeUnit.SECONDS.sleep(20);
-
         // Verify that an MQTT message with the components' status is uploaded.
-        verify(mockMqttClient, atLeast(1)).publish(publishRequestArgumentCaptor.capture());
+        verify(mockMqttClient, timeout(5_000).atLeast(1)).publish(publishRequestArgumentCaptor.capture());
 
         PublishRequest publishRequest = publishRequestArgumentCaptor.getValue();
         assertEquals(QualityOfService.AT_LEAST_ONCE, publishRequest.getQos());

--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/PlatformTestUtils.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/PlatformTestUtils.java
@@ -22,7 +22,7 @@ public abstract class PlatformTestUtils {
 
     private static final Logger logger = LogManager.getLogger(PlatformTestUtils.class);
 
-    public static synchronized PlatformTestUtils getInstance() {
+    public static PlatformTestUtils getInstance() {
         if (INSTANCE != null) {
             return INSTANCE;
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Vendored CycleDetectingLockFactory from Guava. Guava is already in our third-party-licenses file.
2. Replaced usage of `synchronized` with a cycle detecting lock from our new lock factory. LockFactory produces a cycle detecting lock only during testing; normal runtime will use java's ReentrantLock which incurs minimal overhead
3. Removed unnecessary synchronization in places where the cycle detecting locks detected a cycle and the synchronization was not needed. See `FleetStatusService` and `TelemetryAgent` changes.
4. Updated tests to be less flaky and run faster (removed sleeps)

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [x] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [x] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
