### PR TITLE
fix: clean up deployment artifacts

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/BreakingAppJobDoc1.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/BreakingAppJobDoc1.json
@@ -1,0 +1,16 @@
+{
+    "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
+    "Packages": [
+      {
+        "Name": "BreakingApp",
+        "ResolvedVersion": "1.0.0",
+        "RootComponent": true
+      }
+    ],
+    "Timestamp": 1592574829000,
+    "FailureHandlingPolicy": "ROLLBACK",
+    "ComponentUpdatePolicy": {
+      "Timeout": 60,
+      "ComponentUpdatePolicyAction": "NOTIFY_COMPONENTS"
+    }
+  }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/BreakingAppJobDoc2.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/BreakingAppJobDoc2.json
@@ -1,0 +1,16 @@
+{
+    "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
+    "Packages": [
+      {
+        "Name": "BreakingApp",
+        "ResolvedVersion": "2.0.0",
+        "RootComponent": true
+      }
+    ],
+    "Timestamp": 1592574829000,
+    "FailureHandlingPolicy": "ROLLBACK",
+    "ComponentUpdatePolicy": {
+      "Timeout": 60,
+      "ComponentUpdatePolicyAction": "NOTIFY_COMPONENTS"
+    }
+  }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/BreakingAppJobDoc3.json
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/BreakingAppJobDoc3.json
@@ -1,0 +1,16 @@
+{
+    "DeploymentId": "f7fe5b16-574a-11ea-82b4-0242ac130004",
+    "Packages": [
+      {
+        "Name": "BreakingApp",
+        "ResolvedVersion": "3.0.0",
+        "RootComponent": true
+      }
+    ],
+    "Timestamp": 1592574829000,
+    "FailureHandlingPolicy": "ROLLBACK",
+    "ComponentUpdatePolicy": {
+      "Timeout": 60,
+      "ComponentUpdatePolicyAction": "NOTIFY_COMPONENTS"
+    }
+  }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/artifacts/BreakingApp/1.0.0/breakingApp.txt
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/artifacts/BreakingApp/1.0.0/breakingApp.txt
@@ -1,0 +1,5 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/artifacts/BreakingApp/2.0.0/breakingApp.txt
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/artifacts/BreakingApp/2.0.0/breakingApp.txt
@@ -1,0 +1,5 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/artifacts/BreakingApp/3.0.0/breakingApp.txt
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/artifacts/BreakingApp/3.0.0/breakingApp.txt
@@ -1,0 +1,5 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/BreakingApp-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/BreakingApp-1.0.0.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: BreakingApp
+ComponentDescription: A simple test app that breaks
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentConfiguration:
+  DefaultConfiguration:
+    sampleText: This is a test
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      install: echo Broken install. && sleep 5 && exit /b 1
+      run:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/BreakingApp-2.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/BreakingApp-2.0.0.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: BreakingApp
+ComponentDescription: A simple test app that breaks
+ComponentPublisher: Me
+ComponentVersion: '2.0.0'
+ComponentConfiguration:
+  DefaultConfiguration:
+    sampleText: This is a test
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      install: echo Broken install. && sleep 5 && exit /b 1
+      run:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/BreakingApp-3.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/local_store_content/recipes/BreakingApp-3.0.0.yaml
@@ -1,0 +1,15 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: BreakingApp
+ComponentDescription: A simple test app that breaks
+ComponentPublisher: Me
+ComponentVersion: '3.0.0'
+ComponentConfiguration:
+  DefaultConfiguration:
+    sampleText: This is a test
+Manifests:
+  - Platform:
+      os: all
+    Lifecycle:
+      install: echo Broken install. && sleep 5 &&  exit /b 1
+      run:

