### PR TITLE
chore: update device sdk and process killer lib versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-process-killer</artifactId>
-            <version>1.10</version>
+            <version>1.11</version>
         </dependency>
         <dependency>
              <groupId>com.github.oshi</groupId>
@@ -238,7 +238,7 @@
             When updating the version here, ensure you match the correct aws-crt version below.
             Get the correct version from: https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/sdk/pom.xml#L45
             !-->
-            <version>1.20.6-SECRET-SNAPSHOT</version>
+            <version>1.21.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
@@ -389,9 +389,13 @@ class PluginComponentTest extends BaseITCase {
                 artifactPath1_0_0.getParent().getParent(),
                 FileSystemPermission.Option.Recurse);
 
-        FileUtils.copyFile(jarFilePath.toFile(), artifact1_1_0.toFile());
-        FileUtils.copyFile(jarFilePath.toFile(), artifactPath1_0_0.toFile());
-
+        if (!artifact1_1_0.toFile().exists()) {
+            FileUtils.copyFile(jarFilePath.toFile(), artifact1_1_0.toFile());
+        }
+        if (!artifactPath1_0_0.toFile().exists()){
+            FileUtils.copyFile(jarFilePath.toFile(), artifactPath1_0_0.toFile());
+        }
+        
         for (ComponentIdentifier pluginId : pluginIds) {
             Path artifactPath = e2ETestComponentStore.resolveArtifactDirectoryPath(pluginId)
                     .resolve(pluginId.getName() + JAR_FILE_EXTENSION);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Device SDK changes for secret manager are included in 1.21.0 version.
- Update zt-process-killer to patch [CVE-2021-29425](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425)

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
