### PR TITLE
refactor: add platform runtime and fix platform incompatible message

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/exceptions/IncompatiblePlatformClaimByComponentException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/exceptions/IncompatiblePlatformClaimByComponentException.java
@@ -26,14 +26,13 @@ public class IncompatiblePlatformClaimByComponentException extends PackagingExce
     private static String makeMessage(String initialMessage, String componentName,
                                       Map<String, String> platformRequirements) {
         StringBuilder sb = new StringBuilder(initialMessage.trim());
-        sb.append(" Check whether the platform constraints conflict and that the component platform mentioned in the "
-                    + "recipe matches the platform constraints. "
-                    + "If the platform constraints conflict, revise deployments to resolve the conflict. "
-                    + "Component ")
+        sb.append(" Check whether the component platform specifications mentioned in its recipe match the "
+                        + "core device platform constraints. If the component is not supported on the core device "
+                        + "platform with classic runtime, revise deployments to resolve the conflict. Component '")
                 .append(componentName)
-                .append(" claimed platform:");
+                .append("' is incompatible with the core device(classic) platform requirements - ");
         for (Map.Entry<String, String> requirement : platformRequirements.entrySet()) {
-            sb.append(' ').append(requirement.getKey()).append(' ').append(requirement.getValue()).append(',');
+            sb.append(' ').append(requirement.getKey()).append(':').append(requirement.getValue()).append(',');
         }
         if (sb.charAt(sb.length() - 1) == ',') {
             sb.deleteCharAt(sb.length() - 1);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, if the component  is not supported on the core device platform, the FSS message seen on the console is as follows.

> The version of component requested does not claim platform compatibility. Check whether the platform constraints conflict and that the component platform mentioned in the recipe matches the platform constraints. If the platform constraints conflict, revise deployments to resolve the conflict. Component A claimed platform: os linux, architecture aarch64.

With this change, we include the nucleus runtime of the core device and reformat the existing message. 

> The version of component requested does not claim platform compatibility. Check whether the component platform specifications mentioned in its recipe match the core device platform constraints. If the component is not supported on the core device platform with classic runtime, revise deployments to resolve the conflict. Component 'A' is incompatible with the core device(classic) platform requirements -  os:darwin, architecture:aarch64.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
