### PR TITLE
chore: bump up greengrassv2-data to 2.27.x and aws sdk bom to 2.27.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.20.138</version>
+                <version>2.27.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>greengrassv2-data</artifactId>
-            <version>2.20.x-SNAPSHOT</version>
+            <version>2.27.x-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDocumentDownloader.java
@@ -53,7 +53,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 import static org.apache.commons.io.FileUtils.ONE_MB;
-import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.CONTENT_LENGTH_HEADER;
+import static software.amazon.awssdk.services.s3.internal.checksums.ChecksumConstant.CONTENT_LENGTH_HEADER;
 
 public class DeploymentDocumentDownloader {
     private static final Logger logger = LogManager.getLogger(DeploymentDocumentDownloader.class);


### PR DESCRIPTION
**Issue #, if available:**
N/A.

**Description of changes:**
Bump up the version of greengrass-data and bom.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Ran end-to-end tests to ensure no regression introduced in this dependency bump.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [x] Updated the README if applicable.

**Compatibility Checklist:**
- [X] I confirm that the change is backwards compatible.
- [X] Any modification or deletion of public interfaces does not impact other plugin components.
- [X] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
