### PR TITLE
feat: functions to compare the value of Topic and Topics

### DIFF
--- a/src/main/java/com/aws/greengrass/config/Topic.java
+++ b/src/main/java/com/aws/greengrass/config/Topic.java
@@ -325,6 +325,24 @@ public class Topic extends Node {
         return false;
     }
 
+    /**
+     * Checks if two Topic has the same name and value.
+     *
+     * @param a Topic
+     * @param b Topic to compare to a
+     */
+    public static boolean compareValue(Object a, Object b) {
+        if (a instanceof Topic && b instanceof Topic) {
+            Topic t1 = (Topic) a;
+            Topic t2 = (Topic) b;
+            if (!t1.equals(t2)) {
+                return false;
+            }
+            return Objects.equals(t1.getOnce(), t2.getOnce());
+        }
+        return false;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hashCode(getName());

--- a/src/main/java/com/aws/greengrass/config/Topics.java
+++ b/src/main/java/com/aws/greengrass/config/Topics.java
@@ -380,6 +380,39 @@ public class Topics extends Node implements Iterable<Node> {
         return false;
     }
 
+    /**
+     * Checks if the Topics has the same name and children.
+     *
+     * @param a Topics
+     * @param b Topics to compare to a
+     */
+    public static boolean compareChildren(Object a, Object b) {
+        if (a instanceof Topics && b instanceof Topics) {
+            Topics t1 = (Topics) a;
+            Topics t2 = (Topics) b;
+            if (!Objects.equals(t1.getName(), t2.getName()) || t1.children.size() != t2.children.size()) {
+                return false;
+            }
+            for (Map.Entry<CaseInsensitiveString, Node> me : t1.children.entrySet()) {
+                Object meObject = me.getValue();
+                Object themObject = t2.children.get(me.getKey());
+                if (meObject instanceof Topics && themObject instanceof Topics) {
+                    if (!Topics.compareChildren(meObject, themObject)) {
+                        return false;
+                    }
+                } else if (meObject instanceof Topic && themObject instanceof Topic) {
+                    if (!Topic.compareValue(meObject, themObject)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hashCode(children);

--- a/src/test/java/com/aws/greengrass/config/TopicsTest.java
+++ b/src/test/java/com/aws/greengrass/config/TopicsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.config;
+
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(GGExtension.class)
+class TopicsTest {
+
+    private Context context;
+
+    @BeforeEach()
+    void beforeEach() {
+        context = new Context();
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        context.close();
+    }
+
+    @Test
+    void Given_config_Then_compare_root_topics() throws Exception {
+        Topics topicsA = new Topics(context, null, null);
+        Topics topicsB = new Topics(context, null, null);
+        assertTrue(Topics.compareChildren(topicsA, topicsB));
+        topicsA = new Topics(context, "root", null);
+        assertFalse(Topics.compareChildren(topicsA, topicsB));
+        topicsB = new Topics(context, "root", null);
+        assertTrue(Topics.compareChildren(topicsA, topicsB));
+
+        Map<String, Object> topicsMap = ConfigPlatformResolver.resolvePlatformMap(getClass().getResource("topicsConfig.yaml"));
+        UpdateBehaviorTree behavior = new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, 0);
+        topicsA.updateFromMap(topicsMap, behavior);
+        topicsB.updateFromMap(topicsMap, behavior);
+        assertTrue(Topics.compareChildren(topicsA, topicsB));
+
+        String config = "config";
+        String diff = "diff";
+        topicsB.find(config, diff).withValue(5);
+        assertFalse(Topics.compareChildren(topicsA, topicsB));
+        topicsB.find(config, diff).withValue(6);
+        assertTrue(Topics.compareChildren(topicsA, topicsB));
+
+        topicsB.find(config, diff).remove();
+        assertFalse(Topics.compareChildren(topicsA, topicsB));
+        topicsA.find(config, diff).remove();
+        assertTrue(Topics.compareChildren(topicsA, topicsB));
+    }
+}

--- a/src/test/resources/com/aws/greengrass/config/topicsConfig.yaml
+++ b/src/test/resources/com/aws/greengrass/config/topicsConfig.yaml
@@ -1,0 +1,11 @@
+---
+config:
+  apple:
+    types:
+      grannySmith: "oven"
+      honeyCrisp: "sweet"
+      fuji: "snack"
+  banana:
+    length:
+      long: "yes"
+  diff: 6


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Add function to compare two Topic objects by name and value
- Add function to compare two Topics objects by name and children

**Why is this change necessary:**
Needed to check if the deployment configuration has differences to the device configuration

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
