### PR TITLE
fix(deployment): do not track dependencies of broken components in rollback

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/DependencyDoNothing.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/DependencyDoNothing.json
@@ -1,0 +1,31 @@
+{
+  "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
+  "Packages": [
+    {
+      "Name": "BreakingService2",
+      "ResolvedVersion": "1.0.0",
+      "RootComponent": true
+    },
+    {
+      "Name": "DependencyOnBreak",
+      "ResolvedVersion": "1.0.0",
+      "RootComponent": true
+    },
+    {
+      "Name": "DependencyOnDependency",
+      "ResolvedVersion": "1.0.0",
+      "RootComponent": true
+    },
+    {
+      "Name": "SoftDependencyOnBreak",
+      "ResolvedVersion": "1.0.0",
+      "RootComponent": true
+    }
+  ],
+  "Timestamp": 1592574829000,
+  "FailureHandlingPolicy": "DO_NOTHING",
+  "ComponentUpdatePolicy": {
+    "Timeout": 60,
+    "ComponentUpdatePolicyAction": "NOTIFY_COMPONENTS"
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/DependencyRollback.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/DependencyRollback.json
@@ -1,0 +1,31 @@
+{
+  "DeploymentId": "f7fe5b16-574a-11ea-22b4-0242ac130006",
+  "Packages": [
+    {
+      "Name": "BreakingService2",
+      "ResolvedVersion": "1.0.0",
+      "RootComponent": true
+    },
+    {
+      "Name": "DependencyOnBreak",
+      "ResolvedVersion": "1.0.1",
+      "RootComponent": true
+    },
+    {
+      "Name": "DependencyOnDependency",
+      "ResolvedVersion": "1.0.1",
+      "RootComponent": true
+    },
+    {
+      "Name": "SoftDependencyOnBreak",
+      "ResolvedVersion": "1.0.1",
+      "RootComponent": true
+    }
+  ],
+  "Timestamp": 1592594829000,
+  "FailureHandlingPolicy": "ROLLBACK",
+  "ComponentUpdatePolicy": {
+    "Timeout": 60,
+    "ComponentUpdatePolicyAction": "NOTIFY_COMPONENTS"
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/EmptyDeployment.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/EmptyDeployment.json
@@ -1,0 +1,11 @@
+{
+  "DeploymentId": "f7fe5b16-574a-11ea-22b4-0242ac134006",
+  "Packages": [
+  ],
+  "Timestamp": 1592594929000,
+  "FailureHandlingPolicy": "ROLLBACK",
+  "ComponentUpdatePolicy": {
+    "Timeout": 60,
+    "ComponentUpdatePolicyAction": "NOTIFY_COMPONENTS"
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnBreak-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnBreak-1.0.0.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: DependencyOnBreak
+ComponentDescription: A service with dependency on a broken service
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentDependencies:
+  BreakingService2:
+    VersionRequirement: '>=0.0.0'
+    DependencyType: HARD
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnBreak-1.0.1.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnBreak-1.0.1.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: DependencyOnBreak
+ComponentDescription: A service with dependency on a broken service
+ComponentPublisher: Me
+ComponentVersion: '1.0.1'
+ComponentDependencies:
+  BreakingService2:
+    VersionRequirement: '>=0.0.0'
+    DependencyType: HARD
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnDependency-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnDependency-1.0.0.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: DependencyOnDependency
+ComponentDescription: A service with dependency
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentDependencies:
+  DependencyOnBreak:
+    VersionRequirement: '>=0.0.0'
+    DependencyType: HARD
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnDependency-1.0.1.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/DependencyOnDependency-1.0.1.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: DependencyOnDependency
+ComponentDescription: A service with dependency
+ComponentPublisher: Me
+ComponentVersion: '1.0.1'
+ComponentDependencies:
+  DependencyOnBreak:
+    VersionRequirement: '>=0.0.0'
+    DependencyType: HARD
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/SoftDependencyOnBreak-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/SoftDependencyOnBreak-1.0.0.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: SoftDependencyOnBreak
+ComponentDescription: A service with soft dependency on a broken service
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentDependencies:
+  BreakingService2:
+    VersionRequirement: '>=0.0.0'
+    DependencyType: SOFT
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/SoftDependencyOnBreak-1.0.1.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/SoftDependencyOnBreak-1.0.1.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: SoftDependencyOnBreak
+ComponentDescription: A service with soft dependency on a broken service
+ComponentPublisher: Me
+ComponentVersion: '1.0.1'
+ComponentDependencies:
+  BreakingService2:
+    VersionRequirement: '>=0.0.0'
+    DependencyType: SOFT
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      run:

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
@@ -527,7 +527,11 @@ public class GreengrassService implements InjectionActions {
         };
     }
 
-    private List<GreengrassService> getHardDependers() {
+    /**
+     * Get all hard dependers.
+     * @return a List of services which are hard dependers of current service.
+     */
+    public List<GreengrassService> getHardDependers() {
         List<GreengrassService> dependers = new ArrayList<>();
         Kernel kernel = context.get(Kernel.class);
         for (GreengrassService greengrassService : kernel.orderedDependencies()) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Before: when there are 2 components, component A is broken and component B has a hard dependency on A, deployment gets stuck if failure handling policy is rollback. After deployment failed and rollback, component B will always waiting for component A to reach desired state. 
**Why is this change necessary:**
Resolve the issue where deployment rollback gets stuck and device can not receive any more new deployments
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
