### PR TITLE
fix: ignore client disconnected error message in TES

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -171,7 +171,9 @@ public class CredentialRequestHandler implements HttpHandler {
             generateError(exchange, HttpURLConnection.HTTP_GATEWAY_TIMEOUT);
         } catch (Throwable e) {
             // Broken pipe is ignorable; it just means that the client went away
-            if ("Broken pipe".equalsIgnoreCase(e.getMessage())) {
+            if ("Broken pipe".equalsIgnoreCase(e.getMessage())
+                    || "An established connection was aborted by the software in your host machine".equalsIgnoreCase(
+                    e.getMessage())) {
                 LOGGER.atDebug().log("Client gave up before we could respond");
             } else {
                 // Don't let the server crash, swallow problems with a 5xx


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
New versions of java (or java on windows) has slightly different error messages. Push it down to debug to not worry customers.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
