### PR TITLE
fix: allow TES restart on port changes

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
+++ b/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import javax.inject.Inject;
 
@@ -56,10 +56,19 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
                                 CredentialRequestHandler credentialRequestHandler,
                                 AuthorizationHandler authZHandler, DeviceConfiguration deviceConfiguration) {
         super(topics);
-        // Port change should not be allowed
-        topics.lookup(CONFIGURATION_CONFIG_KEY, PORT_TOPIC).dflt(DEFAULT_PORT)
-                .subscribe((why, newv) -> port = Coerce.toInt(newv));
-
+        config.lookup(CONFIGURATION_CONFIG_KEY, PORT_TOPIC).dflt(DEFAULT_PORT);
+        config.subscribe((why, node) -> {
+            if (node != null && node.childOf(PORT_TOPIC)) {
+                logger.atDebug("tes-config-change").kv("node", node).kv("why", why).log();
+                port = Coerce.toInt(node);
+                Topic activePortTopic = config.lookup(CONFIGURATION_CONFIG_KEY, ACTIVE_PORT_TOPIC);
+                if (port != Coerce.toInt(activePortTopic)) {
+                    logger.atInfo("tes-config-change").kv(PORT_TOPIC, port).kv("node", node).kv("why", why)
+                            .log("Restarting TES server due to port config change");
+                    requestRestart();
+                }
+            }
+        });
         deviceConfiguration.getIotRoleAlias().subscribe((why, newv) -> {
             iotRoleAlias = Coerce.toString(newv);
         });
@@ -72,7 +81,8 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
     public void postInject() {
         super.postInject();
         try {
-            authZHandler.registerComponent(this.getName(), new HashSet<>(Arrays.asList(AUTHZ_TES_OPERATION)));
+            authZHandler.registerComponent(this.getName(),
+                    new HashSet<>(Collections.singletonList(AUTHZ_TES_OPERATION)));
         } catch (AuthorizationException e) {
             serviceErrored(e);
         }


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1690

**Description of changes:**
- Allows TES restart on port changes. This was previously disabled due to https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/349#discussion_r465283877
- Only components with hard dependencies on TES will auto restart when TES port changes. After restart they will be able to access TES from the new port
- Components without hard dependencies on TES will not restart and will lose access to TES. Only after restart will they get the new port.

**Why is this change necessary:**
Allow TES restart in-place on port changes


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [x] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
