### PR TITLE
build: use fips version of aws-crt when possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,23 @@
         <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
+            <!--
+            When updating the version here, ensure you match the correct aws-crt version below.
+            Get the correct version from: https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/sdk/pom.xml#L45
+            !-->
             <version>1.20.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk.crt</groupId>
+                    <artifactId>aws-crt</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.29.14</version>
+            <classifier>fips-where-available</classifier>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
             When updating the version here, ensure you match the correct aws-crt version below.
             Get the correct version from: https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/sdk/pom.xml#L45
             !-->
-            <version>1.20.1</version>
+            <version>1.20.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk.crt</groupId>
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.29.14</version>
+            <version>0.29.16</version>
             <classifier>fips-where-available</classifier>
         </dependency>
         <dependency>

--- a/src/main/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/telemetry/ComponentMetricIPCEventStreamAgent.java
@@ -99,7 +99,7 @@ public class ComponentMetricIPCEventStreamAgent {
                     validateComponentMetricRequest(opName, serviceName, metricList);
                 } catch (IllegalArgumentException e) {
                     logger.atError().kv(SERVICE_NAME, serviceName)
-                            .log("invalid component metric request from %s", serviceName);
+                            .log("invalid component metric request from {}", serviceName);
                     throw new InvalidArgumentsError(e.getMessage());
                 } catch (AuthorizationException e) {
                     logger.atError().kv(SERVICE_NAME, serviceName)
@@ -113,11 +113,11 @@ public class ComponentMetricIPCEventStreamAgent {
                     translateAndEmit(metricList, metricNamespace);
                 } catch (IllegalArgumentException e) {
                     logger.atError().kv(SERVICE_NAME, serviceName)
-                            .log("invalid component metric request from %s", serviceName);
+                            .log("invalid component metric request from {}", serviceName);
                     throw new InvalidArgumentsError(e.getMessage());
                 } catch (Exception ex) {
                     logger.atError().kv(SERVICE_NAME, serviceName)
-                            .log("error while emitting metrics from %s", serviceName);
+                            .log("error while emitting metrics from {}", serviceName);
                     throw new ServiceError(ex.getMessage());
                 }
 

--- a/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ComponentManager.java
@@ -455,8 +455,7 @@ public class ComponentManager implements InjectionActions {
                             e);
                 }
             } else {
-                logger.atDebug().log(String.format("Artifact download is not required for [%s]",
-                        artifact.getArtifactUri()));
+                logger.atDebug().log("Artifact download is not required for [{}]", artifact.getArtifactUri());
             }
             if (downloader.canSetFilePermissions()) {
                 File artifactFile = downloader.getArtifactFile();

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -121,7 +121,7 @@ public class DockerImageDownloader extends ArtifactDownloader {
         }
 
         if (DOCKER_TAG_LATEST.equals(image.getTag())) {
-            logger.atDebug().log("Image tag: [%s] found, will require download and not check for the image locally.",
+            logger.atDebug().log("Image tag: [{}] found, will require download and not check for the image locally.",
                 DOCKER_TAG_LATEST);
             return true;
         } else {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use fips version of aws-crt when possible. Also fixes some incorrect log formatting using %s.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
