### PR TITLE
fix: fix operator precedence bug in startup callback state check

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -383,8 +383,8 @@ public class GenericExternalService extends GreengrassService {
                     logger.atInfo().kv(EXIT_CODE, exit).log("Startup script exited");
                     separateLogger.atInfo().kv(EXIT_CODE, exit).log("Startup script exited");
                     State state = getState();
-                    if (startingStateGeneration == getStateGeneration() && State.STARTING.equals(state)
-                            || State.RUNNING.equals(state)) {
+                    if (startingStateGeneration == getStateGeneration()
+                            && (State.STARTING.equals(state) || State.RUNNING.equals(state))) {
                         if (exit == 0 && State.STARTING.equals(state)) {
                             reportState(State.RUNNING);
                         } else if (exit != 0) {


### PR DESCRIPTION
**Issue #, if available:**
V1980934725

## Fix operator precedence bug in startup callback state check

### Description

Fixes a bug in GenericExternalService.startup() where the startup callback could incorrectly report errors for stale callbacks when the service state is RUNNING.

### Problem

The original condition:
```java
if (startingStateGeneration == getStateGeneration()
        && State.STARTING.equals(state) || State.RUNNING.equals(state))
```

Due to operator precedence, this evaluates as:
```java
(startingStateGeneration == getStateGeneration() && State.STARTING.equals(state)) 
    || State.RUNNING.equals(state)
```

This means whenever the state is RUNNING, the block executes regardless of whether the generation has changed. A stale callback from a previous startup attempt could then incorrectly call serviceErrored for a non-zero exit code, even though the service has already moved on to a new lifecycle.

### Fix

Added parentheses to ensure correct evaluation:
```java
if (startingStateGeneration == getStateGeneration()
        && (State.STARTING.equals(state) || State.RUNNING.equals(state)))
```

Now both conditions must be true: the generation must match AND the state must be STARTING or RUNNING.

### Testing

Added a unit test that:
1. Simulates a generation change and state transition to RUNNING before the callback executes
2. Invokes the callback with a non-zero exit code
3. Verifies serviceErrored is NOT called since the generation changed

**Documentation Checklist:**
 - [n/a] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [n/a] Any modification or deletion of public interfaces does not impact other plugin components.
- [n/a] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
