### PR TITLE
test: ignore unknown user error that happens after stopping test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/GenericExternalServiceIntegTest.java
@@ -58,6 +58,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFI
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SYSTEM_RESOURCE_LIMITS_TOPICS;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionUltimateCauseOfType;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessageSubstring;
 import static com.aws.greengrass.testcommons.testutilities.SudoUtil.assumeCanSudoShell;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.createCloseableLogListener;
 import static com.aws.greengrass.util.platforms.unix.UnixPlatform.STDOUT;
@@ -98,6 +99,7 @@ class GenericExternalServiceIntegTest extends BaseITCase {
         kernel = new Kernel();
         NoOpPathOwnershipHandler.register(kernel);
         ignoreExceptionUltimateCauseOfType(context, InterruptedException.class);
+        ignoreExceptionWithMessageSubstring(context, "Unrecognized user: nobody");
     }
 
     @AfterEach


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix flake: https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/8635888684 by ignoring unknown user which is happening because the test is over and interrupting getting the user ID.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
