### PR TITLE
fix: systemd template should not create child process

### DIFF
--- a/scripts/greengrass.service.template
+++ b/scripts/greengrass.service.template
@@ -8,7 +8,7 @@ PIDFile=REPLACE_WITH_GG_LOADER_PID_FILE
 RemainAfterExit=no
 Restart=on-failure
 RestartSec=10
-ExecStart=/bin/sh -c "REPLACE_WITH_GG_LOADER_FILE >> REPLACE_WITH_LOADER_LOG_FILE 2>&1"
+ExecStart=/bin/sh -c "exec REPLACE_WITH_GG_LOADER_FILE >> REPLACE_WITH_LOADER_LOG_FILE 2>&1"
 KillMode=mixed
 
 [Install]


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1685
**Description of changes:**
`sh -c` creates a new shell process to execute the command which broke how GG systemd handles SIGTERM.

```
systemd
  └── sh
      └── sh -c
          └── greengrass loader
```
Previously before v2.14.0, it was 
```
systemd
  └── sh
      └── greengrass loader
```

The change uses exec to remove the additional shell process.
**Why is this change necessary:**
Make sure the loader correctly propagates SIGTERM to the java process.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
