### PR TITLE
fix: set fss launch flag correctly when device is initially offline

### DIFF
--- a/src/main/java/com/aws/greengrass/status/FleetStatusService.java
+++ b/src/main/java/com/aws/greengrass/status/FleetStatusService.java
@@ -398,6 +398,8 @@ public class FleetStatusService extends GreengrassService {
      * Trigger a Fleet Status update at kernel launch.
      */
     public void triggerFleetStatusUpdateAtKernelLaunch() {
+        // kernel launch indicates FSS setup is completed
+        isLaunchMessageSent.set(true);
         if (!deviceConfiguration.isDeviceConfiguredToTalkToCloud()) {
             logger.atWarn().kv("trigger", Trigger.NUCLEUS_LAUNCH).log("Status won't be published until Nucleus is "
                     + "configured online");
@@ -524,7 +526,6 @@ public class FleetStatusService extends GreengrassService {
             logger.atDebug().log("Not updating fleet status data since FSS is being set up");
             return;
         }
-        isLaunchMessageSent.compareAndSet(false, true);
 
         if (!isConnected.get() && !Trigger.isCloudDeploymentTrigger(trigger)) {
             logger.atDebug().log("Not updating fleet status data since MQTT connection is interrupted");


### PR DESCRIPTION
**Description of changes:**
If device is initially offline (due to executing provisioning plugin), `isLaunchMessageSent` is never marked as true, which prevents any subsequent FSS updates when device is fully provisioned.

**Why is this change necessary:**
Make sure status updates are published correctly.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
