### PR TITLE
feat(fips): accept endpoints from external config

### DIFF
--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -188,7 +188,7 @@ public class DeviceProvisioningHelper {
      */
     public ThingInfo createThingForE2ETests() {
         return createThing(iotClient, E2E_TESTS_POLICY_NAME_PREFIX,
-                E2E_TESTS_THING_NAME_PREFIX + UUID.randomUUID().toString());
+                E2E_TESTS_THING_NAME_PREFIX + UUID.randomUUID().toString(), "", "");
     }
 
     /**
@@ -197,9 +197,13 @@ public class DeviceProvisioningHelper {
      * @param client     iotClient to use
      * @param policyName policyName
      * @param thingName  thingName
+     * @param iotDataEndpoint  iotDataEndpoint
+     * @param iotCredEndpoint  iotCredEndpoint
      * @return created thing info
      */
-    public ThingInfo createThing(IotClient client, String policyName, String thingName) {
+    @SuppressWarnings("PMD.UseObjectForClearerAPI")
+    public ThingInfo createThing(IotClient client, String policyName, String thingName,
+                                 String iotDataEndpoint, String iotCredEndpoint) {
         // Find or create IoT policy
         try {
             client.getPolicy(GetPolicyRequest.builder().policyName(policyName).build());
@@ -214,6 +218,16 @@ public class DeviceProvisioningHelper {
                             + "                \"greengrass:*\"\n],\n"
                             + "      \"Resource\": \"*\"\n    }\n  ]\n}")
                     .build());
+        }
+
+        // handle endpoints
+        if (Utils.isEmpty(iotDataEndpoint)) {
+            iotDataEndpoint = client.describeEndpoint(DescribeEndpointRequest.builder()
+                    .endpointType("iot:Data-ATS").build()).endpointAddress();
+        }
+        if (Utils.isEmpty(iotCredEndpoint)) {
+            iotCredEndpoint = client.describeEndpoint(DescribeEndpointRequest.builder()
+                    .endpointType("iot:CredentialProvider").build()).endpointAddress();
         }
 
         // Create cert
@@ -235,10 +249,7 @@ public class DeviceProvisioningHelper {
                         .build());
 
         return new ThingInfo(thingArn, thingName, keyResponse.certificateArn(), keyResponse.certificateId(),
-                keyResponse.certificatePem(), keyResponse.keyPair(),
-                client.describeEndpoint(DescribeEndpointRequest.builder().endpointType("iot:Data-ATS").build())
-                        .endpointAddress(), client.describeEndpoint(
-                DescribeEndpointRequest.builder().endpointType("iot:CredentialProvider").build()).endpointAddress());
+                keyResponse.certificatePem(), keyResponse.keyPair(), iotDataEndpoint, iotCredEndpoint);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
+++ b/src/main/java/com/aws/greengrass/easysetup/GreengrassSetup.java
@@ -37,7 +37,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_CRED_ENDPOINT;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_DATA_ENDPOINT;
 import static com.aws.greengrass.easysetup.DeviceProvisioningHelper.ThingInfo;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+
 
 /**
  * Easy setup for getting started with Greengrass kernel on a device.
@@ -510,9 +516,15 @@ public class GreengrassSetup {
 
     void provision(Kernel kernel) throws IOException, DeviceConfigurationException {
         outStream.printf("Provisioning AWS IoT resources for the device with IoT Thing Name: [%s]...%n", thingName);
-        final ThingInfo thingInfo =
-                deviceProvisioningHelper.createThing(deviceProvisioningHelper.getIotClient(), thingPolicyName,
-                        thingName);
+        // handle endpoints provided by external config
+        String iotDataEndpoint  = Coerce.toString(kernel.getConfig().find(SERVICES_NAMESPACE_TOPIC,
+                DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY, DEVICE_PARAM_IOT_DATA_ENDPOINT));
+        String iotCredEndpoint = Coerce.toString(kernel.getConfig().find(SERVICES_NAMESPACE_TOPIC,
+                DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY, DEVICE_PARAM_IOT_CRED_ENDPOINT));
+
+        final ThingInfo thingInfo = deviceProvisioningHelper.createThing(deviceProvisioningHelper.getIotClient(),
+                thingPolicyName, thingName, iotDataEndpoint, iotCredEndpoint);
+
         outStream.printf("Successfully provisioned AWS IoT resources for the device with IoT Thing Name: [%s]!%n",
                 thingName);
         if (!Utils.isEmpty(thingGroupName)) {

--- a/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/GreengrassSetupTest.java
@@ -93,7 +93,7 @@ class GreengrassSetupTest {
 
     @Test
     void GIVEN_setup_script_WHEN_script_is_used_THEN_setup_actions_are_performed() throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name",
@@ -103,7 +103,7 @@ class GreengrassSetupTest {
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);
-        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
@@ -113,7 +113,7 @@ class GreengrassSetupTest {
     @ParameterizedTest
     @CsvSource({"--cert-path,/a/b"})
     void GIVEN_setup_script_WHEN_script_is_used_THEN_setup_actions_are_performed_for_cert_path_specified(String certOption, String certPath) throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name",
@@ -129,7 +129,7 @@ class GreengrassSetupTest {
 
     @Test
     void GIVEN_setup_script_WHEN_script_is_used_THEN_setup_actions_are_performed_for_cert_path_not_specified() throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name",
@@ -385,7 +385,7 @@ class GreengrassSetupTest {
 
     @Test
     void GIVEN_setup_script_WHEN_no_thing_policy_name_args_provided_THEN_policy_setup_with_default() throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name",
@@ -393,7 +393,7 @@ class GreengrassSetupTest {
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);
-        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any());
@@ -401,7 +401,7 @@ class GreengrassSetupTest {
 
     @Test
     void GIVEN_setup_script_WHEN_no_tes_role_args_provided_THEN_tes_setup_with_default() throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup =
                 new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "--config",
                         "mock_config_path", "--root", "mock_root", "--thing-name", "mock_thing_name", "--provision",
@@ -409,7 +409,7 @@ class GreengrassSetupTest {
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);
-        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).createAndAttachRolePolicy(any(), any());
@@ -418,7 +418,7 @@ class GreengrassSetupTest {
     @Test
     void GIVEN_setup_script_WHEN_script_is_used_with_short_arg_notations_THEN_setup_actions_are_performed()
             throws Exception {
-        when(deviceProvisioningHelper.createThing(any(), any(), any())).thenReturn(thingInfo);
+        when(deviceProvisioningHelper.createThing(any(), any(), any(), any(), any())).thenReturn(thingInfo);
         greengrassSetup = new GreengrassSetup(System.out, System.err, deviceProvisioningHelper, platform, kernel, "-i",
                 "mock_config_path", "-r", "mock_root", "-tn", "mock_thing_name", "-tgn", "mock_thing_group_name",
                 "-trn", "mock_tes_role_name", "-tra", "mock_tes_role_alias_name", "-p", "y", "-ar", "us-east-1", "-ss",
@@ -426,7 +426,7 @@ class GreengrassSetupTest {
         greengrassSetup.parseArgs();
         greengrassSetup.setDeviceProvisioningHelper(deviceProvisioningHelper);
         greengrassSetup.provision(kernel);
-        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any());
+        verify(deviceProvisioningHelper, times(1)).createThing(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).addThingToGroup(any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).updateKernelConfigWithIotConfiguration(any(), any(), any(), any(), any());
         verify(deviceProvisioningHelper, times(1)).setupIoTRoleForTes(any(), any(), any());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Get the endpoints from external config file before creating a thing
2. Assign endpoints accordingly

**Why is this change necessary:**
Currently, when customer uses auto provisioning and provide endpoints with init-config, the endpoints will be overwritten when creating thing info. We now check the external config first before creating endpoints for auto provisioning flow
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
