### PR TITLE
chore: update ubuntu version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -18,7 +18,7 @@ A clear and concise description of what you expected to happen.
 Tell us what actually happened.
 
 **Environment**
- - OS: [e.g. Ubuntu 20.04]
+ - OS: [e.g. Ubuntu 24.04]
  - JDK version:
  - Nucleus version:
 

--- a/.github/workflows/flakeFinder.yaml
+++ b/.github/workflows/flakeFinder.yaml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   flake:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 1.8

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
     name: Build on ${{ matrix.os }}
     steps:
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
       - name: Set up JDK 1.8
         uses: actions/setup-java@v4
         with:
@@ -31,7 +31,7 @@ jobs:
           java-version: 8
           cache: maven
       - run: rm -rf /tmp/*
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
       - name: Build with Maven (Windows)
         env:
@@ -39,14 +39,14 @@ jobs:
           TEMP: "C:\\Temp"
         run: "mvn -ntp -U verify -Djava.io.tmpdir=C:\\Temp"
         shell: cmd
-        if: matrix.os != 'ubuntu-20.04'
+        if: matrix.os != 'ubuntu-latest'
       - name: Build with Maven (not Windows)
         env:
           AWS_REGION: us-west-2
         run: |
           sudo -E mvn -ntp -U verify
           sudo chown -R runner target
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
       - name: Upload Failed Test Report
         uses: actions/upload-artifact@v4
         if: failure()
@@ -56,34 +56,34 @@ jobs:
           overwrite: true
       - name: Upload Coverage
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
         with:
           name: Coverage Report ${{ matrix.os }}
           path: target/jacoco-report
           overwrite: true
       - name: Convert Jacoco unit test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco.xml src/main/java > target/jacoco-report/cobertura.xml
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
       - name: Convert Jacoco interation test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco-it/jacoco.xml src/main/java > target/jacoco-report/cobertura-it.xml
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
       - name: Check compatibility
         run: >-
           mvn -ntp japicmp:cmp -DskipTests
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload Compatibility Report
         uses: actions/upload-artifact@v4
         with:
           name: Binary Compatibility Report
           path: target/japicmp/default-cli.html
           overwrite: true
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Build benchmark with Maven
         # Changes can break the benchmark, so compile it now to make sure it is buildable
         run: |
           sudo mvn -ntp -U install -DskipTests
           sudo mvn -ntp -U -f src/test/greengrass-nucleus-benchmark install
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
       - name: Save PR number
         run: |
           mkdir -p ./pr/jacoco-report
@@ -95,11 +95,11 @@ jobs:
           cp -R target/japicmp/default-cli.xml ./pr/japicmp/default-cli.xml
           cp target/jacoco-report/cobertura.xml ./pr/jacoco-report/cobertura.xml
           cp target/jacoco-report/cobertura-it.xml ./pr/jacoco-report/cobertura-it.xml
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload files
         uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/
           overwrite: true
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update ubuntu version to latest due to ubuntu 20 version closing down soon https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down
**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
