### PR TITLE
fix: Apply proper error caching for SSL certificate failures in TES

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -314,10 +314,11 @@ public class CredentialRequestHandler implements HttpHandler {
             tesCache.get(iotCredentialsPath).expiry = newExpiry;
             tesCache.get(iotCredentialsPath).credentials = response;
         } catch (AWSIotException | TLSAuthException e) {
-            // Http connection error should expire immediately
+            // Http connection error should be cached to avoid excessive retries
             String responseString = "Failed to get connection";
             response = responseString.getBytes(StandardCharsets.UTF_8);
-            newExpiry = Instant.now(clock);
+            // Use unknown error cache policy for SSL/TLS connection errors to prevent excessive retries
+            newExpiry = Instant.now(clock).plus(Duration.ofMinutes(UNKNOWN_ERROR_CACHE_IN_MIN));
             tesCache.get(iotCredentialsPath).responseCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
             tesCache.get(iotCredentialsPath).expiry = newExpiry;
             tesCache.get(iotCredentialsPath).credentials = response;


### PR DESCRIPTION
- SSL certificate errors (AWSIotException/TLSAuthException) now use UNKNOWN_ERROR_CACHE_IN_MIN (5 minutes) instead of immediate expiry
- Prevents excessive bandwidth usage from continuous retry loops when SSL handshake fails
- Maintains proper error caching behavior for connection failures

This resolves an issue where SSL certificate validation failures would bypass
the intended error caching mechanism, causing credential requests to retry
every ~2 seconds instead of respecting the configured 5-minute cache timeout.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
