### PR TITLE
fix: revert aws device sdk to 1.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
             When updating the version here, ensure you match the correct aws-crt version below.
             Get the correct version from: https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/sdk/pom.xml#L45
             !-->
-            <version>1.20.6-SECRET-SNAPSHOT</version>
+            <version>1.20.1</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Revert aws-iot-device-sdk to use version 1.20.1, customer has confirmed Greengrass 2.12.4 is not crashing for them
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1622

**Why is this change necessary:**
Fixes Nucleus crashing on Jetson Nano devices

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
