### PR TITLE
feat(fips): enable fips support deployment flow

### DIFF
--- a/src/main/java/com/aws/greengrass/util/RootCAUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RootCAUtils.java
@@ -82,7 +82,7 @@ public final class RootCAUtils {
                 }
             }
         } catch (IOException e) {
-            logger.atDebug().log("Failed to remove duplicate certificates - %s%n", e);
+            logger.atDebug().log("Failed to remove duplicate certificates ", e);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/S3SdkClientFactory.java
@@ -89,7 +89,7 @@ public class S3SdkClientFactory {
      * @return s3client
      */
     public S3Client getClientForRegion(Region r) {
-        setS3EndpointType(Coerce.toString(deviceConfiguration.gets3EndpointType()));
+        handleS3EndpointType(Coerce.toString(deviceConfiguration.gets3EndpointType()));
         return clientCache.computeIfAbsent(r, (region) -> S3Client.builder()
                 .httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder())
                 .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build())
@@ -97,11 +97,11 @@ public class S3SdkClientFactory {
     }
 
     /**
-     * Set s3 endpoint type.
+     * Handle s3 endpoint type. Refresh client if system property updated
      *
      * @param type s3EndpointType
      */
-    private void setS3EndpointType(String type) {
+    private void handleS3EndpointType(String type) {
         //Check if system property and device config are consistent
         //If not consistent, set system property according to device config value
         String s3EndpointSystemProp = System.getProperty(S3_ENDPOINT_PROP_NAME);
@@ -109,12 +109,12 @@ public class S3SdkClientFactory {
 
         if (isGlobal && S3_REGIONAL_ENDPOINT_VALUE.equals(s3EndpointSystemProp)) {
             System.clearProperty(S3_ENDPOINT_PROP_NAME);
-            refreshClientCache();
             logger.atDebug().log("s3 endpoint set to global");
+            refreshClientCache();
         } else if (!isGlobal && !S3_REGIONAL_ENDPOINT_VALUE.equals(s3EndpointSystemProp)) {
             System.setProperty(S3_ENDPOINT_PROP_NAME, S3_REGIONAL_ENDPOINT_VALUE);
-            refreshClientCache();
             logger.atDebug().log("s3 endpoint set to regional");
+            refreshClientCache();
         }
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Combined update device configuration based on existing system property
2. When fips mode is true, download root ca 3 to support iot endpoint
3. When fips is enabled, override the `GreengrassV2DataClient` endpoint with `endpointProvider` 
4. Refresh S3 cached client when `fipsMode` change

**Why is this change necessary:**
This is to support new config fipsMode and to ensure all clients in Nucleus supports fips endpoint
**How was this change tested:**
- [X] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
