### PR TITLE
feat: support sso for greengrass installation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- To support SSO login for Greengrass Installer -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sso</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssooidc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-process-killer</artifactId>


### PR DESCRIPTION
**Issue #, if available:**

Closes https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1618

**Description of changes:**

Add AWS SDK SSO dependencies so SSO login can be used during Greengrass installer. See above issue for details.

**Why is this change necessary:**

**How was this change tested:**

Built locally and verified with dummy sso profiles in ~/.aws/config that aws sso provider was being used

- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
