### PR TITLE
fix: remove warning when limit is set to 0

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/unix/linux/LinuxSystemResourceController.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/linux/LinuxSystemResourceController.java
@@ -111,12 +111,15 @@ public class LinuxSystemResourceController implements SystemResourceController {
                 initializeCgroup(component, memoryManager);
             }
             if (resourceLimit.containsKey(MEMORY_KEY)) {
-                long memoryLimitInKB = Coerce.toLong(resourceLimit.get(MEMORY_KEY));
-                if (memoryLimitInKB > 0) {
-                    memoryManager.setMemoryLimit(component.getServiceName(), memoryLimitInKB);
-                } else {
-                    logger.atWarn().kv(COMPONENT_NAME, component.getServiceName()).kv(MEMORY_KEY, memoryLimitInKB)
-                            .log("The provided memory limit is invalid");
+                Object memoryValue = resourceLimit.get(MEMORY_KEY);
+                if (memoryValue != null) {
+                    long memoryLimitInKB = Coerce.toLong(memoryValue);
+                    if (memoryLimitInKB > 0) {
+                        memoryManager.setMemoryLimit(component.getServiceName(), memoryLimitInKB);
+                    } else {
+                        logger.atWarn().kv(COMPONENT_NAME, component.getServiceName()).kv(MEMORY_KEY, memoryLimitInKB)
+                                .log("The provided memory limit is invalid");
+                    }
                 }
             }
 
@@ -125,12 +128,15 @@ public class LinuxSystemResourceController implements SystemResourceController {
                 initializeCgroup(component, cpuManager);
             }
             if (resourceLimit.containsKey(CPUS_KEY)) {
-                double cpu = Coerce.toDouble(resourceLimit.get(CPUS_KEY));
-                if (cpu > 0) {
-                    cpuManager.setCpuLimit(component.getServiceName(), cpu);
-                } else {
-                    logger.atWarn().kv(COMPONENT_NAME, component.getServiceName()).kv(CPUS_KEY, cpu)
-                            .log("The provided cpu limit is invalid");
+                Object cpuValue = resourceLimit.get(CPUS_KEY);
+                if (cpuValue != null) {
+                    double cpu = Coerce.toDouble(cpuValue);
+                    if (cpu > 0) {
+                        cpuManager.setCpuLimit(component.getServiceName(), cpu);
+                    } else {
+                        logger.atWarn().kv(COMPONENT_NAME, component.getServiceName()).kv(CPUS_KEY, cpu)
+                                .log("The provided cpu limit is invalid");
+                    }
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
**Issue #, if available:**
The default input value for cpu limit and memory limit is 0, so there shouldn't be warning regarding limit set to 0.

**Description of changes:**
Updated resource limit validation

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
