### PR TITLE
fix: mark run as done when skipif is true

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/skipif_lifecycle.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/lifecyclemanager/skipif_lifecycle.yaml
@@ -1,0 +1,77 @@
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+      logging:
+        level: DEBUG
+  skipInstallAndRun:
+    lifecycle:
+      install:
+        skipif: onpath git
+        script: touch skipInstallAndRunIndicator
+      run: echo "running after skipping install"
+  skipInstallAndStartup:
+    lifecycle:
+      install:
+        skipif: onpath git
+        script: touch skipInstallAndStartupIndicator
+      startup:
+        script: echo "startup after skipping install"
+  skipStartup:
+    lifecycle:
+      startup:
+        skipif: onpath git
+        script: touch skipStartupIndicator
+  skipRun:
+    lifecycle:
+      run:
+        skipif: onpath git
+        script: touch skipRunIndicator
+  skipShutdown:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: touch skipShutdownIndicator
+        shutdown:
+          skipif: onpath git
+          script: rm skipShutdownIndicator
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > skipShutdownIndicator
+        shutdown:
+          skipif: onpath git
+          script: del skipShutdownIndicator
+  skipRecover:
+    lifecycle:
+      posix:
+        install:
+          requiresPrivilege: true
+          script: touch skipRecoverIndicator
+        run: |-
+          exit 1
+        recover:
+          skipif: onpath git
+          script: rm skipRecoverIndicator
+      windows:
+        install:
+          requiresPrivilege: true
+          script: echo NUL > skipRecoverIndicator
+        run: powershell -command "exit 1;"
+        recover:
+          skipif: onpath git
+          script: del skipRecoverIndicator
+  main:
+    lifecycle:
+      run:
+          echo "Running main"
+    dependencies:
+      - skipInstallAndRun
+      - skipInstallAndStartup
+      - skipStartup
+      - skipRun
+      - skipShutdown
+      - skipRecover

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -791,7 +791,7 @@ public class GenericExternalService extends GreengrassService {
         try {
             if (shouldSkip(t)) {
                 logger.atDebug().setEventType("generic-service-skipped").addKeyValue("script", t.getFullName()).log();
-                return new RunResult(RunStatus.OK, null, null);
+                return new RunResult(RunStatus.NothingDone, null, null);
             }
         } catch (InputValidationException e) {
             return new RunResult(RunStatus.Errored, null, ComponentStatusCode.getCodeInvalidConfigForState(name));

--- a/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
@@ -499,7 +499,8 @@ class DeviceProvisioningHelperTest {
                 .parseArgs("-i", getClass().getResource("blank_config.yaml").toString(), "-r", tempRootDir.toString());
         DeviceProvisioningHelper.ThingInfo thingInfo = deviceProvisioningHelper.createThing(iotClient, "TestThingPolicy", "TestThing", "mockEndpoint", "");
 
-        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, "us-east-1", "TestRoleAliasName", "TestCertPath");
+        deviceProvisioningHelper.updateKernelConfigWithIotConfiguration(kernel, thingInfo, "us-east-1",
+                "TestRoleAliasName", tempRootDir.resolve("TestCertPath").toString());
          assertEquals("mockEndpoint", kernel.getConfig().lookup(SERVICES_NAMESPACE_TOPIC,
                 DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY, DEVICE_PARAM_IOT_DATA_ENDPOINT).getOnce());
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, when `skipif` evaluates to `true`, `RunStatus` is set to `OK` in the result. But, `RunStatus.OK` is currently not handled in by the Run handler. We could either add a case to handle `OK` or mark the skipif `RunStatus` to `NothingDone`.  

This doesn't impact INSTALL lifecycle as it only cares when `RunStatus` is `Errored`. SkipIf result is also not used in shutdown, recovery lifecycles. 

 https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/fa01ab35e24390dfc64b08c26f5810783f091e6b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java#L523-L538


**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
