### PR TITLE
chore: update checkstyle plugin to 3.6.0

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -304,7 +304,7 @@
         </module>
         <module name="JavadocMethod">
             <property name="severity" value="warning"/>
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="false"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="validateThrows" value="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -447,12 +447,12 @@
             </plugin>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
+                        <version>10.3.4</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.3.4</version>
+                        <version>9.3</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/lifecycle/LifecycleIPCEventStreamAgent.java
@@ -271,6 +271,7 @@ public class LifecycleIPCEventStreamAgent {
      * @param request     DeferComponentUpdateRequest object
      * @param serviceName nam of the service deferring the update
      * @throws InvalidArgumentsError if service name or deployment id inputs are invalid
+     * @throws ServiceError if the time limit to respond has been exceeded
      */
     public void deferComponentUpdate(DeferComponentUpdateRequest request, String serviceName) {
         if (!componentUpdateListeners.containsKey(serviceName) && !componentUpdateListenersInternal.containsKey(

--- a/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/ClientConfigurationUtils.java
@@ -44,6 +44,7 @@ public final class ClientConfigurationUtils {
      *
      * @param deviceConfiguration {@link DeviceConfiguration}
      * @return service endpoint URI
+     * @throws RuntimeException when an invalid environment stage is given
      */
     @SuppressWarnings("PMD.UseStringBufferForStringAppends")
     public static String getGreengrassServiceEndpoint(DeviceConfiguration deviceConfiguration) {

--- a/src/main/java/com/aws/greengrass/config/Configuration.java
+++ b/src/main/java/com/aws/greengrass/config/Configuration.java
@@ -70,7 +70,7 @@ public class Configuration {
      * file. Never returns null.
      * @param timestamp modtime of newly created nodes
      * @param path String[] of node names to traverse to find or create the Topic
-     * @return
+     * @return the topic as it existed or was created
      */
     public Topic lookup(long timestamp, String... path) {
         return root.lookup(timestamp, path);

--- a/src/main/java/com/aws/greengrass/config/Topics.java
+++ b/src/main/java/com/aws/greengrass/config/Topics.java
@@ -108,7 +108,7 @@ public class Topics extends Node implements Iterable<Node> {
      *
      * @param name name of the leaf node
      * @param timestamp modtime of the leaf node
-     * @return
+     * @return leaf topic as it existed or was created
      */
     public Topic createLeafChild(String name, long timestamp) {
         return createLeafChild(new CaseInsensitiveString(name),  timestamp);
@@ -145,7 +145,7 @@ public class Topics extends Node implements Iterable<Node> {
      * Returns the new node or the existing node if it already existed.
      * @param name name for the new node
      * @param timestamp modtime of the new node
-     * @return
+     * @return the newly created topic or the existing topic
      */
     public Topics createInteriorChild(String name, long timestamp) {
         return createInteriorChild(new CaseInsensitiveString(name), timestamp);
@@ -198,7 +198,7 @@ public class Topics extends Node implements Iterable<Node> {
      * file. Never returns null.
      * @param timestamp modtime of newly created nodes
      * @param path String[] of node names to traverse to find or create the Topic
-     * @return
+     * @return the topic as it exited or was created
      */
     public Topic lookup(long timestamp, String... path) {
         int limit = path.length - 1;
@@ -225,7 +225,7 @@ public class Topics extends Node implements Iterable<Node> {
      *
      * @param timestamp modtime of newly created nodes
      * @param path String[] of node names to traverse to find or create the Topics
-     * @return
+     * @return the topic as it existed or was created
      */
     public Topics lookupTopics(long timestamp, String... path) {
         Topics n = this;

--- a/src/main/java/com/aws/greengrass/jna/Kernel32Ex.java
+++ b/src/main/java/com/aws/greengrass/jna/Kernel32Ex.java
@@ -11,6 +11,7 @@ import com.sun.jna.win32.W32APIOptions;
 
 public interface Kernel32Ex extends Library {
     Kernel32Ex INSTANCE = Native.load("kernel32", Kernel32Ex.class, W32APIOptions.DEFAULT_OPTIONS);
+
     @SuppressWarnings({"checkstyle:MethodName", "PMD.MethodNamingConventions"})
     boolean SetConsoleCtrlHandler(HandlerRoutine handlerRoutine, boolean add);
 }

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GreengrassService.java
@@ -235,7 +235,7 @@ public class GreengrassService implements InjectionActions {
     /**
      * Returns true if the service has reached its desired state.
      *
-     * @return
+     * @return true if the desired state has been reached
      */
     public boolean reachedDesiredState() {
         return lifecycle.reachedDesiredState();
@@ -645,7 +645,7 @@ public class GreengrassService implements InjectionActions {
      * Get the config topics for service local data-store during runtime. content under runtimeConfig will not be
      * affected by DeploymentService or DeploymentService roll-back.
      *
-     * @return
+     * @return the runtime topic
      */
     public Topics getRuntimeConfig() {
         return config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC);

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -139,8 +139,10 @@ public class KernelLifecycle {
 
     /**
      * Startup the Kernel and all services.
+     *
+     * @throws RuntimeException when plugin ordering is required
      */
-    public void launch() {
+    public void launch()  {
         logger.atInfo("system-start").kv("version",
                 kernel.getContext().get(DeviceConfiguration.class).getNucleusVersion())
                 .kv("rootPath", nucleusPaths.rootPath())

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -294,7 +294,7 @@ public class Lifecycle {
     /**
      * Returns true if the service has reached its desired state.
      *
-     * @return
+     * @return true if desired state is reached
      */
     protected boolean reachedDesiredState() {
         try (LockScope ls = LockScope.lock(desiredStateLock)) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/PluginService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/PluginService.java
@@ -35,7 +35,7 @@ public class PluginService extends GreengrassService {
      * workflow.
      *
      * @param newServiceConfig new service config for the update
-     * @return
+     * @return true if bootstrap is required for update
      */
     @Override
     public boolean isBootstrapRequired(Map<String, Object> newServiceConfig) {

--- a/src/main/java/com/aws/greengrass/security/SecurityService.java
+++ b/src/main/java/com/aws/greengrass/security/SecurityService.java
@@ -71,6 +71,7 @@ public final class SecurityService {
     /**
      * Constructor of security service.
      * @param deviceConfiguration device configuration
+     * @throws RuntimeException when the crypto key or mqtt connection provider has already been registered
      */
     @Inject
     public SecurityService(DeviceConfiguration deviceConfiguration) {

--- a/src/main/java/com/aws/greengrass/util/DependencyOrder.java
+++ b/src/main/java/com/aws/greengrass/util/DependencyOrder.java
@@ -24,7 +24,7 @@ public class DependencyOrder<T> {
      *
      * @param pendingDependencies a set of inter-dependent elements
      * @param dependencyGetter function to get all dependency elements of the given element
-     * @return
+     * @return unique dependency order
      */
     @SuppressWarnings("PMD.LooseCoupling")
     public LinkedHashSet<T> computeOrderedDependencies(Set<T> pendingDependencies,

--- a/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
+++ b/src/main/java/com/aws/greengrass/util/GreengrassServiceClientFactory.java
@@ -138,8 +138,8 @@ public class GreengrassServiceClientFactory {
     /**
      * Initializes and returns GreengrassV2DataClient.
      * Note that this method can return null if there is a config validation error.
-     * @deprecated use fetchGreengrassV2DataClient instead.
      * @throws TLSAuthException if the client is not configured properly.
+     * @deprecated use fetchGreengrassV2DataClient instead.
      */
     @Deprecated
     public GreengrassV2DataClient getGreengrassV2DataClient() throws TLSAuthException {

--- a/src/main/java/com/aws/greengrass/util/ProxyUtils.java
+++ b/src/main/java/com/aws/greengrass/util/ProxyUtils.java
@@ -112,7 +112,7 @@ public final class ProxyUtils {
      *
      * @param url User provided URL value from config
      * @return <code>port</code> in <code>scheme://user:pass@host:port</code> or the default for the
-     * <code>scheme</code>, -1 if <code>scheme</code> isn't recognized
+     *      <code>scheme</code>, -1 if <code>scheme</code> isn't recognized
      */
     public static int getPortFromProxyUrl(String url) {
         int userProvidedPort = URI.create(url).getPort();

--- a/src/main/java/com/aws/greengrass/util/RetryUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RetryUtils.java
@@ -55,6 +55,7 @@ public class RetryUtils {
      * @param <T>             return type
      * @return return value
      * @throws Exception Exception
+     * @throws InterruptedException when the task thread is interrupted
      */
     @SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.AvoidCatchingGenericException",
             "PMD.AvoidInstanceofChecksInCatchClause"})


### PR DESCRIPTION
**Issue #, if available:**
No issue. I was simply annoyed that I had to build the code to run checkstyle checks. This PR allows the checks to be ran through the [Checkstyle-Idea plugin](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea).

**Description of changes:**
The maven checkstyle plugin version 3.6.0
is the latest version of the plugin and supports
newer checkstyle versions. This commit bumps
checkstyle to the latest version (10.3.4) and
fixes violations.


**Why is this change necessary:**
Simplifies development work by allowing checks to be performed while developing.

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**
You can install [Checkstyle-Idea plugin](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) and try out the configuration.

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
