### PR TITLE
fix: link launch dir with existing nucleus package if does not exist

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
+++ b/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
@@ -64,7 +64,7 @@ public enum DeploymentErrorCode {
     // JVM hashing issue
     HASHING_ALGORITHM_UNAVAILABLE(DeploymentErrorType.DEVICE_ERROR),
     // Could be a local file issue or a Nucleus issue; we will categorize as the latter for visibility
-    LAUNCH_DIRECTORY_CORRUPTED(DeploymentErrorType.NUCLEUS_ERROR),
+    LAUNCH_DIRECTORY_CORRUPTED(DeploymentErrorType.DEVICE_ERROR),
 
     /* Component recipe errors */
     RECIPE_PARSE_ERROR(DeploymentErrorType.COMPONENT_RECIPE_ERROR),

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/exceptions/DirectoryValidationException.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/exceptions/DirectoryValidationException.java
@@ -15,4 +15,9 @@ public class DirectoryValidationException extends DeploymentException {
         super(message);
         super.addErrorCode(DeploymentErrorCode.LAUNCH_DIRECTORY_CORRUPTED);
     }
+
+    public DirectoryValidationException(String message, Throwable throwable) {
+        super(message, throwable);
+        super.addErrorCode(DeploymentErrorCode.LAUNCH_DIRECTORY_CORRUPTED);
+    }
 }

--- a/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
@@ -227,7 +227,7 @@ class KernelUpdateActivatorTest {
         assertEquals(mockException, result.getFailureCause().getCause());
 
         List<String> expectedStack = Arrays.asList("DEPLOYMENT_FAILURE", "LAUNCH_DIRECTORY_CORRUPTED");
-        List<String> expectedTypes = Collections.singletonList("NUCLEUS_ERROR");
+        List<String> expectedTypes = Collections.singletonList("DEVICE_ERROR");
         TestUtils.validateGenerateErrorReport(result.getFailureCause(), expectedStack, expectedTypes);
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Re create (if not present) and re link the current launch directory symbolic link with the Nucleus package which is currently being executed. This will only be executed if the current launch directory symbolic link does not exist.

If the current Nucleus package in execution does not have a loader file in its un-archived path, un-archive the the current Nucleus package artifact to re-populate the loader paths.

**Why is this change necessary:**
This change is necessary to mitigate deployment failures due to Launch Dir Corrupted.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
