### PR TITLE
fix: use max session expiry sec supported by AWS IoT Core

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java
@@ -72,6 +72,7 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
 
     static final String TOPIC_KEY = "topic";
     private static final String RESUB_LOG_EVENT = "resubscribe";
+    private static final long DEFAULT_SESSION_EXPIRY_SECONDS = 604_800L; // Maximum time supported by AWS IoT Core
     private final Provider<AwsIotMqtt5ClientBuilder> builderProvider;
 
     private Mqtt5Client client = null;
@@ -346,7 +347,7 @@ class AwsIotMqtt5Client implements IndividualMqttClient {
                                         .withReceiveMaximum(Coerce.toLong(mqttTopics.findOrDefault(100L,
                                                 "receiveMaximum")))
                                         .withSessionExpiryIntervalSeconds(
-                                                Coerce.toLong(mqttTopics.findOrDefault(10_080L,
+                                                Coerce.toLong(mqttTopics.findOrDefault(DEFAULT_SESSION_EXPIRY_SECONDS,
                                                         "sessionExpirySeconds"))));
                 client = builder.build();
             } catch (MqttException e) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- `sessionExpirySeconds` (nucleus config) - If this value is not configured, we use default time in seconds for the mqtt client session expiry with IoT Core. The default is the maximum time supported by AWS IoT Core which is 604800 seconds (7 days). 
- The value currently used is in minutes (10080 minutes is 7 days), so updating the code to reflect the expiry time in seconds.  

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
