### PR TITLE
feat: allow bootstrap deployments to cancel while waiting for service…

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -178,26 +178,6 @@ public class DeploymentConfigMerger {
 
     /**
      * Completes the provided future when all the listed services are running.
-     *
-     * @param servicesToTrack       services to track
-     * @param mergeTime             time the merge was started, used to check if a service is broken due to the merge
-     * @param kernel                kernel
-     * @throws InterruptedException   if the thread is interrupted while waiting here
-     * @throws ServiceUpdateException if a service could not be updated
-     */
-    // TODO - remove this in follow up CR for cancel deployment, it's being used by kernel update deployment
-    public static void waitForServicesToStart(Collection<GreengrassService> servicesToTrack, long mergeTime,
-                                              Kernel kernel)
-            throws InterruptedException, ServiceUpdateException {
-        // Relying on the fact that all service lifecycle steps should have timeouts,
-        // assuming this loop will not get stuck waiting forever
-        while (!areAllServiceInDesiredState(servicesToTrack, mergeTime, kernel)) {
-            Thread.sleep(WAIT_SVC_START_POLL_INTERVAL_MILLISEC); // hardcoded
-        }
-    }
-
-    /**
-     * Completes the provided future when all the listed services are running.
      * Exits early if the future is cancelled
      *
      * @param servicesToTrack       services to track

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -653,7 +653,7 @@ public class IotJobsHelper implements InjectionActions {
                 // in that case don't add a cancellation deployment because it can't be added to the front of the queue
                 // we will just have to let current deployment finish
                 Deployment deployment = new Deployment(DeploymentType.IOT_JOBS, UUID.randomUUID().toString(), true);
-                if (deploymentQueue.isEmpty() && currentDeployment != null && currentDeployment.isCancellable()
+                if (deploymentQueue.isEmpty() && currentDeployment != null
                         && DeploymentType.IOT_JOBS.equals(currentDeployment.getDeploymentType())
                         && deploymentQueue.offer(deployment)) {
                     logger.atInfo().log("Added cancellation deployment to the queue");

--- a/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
@@ -25,6 +25,10 @@ import com.aws.greengrass.util.Utils;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_ID_LOG_KEY;
@@ -38,13 +42,14 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
     private final Logger logger;
     private final Deployment deployment;
     private final ComponentManager componentManager;
+    private final CompletableFuture<DeploymentResult> deploymentResultCompletableFuture;
 
     /**
      * Constructor for DefaultDeploymentTask.
      *
-     * @param kernel Kernel instance
-     * @param logger Logger instance
-     * @param deployment Deployment instance
+     * @param kernel           Kernel instance
+     * @param logger           Logger instance
+     * @param deployment       Deployment instance
      * @param componentManager ComponentManager instance
      */
     public KernelUpdateDeploymentTask(Kernel kernel, Logger logger, Deployment deployment,
@@ -53,23 +58,41 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
         this.deployment = deployment;
         this.logger = logger.dfltKv(DEPLOYMENT_ID_LOG_KEY, deployment.getGreengrassDeploymentId());
         this.componentManager = componentManager;
+        this.deploymentResultCompletableFuture = new CompletableFuture<>();
     }
 
     @SuppressWarnings({"PMD.AvoidDuplicateLiterals"})
     @Override
     public DeploymentResult call() {
+        kernel.getContext().get(ExecutorService.class).execute(this::waitForServicesToStart);
+        DeploymentResult result;
+        try {
+            result = deploymentResultCompletableFuture.get();
+        } catch (InterruptedException | ExecutionException | CancellationException e) {
+            // nothing to report when deployment is cancelled
+            return null;
+        }
+        componentManager.cleanupStaleVersions();
+        return result;
+
+    }
+
+    private void waitForServicesToStart() {
         Deployment.DeploymentStage stage = deployment.getDeploymentStage();
+        DeploymentResult result = null;
         try {
             List<GreengrassService> servicesToTrack =
                     kernel.orderedDependencies().stream().filter(GreengrassService::shouldAutoStart)
                             .filter(o -> !kernel.getMain().equals(o)).collect(Collectors.toList());
             long mergeTimestamp = kernel.getConfig().lookup("system", "rootpath").getModtime();
-            logger.atDebug().kv("serviceToTrack", servicesToTrack).kv("mergeTime", mergeTimestamp)
-                    .log("Nucleus update workflow waiting for services to complete update");
-            DeploymentConfigMerger.waitForServicesToStart(servicesToTrack, mergeTimestamp, kernel);
 
-            DeploymentResult result = null;
-            if (KERNEL_ACTIVATION.equals(stage)) {
+            logger.atInfo().kv("serviceToTrack", servicesToTrack).kv("mergeTime", mergeTimestamp)
+                    .log("Nucleus update workflow waiting for services to complete update");
+            DeploymentConfigMerger.waitForServicesToStart(servicesToTrack, mergeTimestamp, kernel,
+                    deploymentResultCompletableFuture);
+            if (deploymentResultCompletableFuture.isCancelled()) {
+                logger.atDebug().log("Kernel update deployment is cancelled");
+            } else if (KERNEL_ACTIVATION.equals(stage)) {
                 result = new DeploymentResult(DeploymentResult.DeploymentStatus.SUCCESSFUL, null);
             } else if (KERNEL_ROLLBACK.equals(stage)) {
                 result = new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_COMPLETE,
@@ -78,19 +101,17 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
                 result = new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_UNABLE_TO_ROLLBACK,
                         getDeploymentStatusDetails());
             }
-
-            componentManager.cleanupStaleVersions();
-            return result;
         } catch (InterruptedException e) {
-            logger.atError("deployment-interrupted", e).log();
-            try {
-                saveDeploymentStatusDetails(e);
-            } catch (IOException ioException) {
-                logger.atError().log("Failed to persist deployment error information", ioException);
+            if (!deploymentResultCompletableFuture.isCancelled()) {
+                logger.atError("deployment-interrupted", e).log();
+                try {
+                    saveDeploymentStatusDetails(e);
+                } catch (IOException ioException) {
+                    logger.atError().log("Failed to persist deployment error information", ioException);
+                }
+                // Interrupted workflow. Shutdown kernel and retry this stage.
+                kernel.shutdown(30, REQUEST_RESTART);
             }
-            // Interrupted workflow. Shutdown kernel and retry this stage.
-            kernel.shutdown(30, REQUEST_RESTART);
-            return null;
         } catch (ServiceUpdateException e) {
             logger.atError("deployment-errored", e).log();
             if (KERNEL_ACTIVATION.equals(stage)) {
@@ -106,16 +127,15 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
                     kernel.shutdown(30, REQUEST_RESTART);
                 } catch (IOException ioException) {
                     logger.atError().log("Failed to set up Nucleus rollback directory", ioException);
-                    return new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_UNABLE_TO_ROLLBACK, e);
+                    result = new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_UNABLE_TO_ROLLBACK, e);
                 }
-                return null;
             } else if (KERNEL_ROLLBACK.equals(stage) || ROLLBACK_BOOTSTRAP.equals(stage)) {
                 logger.atError().log("Nucleus update workflow failed on rollback", e);
-                return new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_UNABLE_TO_ROLLBACK,
+                result = new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_UNABLE_TO_ROLLBACK,
                         getDeploymentStatusDetails());
             }
