### PR TITLE
feat: add ability to configure tes error cache expire time

### DIFF
--- a/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
@@ -47,10 +47,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_4XX_ERROR_CACHE_IN_MIN;
-import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_5XX_ERROR_CACHE_IN_MIN;
-import static com.aws.greengrass.tes.CredentialRequestHandler.TIME_BEFORE_CACHE_EXPIRE_IN_MIN;
-import static com.aws.greengrass.tes.CredentialRequestHandler.UNKNOWN_ERROR_CACHE_IN_MIN;
+import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_4XX_ERROR_CACHE_IN_SEC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_5XX_ERROR_CACHE_IN_SEC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.TIME_BEFORE_CACHE_EXPIRE_IN_SEC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.UNKNOWN_ERROR_CACHE_IN_SEC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -320,7 +320,7 @@ class CredentialRequestHandlerTest {
         verify(mockStream, times(1)).write(expectedResponse);
 
         // Expiry time in recent future won't give error but there wil be no caching
-        expirationTime = Instant.now().plus(Duration.ofMinutes(TIME_BEFORE_CACHE_EXPIRE_IN_MIN - 1));
+        expirationTime = Instant.now().plus(Duration.ofSeconds(TIME_BEFORE_CACHE_EXPIRE_IN_SEC - 60));
         responseStr = String.format(RESPONSE_STR, expirationTime.toString());
         mockResponse = new IotCloudResponse(responseStr.getBytes(StandardCharsets.UTF_8), 200);
         when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any())).thenReturn(mockResponse);
@@ -328,7 +328,7 @@ class CredentialRequestHandlerTest {
         verify(mockCloudHelper, times(2)).sendHttpRequest(any(), any(), any(), any(), any());
 
         // Expiry time in future will result in credentials being cached
-        expirationTime = Instant.now().plus(Duration.ofMinutes(TIME_BEFORE_CACHE_EXPIRE_IN_MIN + 1));
+        expirationTime = Instant.now().plus(Duration.ofSeconds(TIME_BEFORE_CACHE_EXPIRE_IN_SEC + 60));
         responseStr = String.format(RESPONSE_STR, expirationTime.toString());
         mockResponse = new IotCloudResponse(responseStr.getBytes(StandardCharsets.UTF_8), 200);
         when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any())).thenReturn(mockResponse);
@@ -401,7 +401,7 @@ class CredentialRequestHandlerTest {
                 String.format("TES responded with status code: %d. Caching response. ", expectedStatus).getBytes();
         // expire in 2 minutes
         handler.getAwsCredentials();
-        Instant expirationTime = Instant.now().plus(Duration.ofMinutes(CLOUD_4XX_ERROR_CACHE_IN_MIN));
+        Instant expirationTime = Instant.now().plus(Duration.ofSeconds(CLOUD_4XX_ERROR_CACHE_IN_SEC));
         Clock mockClock = Clock.fixed(expirationTime, ZoneId.of("UTC"));
         handler.setClock(mockClock);
         handler.getAwsCredentials();
@@ -425,7 +425,7 @@ class CredentialRequestHandlerTest {
                 String.format("TES responded with status code: %d. Caching response. ", expectedStatus).getBytes();
         // expire in 1 minute
         handler.getAwsCredentials();
-        Instant expirationTime = Instant.now().plus(Duration.ofMinutes(CLOUD_5XX_ERROR_CACHE_IN_MIN));
+        Instant expirationTime = Instant.now().plus(Duration.ofSeconds(CLOUD_5XX_ERROR_CACHE_IN_SEC));
         Clock mockClock = Clock.fixed(expirationTime, ZoneId.of("UTC"));
         handler.setClock(mockClock);
         handler.getAwsCredentials();
@@ -449,7 +449,7 @@ class CredentialRequestHandlerTest {
                 String.format("TES responded with status code: %d. Caching response. ", expectedStatus).getBytes();
         // expire in 5 minutes
         handler.getAwsCredentials();
-        Instant expirationTime = Instant.now().plus(Duration.ofMinutes(UNKNOWN_ERROR_CACHE_IN_MIN));
+        Instant expirationTime = Instant.now().plus(Duration.ofSeconds(UNKNOWN_ERROR_CACHE_IN_SEC));
         Clock mockClock = Clock.fixed(expirationTime, ZoneId.of("UTC"));
         handler.setClock(mockClock);
         handler.getAwsCredentials();

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -48,6 +48,12 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_DEPE
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.greengrass.lifecyclemanager.Kernel.SERVICE_TYPE_TOPIC_KEY;
 import static com.aws.greengrass.lifecyclemanager.KernelCommandLine.MAIN_SERVICE_NAME;
+import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_4XX_ERROR_CACHE_TOPIC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_5XX_ERROR_CACHE_TOPIC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.UNKNOWN_ERROR_CACHE_TOPIC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_4XX_ERROR_CACHE_IN_SEC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.CLOUD_5XX_ERROR_CACHE_IN_SEC;
+import static com.aws.greengrass.tes.CredentialRequestHandler.UNKNOWN_ERROR_CACHE_IN_SEC;
 import static com.aws.greengrass.tes.TokenExchangeService.ACTIVE_PORT_TOPIC;
 import static com.aws.greengrass.tes.TokenExchangeService.PORT_TOPIC;
 import static com.aws.greengrass.tes.TokenExchangeService.TES_URI_ENV_VARIABLE_NAME;
@@ -156,6 +162,25 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
             return null;
         });
 
+        Topic cloud4xxCacheTopic = mock(Topic.class);
+        when(cloud4xxCacheTopic.dflt(CLOUD_4XX_ERROR_CACHE_IN_SEC))
+                .thenReturn(cloud4xxCacheTopic);
+
+        Topic cloud5xxCacheTopic = mock(Topic.class);
+        when(cloud5xxCacheTopic.dflt(CLOUD_5XX_ERROR_CACHE_IN_SEC))
+                .thenReturn(cloud5xxCacheTopic);
+
+        Topic unknownCacheTopic = mock(Topic.class);
+        when(unknownCacheTopic.dflt(UNKNOWN_ERROR_CACHE_IN_SEC))
+                .thenReturn(unknownCacheTopic);
+
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CLOUD_4XX_ERROR_CACHE_TOPIC))
+                .thenReturn(cloud4xxCacheTopic);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CLOUD_5XX_ERROR_CACHE_TOPIC))
+                .thenReturn(cloud5xxCacheTopic);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, UNKNOWN_ERROR_CACHE_TOPIC))
+                .thenReturn(unknownCacheTopic);
+
         TokenExchangeService tes = new TokenExchangeService(config,
                 mockCredentialHandler,
                 mockAuthZHandler, deviceConfigurationWithRoleAlias(MOCK_ROLE_ALIAS));
