### PR TITLE
feat: add deploymentConfigurationTimeSource configuration

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentConfigMergingTest.java
@@ -158,7 +158,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         ((Map<String, Object>)newConfig.get(SERVICES_NAMESPACE_TOPIC)).put(DEFAULT_NUCLEUS_COMPONENT_NAME,
                 getNucleusConfig());
 
-        deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig).get(60, TimeUnit.SECONDS);
+        deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
 
         t = kernel.findServiceTopic(FleetStatusService.FLEET_STATUS_SERVICE_TOPICS);
         assertNotNull(t, "FSS Topics should not be null after merging");
@@ -210,7 +210,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
                     }});
                     put(DEFAULT_NUCLEUS_COMPONENT_NAME, getNucleusConfig());
                 }});
-            }}).get(60, TimeUnit.SECONDS);
+            }}, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
 
             // THEN
             assertTrue(mainRestarted.await(10, TimeUnit.SECONDS), "main restarted");
@@ -268,7 +268,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
 
                 put(DEFAULT_NUCLEUS_COMPONENT_NAME, getNucleusConfig());
             }});
-        }}).get(60, TimeUnit.SECONDS);
+        }}, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
         // THEN
         assertTrue(newServiceStarted.get(), "new service started");
     }
@@ -338,7 +338,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
 
                 put(DEFAULT_NUCLEUS_COMPONENT_NAME, getNucleusConfig());
             }});
-        }}).get(60, TimeUnit.SECONDS);
+        }}, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
 
         // THEN
         assertTrue(newService2Started.get());
@@ -411,7 +411,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         kernel.getContext().addGlobalStateChangeListener(listener);
 
         GreengrassService main = kernel.locate("main");
-        deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig).get(60, TimeUnit.SECONDS);
+        deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
         kernel.getContext().waitForPublishQueueToClear();
 
         // Verify that first merge succeeded.
@@ -437,7 +437,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         // THEN
         // merge in the same config the second time
         // merge shouldn't block
-        deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig).get(60, TimeUnit.SECONDS);
+        deploymentConfigMerger.mergeInNewConfig(testDeployment(), newConfig, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
         kernel.getContext().waitForPublishQueueToClear();
 
         // main should be finished
@@ -484,7 +484,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         lifecycle.put(LIFECYCLE_RUN_NAMESPACE_TOPIC,
                 ((String) lifecycle.get(LIFECYCLE_RUN_NAMESPACE_TOPIC)).replace("5", "10"));
 
-        Future<DeploymentResult> deploymentFuture = deploymentConfigMerger.mergeInNewConfig(testDeployment(), currentConfig);
+        Future<DeploymentResult> deploymentFuture = deploymentConfigMerger.mergeInNewConfig(testDeployment(), currentConfig, System.currentTimeMillis());
 
         DeploymentResult deploymentResult = deploymentFuture.get(30, TimeUnit.SECONDS);
 
@@ -588,7 +588,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
         Map<String, Object> currentConfig = new HashMap<>(kernel.getConfig().toPOJO());
         Deployment testDeployment = testDeployment();
         Future<DeploymentResult> future =
-                deploymentConfigMerger.mergeInNewConfig(testDeployment, currentConfig);
+                deploymentConfigMerger.mergeInNewConfig(testDeployment, currentConfig, System.currentTimeMillis());
 
         // update should be deferred for 5 seconds
         assertThrows(TimeoutException.class, () -> future.get(5, TimeUnit.SECONDS),
@@ -632,7 +632,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
                     }});
                     put(DEFAULT_NUCLEUS_COMPONENT_NAME, getNucleusConfig());
                 }});
-            }}).get(60, TimeUnit.SECONDS);
+            }}, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
 
             // THEN
             mainRestarted.run();
@@ -696,7 +696,7 @@ class DeploymentConfigMergingTest extends BaseITCase {
 
                     put(DEFAULT_NUCLEUS_COMPONENT_NAME, getNucleusConfig());
                 }});
-            }}).get(60, TimeUnit.SECONDS);
+            }}, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
 
             // THEN
             serviceRestarts.run();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.deployment.DeploymentConfigMerger;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
 import com.aws.greengrass.deployment.DeploymentDocumentDownloader;
 import com.aws.greengrass.deployment.DeploymentService;
