### PR TITLE
fix: reduce memory footprint of large configuration logs

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -189,7 +189,8 @@ public class KernelConfigResolver {
         servicesConfig.putIfAbsent(nucleusComponentName, getNucleusComponentConfig(nucleusComponentName));
         servicesConfig.put(kernel.getMain().getName(), getMainConfig(rootPackages, nucleusComponentName));
 
-        LOGGER.atDebug().kv("Services Configuration", servicesConfig).log("Resolved services configuration.");
+        LOGGER.atDebug().log("Resolved services configuration.");
+        LOGGER.atTrace().kv("Services Configuration", servicesConfig).log();
         // Services need to be under the services namespace in kernel config
         return Collections.singletonMap(SERVICES_NAMESPACE_TOPIC, servicesConfig);
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Moved actual deployment config log from debug level to trace level
**Why is this change necessary:**
Printing logs would consume memory usage, in case the configuration is exceptionally large, printing the configuration would increase the memory allocation significantly.
**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
