### PR TITLE
fix: avoid NPE when detailed deployment status is not present

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -368,7 +368,8 @@ public class ShadowDeploymentListener implements InjectionActions {
                 (Map<String, Object>) deploymentDetails.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
 
         HashMap<String, Object> statusDetails = new HashMap<>();
-        statusDetails.put(DETAILED_STATUS_KEY, deploymentStatusDetails.get(DEPLOYMENT_DETAILED_STATUS_KEY));
+        statusDetails.put(DETAILED_STATUS_KEY,
+                Optional.ofNullable(deploymentStatusDetails.get(DEPLOYMENT_DETAILED_STATUS_KEY)).orElse(""));
         // if the field doesn't exist, report an empty string/list to clear the existing values
         statusDetails.put(FAILURE_CAUSE_KEY,
                 Optional.ofNullable(deploymentStatusDetails.get(DEPLOYMENT_FAILURE_CAUSE_KEY))


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
