### PR TITLE
fix: assume processes have not stopped if we can't check their status

### DIFF
--- a/src/main/java/com/aws/greengrass/util/platforms/unix/UnixExec.java
+++ b/src/main/java/com/aws/greengrass/util/platforms/unix/UnixExec.java
@@ -126,11 +126,16 @@ public class UnixExec extends Exec {
                 boolean isAnyProcessAlive = pidProcesses.stream().anyMatch(pidProcess -> {
                     try {
                         return pidProcess.isAlive();
-                    } catch (IOException ignored) {
+                    } catch (IOException e) {
+                        logger.atWarn().cause(e).log("Unable to determine if process is alive, "
+                                + "assuming it is to allow further cleanup attempts");
+                        return true;
                     } catch (InterruptedException e) {
+                        logger.atWarn().cause(e).log("Unable to determine if process is alive, "
+                                + "assuming it is to allow further cleanup attempts");
                         Thread.currentThread().interrupt();
+                        return true;
                     }
-                    return false;
                 });
                 if (isAnyProcessAlive) {
                     logger.atWarn()


### PR DESCRIPTION
**Issue #, if available:**
V1980934725

**Description of changes:**
Changed exception handling to return true (process is alive) when status checks fail, allowing further cleanup attempts.

**Why is this change necessary:**
When checking if processes are alive, IOException and InterruptedException were caught and ignored, causing the method to return false (process is dead) by default. This could in theory leave dangling processes behind because further cleanup attempts would not happen.

**How was this change tested:**
- [n/a] Updated or added new unit tests.
- [n/a] Updated or added new integration tests.
- [n/a] Updated or added new end-to-end tests.
- [n/a] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [n/a] Updated the README if applicable.

**Compatibility Checklist:**
- [yes] I confirm that the change is backwards compatible.
- [n/a] Any modification or deletion of public interfaces does not impact other plugin components.
- [n/a] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