+import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.ThingGroupHelper;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
@@ -1306,7 +1307,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                 new DefaultDeploymentTask(dependencyResolver, componentManager, kernelConfigResolver,
                         deploymentConfigMerger, logger,
                         new Deployment(sampleJobDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
-                        deploymentServiceTopics, kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper);
+                        deploymentServiceTopics, kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper, kernel.getContext().get(DeviceConfiguration.class));
         return executorService.submit(deploymentTask);
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DynamicComponentConfigurationValidationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DynamicComponentConfigurationValidationTest.java
@@ -130,7 +130,7 @@ class DynamicComponentConfigurationValidationTest extends BaseITCase {
                 }});
             }});
         }};
-        deploymentConfigMerger.mergeInNewConfig(createTestDeployment(), newConfig).get(60, TimeUnit.SECONDS);
+        deploymentConfigMerger.mergeInNewConfig(createTestDeployment(), newConfig, System.currentTimeMillis()).get(60, TimeUnit.SECONDS);
 
         assertTrue(mainRestarted.get());
         assertTrue(serviceStarted.get());
@@ -217,7 +217,7 @@ class DynamicComponentConfigurationValidationTest extends BaseITCase {
                     put(DEFAULT_NUCLEUS_COMPONENT_NAME, getNucleusConfig(kernel));
                 }});
             }};
-            DeploymentResult result = deploymentConfigMerger.mergeInNewConfig(createTestDeployment(), newConfig)
+            DeploymentResult result = deploymentConfigMerger.mergeInNewConfig(createTestDeployment(), newConfig, System.currentTimeMillis())
                     .get(60, TimeUnit.SECONDS);
             assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result.getDeploymentStatus());
             assertTrue(eventReceivedByClient.await(20, TimeUnit.SECONDS));
@@ -289,7 +289,7 @@ class DynamicComponentConfigurationValidationTest extends BaseITCase {
                     put(DEFAULT_NUCLEUS_COMPONENT_NAME, getNucleusConfig(kernel));
                 }});
             }};
-            DeploymentResult result = deploymentConfigMerger.mergeInNewConfig(createTestDeployment(), newConfig)
+            DeploymentResult result = deploymentConfigMerger.mergeInNewConfig(createTestDeployment(), newConfig, System.currentTimeMillis())
                     .get(60, TimeUnit.SECONDS);
             assertEquals(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE, result.getDeploymentStatus());
             assertTrue(result.getFailureCause() instanceof ComponentConfigurationValidationException);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.deployment.DeploymentConfigMerger;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
 import com.aws.greengrass.deployment.DeploymentDocumentDownloader;
 import com.aws.greengrass.deployment.DeploymentService;
+import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.deployment.ThingGroupHelper;
 import com.aws.greengrass.deployment.activator.KernelUpdateActivator;
 import com.aws.greengrass.deployment.bootstrap.BootstrapManager;
@@ -116,7 +117,7 @@ class PluginComponentTest extends BaseITCase {
                         deploymentConfigMerger, LogManager.getLogger("Deployer"),
                         new Deployment(sampleJobDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
                         Topics.of(kernel.getContext(), DeploymentService.DEPLOYMENT_SERVICE_TOPICS, null),
-                        kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper);
+                        kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper, kernel.getContext().get(DeviceConfiguration.class));
         return kernel.getContext().get(ExecutorService.class).submit(deploymentTask);
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
@@ -201,7 +201,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_LONG_TIMEOUT, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep).get(60,
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep, System.currentTimeMillis()).get(60,
                         TimeUnit.SECONDS),
                 "dependency removed", expectedDepRemoved, unexpectedDepRemoved);
 
@@ -219,7 +219,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(60, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep).get(10, TimeUnit.SECONDS),
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep, System.currentTimeMillis()).get(10, TimeUnit.SECONDS),
                 "dependency added", expectedDepAdded, Collections.emptySet());
 
 
@@ -314,7 +314,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_MEDIUM_TIMEOUT, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep).get(30,
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep, System.currentTimeMillis()).get(30,
                         TimeUnit.SECONDS),
                 "dependency removed", expectedDepRemoved, unexpectedDuringAllSoftDepChange);
 
