### PR TITLE
feat: enable s3 dualstack endpoint with deployment

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/model/S3EndpointType.java
+++ b/src/main/java/com/aws/greengrass/deployment/model/S3EndpointType.java
@@ -6,5 +6,5 @@
 package com.aws.greengrass.deployment.model;
 
 public enum S3EndpointType {
-    GLOBAL,REGIONAL
+    GLOBAL,REGIONAL,DUALSTACK
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Introduced new config parameter `DUALSTACK` to `s3EndpointType`
**Why is this change necessary:**
To fully enable dualstack endpoint, customer need to make a deployment to change the following configurations: 
1. Set `aws.useDualstackEndpoint` to `true` under `jvmOptions`. This setting would enable all the http calls made by aws client to point to dualstack endpoints.
2. Set the `s3EndpointType` to `DUALSTACK`. This configuration will ensure that the pre-signed URLs returned by the AWS Greengrass dataplane API (GetComponentVersionArtifact and GetDeploymentConfiguration APIs) points to dual-stack endpoints for Amazon S3. 

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