--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -112,6 +112,8 @@ public class DefaultDeploymentTask implements DeploymentTask {
         Future<List<ComponentIdentifier>> resolveDependenciesFuture = null;
         Future<Void> preparePackagesFuture = null;
         Future<DeploymentResult> deploymentMergeFuture = null;
+        DeploymentResult deploymentResult = null;
+        List<ComponentIdentifier> desiredPackages = null;
         DeploymentDocument deploymentDocument = deployment.getDeploymentDocumentObj();
         try {
             logger.atInfo().setEventType(DEPLOYMENT_TASK_EVENT_TYPE)
@@ -131,7 +133,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
             resolveDependenciesFuture = executorService.submit(() ->
                     dependencyResolver.resolveDependencies(deploymentDocument, nonTargetGroupsToRootPackagesMap));
 
-            List<ComponentIdentifier> desiredPackages = resolveDependenciesFuture.get();
+            desiredPackages = resolveDependenciesFuture.get();
 
             // download configuration if large
             List<String> requiredCapabilities = deploymentDocument.getRequiredCapabilities();
@@ -163,21 +165,16 @@ public class DefaultDeploymentTask implements DeploymentTask {
             //   on the device before the deployment started, and finding one of type nucleus.
             Optional<DeploymentPackageConfiguration> incomingNucleusComponentConfiguration =
                     deploymentDocument.getDeploymentPackageConfigurationList() == null ? Optional.empty() :
-                    deploymentDocument.getDeploymentPackageConfigurationList().stream()
-                        .filter(c -> c.getPackageName().equals(deviceConfiguration.getNucleusComponentName()))
-                        .findAny();
+                            deploymentDocument.getDeploymentPackageConfigurationList().stream()
+                                    .filter(c -> c.getPackageName()
+                                            .equals(deviceConfiguration.getNucleusComponentName()))
+                                    .findAny();
 
             if (incomingNucleusComponentConfiguration.isPresent()
-                    && incomingNucleusComponentConfiguration
-                        .get()
-                        .getConfigurationUpdateOperation() != null
-                    && incomingNucleusComponentConfiguration
-                        .get()
-                        .getConfigurationUpdateOperation()
+                    && incomingNucleusComponentConfiguration.get().getConfigurationUpdateOperation() != null
+                    && incomingNucleusComponentConfiguration.get().getConfigurationUpdateOperation()
                         .getValueToMerge() != null
-                    && incomingNucleusComponentConfiguration
-                        .get()
-                        .getConfigurationUpdateOperation()
+                    && incomingNucleusComponentConfiguration.get().getConfigurationUpdateOperation()
                         .getValueToMerge()
                         .containsKey(DEVICE_PARAM_DEPLOYMENT_CONFIGURATION_TIME_SOURCE)) {
                 logger.atDebug(DEPLOYMENT_TASK_EVENT_TYPE).log(
@@ -222,29 +219,46 @@ public class DefaultDeploymentTask implements DeploymentTask {
 
             // Block this without timeout because it can take a long time for the device to update the config
             // (if it's not in a safe window).
-            DeploymentResult result = deploymentMergeFuture.get();
+            deploymentResult = deploymentMergeFuture.get();
 
             logger.atInfo(DEPLOYMENT_TASK_EVENT_TYPE).setEventType(DEPLOYMENT_TASK_EVENT_TYPE)
                     .log("Finished deployment task");
 
-            componentManager.cleanupStaleVersions();
-            return result;
+            return deploymentResult;
         } catch (PackageLoadingException | DeploymentTaskFailureException | IOException e) {
             logger.atError().setCause(e).log("Error occurred while processing deployment");
-            return new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE, e);
+            deploymentResult = new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE, e);
+            return deploymentResult;
         } catch (ExecutionException e) {
             logger.atError().setCause(e).log("Error occurred while processing deployment");
             Throwable t = e.getCause();
             if (t instanceof InterruptedException) {
                 throw (InterruptedException) t;
             } else {
-                return new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE, t);
+                deploymentResult = new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE, t);
+                return deploymentResult;
             }
         } catch (InterruptedException e) {
             // DeploymentTask got interrupted while performing a blocking step.
             cancelDeploymentTask(resolveDependenciesFuture, preparePackagesFuture, deploymentMergeFuture);
             // Populate the exception up to the stack
             throw e;
+        } finally {
+            // Clean up stale artifacts from previous deployments after downloading deployment document
+            // if we have desiredPackages then the artifact download has started
+            Map<String, String> currentDeploymentComponentVersions = null;
+            if (desiredPackages != null) {
+                currentDeploymentComponentVersions = desiredPackages.stream()
+                        .collect(Collectors.toMap(
+                                ComponentIdentifier::getName,
+                                ci -> ci.getVersion().getValue()));
+                logger.atDebug(DEPLOYMENT_TASK_EVENT_TYPE)
+                        .kv("Current deployment map", currentDeploymentComponentVersions.toString())
+                        .log("Found current deployment artifacts, will preserve.");
+            }
+            boolean isDeploymentAborted = deploymentResult == null
+                    || deploymentResult.getDeploymentStatus() != DeploymentResult.DeploymentStatus.SUCCESSFUL;
+            componentManager.cleanupStaleVersions(isDeploymentAborted, currentDeploymentComponentVersions);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/KernelUpdateDeploymentTask.java
@@ -79,6 +79,7 @@ public class KernelUpdateDeploymentTask implements DeploymentTask {
             result = deploymentResultCompletableFuture.get();
         } catch (InterruptedException | ExecutionException | CancellationException e) {
             // nothing to report when deployment is cancelled
+            componentManager.cleanupStaleVersions();
             return null;
         }
         componentManager.cleanupStaleVersions();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix: Clean up deployment artifact logic to keep 2 successful deployments + 1 failed deployment artifacts.

minor fix: Account for possible null recheckTime.


**Why is this change necessary:**

Upon consecutive failed deployments, failed artifacts could accumulate indefinitely.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
