### PR TITLE
chore: override state transitions into topic

### DIFF
--- a/src/main/java/com/aws/greengrass/config/Topic.java
+++ b/src/main/java/com/aws/greengrass/config/Topic.java
@@ -128,6 +128,10 @@ public class Topic extends Node {
         return withNewerValue(this.modtime, nv);
     }
 
+    private Topic overrideValue(Object nv, long proposedModTime) {
+        return withNewerValue(proposedModTime, nv);
+    }
+
     /**
      * Update the value in place without changing the timestamp.
      * @param nv new value
@@ -139,6 +143,14 @@ public class Topic extends Node {
 
     public Topic overrideValue(Number nv) {
         return overrideValue((Object) nv);
+    }
+
+    public Topic overrideValueWithCurrentTimestamp(String nv) {
+        return overrideValue(nv, System.currentTimeMillis());
+    }
+
+    public Topic overrideValueWithCurrentTimestamp(Number nv) {
+        return overrideValue(nv, System.currentTimeMillis());
     }
 
     private Topic withValue(Object nv) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -441,9 +441,9 @@ public class Lifecycle {
         // Sync on State.class to make sure the order of setValue and globalNotifyStateChanged
         // are consistent across different services.
         try (LockScope ls = LockScope.lock(globalLock)) {
-            stateTopic.withValue(newState.ordinal());
-            statusCodeTopic.withValue(stateTransitionEvent.getStatusCode().name());
-            statusReasonTopic.withValue(stateTransitionEvent.getStatusReason());
+            stateTopic.overrideValueWithCurrentTimestamp(newState.ordinal());
+            statusCodeTopic.overrideValueWithCurrentTimestamp(stateTransitionEvent.getStatusCode().name());
+            statusReasonTopic.overrideValueWithCurrentTimestamp(stateTransitionEvent.getStatusReason());
             greengrassService.getContext().globalNotifyStateChanged(greengrassService, current, newState);
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Override changes to lifecycle state transition into the Nucleus config tree.

**Why is this change necessary:**
Today, we first compare the timestamps of the previously persisted lifecycle state and the incoming lifecycle state. If, due to clock skew, previously persisted state is in the future compared to the incoming state, the incoming state is rejected. This can cause an endless loop of timestamp comparisons between persisted and incoming state, blocking the main thread, bricking the device.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
