### PR TITLE
feat: allow deployments to cancel while waiting for services to start

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartup.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartup.json
@@ -1,0 +1,18 @@
+{
+  "deploymentId": "TestComponentTakesLongToStartup",
+  "components": {
+    "ComponentTakesLongToStartup": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}
+

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartupAndBrokenService.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartupAndBrokenService.json
@@ -1,0 +1,21 @@
+{
+  "deploymentId": "TestBreakingService",
+  "configurationArn": "Test",
+  "components": {
+    "ComponentTakesLongToStartup": {
+      "version": "1.0.1"
+    },
+    "BreakingService": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartupNoNotify.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/FleetConfigWithComponentTakesLongToStartupNoNotify.json
@@ -1,0 +1,18 @@
+{
+  "deploymentId": "TestComponentTakesLongToStartupNoNotify",
+  "components": {
+    "ComponentTakesLongToStartup": {
+      "version": "1.0.0"
+    }
+  },
+  "creationTimestamp": 1601276785085,
+  "failureHandlingPolicy": "ROLLBACK",
+  "componentUpdatePolicy": {
+    "timeout": 60,
+    "action": "SKIP_NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": 60
+  }
+}
+

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentTakesLongToStartup-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentTakesLongToStartup-1.0.0.yaml
@@ -1,0 +1,19 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: ComponentTakesLongToStartup
+ComponentDescription: A component that takes 10 seconds to install
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      install: |-
+        powershell -command "& { echo 'Start install.'; sleep 15; echo 'Finish install.' }"
+  - Platform:
+      os: all
+    Lifecycle:
+      install: |-
+        echo "Start install."
+        sleep 15
+        echo "Finish install."

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentTakesLongToStartup-1.0.1.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/ComponentTakesLongToStartup-1.0.1.yaml
@@ -1,0 +1,19 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: ComponentTakesLongToStartup
+ComponentDescription: A component that takes 10 seconds to install
+ComponentPublisher: Me
+ComponentVersion: '1.0.1'
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      install: |-
+        powershell -command "& { echo 'Start install.'; sleep 15; echo 'Finish install.' }"
+  - Platform:
+      os: all
+    Lifecycle:
+      install: |-
+        echo "Start install."
+        sleep 15
+        echo "Finish install."

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -154,7 +154,7 @@ public class DeploymentConfigMerger {
         }
 
         logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv("deployment", deploymentId)
-                .log("Applying deployment changes, deployment cannot be cancelled now");
+                .log("Applying deployment changes");
         activator.activate(newConfig, deployment, totallyCompleteFuture);
     }
 
@@ -177,7 +177,7 @@ public class DeploymentConfigMerger {
     }
 
     /**
-     * Completes the provided future when all of the listed services are running.
+     * Completes the provided future when all the listed services are running.
      *
      * @param servicesToTrack       services to track
      * @param mergeTime             time the merge was started, used to check if a service is broken due to the merge
@@ -185,41 +185,67 @@ public class DeploymentConfigMerger {
      * @throws InterruptedException   if the thread is interrupted while waiting here
      * @throws ServiceUpdateException if a service could not be updated
      */
+    // TODO - remove this in follow up CR for cancel deployment, it's being used by kernel update deployment
     public static void waitForServicesToStart(Collection<GreengrassService> servicesToTrack, long mergeTime,
                                               Kernel kernel)
             throws InterruptedException, ServiceUpdateException {
         // Relying on the fact that all service lifecycle steps should have timeouts,
         // assuming this loop will not get stuck waiting forever
-        while (true) {
-            boolean allServicesRunning = true;
-            for (GreengrassService service : servicesToTrack) {
-                State state = service.getState();
+        while (!areAllServiceInDesiredState(servicesToTrack, mergeTime, kernel)) {
+            Thread.sleep(WAIT_SVC_START_POLL_INTERVAL_MILLISEC); // hardcoded
+        }
+    }
 
-                // If a service is previously BROKEN, its state might have not been updated yet when this check
-                // executes. Therefore we first check the service state has been updated since merge map occurs.
-                if (service.getStateModTime() > mergeTime && State.BROKEN.equals(state)) {
-                    logger.atWarn(MERGE_CONFIG_EVENT_KEY).kv(SERVICE_NAME_LOG_KEY, service.getName())
-                            .log("merge-config-service BROKEN");
-                    throw new ServiceUpdateException(
-                            String.format("Service %s in broken state after deployment", service.getName()),
-                            DeploymentErrorCode.COMPONENT_BROKEN,
-                            DeploymentErrorCodeUtils.classifyComponentError(service, kernel));
-                }
-                if (!service.reachedDesiredState()) {
-                    allServicesRunning = false;
-                    continue;
-                }
-                if (State.RUNNING.equals(state) || State.FINISHED.equals(state) || !service.shouldAutoStart()
-                        && service.reachedDesiredState()) {
-                    continue;
-                }
-                allServicesRunning = false;
-            }
-            if (allServicesRunning) {
+    /**
+     * Completes the provided future when all the listed services are running.
+     * Exits early if the future is cancelled
+     *
+     * @param servicesToTrack       services to track
+     * @param mergeTime             time the merge was started, used to check if a service is broken due to the merge
+     * @param kernel                kernel
+     * @param totallyCompleteFuture used to check if a deployment is cancelled
+     * @throws InterruptedException   if the thread is interrupted while waiting here
+     * @throws ServiceUpdateException if a service could not be updated
+     */
+    public static void waitForServicesToStart(Collection<GreengrassService> servicesToTrack, long mergeTime,
+                                              Kernel kernel, CompletableFuture<DeploymentResult> totallyCompleteFuture)
+            throws InterruptedException, ServiceUpdateException {
+        while (!areAllServiceInDesiredState(servicesToTrack, mergeTime, kernel)) {
+            if (totallyCompleteFuture.isCancelled()) {
+                logger.atWarn(MERGE_CONFIG_EVENT_KEY)
+                        .log("deployment cancelled while waiting for services to start");
                 return;
             }
             Thread.sleep(WAIT_SVC_START_POLL_INTERVAL_MILLISEC); // hardcoded
         }
+    }
+
+    private static boolean areAllServiceInDesiredState(Collection<GreengrassService> servicesToTrack, long mergeTime,
+                                                       Kernel kernel) throws ServiceUpdateException {
+        boolean allServicesRunning = true;
+        for (GreengrassService service : servicesToTrack) {
+            State state = service.getState();
+            // If a service is previously BROKEN, its state might have not been updated yet when this check
+            // executes. We must check the service broke after merge map occurs.
+            if (service.getStateModTime() > mergeTime && State.BROKEN.equals(state)) {
+                logger.atWarn(MERGE_CONFIG_EVENT_KEY).kv(SERVICE_NAME_LOG_KEY, service.getName())
+                        .log("merge-config-service BROKEN");
+                throw new ServiceUpdateException(
+                        String.format("Service %s in broken state after deployment", service.getName()),
+                        DeploymentErrorCode.COMPONENT_BROKEN,
+                        DeploymentErrorCodeUtils.classifyComponentError(service, kernel));
+            }
+            if (!service.reachedDesiredState()) {
+                allServicesRunning = false;
+                continue;
+            }
+            if (State.RUNNING.equals(state) || State.FINISHED.equals(state) || !service.shouldAutoStart()
+                    && service.reachedDesiredState()) {
+                continue;
+            }
+            allServicesRunning = false;
+        }
+        return allServicesRunning;
     }
 
     private String tryGetAwsRegionFromNewConfig(Map<String, Object> kernelConfig) {

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -84,7 +84,7 @@ public class DefaultActivator extends DeploymentActivator {
             Set<GreengrassService> servicesToTrack = servicesChangeManager.servicesToTrack();
             logger.atDebug(MERGE_CONFIG_EVENT_KEY).kv("serviceToTrack", servicesToTrack).kv("mergeTime", mergeTime)
                     .log("Applied new service config. Waiting for services to complete update");
-            waitForServicesToStart(servicesToTrack, mergeTime, kernel);
+            waitForServicesToStart(servicesToTrack, mergeTime, kernel, totallyCompleteFuture);
             logger.atDebug(MERGE_CONFIG_EVENT_KEY)
                     .log("new/updated services are running, will now remove old services");
             servicesChangeManager.removeObsoleteServices();
@@ -157,7 +157,7 @@ public class DefaultActivator extends DeploymentActivator {
                     .kv("serviceToTrackForRollback", servicesToTrackForRollback)
                     .kv("mergeTime", mergeTime)
                     .log("Applied rollback service config. Waiting for services to complete update");
-            waitForServicesToStart(servicesToTrackForRollback, mergeTime, kernel);
+            waitForServicesToStart(servicesToTrackForRollback, mergeTime, kernel, totallyCompleteFuture);
 
             rollbackManager.removeObsoleteServices();
             logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv(DEPLOYMENT_ID_LOG_KEY, deploymentId)

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -659,7 +659,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         // Expecting three invocations, once for each retry attempt
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         verify(updateSystemPolicyService, WAIT_FOUR_SECONDS).discardPendingUpdateAction(TEST_DEPLOYMENT_ID);
-        verify(mockFuture, times(0)).cancel(true);
+        verify(mockFuture, WAIT_FOUR_SECONDS).cancel(true);
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
                 eq(JobStatus.IN_PROGRESS.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Overload `waitForServicesToStart` to check if the Future has been cancelled and exit early
    a. Finish removing on next PR for kernel update deployment changes
3. Extracted code from `waitForServicesToStart` to new function `isAllServiceInDesiredState` that checks if all services have reached a desired state
4. Deployment service will now attempt to cancel ongoing deployments
5. Updated log statements to reflect changes

**Why is this change necessary:**
Allows users to cancel their ongoing deployment if it gets stuck or takes longer than expected to complete.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Tested against local UATs

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
