### PR TITLE
chore: fix panic file touch

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -100,9 +100,9 @@ done
 if [ $sigterm_received -eq 0 ] && is_directory_link "${GG_ROOT}/alts/old" && is_directory_link "${LAUNCH_DIR}"; then
   flip_link "${LAUNCH_DIR}" "${GG_ROOT}/alts/broken"
   flip_link "${GG_ROOT}/alts/old" "${LAUNCH_DIR}"
-fi
 
-## Touch an empty file to indicate rollback due to unexpected Nucleus exit
-touch "${GG_ROOT}/work/aws.greengrass.Nucleus/restart_panic"
+  ## Touch an empty file to indicate rollback due to unexpected Nucleus exit
+  touch "${GG_ROOT}/work/aws.greengrass.Nucleus/restart_panic"
+fi
 
 exit ${kernel_exit_code}

--- a/scripts/loader.cmd
+++ b/scripts/loader.cmd
@@ -117,6 +117,9 @@ IF !IS_SYMLINK! EQU 1 (
     IF !IS_SYMLINK! EQU 1 (
         CALL :flip_links "%LAUNCH_DIR%" "%GG_ROOT%\alts\broken"
         CALL :flip_links "%GG_ROOT%\alts\old" "%LAUNCH_DIR%"
+
+        @REM Touch an empty file to indicate rollback due to unexpected Nucleus exit
+        echo. > "%GG_ROOT%\work\aws.greengrass.Nucleus\restart_panic"
     )
 )
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixing when the loader touches the panic file in the local file system.

**Why is this change necessary:**
Earlier, loader would have touched a panic file at each closure of the loader process, including a planned or external restart of Greengrass via systemd or wincw. The panic script should only be touched when Nucleus exits unexpectedly.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
