### PR TITLE
fix: prune subscriptions trie when topics are unsubscribed

### DIFF
--- a/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
@@ -499,7 +499,8 @@ class DeviceProvisioningHelperTest {
                 .parseArgs("-i", getClass().getResource("blank_config.yaml").toString(), "-r", tempRootDir.toString());
         DeviceProvisioningHelper.ThingInfo thingInfo = deviceProvisioningHelper.createThing(iotClient, "TestThingPolicy", "TestThing", "mockEndpoint", "");
 
-        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, "us-east-1", "TestRoleAliasName", "TestCertPath");
+        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, "us-east-1",
+                "TestRoleAliasName", tempRootDir.resolve("TestCertPath").toString());
          assertEquals("mockEndpoint", kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC,
                 DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY, DEVICE_PARAM_IOT_DATA_ENDPOINT).getOnce());
     }


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1670

**Description of changes:**
----
**Background**

`PubSubIPCEventStreamAgent` handles all the IPC local pubsub requests. It implements the handlers for `SubscribeToTopicRequest` and `PublishToTopicRequest` where the topics are stored in a `SubscriptionTrie` trie. 

When a topic is subscribed to, it is added to the `SubscriptionTrie` trie where the topic levels as represented as nodes of the trie. When you subscribe to a topic with a handler, the handler is registered as a listener of that topic where the last topic level node of that topic increments its listeners count by 1. So, for a valid topic in a trie, the number of subscriptions count at the last topic level of that topic is greater than or equal to one.

Eg. When topics like a/b, a/b/c, a/# and d/+ are registered with a callback, the trie representation is as follows where the nodes `b`, `c`, `#` and `+` maintain the number of subscription handlers held by a topic that ends at their topic level. 
```
        root
       /  \
      a    d
    /   \    \
    b(1) #(1) +(1)
  / 
  c(1)
 ```

**Problem**

When an IPC subscription for a topic is closed, it is expected that topic references are removed from the trie if there are no others listeners for the same topic. But, currently, we only remove the registered subscription handler from the list of handlers maintained at that topic level, leaving behind all the nodes as is.  That means, once a topic is subscribed to, it is never removed from the heap memory even when it is closed/unsubscribed to and no longer used. 

----
**Changes**

When a topic is unsubscribed to, we clear up the references from the `SubscriptionTrie`, which manages topics along with their listeners for matching and filtering. 

If a topic node has no children or no callbacks registered, it means that the path to that topic node is not a complete topic or a prefix of other topic(s). So, it can be removed. 

We modify the trie in the following way when a topic is unsubscribed to or a subscription is closed:

- We first identify the leaf node of the unsubscribed/closed topic. We do this by simply going one level after another till we reach the end of the topic. While doing this, we also store the last node along the topic path that has one or more callbacks registered along with the next topic level. In this process, if a node becomes null, that means the topic doesn't exist in the trie. So, we remove it. 
- Once the final node of the topic is reached, we remove the unsubscribed/closed handlers of the topic from the list of handlers maintained at that level. 
- After removing the handlers, if the final topic node cannot be removed, it means that it's still a valid topic or prefix of other topic(s) in the trie. So, do nothing but return true. 
- If the topic node can be removed, then remove all the topic nodes after the last known node with callbacks in the topic path, as they no longer form a valid topic or prefix of other topics.  
- After removing the unneeded topic nodes, if the last known node to keep can also be removed, then prune the trie along the given topic path recursively where the topic nodes are removed in the reverse order. 

**Why is this change necessary:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1670

The heap memory  keeps growing by retaining the object references even when they're no longer needed. If the heap size continues to grows due to `SubscribeToTopicRequest` object, the IPC event loop thread which handles IPC requests is killed due to out of memory error leaving the JVM in a bad state.


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