-            return null;
         }
+        deploymentResultCompletableFuture.complete(result);
     }
 
     private void saveDeploymentStatusDetails(Throwable failureCause) throws IOException {
@@ -140,5 +160,10 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
                 : deployment.getErrorTypes().stream().map(DeploymentErrorType::valueOf).collect(Collectors.toList());
 
         return new DeploymentException(deployment.getStageDetails(), errorStack, errorTypes);
+    }
+
+    @Override
+    public void cancel() {
+        deploymentResultCompletableFuture.cancel(false);
     }
 }

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentTask.java
@@ -10,4 +10,7 @@ import java.util.concurrent.Callable;
 public interface DeploymentTask extends Callable<DeploymentResult> {
     @Override
     DeploymentResult call() throws InterruptedException;
+
+    default void cancel() {
+    }
 }

--- a/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/DeploymentTaskMetadata.java
@@ -25,8 +25,6 @@ public class DeploymentTaskMetadata {
     private Future<DeploymentResult> deploymentResultFuture;
     @NonNull @Getter
     private AtomicInteger deploymentAttemptCount;
-    @NonNull @Getter
-    private boolean cancellable;
 
     @Synchronized
     public void setDeploymentResultFuture(Future<DeploymentResult> deploymentResultFuture) {
@@ -60,5 +58,10 @@ public class DeploymentTaskMetadata {
 
     public List<String> getRootPackages() {
         return this.getDeploymentDocument().getRootPackages();
+    }
+
+    public void cancel(boolean mayInterruptIfRunning) {
+        deploymentTask.cancel();
+        deploymentResultFuture.cancel(mayInterruptIfRunning);
     }
 }

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -309,7 +309,6 @@ class IotJobsHelperTest {
                 , eq(QualityOfService.AT_LEAST_ONCE), any())).thenReturn(integerCompletableFuture);
         DeploymentTaskMetadata mockCurrentDeploymentTaskMetadata = mock(DeploymentTaskMetadata.class);
         when(mockCurrentDeploymentTaskMetadata.getDeploymentType()).thenReturn(IOT_JOBS);
-        when(mockCurrentDeploymentTaskMetadata.isCancellable()).thenReturn(true);
         when(mockDeploymentService.getCurrentDeploymentTaskMetadata()).thenReturn(mockCurrentDeploymentTaskMetadata);
         iotJobsHelper.subscribeToJobsTopics();
         verify(mockIotJobsClientWrapper, times(2)).SubscribeToDescribeJobExecutionAccepted(any(), eq(
@@ -350,7 +349,6 @@ class IotJobsHelperTest {
                 , eq(QualityOfService.AT_LEAST_ONCE), any())).thenReturn(integerCompletableFuture);
         DeploymentTaskMetadata mockCurrentDeploymentTaskMetadata = mock(DeploymentTaskMetadata.class);
         when(mockCurrentDeploymentTaskMetadata.getDeploymentType()).thenReturn(IOT_JOBS);
-        when(mockCurrentDeploymentTaskMetadata.isCancellable()).thenReturn(true);
         when(mockDeploymentService.getCurrentDeploymentTaskMetadata()).thenReturn(mockCurrentDeploymentTaskMetadata);
         iotJobsHelper.subscribeToJobsTopics();
         verify(mockIotJobsClientWrapper, times(2)).SubscribeToJobExecutionsChangedEvents(any(), eq(
@@ -382,7 +380,6 @@ class IotJobsHelperTest {
                 , eq(QualityOfService.AT_LEAST_ONCE), any())).thenReturn(integerCompletableFuture);
         DeploymentTaskMetadata mockCurrentDeploymentTaskMetadata = mock(DeploymentTaskMetadata.class);
         when(mockCurrentDeploymentTaskMetadata.getDeploymentType()).thenReturn(LOCAL);
-        when(mockCurrentDeploymentTaskMetadata.isCancellable()).thenReturn(true);
         when(mockDeploymentService.getCurrentDeploymentTaskMetadata()).thenReturn(mockCurrentDeploymentTaskMetadata);
         iotJobsHelper.subscribeToJobsTopics();
         verify(mockIotJobsClientWrapper, times(2)).SubscribeToJobExecutionsChangedEvents(any(), eq(

--- a/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.lifecyclemanager.KernelAlternatives;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static com.aws.greengrass.dependency.State.BROKEN;
 import static com.aws.greengrass.dependency.State.FINISHED;
@@ -40,6 +44,7 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
@@ -69,6 +74,7 @@ class KernelUpdateDeploymentTaskTest {
     GreengrassService mainService;
     @Mock
     ComponentManager componentManager;
+    ExecutorService executorService;
 
     KernelUpdateDeploymentTask task;
 
@@ -88,7 +94,16 @@ class KernelUpdateDeploymentTaskTest {
         Configuration configuration = mock(Configuration.class);
         lenient().doReturn(topic).when(configuration).lookup(any());
         lenient().doReturn(configuration).when(kernel).getConfig();
+
+        executorService = Executors.newSingleThreadExecutor();
+        doReturn(executorService).when(context).get(ExecutorService.class);
+
         task = new KernelUpdateDeploymentTask(kernel, logger, deployment, componentManager);
+    }
+
+    @AfterEach
+    public void close() {
+        executorService.shutdownNow();
     }
 
     @Test
@@ -155,5 +170,13 @@ class KernelUpdateDeploymentTaskTest {
         assertEquals(DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_COMPLETE, result.getDeploymentStatus());
         assertThat(result.getFailureCause(), isA(DeploymentException.class));
         assertEquals("mock message", result.getFailureCause().getMessage());
+    }
+
+    @Test
+    void GIVEN_deployment_activation_WHEN_deployment_cancelled_THEN_null_result() throws Exception {
+        Future<DeploymentResult> result = executorService.submit(task);
+        task.cancel();
+
+        assertNull(result.get());
     }
 }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/MergeTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/MergeTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeploymentConfigMerger;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
+import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -64,8 +67,10 @@ class MergeTest {
         when(mockServiceB.reachedDesiredState()).thenReturn(true);
         Set<GreengrassService> greengrassServices =
                 new HashSet<>(Arrays.asList(mockMainService, mockServiceA, mockServiceB));
+        CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
         DeploymentConfigMerger.waitForServicesToStart(greengrassServices, System.currentTimeMillis(),
-                kernel);
+                kernel, future);
+        assertFalse(future.isDone());
     }
 
     @Test
@@ -82,12 +87,14 @@ class MergeTest {
         when(mockServiceB.reachedDesiredState()).thenReturn(true);
         Set<GreengrassService>
                 greengrassServices = new HashSet<>(Arrays.asList(mockMainService, mockServiceA, mockServiceB));
+        CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
 
         ServiceUpdateException ex = assertThrows(ServiceUpdateException.class,
                 () -> DeploymentConfigMerger.waitForServicesToStart(greengrassServices, curTime - 10L,
-                        kernel));
+                        kernel, future));
 
         assertEquals("Service main in broken state after deployment", ex.getMessage());
+        assertFalse(future.isDone());
     }
 
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Removed old waitForServicesToStart function
2. Added default no-op cancel function to DeploymentTask
3. Enabled Kernel Update Deployments to be cancellable
4. Remove boolean cancellable from DeploymentTaskMetadata
5. Kernel Update Deployments overrides DeploymentTask cancel function to cancel the CompletableFuture
6. Refactor Kernel Update Deployments to use new waitForServicesToStart function

**Why is this change necessary:**
Allows deployments with bootstrap to be cancelled

**How was this change tested:**
- [X] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
