### PR TITLE
fix: prevent double injection of service class

### DIFF
--- a/src/main/java/com/aws/greengrass/dependency/Context.java
+++ b/src/main/java/com/aws/greengrass/dependency/Context.java
@@ -580,8 +580,6 @@ public class Context implements Closeable {
                 if (object != null) {
                     return object;
                 }
-                // Mapping function should make sure that the object is not injected already. Otherwise, it results in
-                // double injection of the same object.
                 return putAndInjectFields(mappingFunction.apply(this));
             }
         }

--- a/src/main/java/com/aws/greengrass/dependency/Context.java
+++ b/src/main/java/com/aws/greengrass/dependency/Context.java
@@ -121,7 +121,7 @@ public class Context implements Closeable {
     }
 
     public <T> T newInstance(Class<T> cl) {
-        return new Value<>(cl, null).get();
+        return new Value<>(cl, null).getObjectWithoutInjection();
     }
 
     /**
@@ -434,6 +434,17 @@ public class Context implements Closeable {
             return constructObjectWithInjection();
         }
 
+        /**
+         * Constructs an object without injection.
+         * @return object
+         */
+        public final T getObjectWithoutInjection() {
+            if (object != null && injectionCompleted) {
+                return object;
+            }
+            return constructObject();
+        }
+
 
         /**
          * Put a new object instance and inject fields with pre and post actions, if the new object is not equal to
@@ -462,7 +473,7 @@ public class Context implements Closeable {
         }
 
         @SuppressWarnings("PMD.AvoidCatchingThrowable")
-        private T constructObjectWithInjection() {
+        private T constructObject() {
             try (LockScope ls = LockScope.lock(lock)) {
                 if (object != null) {
                     return object;
@@ -483,14 +494,20 @@ public class Context implements Closeable {
                     int paramCount = pickedConstructor.getParameterCount();
                     if (paramCount == 0) {
                         // no arg constructor
-                        return putAndInjectFields(pickedConstructor.newInstance());
+                        return pickedConstructor.newInstance();
                     }
 
                     Object[] args = getOrCreateArgInstances(clazz, pickedConstructor, paramCount);
-                    return putAndInjectFields(pickedConstructor.newInstance(args));
+                    return pickedConstructor.newInstance(args);
                 } catch (Throwable ex) {
                     throw new IllegalArgumentException("Can't create instance of " + targetClass.getName(), ex);
                 }
+            }
+        }
+
+        private T constructObjectWithInjection() {
+            try (LockScope ls = LockScope.lock(lock)) {
+                return putAndInjectFields(constructObject());
             }
         }
 
@@ -563,7 +580,8 @@ public class Context implements Closeable {
                 if (object != null) {
                     return object;
                 }
-
+                // Mapping function should make sure that the object is not injected already. Otherwise, it results in
+                // double injection of the same object.
                 return putAndInjectFields(mappingFunction.apply(this));
             }
         }

--- a/src/main/java/com/aws/greengrass/dependency/Context.java
+++ b/src/main/java/com/aws/greengrass/dependency/Context.java
@@ -566,8 +566,9 @@ public class Context implements Closeable {
         }
 
         /**
-         * Computes and return T if object instance is null. TODO revisit to see if there is a better way because the
-         * mapping function usage is weird.
+         * Computes and returns T if object instance is null. The mapping function used for the instance creation should
+         * not inject the created object into the context as it will anyway be injected as part of this method.
+         * TODO revisit to see if there is a better way because the mapping function usage is weird.
          *
          * @param mappingFunction maps from Value to T
          * @param <E>             CheckedException

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -479,6 +479,16 @@ public class Kernel {
         shutdown(30, exitCode == REQUEST_REBOOT ? REQUEST_REBOOT : REQUEST_RESTART);
     }
 
+    /**
+     * Creates an instance of a `GreengrassService` based on the service type and the constructor type. This method
+     * should not inject the constructed objects.
+     *
+     * @param v value of the object in the Context
+     * @param name name of the service to locate
+     * @param locateFunction function to locate the service from the context
+     * @return instance of a GreengrassService
+     * @throws ServiceLoadException if the service cannot be constructed
+     */
     @SuppressWarnings(
             {"UseSpecificCatch", "PMD.AvoidCatchingThrowable", "PMD.AvoidDeeplyNestedIfStmts", "PMD.ConfusingTernary"})
     private GreengrassService locateGreengrassService(Context.Value v, String name, CrashableFunction<String,

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -444,7 +444,7 @@ public class Kernel {
      */
     public GreengrassService locate(String name) throws ServiceLoadException {
         return context.getValue(GreengrassService.class, name).computeObjectIfEmpty(v ->
-                locateGreengrassService(v, name, this::locate));
+                createGreengrassServiceInstance(v, name, this::locate));
     }
 
     /**
@@ -456,7 +456,7 @@ public class Kernel {
     public GreengrassService locateIgnoreError(String name) {
         return context.getValue(GreengrassService.class, name).computeObjectIfEmpty(v -> {
             try {
-                return locateGreengrassService(v, name, this::locateIgnoreError);
+                return createGreengrassServiceInstance(v, name, this::locateIgnoreError);
             } catch (ServiceLoadException e) {
                 logger.atError().log("Cannot load service", e);
                 return new UnloadableService(
@@ -479,19 +479,9 @@ public class Kernel {
         shutdown(30, exitCode == REQUEST_REBOOT ? REQUEST_REBOOT : REQUEST_RESTART);
     }
 
-    /**
-     * Creates an instance of a `GreengrassService` based on the service type and the constructor type. This method
-     * should not inject the constructed objects.
-     *
-     * @param v value of the object in the Context
-     * @param name name of the service to locate
-     * @param locateFunction function to locate the service from the context
-     * @return instance of a GreengrassService
-     * @throws ServiceLoadException if the service cannot be constructed
-     */
     @SuppressWarnings(
             {"UseSpecificCatch", "PMD.AvoidCatchingThrowable", "PMD.AvoidDeeplyNestedIfStmts", "PMD.ConfusingTernary"})
-    private GreengrassService locateGreengrassService(Context.Value v, String name, CrashableFunction<String,
+    private GreengrassService createGreengrassServiceInstance(Context.Value v, String name, CrashableFunction<String,
             GreengrassService, ServiceLoadException> locateFunction) throws ServiceLoadException {
         Topics serviceRootTopics = findServiceTopic(name);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When Nucleus is started, all the plugin/builtin Greengrass services are injected twice. These changes help 

**Current flow:**

When Greengrass is restarted, it starts all the auto-startable services in order after locating them from the context. When a service doesn't already exist in the Context, it is created and injected in to the context in the following way:

At a high-level, a new instance of the Service is created as the following:
  1. If it exists in the config file under service topic dependencies, it is created after its dependencies are created. 
  2. For an external plugin, it is loaded from the plugins path.
  3. For a builtin/plugin service, if a constructor with `Topics` exists, an instance of it is created from the constructor(Not injected) and returned. Otherwise, an instance of the service is created from `@Inject` constructor if it exists (or a default constructor otherwise) and injection hooks (preInject, Inject, PostInject) are executed where the object is injected into the context along with all the injectable args of the class. 
  4. If it is not a plugin or a builtin service, a new instance of `GenericExternalService` is created. 

After the new instance of a service is created, all context injection hooks  (preInject, Inject and postInject) are executed where the object is injected into the context along with all the injectable args of the class. 

Thus the builtin/plugin service injection hooks are executed twice resulting in other side effects such as 
- When a service subscribes to config changes in post inject, two listeners are created and fired for the same events. 
- Any config writes in those hooks is written twice to the config.tlog file. This is applied to logging as well. 

**Fixed flow**
When a new instance of the builtin/plugin service is requested, we only return the constructed instance without injecting itself or its dependencies/args as they will be injected later.  

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