@@ -333,7 +333,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_LONG_TIMEOUT, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep).get(60, TimeUnit.SECONDS),
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep, System.currentTimeMillis()).get(60, TimeUnit.SECONDS),
                 "dependency added", expectedDepAdded, Collections.emptySet());
 
 
@@ -402,7 +402,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(5, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), depTypeSoftToHard).get(10, TimeUnit.SECONDS),
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), depTypeSoftToHard, System.currentTimeMillis()).get(10, TimeUnit.SECONDS),
                 "dependency type changes from soft to hard", new LinkedList<>(), new HashSet<>(stateTransitions));
 
 
@@ -416,7 +416,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(5, kernel,
-                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), depTypeHardToSoft).get(10, TimeUnit.SECONDS),
+                () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), depTypeHardToSoft, System.currentTimeMillis()).get(10, TimeUnit.SECONDS),
                 "dependency type changes from hard to soft", new LinkedList<>(), new HashSet<>(stateTransitions));
     }
 

--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -151,6 +151,8 @@ public class KernelConfigResolver {
     public Map<String, Object> resolve(List<ComponentIdentifier> componentsToDeploy, DeploymentDocument document,
             List<String> rootPackages, long configMergeTimestamp) throws PackageLoadingException, IOException {
         Map<String, Object> servicesConfig = new HashMap<>();
+        LOGGER.atDebug().kv("Components to deploy", componentsToDeploy).kv("Root packages", rootPackages)
+                .log("Resolving services configuration");
         // resolve configuration
         for (ComponentIdentifier componentToDeploy : componentsToDeploy) {
             servicesConfig.put(componentToDeploy.getName(), getServiceConfig(componentToDeploy, document,
@@ -187,6 +189,7 @@ public class KernelConfigResolver {
         servicesConfig.putIfAbsent(nucleusComponentName, getNucleusComponentConfig(nucleusComponentName));
         servicesConfig.put(kernel.getMain().getName(), getMainConfig(rootPackages, nucleusComponentName));
 
+        LOGGER.atDebug().kv("Services Configuration", servicesConfig).log("Resolved services configuration.");
         // Services need to be under the services namespace in kernel config
         return Collections.singletonMap(SERVICES_NAMESPACE_TOPIC, servicesConfig);
     }

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -872,7 +872,7 @@ public class DeploymentService extends GreengrassService {
         }
         return new DefaultDeploymentTask(dependencyResolver, componentManager, kernelConfigResolver,
                 deploymentConfigMerger, logger.createChild(), deployment, config, executorService,
-                deploymentDocumentDownloader, thingGroupHelper);
+                deploymentDocumentDownloader, thingGroupHelper, deviceConfiguration);
     }
 
     private DeploymentDocument parseAndValidateJobDocument(Deployment deployment) throws InvalidRequestException {

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -84,6 +84,10 @@ public class DeviceConfiguration {
     public static final String DEVICE_PARAM_CERTIFICATE_FILE_PATH = "certificateFilePath";
     public static final String DEVICE_PARAM_ROOT_CA_PATH = "rootCaPath";
     public static final String DEVICE_PARAM_INTERPOLATE_COMPONENT_CONFIGURATION = "interpolateComponentConfiguration";
+    public static final String DEVICE_PARAM_DEPLOYMENT_CONFIGURATION_TIME_SOURCE = "deploymentConfigurationTimeSource";
+    public static final String DEPLOYMENT_CONFIGURATION_TIME_SOURCE_DEPLOYMENT_CREATION_TIME = "deploymentCreationTime";
+    public static final String DEPLOYMENT_CONFIGURATION_TIME_SOURCE_DEPLOYMENT_PROCESSING_TIME =
+            "deploymentProcessingTime";
     public static final String DEVICE_PARAM_IPC_SOCKET_PATH = "ipcSocketPath";
     public static final String SYSTEM_NAMESPACE_KEY = "system";
     public static final String PLATFORM_OVERRIDE_TOPIC = "platformOverride";
@@ -449,6 +453,11 @@ public class DeviceConfiguration {
 
     public Topic getInterpolateComponentConfiguration() {
         return getTopic(DEVICE_PARAM_INTERPOLATE_COMPONENT_CONFIGURATION).dflt(false);
+    }
+
+    public Topic getDeploymentConfigurationTimeSource() {
+        return getTopic(DEVICE_PARAM_DEPLOYMENT_CONFIGURATION_TIME_SOURCE)
+                .dflt(DEPLOYMENT_CONFIGURATION_TIME_SOURCE_DEPLOYMENT_CREATION_TIME);
     }
 
     public Topic getGGDataEndpoint() {

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -39,7 +39,7 @@ public class DefaultActivator extends DeploymentActivator {
 
     @Override
     @SuppressWarnings("PMD.PrematureDeclaration")
-    public void activate(Map<String, Object> newConfig, Deployment deployment,
+    public void activate(Map<String, Object> newConfig, Deployment deployment, long configMergeTimestamp,
                          CompletableFuture<DeploymentResult> totallyCompleteFuture) {
         Map<String, Object> serviceConfig;
         if (newConfig.containsKey(SERVICES_NAMESPACE_TOPIC)) {
@@ -59,7 +59,7 @@ public class DefaultActivator extends DeploymentActivator {
         // Get the timestamp before updateMap(). It will be used to check whether services have started.
         long mergeTime = System.currentTimeMillis();
 
-        updateConfiguration(deploymentDocument.getTimestamp(), newConfig);
+        updateConfiguration(configMergeTimestamp, newConfig);
 
         // wait until topic listeners finished processing mergeMap changes.
         Throwable setDesiredStateFailureCause = kernel.getContext().runOnPublishQueueAndWait(() -> {

--- a/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
@@ -40,7 +40,7 @@ public abstract class DeploymentActivator {
         this.deploymentDirectoryManager = kernel.getContext().get(DeploymentDirectoryManager.class);
     }
 
-    public abstract void activate(Map<String, Object> newConfig, Deployment deployment,
+    public abstract void activate(Map<String, Object> newConfig, Deployment deployment, long configMergeTimestamp,
                                   CompletableFuture<DeploymentResult> totallyCompleteFuture);
 
     protected boolean takeConfigSnapshot(CompletableFuture<DeploymentResult> totallyCompleteFuture) {

--- a/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
@@ -145,6 +145,8 @@ public abstract class DeploymentActivator {
         insideServiceMergeBehavior.getChildOverride().put(
                 CONFIGURATION_CONFIG_KEY, serviceConfigurationMergeBehavior);
 
+        logger.atDebug().kv("Root merge behavior", rootMergeBehavior)
+                .log("Created deployment configuration root merge behavior.");
         return rootMergeBehavior;
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/KernelUpdateActivator.java
@@ -66,7 +66,7 @@ public class KernelUpdateActivator extends DeploymentActivator {
     }
 
     @Override
-    public void activate(Map<String, Object> newConfig, Deployment deployment,
+    public void activate(Map<String, Object> newConfig, Deployment deployment, long configMergeTimestamp,
                          CompletableFuture<DeploymentResult> totallyCompleteFuture) {
         if (!takeConfigSnapshot(totallyCompleteFuture)) {
             return;
@@ -101,7 +101,7 @@ public class KernelUpdateActivator extends DeploymentActivator {
         // Wait for all services to close.
         lifecycle.softShutdown(30);
 
-        updateConfiguration(deploymentDocument.getTimestamp(), newConfig);
+        updateConfiguration(configMergeTimestamp, newConfig);
 
         // Try and delete restart panic file if it exists
         try {

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -214,7 +214,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         // service config
@@ -275,7 +275,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         // service config
@@ -333,7 +333,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         // service config
@@ -381,7 +381,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         Map<String, Object> servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -431,7 +431,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         Map<String, Object> servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -467,7 +467,7 @@ class KernelConfigResolverTest {
         packagesToDeploy = Arrays.asList(rootComponentIdentifier, nucleusComponentIdentifier);
         resolvedConfig =
                 kernelConfigResolver.resolve(packagesToDeploy, document,
-                        Arrays.asList(TEST_INPUT_PACKAGE_A, DEFAULT_NUCLEUS_COMPONENT_NAME));
+                        Arrays.asList(TEST_INPUT_PACKAGE_A, DEFAULT_NUCLEUS_COMPONENT_NAME), document.getTimestamp());
 
         // THEN
         servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -499,7 +499,7 @@ class KernelConfigResolverTest {
         packagesToDeploy = Arrays.asList(rootComponentIdentifier, nucleusComponentIdentifier);
         resolvedConfig =
                 kernelConfigResolver.resolve(packagesToDeploy, document,
-                        Arrays.asList(TEST_INPUT_PACKAGE_A, DEFAULT_NUCLEUS_COMPONENT_NAME));
+                        Arrays.asList(TEST_INPUT_PACKAGE_A, DEFAULT_NUCLEUS_COMPONENT_NAME), document.getTimestamp());
 
         // THEN
         servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -545,7 +545,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver =
                 new KernelConfigResolver(componentStore, kernel, nucleusPaths, deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         Map<String, Object> servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -597,7 +597,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         Map<String, Object> servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -655,7 +655,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         Map<String, Object> servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -703,7 +703,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         Map<String, Object> servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -840,7 +840,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         Map<String, Object> servicesConfig = (Map<String, Object>) resolvedConfig.get(SERVICES_NAMESPACE_TOPIC);
@@ -1061,6 +1061,7 @@ class KernelConfigResolverTest {
                 .build();
         DeploymentDocument document = DeploymentDocument.builder()
                 .deploymentPackageConfigurationList(Collections.singletonList(rootPackageDeploymentConfig))
+                .timestamp(System.currentTimeMillis())
                 .build();
 
         Map<String, Object> servicesConfig = serviceConfigurationProperlyResolved(document,
@@ -1100,6 +1101,7 @@ class KernelConfigResolverTest {
                 .build();
         DeploymentDocument document = DeploymentDocument.builder()
                 .deploymentPackageConfigurationList(Collections.singletonList(rootPackageDeploymentConfig))
+                .timestamp(System.currentTimeMillis())
                 .build();
 
         Map<String, Object> servicesConfig = serviceConfigurationProperlyResolved(document,
@@ -1405,7 +1407,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         // service config
@@ -1481,7 +1483,7 @@ class KernelConfigResolverTest {
         KernelConfigResolver kernelConfigResolver = new KernelConfigResolver(componentStore, kernel, nucleusPaths,
                 deviceConfiguration);
         Map<String, Object> resolvedConfig =
-                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A));
+                kernelConfigResolver.resolve(packagesToDeploy, document, Arrays.asList(TEST_INPUT_PACKAGE_A), document.getTimestamp());
 
         // THEN
         // service config
@@ -1520,7 +1522,7 @@ class KernelConfigResolverTest {
                         deploymentDocument.getDeploymentPackageConfigurationList().stream().filter(
                                 DeploymentPackageConfiguration::isRootComponent).map(
                                 DeploymentPackageConfiguration::getPackageName).collect(
-                                Collectors.toList()));
+                                Collectors.toList()), deploymentDocument.getTimestamp());
 
         // THEN
         // service config

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -351,14 +351,14 @@ class DeploymentConfigMergerTest {
                 new ComponentUpdatePolicy(0, SKIP_NOTIFY_COMPONENTS));
 
 
-        merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>());
+        merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>(), System.currentTimeMillis());
         verify(updateSystemPolicyService, times(0)).addUpdateAction(any(), any());
 
         doc.setConfigurationArn("DeploymentId");
         doc.setComponentUpdatePolicy(
                 new ComponentUpdatePolicy(60, NOTIFY_COMPONENTS));
 
-        merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>());
+        merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>(), System.currentTimeMillis());
 
         verify(updateSystemPolicyService).addUpdateAction(any(), any());
     }
@@ -387,7 +387,7 @@ class DeploymentConfigMergerTest {
         when(doc.getComponentUpdatePolicy()).thenReturn(
                 new ComponentUpdatePolicy(0, NOTIFY_COMPONENTS));
 
-        Future<DeploymentResult> fut = merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>());
+        Future<DeploymentResult> fut = merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>(), System.currentTimeMillis());
 
         verify(updateSystemPolicyService)
                 .addUpdateAction(any(), cancelledTaskCaptor.capture());
@@ -423,7 +423,7 @@ class DeploymentConfigMergerTest {
         when(doc.getComponentUpdatePolicy()).thenReturn(
                 new ComponentUpdatePolicy(0, NOTIFY_COMPONENTS));
 
-        merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>());
+        merger.mergeInNewConfig(createMockDeployment(doc), new HashMap<>(), System.currentTimeMillis());
 
         verify(updateSystemPolicyService).addUpdateAction(any(), taskCaptor.capture());
 
@@ -434,7 +434,7 @@ class DeploymentConfigMergerTest {
         taskCaptor.getValue().getAction().run();
 
         // THEN
-        verify(defaultActivator, times(1)).activate(any(), any(), any());
+        verify(defaultActivator, times(1)).activate(any(), any(), any(Long.class), any());
     }
 
     @Test
@@ -479,7 +479,7 @@ class DeploymentConfigMergerTest {
         when(doc.getComponentUpdatePolicy()).thenReturn(
                 new ComponentUpdatePolicy(0, NOTIFY_COMPONENTS));
 
-        merger.mergeInNewConfig(createMockDeployment(doc), newConfig);
+        merger.mergeInNewConfig(createMockDeployment(doc), newConfig, System.currentTimeMillis());
 
         verify(updateSystemPolicyService).addUpdateAction(any(), taskCaptor.capture());
 
@@ -490,7 +490,7 @@ class DeploymentConfigMergerTest {
         taskCaptor.getValue().getAction().run();
 
         // THEN
-        verify(defaultActivator, times(1)).activate(any(), any(), any());
+        verify(defaultActivator, times(1)).activate(any(), any(), any(Long.class), any());
 
         verify(deviceConfiguration, times(1)).validateEndpoints(regionCaptor.capture(), credEndpointCaptor.capture(), dataEndpointCaptor.capture());
         assertNotNull(regionCaptor.getValue());
@@ -540,7 +540,7 @@ class DeploymentConfigMergerTest {
         when(doc.getComponentUpdatePolicy()).thenReturn(
                 new ComponentUpdatePolicy(0, NOTIFY_COMPONENTS));
 
-        merger.mergeInNewConfig(createMockDeployment(doc), newConfig);
+        merger.mergeInNewConfig(createMockDeployment(doc), newConfig, System.currentTimeMillis());
 
         verify(updateSystemPolicyService).addUpdateAction(any(), taskCaptor.capture());
 
@@ -551,7 +551,7 @@ class DeploymentConfigMergerTest {
         taskCaptor.getValue().getAction().run();
 
         // THEN
-        verify(defaultActivator, times(1)).activate(any(), any(), any());
+        verify(defaultActivator, times(1)).activate(any(), any(), any(Long.class), any());
 
         verify(deviceConfiguration, times(1)).validateEndpoints(regionCaptor.capture(), credEndpointCaptor.capture(), dataEndpointCaptor.capture());
 


### PR DESCRIPTION
**Issue #, if available:**
P200769160

**Description of changes:**

Introduce a new configuration for the nucleus component: deploymentConfigurationTimeSource with two possible values: 

* deploymentCreationTime - (Default, current behavior) - When a deployment is processed on a device, the configuration update uses the deployment creation timestamp to resolve conflicts on config keys existing on the device. This ensures a consistent config state when multiple deployments are applied to the same device at the same time. A config value from a deployment will not be overwritten by other deployments with older creation times while this behavior is selected, even if the deployment is processed on the device at a later (more recent) time.
* deploymentProcessingTime - When a deployment is processed on a device, the configuration update uses the current device local timestamp to resolve conflicts on config keys existing on the device. In effect, config will always be updated and overwrite during any conflicts while this behavior is selected because the deployment processing timestamp will be greater than any deployment creation timestamp, assuming the device clock is calibrated. This means that the config state can be non-deterministic when multiple deployments that set the same config key to different values are active and queued to be deployed to the device at the same time, because the deployments could happen in any order- these situations should be avoided (and we strongly recommend avoiding them) when using this option.

**Why is this change necessary:**

Have an option for more-recently-processed deployments to always update config (regardless of configs set by previously processed deployments which may have had priority by deployment creation timestamp).

**How was this change tested:**
- [ ] Updated or added new unit tests.
  - Attempted but aborted as the existing unit tests for these modules don't actually check these code paths
- [ ] Updated or added new integration tests.
  - Attempted but aborted in favor of end-to-end tests
- [X] Updated or added new end-to-end tests.
  - See CR-189181118
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.
   - n/a

**Compatibility Checklist:**
- [X] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
  - n/a
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.
  - n/a

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
