### PR TITLE
fix: separate nrf due to nucleus exit

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -14,6 +14,8 @@ echo "Greengrass root: "${GG_ROOT}
 LAUNCH_DIR="$GG_ROOT/alts/current"
 CONFIG_FILE=""
 
+echo "Absolute launch dir: "$(readlink $LAUNCH_DIR)
+
 is_directory_link() {
   [ -L "$1" ] && [ -d "$1" ]
 }
@@ -99,5 +101,8 @@ if [ $sigterm_received -eq 0 ] && is_directory_link "${GG_ROOT}/alts/old" && is_
   flip_link "${LAUNCH_DIR}" "${GG_ROOT}/alts/broken"
   flip_link "${GG_ROOT}/alts/old" "${LAUNCH_DIR}"
 fi
+
+## Touch an empty file to indicate rollback due to unexpected Nucleus exit
+touch "${GG_ROOT}/work/aws.greengrass.Nucleus/restart_panic"
 
 exit ${kernel_exit_code}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Nucleus returns 1 when it exits unexpectedly. 3 consecutive such exits during a deployment causes the loader to orchestrate a forced rollback. Nucleus, after rolling back, fails the ongoing deployment with a NUCLEUS_RESTART_FAILURE. A caveat here is if Nucleus is unable to persist stage details in deployment metadata during a normal rollback, Nucleus still fails a deployment with NUCLEUS_RESTART_FAILURE after rolling back, which is inaccurate.

In this change, the loader script touches a panic file before orchestrating a forced rollback. Nucleus looks for this panic file after starting up and fails a deployment with NUCLEUS_RESTART_FAILURE only if it finds this file. Any other reason for restart failure should come under device IO error.

A possible risk with this change is Nucleus unable to delete the panic file across deployments and a future deployment being classified as NRF incorrectly. However, this can only happen if the stage details for this future deployment were not set as expected due to a correct NRF issue or device IO issue. In either case, this is a low risk.

**Why is this change necessary:**
It has become necessary to separate out nucleus update workflow failures due to unexpected exits and device IO issues. Device IO issues can happen anytime and are independent of the Nucleus process and should not be considered as system errors.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