@@ -205,6 +230,25 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 IOT_ROLE_ALIAS_TOPIC)).thenReturn(roleTopic);
 
+        Topic cloud4xxCacheTopic = mock(Topic.class);
+        when(cloud4xxCacheTopic.dflt(CLOUD_4XX_ERROR_CACHE_IN_SEC))
+                .thenReturn(cloud4xxCacheTopic);
+
+        Topic cloud5xxCacheTopic = mock(Topic.class);
+        when(cloud5xxCacheTopic.dflt(CLOUD_5XX_ERROR_CACHE_IN_SEC))
+                .thenReturn(cloud5xxCacheTopic);
+
+        Topic unknownCacheTopic = mock(Topic.class);
+        when(unknownCacheTopic.dflt(UNKNOWN_ERROR_CACHE_IN_SEC))
+                .thenReturn(unknownCacheTopic);
+
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CLOUD_4XX_ERROR_CACHE_TOPIC))
+                .thenReturn(cloud4xxCacheTopic);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CLOUD_5XX_ERROR_CACHE_TOPIC))
+                .thenReturn(cloud5xxCacheTopic);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, UNKNOWN_ERROR_CACHE_TOPIC))
+                .thenReturn(unknownCacheTopic);
+
         TokenExchangeService tes = spy(new TokenExchangeService(config,
                 mockCredentialHandler,
                 mockAuthZHandler, deviceConfigurationWithRoleAlias(roleAlias)));
@@ -235,6 +279,25 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         when(config.lookup(CONFIGURATION_CONFIG_KEY, PORT_TOPIC)).thenReturn(portTopic);
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 IOT_ROLE_ALIAS_TOPIC)).thenReturn(roleTopic);
+
+        Topic cloud4xxCacheTopic = mock(Topic.class);
+        when(cloud4xxCacheTopic.dflt(CLOUD_4XX_ERROR_CACHE_IN_SEC))
+                .thenReturn(cloud4xxCacheTopic);
+
+        Topic cloud5xxCacheTopic = mock(Topic.class);
+        when(cloud5xxCacheTopic.dflt(CLOUD_5XX_ERROR_CACHE_IN_SEC))
+                .thenReturn(cloud5xxCacheTopic);
+
+        Topic unknownCacheTopic = mock(Topic.class);
+        when(unknownCacheTopic.dflt(UNKNOWN_ERROR_CACHE_IN_SEC))
+                .thenReturn(unknownCacheTopic);
+
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CLOUD_4XX_ERROR_CACHE_TOPIC))
+                .thenReturn(cloud4xxCacheTopic);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CLOUD_5XX_ERROR_CACHE_TOPIC))
+                .thenReturn(cloud5xxCacheTopic);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, UNKNOWN_ERROR_CACHE_TOPIC))
+                .thenReturn(unknownCacheTopic);
 
         TokenExchangeService tes = spy(new TokenExchangeService(config,
                 mockCredentialHandler,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add the ability to for users configure TES error cache expire time

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
