### PR TITLE
fix(fss): exclude waiting for non-autostartable services and their ha…

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -89,9 +90,7 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
         Deployment.DeploymentStage stage = deployment.getDeploymentStage();
         DeploymentResult result = null;
         try {
-            List<GreengrassService> servicesToTrack =
-                    kernel.orderedDependencies().stream().filter(GreengrassService::shouldAutoStart)
-                            .filter(o -> !kernel.getMain().equals(o)).collect(Collectors.toList());
+            Set<GreengrassService> servicesToTrack = kernel.findAutoStartableServicesToTrack();
             long mergeTimestamp = kernel.getConfig().lookup("system", "rootpath").getModtime();
 
             logger.atInfo().kv("serviceToTrack", servicesToTrack).kv("mergeTime", mergeTimestamp)

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -600,19 +600,19 @@ public class KernelLifecycle {
      * @return true if all services in terminal states
      */
     public boolean allServicesInTerminalState() {
-        List<GreengrassService> servicesToTrack = kernel.orderedDependencies().stream()
-                .filter(GreengrassService::shouldAutoStart).collect(Collectors.toList());
+        List<GreengrassService> servicesToTrack = kernel.findAutoStartableServicesToTrack()
+                .stream().collect(Collectors.toList());
         return servicesToTrack.stream().allMatch(service -> {
-                    State state = service.getState();
-                    // service is broken
-                    if (State.BROKEN.equals(state)) {
-                        return true;
-                    }
-                    // or service has reached desired state, and it is either running or finished
-                    if (service.reachedDesiredState()) {
-                        return State.RUNNING.equals(state) || State.FINISHED.equals(state);
-                    }
-                    return false;
-                });
+            State state = service.getState();
+            // service is broken
+            if (State.BROKEN.equals(state)) {
+                return true;
+            }
+            // or service has reached desired state, and it is either running or finished
+            if (service.reachedDesiredState()) {
+                return State.RUNNING.equals(state) || State.FINISHED.equals(state);
+            }
+            return false;
+        });
     }
 }

--- a/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTaskTest.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static com.aws.greengrass.dependency.State.BROKEN;
 import static com.aws.greengrass.dependency.State.FINISHED;
@@ -99,7 +100,7 @@ class KernelUpdateDeploymentTaskTest {
         lenient().doReturn("A").when(greengrassService).getName();
         lenient().doReturn(mainService).when(kernel).getMain();
         lenient().doReturn(true).when(greengrassService).shouldAutoStart();
-        lenient().doReturn(Arrays.asList(greengrassService)).when(kernel).orderedDependencies();
+        lenient().doReturn(Arrays.asList(greengrassService).stream().collect(Collectors.toSet())).when(kernel).findAutoStartableServicesToTrack();
         lenient().doNothing().when(componentManager).cleanupStaleVersions();
         lenient().doReturn(nucleusPaths).when(kernel).getNucleusPaths();
 


### PR DESCRIPTION
…rd dependencies

**Issue #, if available:**
Right now, Nucleus (main service) is waiting for unpinned lambda (not auto startable components) lifecycle to be triggered and reach the terminal state for fss to send component status change message. This is due to all services are hard dependency of main and fss will wait until all services, including main, to reach their terminal state to send component status change  message

**Description of changes:**
The new waiting strategy is: Nucleus exclude waiting for non autostartable components and any components have a hard dependencies of non autostartable components

This logic applies to both 1) when all deployments going on, bootstrap and default. 2) when fss sending component status change message

**Why is this change necessary:**
1. FSS will wait forever to send the component status change message unless the unpinned lambda is triggered
2. Deployment might stuck if a component has a hard dependency of unpinned lambda

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
