### PR TITLE
docs: clarify windows credential errors during lifecycle script process creation

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/ShellRunner.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/ShellRunner.java
@@ -111,7 +111,7 @@ public interface ShellRunner {
                 }
             } catch (IOException ex) {
                 logger.atError("shell-runner-error").kv(SCRIPT_NAME_KEY, note).kv("command", e.toString())
-                        .log("Error while running process", ex);
+                        .log("Error while running component lifecycle script", ex);
                 return false;
             }
             return true;

--- a/src/main/java/vendored/com/microsoft/alm/storage/windows/internal/WindowsCredUtils.java
+++ b/src/main/java/vendored/com/microsoft/alm/storage/windows/internal/WindowsCredUtils.java
@@ -38,7 +38,7 @@ public class WindowsCredUtils {
             final CredAdvapi32.CREDENTIAL credential = new CredAdvapi32.CREDENTIAL(pCredential.credential);
             return credential.CredentialBlob.getByteArray(0, credential.CredentialBlobSize);
         } catch (LastErrorException e) {
-            throw new IOException("Failed to read credential", e);
+            throw new IOException("Failed to read credential for " + key, e);
         } finally {
             if (pCredential.credential != null) {
                 try (LockScope ls = LockScope.lock(lock)) {


### PR DESCRIPTION
**Description of changes:**
**Why is this change necessary:**

We've seen customers confused when Greengrass fails to create a component process because the component user credentials are not available from windows. 

Part of this confusion is that the Greengrass lifecycle script process creation logs show up in the component log, making it look like an issue with the Component, when it is rather an issue with Greengrass setting up the environment for the component to run. The error log has been updated to clarify that it is coming from the component lifecycle script setup. This change is accurate because ShellRunner is only used in the context of lifecycle steps.

Another part of the confusion is that it is not obvious which credential can't be found. The error log has been updated to include the user key for debugging purposes. Note that this is not the value of the credential, which we would not want to expose.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Logging change only, no local testing was done.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ NA ] Updated the README if applicable.

**Compatibility Checklist:**
- [ X] I confirm that the change is backwards compatible.
- [ X] Any modification or deletion of public interfaces does not impact other plugin components.
- [ X] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
