### PR TITLE
fix: cleanup wrapper MQTT resources, update device sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
             When updating the version here, ensure you match the correct aws-crt version below.
             Get the correct version from: https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/sdk/pom.xml#L45
             !-->
-            <version>1.20.2</version>
+            <version>1.20.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk.crt</groupId>
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.29.16</version>
+            <version>0.29.17</version>
             <classifier>fips-where-available</classifier>
         </dependency>
         <dependency>

--- a/src/main/java/com/aws/greengrass/mqttclient/WrapperMqttClientConnection.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/WrapperMqttClientConnection.java
@@ -36,6 +36,9 @@ public class WrapperMqttClientConnection extends MqttClientConnection {
     public WrapperMqttClientConnection(MqttClient mqttClient) {
         super(getMqttConnectionConfig());
         this.mqttClient = mqttClient;
+        // Immediately decrement the refcount since this object is _not_ a native object and should release
+        // any native objects created as part of instantiation.
+        decRef();
     }
 
     /*
@@ -49,11 +52,12 @@ public class WrapperMqttClientConnection extends MqttClientConnection {
              HostResolver resolver = new HostResolver(eventLoopGroup);
              ClientBootstrap clientBootstrap = new ClientBootstrap(eventLoopGroup, resolver);
              software.amazon.awssdk.crt.mqtt.MqttClient oldMqttClient = new software.amazon.awssdk.crt.mqtt.MqttClient(
-                     clientBootstrap);) {
+                     clientBootstrap)) {
             String fakeClientId = "fakeClientId";
             String fakeEndpoint = "fakeEndpoint";
             int fakePortNumber = 1;
             MqttConnectionConfig fakeConfig = new MqttConnectionConfig();
+            fakeConfig.close();
             fakeConfig.setMqttClient(oldMqttClient);
             fakeConfig.setPort(fakePortNumber);
             fakeConfig.setClientId(fakeClientId);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Immediately decrement the reference count to the WrapperMqttConnection class because it is not a native resource at all. It is just a Java resource which is wrapping the real MQTT client behind the scenes which is already being properly refcounted. This fixes an issue during repeated testing (such as running the FSS test 400+ times) where we would run out of file descriptors because each run allocated a new event loop group which was never able to close. This issue does not impact production because the wrapper MQTT connection is only ever created one time, so we are not leaking anything.

Updates the device SDK to 1.20.3 to get a fix for p521: https://github.com/aws/s2n-tls/pull/4496

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
