### PR TITLE
fix: fail deployment if prepare bootstrap fails

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
@@ -89,7 +89,13 @@ public class KernelUpdateActivator extends DeploymentActivator {
             kernelAlternatives.prepareBootstrap(deploymentDocument.getDeploymentId());
         } catch (IOException e) {
             // TODO: better handling of error codes for different IO operations
-            rollback(deployment, e);
+            rollback(deployment, e, false);
+            lifecycle.startupAllServices();
+
+            totallyCompleteFuture.complete(
+                    new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE,
+                            new DeploymentException("Unable to process deployment. Greengrass could not prepare for"
+                                    + " bootstrap.", e)));
             return;
         }
 
@@ -105,11 +111,11 @@ public class KernelUpdateActivator extends DeploymentActivator {
 
             kernel.shutdown(30, exitCode == REQUEST_REBOOT ? REQUEST_REBOOT : REQUEST_RESTART);
         } catch (ServiceUpdateException | IOException e) {
-            rollback(deployment, e);
+            rollback(deployment, e, true);
         }
     }
 
-    void rollback(Deployment deployment, Throwable failureCause) {
+    void rollback(Deployment deployment, Throwable failureCause, boolean requiresRestart) {
         logger.atInfo(MERGE_CONFIG_EVENT_KEY, failureCause)
                 .kv(DEPLOYMENT_ID_LOG_KEY, deployment.getGreengrassDeploymentId())
                 .log("Rolling back failed deployment");
@@ -120,10 +126,13 @@ public class KernelUpdateActivator extends DeploymentActivator {
         deployment.setErrorTypes(errorReport.getRight());
         deployment.setStageDetails(Utils.generateFailureMessage(failureCause));
 
-        final boolean bootstrapOnRollbackRequired = kernelAlternatives.prepareBootstrapOnRollbackIfNeeded(
-                kernel.getContext(), deploymentDirectoryManager, bootstrapManager);
+        // Persist deployment metadata only if restart is required
+        if (requiresRestart) {
+            final boolean bootstrapOnRollbackRequired = kernelAlternatives.prepareBootstrapOnRollbackIfNeeded(
+                    kernel.getContext(), deploymentDirectoryManager, bootstrapManager);
 
-        deployment.setDeploymentStage(bootstrapOnRollbackRequired ? ROLLBACK_BOOTSTRAP : KERNEL_ROLLBACK);
+            deployment.setDeploymentStage(bootstrapOnRollbackRequired ? ROLLBACK_BOOTSTRAP : KERNEL_ROLLBACK);
+        }
 
         try {
             deploymentDirectoryManager.writeDeploymentMetadata(deployment);
@@ -135,7 +144,10 @@ public class KernelUpdateActivator extends DeploymentActivator {
         } catch (IOException e) {
             logger.atError().setCause(e).log("Failed to set up rollback directory");
         }
+
         // Restart Kernel regardless and rely on loader orchestration
-        kernel.shutdown(30, REQUEST_RESTART);
+        if (requiresRestart) {
+            kernel.shutdown(30, REQUEST_RESTART);
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Do not restart Nucleus if kernel update deployment fails while preparing bootstrap. Instead, fail the deployment and start up all the services currently configured.

Something which is a bit unknown is what should the behavior be like if rollback fails.

**Why is this change necessary:**
Nucleus restart is unnecessary if preparing bootstrap fails and adds the possibility of a Nucleus Restart Failure when the Nucleus does eventually start up.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
