### PR TITLE
fix: github ci upload-artifact

### DIFF
--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -23,8 +23,9 @@ jobs:
         env:
           AWS_REGION: us-west-2
       - name: Upload Errors
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Flaky test results
           path: failed_tests/
+          overwrite: true
         continue-on-error: true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,17 +48,19 @@ jobs:
           sudo chown -R runner target
         if: matrix.os == 'ubuntu-20.04'
       - name: Upload Failed Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Failed Test Report ${{ matrix.os }}
           path: target/surefire-reports
+          overwrite: true
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-20.04'
         with:
           name: Coverage Report ${{ matrix.os }}
           path: target/jacoco-report
+          overwrite: true
       - name: Convert Jacoco unit test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco.xml src/main/java > target/jacoco-report/cobertura.xml
         if: matrix.os == 'ubuntu-20.04'
@@ -70,10 +72,11 @@ jobs:
           mvn -ntp japicmp:cmp -DskipTests
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
       - name: Upload Compatibility Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Binary Compatibility Report
           path: target/japicmp/default-cli.html
+          overwrite: true
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
       - name: Build benchmark with Maven
         # Changes can break the benchmark, so compile it now to make sure it is buildable
@@ -94,8 +97,9 @@ jobs:
           cp target/jacoco-report/cobertura-it.xml ./pr/jacoco-report/cobertura-it.xml
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
       - name: Upload files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/
+          overwrite: true
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'


### PR DESCRIPTION
**Description of changes:**
Address https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
