### PR TITLE
feat(fips): refactor CA downloader, allow downloading multiple CAs

### DIFF
--- a/src/main/java/com/aws/greengrass/util/RootCAUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RootCAUtils.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.utils.IoUtils;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class RootCAUtils {
+    public static final String AMAZON_ROOT_CA_1_URL = "https://www.amazontrust.com/repository/AmazonRootCA1.pem";
+    public static final String AMAZON_ROOT_CA_2_URL = "https://www.amazontrust.com/repository/AmazonRootCA2.pem";
+    public static final String AMAZON_ROOT_CA_3_URL = "https://www.amazontrust.com/repository/AmazonRootCA3.pem";
+    public static final String AMAZON_ROOT_CA_4_URL = "https://www.amazontrust.com/repository/AmazonRootCA4.pem";
+    private static final Logger logger = LogManager.getLogger(ProxyUtils.class);
+
+    private RootCAUtils() {
+
+    }
+
+    /**
+     * Download root CA to a local file.
+     * To support HTTPS proxies and other custom truststore configurations, append to the file if it exists.
+     * @param f destination file
+     * @param urls list of URLs needs to be downloaded
+     * @throws IOException if download failed
+     */
+    public static void downloadRootCAToFile(File f, String... urls) throws IOException {
+        if (f.exists()) {
+            logger.atInfo().log("CA file found at {}. Contents will be preserved.", f);
+        }
+        try {
+            for (String url : urls) {
+                logger.atInfo().log("Downloading CA from {}", url);
+                downloadFileFromURL(url, f);
+            }
+            removeDuplicateCertificates(f);
+        } catch (IOException e) {
+            throw new IOException("Failed to download CA from path", e);
+        }
+    }
+
+    private static void removeDuplicateCertificates(File f) {
+        try {
+            String certificates = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+            Set<String> uniqueCertificates =
+                    Arrays.stream(certificates.split(EncryptionUtils.CERTIFICATE_PEM_HEADER))
+                            .map(s -> s.trim())
+                            .collect(Collectors.toSet());
+
+            try (BufferedWriter bw = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
+                for (String certificate : uniqueCertificates) {
+                    if (certificate.length() > 0) {
+                        bw.write(EncryptionUtils.CERTIFICATE_PEM_HEADER);
+                        bw.write("\n");
+                        bw.write(certificate);
+                        bw.write("\n");
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.atDebug().log("Failed to remove duplicate certificates - %s%n", e);
+        }
+    }
+
+    /**
+     * Download content from a URL to a local file.
+     * @param url the URL from which the content needs to be downloaded
+     * @param f destination local file
+     * @throws IOException if download failed
+     */
+    @SuppressWarnings("PMD.AvoidFileStream")
+    public static void downloadFileFromURL(String url, File f) throws IOException {
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                .uri(URI.create(url))
+                .method(SdkHttpMethod.GET)
+                .build();
+
+        HttpExecuteRequest executeRequest = HttpExecuteRequest.builder()
+                .request(request)
+                .build();
+
+        try (SdkHttpClient client = ProxyUtils.getSdkHttpClientBuilder().build()) {
+            HttpExecuteResponse executeResponse = client.prepareRequest(executeRequest).call();
+
+            int responseCode = executeResponse.httpResponse().statusCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new IOException("Received invalid response code: " + responseCode);
+            }
+
+            try (InputStream inputStream = executeResponse.responseBody().get();
+                 OutputStream outputStream = Files.newOutputStream(f.toPath(), StandardOpenOption.CREATE,
+                         StandardOpenOption.APPEND, StandardOpenOption.SYNC)) {
+                IoUtils.copy(inputStream, outputStream);
+            }
+        }
+    }
+
+    /**
+     * Download rootCA 3 to root path.
+     * @param rootCAPath the root path for CAs
+     * @param urls the CA url array
+     * @return if CA downloaded
+     */
+    public static boolean downloadRootCAsWithPath(String rootCAPath, String... urls) {
+        if (rootCAPath == null || rootCAPath.isEmpty()) {
+            return false;
+        }
+        Path caFilePath = Paths.get(rootCAPath);
+        if (!Files.exists(caFilePath)) {
+            return false;
+        }
+        try {
+            downloadRootCAToFile(caFilePath.toFile(), urls);
+        } catch (IOException e) {
+            logger.atError().log("Failed to download CA from path - {}", caFilePath.toAbsolutePath(), e);
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
@@ -7,8 +7,10 @@ package com.aws.greengrass.easysetup;
 
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.EncryptionUtils;
 import com.aws.greengrass.util.IamSdkClientFactory;
 import com.aws.greengrass.util.IotSdkClientFactory;
+import com.aws.greengrass.util.RootCAUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,9 +61,15 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
+import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
@@ -416,6 +424,28 @@ class DeviceProvisioningHelperTest {
         assertEquals("roleAliasName", kernel.getConfig()
                 .lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                         IOT_ROLE_ALIAS_TOPIC).getOnce());
+    }
+
+    @Test
+    void GIVEN_device_config_WHEN_download_multiple_CAs_THEN_combine_and_save_at_Root_CA_file_location()
+            throws Exception {
+        kernel = new Kernel()
+                .parseArgs("-i", getClass().getResource("blank_config.yaml").toString(), "-r", tempRootDir.toString());
+
+        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel,
+                new DeviceProvisioningHelper.ThingInfo(getThingArn(), "thingname", "certarn", "certid", "certpem",
+                        KeyPair.builder().privateKey("privateKey").publicKey("publicKey").build(), "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                        "xxxxxx.credentials.iot.us-east-1.amazonaws.com"), TEST_REGION, "roleAliasName", null);
+        Path certPath = kernel.getNucleusPaths().rootPath();
+        Path caFilePath = certPath.resolve("rootCA.pem");
+        File caFile = caFilePath.toFile();
+
+        RootCAUtils.downloadRootCAToFile(caFile, RootCAUtils.AMAZON_ROOT_CA_3_URL);
+
+        String certificates = new String(Files.readAllBytes(caFile.toPath()), StandardCharsets.UTF_8);
+        List<String> certificateArray = Arrays.stream(certificates.split(EncryptionUtils.CERTIFICATE_PEM_HEADER)).filter(s -> !s.isEmpty()).collect(Collectors.toList());
+
+        assertEquals(2, certificateArray.size());
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactoring download CA file to root path as a util class since it will be used other than provisioning step
Allowing download multiple CAs to rootCA file.
**Why is this change necessary:**
This change is required to enable fips endpoints, fips priorities CA3 for authentication.
**How was this change tested:**
- [X] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
No need integration test since this flow is the same as adding http certificate
**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
