### PR TITLE
chore: add user name character warning

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelCommandLine.java
@@ -64,6 +64,7 @@ public class KernelCommandLine {
     private static final String deploymentsPathName = "~root/deployments";
     private static final String cliIpcInfoPathName = "~root/cli_ipc_info";
     private static final String binPathName = "~root/bin";
+    private static final String validUserCharExpr = "^[a-zA-Z0-9._]+[a-zA-Z0-9._-]*$";
 
     public KernelCommandLine(Kernel kernel) {
         this(kernel, kernel.getNucleusPaths());
@@ -158,6 +159,10 @@ public class KernelCommandLine {
         }
         if (defaultUserFromCmdLine != null) {
             if (PlatformResolver.isWindows) {
+                if (!defaultUserFromCmdLine.matches(validUserCharExpr)) {
+                    logger.warn("Component user may contain invalid characters. This can cause issues starting a "
+                            + "component.");
+                }
                 deviceConfiguration.getRunWithDefaultWindowsUser().withValue(defaultUserFromCmdLine);
             } else {
                 deviceConfiguration.getRunWithDefaultPosixUser().withValue(defaultUserFromCmdLine);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds a warning log when potentially
invalid characters are used in a username.

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
This change aims to raise awareness around invalid user names which can cause component failures.
For Linux [see this](https://systemd.io/USER_NAMES/#:~:text=On%20POSIX%20the%20set%20of,character%20of%20the%20user%20name.) (best doc I could find).
For Windows [see this](https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-autologon-username#values).
**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
