### PR TITLE
fix: use service name for service set operations

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -81,7 +81,14 @@ public class DefaultActivator extends DeploymentActivator {
             Set<GreengrassService> servicesToTrack = servicesChangeManager.servicesToTrack();
             // Exclude all non-autoStartable services and their dependers
             // Find the services which both changed and auto startable
-            servicesToTrack.retainAll(kernel.findAutoStartableServicesToTrack());
+            Set<String> autoStartableServiceNames = kernel.findAutoStartableServicesToTrack()
+                    .stream()
+                    .map(GreengrassService::getName)
+                    .collect(Collectors.toSet());
+            servicesToTrack = servicesToTrack
+                    .stream()
+                    .filter(service -> autoStartableServiceNames.contains(service.getName()))
+                    .collect(Collectors.toSet());
             logger.atDebug(MERGE_CONFIG_EVENT_KEY).kv("serviceToTrack", servicesToTrack).kv("mergeTime", mergeTime)
                     .log("Applied new service config. Waiting for services to complete update");
             waitForServicesToStart(servicesToTrack, mergeTime, kernel, totallyCompleteFuture);


### PR DESCRIPTION
**Issue #, if available:**
The method `retainAll` [here](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/2870f12ff4ae20bc69b64ea409e5634290cf7077/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java#L84) compares objects of the GreengrassService class. If a service is broken from a previous deployment, an incoming deployment will attempt to replace the original and hence, create a new object for the same service. In this scenario, `retainAll` will exclude the broken service in its operations.

**Description of changes:**
Instead of comparing GreengrassService objects directly, compare their names when performing the `retainAll` operation.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
