### PR TITLE
chore: bump version 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>nucleus</artifactId>
-    <version>2.14.0-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -858,7 +858,7 @@
         <excludedGroups>E2E,E2E-INTRUSIVE</excludedGroups>
         <groups></groups>
         <greengrassjar.name>Greengrass</greengrassjar.name>
-        <lastVersion>2.13.0-SNAPSHOT</lastVersion>
+        <lastVersion>2.14.0-SNAPSHOT</lastVersion>
     </properties>
     <distributionManagement>
         <snapshotRepository>

--- a/src/test/greengrass-nucleus-benchmark/pom.xml
+++ b/src/test/greengrass-nucleus-benchmark/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.aws.greengrass</groupId>
     <artifactId>greengrass-nucleus-benchmark</artifactId>
-    <version>2.14.0-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JMH benchmark sample: Java</name>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.14.0-SNAPSHOT</version>
+            <version>2.15.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump Nucleus snapshot version to 2.15.0
 Update all the references like this https://github.com/aws-greengrass/aws-greengrass-nucleus/commit/991fa35fb54fc6b191c3a7d9c099212532ab6fba

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
