### PR TITLE
fix: retry GetDeploymentConfiguration on 404

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -184,9 +184,10 @@ public class DeploymentDocumentDownloader {
                             .getDeploymentConfiguration(getDeploymentConfigurationRequest);
 
         } catch (GreengrassV2DataException e) {
-            if (RetryUtils.retryErrorCodes(e.statusCode())) {
+            // also retry on 404s because sometimes querying DDB may fail initially due to its eventual consistency
+            if (RetryUtils.retryErrorCodes(e.statusCode()) || e.statusCode() == HttpStatusCode.NOT_FOUND) {
                 throw new RetryableServerErrorException("Failed with retryable error: " + e.statusCode()
-                        + "while calling getDeploymetnConfiguration", e);
+                        + "while calling getDeploymentConfiguration", e);
             }
             if (e.statusCode() == HttpStatusCode.FORBIDDEN)  {
                 throw new DeploymentTaskFailureException(

--- a/src/main/java/com/aws/greengrass/deployment/exceptions/RetryableClientErrorException.java
+++ b/src/main/java/com/aws/greengrass/deployment/exceptions/RetryableClientErrorException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.exceptions;
+
+/**
+ * Exception for handling 4xx deployment failures.
+ */
+public class RetryableClientErrorException extends DeploymentException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public RetryableClientErrorException(String message) {
+        super(message);
+    }
+
+    public RetryableClientErrorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentDocumentDownloaderTest.java
@@ -426,8 +426,7 @@ class DeploymentDocumentDownloaderTest {
                         .responseBody(AbortableInputStream.create(Files.newInputStream(testFcsDeploymentJsonPath)))
                         .build());
 
-        downloader.setClientExceptionRetryConfig(
-                downloader.getClientExceptionRetryConfig().toBuilder().initialRetryInterval(Duration.ZERO).build());
+        downloader.getClientExceptionRetryConfig().setInitialRetryIntervalForAll(Duration.ZERO);
         downloader.download(DEPLOYMENT_ID);
 
         // verify

--- a/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
@@ -11,10 +11,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,14 +53,18 @@ class RetryUtilsTest {
     @Test
     void GIVEN_differentiatedRetryConfig_WHEN_runWithRetry_THEN_retryDifferently() {
         AtomicInteger invoked = new AtomicInteger(0);
-        Map<Set<Class>, Integer> retryMap = new HashMap<>();
-        retryMap.put(Collections.singleton(IOException.class), 3);
-        retryMap.put(Collections.singleton(RuntimeException.class), 2);
+        List<RetryUtils.RetryConfig> configList = new ArrayList<>();
+
+        configList.add(RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(1))
+                .maxRetryInterval(Duration.ofSeconds(1)).maxAttempt(3).retryableExceptions(
+                        Collections.singletonList(IOException.class)).build());
+
+        configList.add(RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(1))
+                .maxRetryInterval(Duration.ofSeconds(1)).maxAttempt(2).retryableExceptions(
+                        Collections.singletonList(RuntimeException.class)).build());
 
         RetryUtils.DifferentiatedRetryConfig config = RetryUtils.DifferentiatedRetryConfig.builder()
-                .initialRetryInterval(Duration.ofSeconds(1))
-                .maxRetryInterval(Duration.ofSeconds(1))
-                .retryMap(retryMap)
+                .retryConfigList(configList)
                 .build();
 
         assertThrows(RuntimeException.class, () -> RetryUtils.runWithRetry(config, () -> {

--- a/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +25,7 @@ class RetryUtilsTest {
     Logger logger = LogManager.getLogger(this.getClass()).createChild();
     RetryUtils.RetryConfig config = RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(1))
             .maxRetryInterval(Duration.ofSeconds(1)).maxAttempt(Integer.MAX_VALUE).retryableExceptions(
-                    Arrays.asList(IOException.class)).build();
+                    Collections.singletonList(IOException.class)).build();
 
     @Test
     void GIVEN_retryableException_WHEN_runWithRetry_THEN_retry() throws Exception {
@@ -46,5 +49,31 @@ class RetryUtilsTest {
             return invoked;
         }, "", logger));
         assertEquals(1, invoked.get());
+    }
+
+    @Test
+    void GIVEN_differentiatedRetryConfig_WHEN_runWithRetry_THEN_retryDifferently() {
+        AtomicInteger invoked = new AtomicInteger(0);
+        Map<Set<Class>, Integer> retryMap = new HashMap<>();
+        retryMap.put(Collections.singleton(IOException.class), 3);
+        retryMap.put(Collections.singleton(RuntimeException.class), 2);
+
+        RetryUtils.DifferentiatedRetryConfig config = RetryUtils.DifferentiatedRetryConfig.builder()
+                .initialRetryInterval(Duration.ofSeconds(1))
+                .maxRetryInterval(Duration.ofSeconds(1))
+                .retryMap(retryMap)
+                .build();
+
+        assertThrows(RuntimeException.class, () -> RetryUtils.runWithRetry(config, () -> {
+            // throw IO exception on even number attempts -> 2 times
+            // throw runtime exception on odd number attempts -> 1 times
+            // at last it will throw runtime exception out because we only allow 2 max retries
+            if (invoked.getAndIncrement() % 2 == 0) {
+                throw new IOException();
+            } else {
+                throw new RuntimeException();
+            }
+        }, "", logger));
+        assertEquals(4, invoked.get());
     }
 }


### PR DESCRIPTION
**Description of changes:**
Occasionally a deployment calling `GetDeploymentConfiguration` may receive a 404 because of DDB eventual consistency. Adding retry on 404s instead of failing directly.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
