### PR TITLE
fix: add TestFeatureParameters to override cache value in UAT

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -88,6 +88,11 @@ public class CredentialRequestHandler implements HttpHandler {
 
     private Clock clock = Clock.systemUTC();
 
+    private final AtomicReference<Integer> cacheExpireTimeMinutes =
+            new AtomicReference<>(TIME_BEFORE_CACHE_EXPIRE_IN_MIN);
+    private final AtomicReference<Integer> unknownErrorExpireTimeMinutes =
+            new AtomicReference<>(UNKNOWN_ERROR_CACHE_IN_MIN);
+
     private final Map<String, TESCache> tesCache = new DefaultConcurrentHashMap<>(() -> {
         TESCache cache = new TESCache();
         cache.expiry = Instant.EPOCH;
@@ -103,11 +108,6 @@ public class CredentialRequestHandler implements HttpHandler {
         private final AtomicReference<CompletableFuture<Void>> future = new AtomicReference<>(null);
         private final Lock lock = LockFactory.newReentrantLock(this);
     }
-
-    private final AtomicReference<Integer> cacheExpireTimeMinutes =
-            new AtomicReference<>(TIME_BEFORE_CACHE_EXPIRE_IN_MIN);
-    private final AtomicReference<Integer> unknownErrorExpireTimeMinutes =
-            new AtomicReference<>(UNKNOWN_ERROR_CACHE_IN_MIN);
 
     @SuppressWarnings("PMD.UnusedFormalParameter")
     private void handleTestFeatureParametersHandlerChange(Boolean isDefault) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added TestFeatureParameters to CredentialRequestHandler for configurable cache timeouts (TIME_BEFORE_CACHE_EXPIRE_IN_MIN and UNKNOWN_ERROR_CACHE_IN_MIN) during UAT testing.

**Why is this change necessary:**
By making cache timeout configurable during tests, this handler can eliminate flaky test failures
caused by stale cached credentials, ensuring test reliability by allowing fresh credentials to be
fetched more frequently when needed.


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
