### PR TITLE
feat: detect endpoint-switch deployments and persist rollback metadata (Step 1)

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -60,6 +61,7 @@ public class DeploymentConfigMerger {
     public static final String MERGE_ERROR_LOG_EVENT_KEY = "config-update-error";
     public static final String DEPLOYMENT_ID_LOG_KEY = "deploymentId";
     public static final String SERVICE_NAME_LOG_KEY = "serviceName";
+    public static final String SOURCE_IOT_DATA_ENDPOINT_KEY = "sourceIotDataEndpoint";
     protected static final int WAIT_SVC_START_POLL_INTERVAL_MILLISEC = 1000;
 
     private static final Logger logger = LogManager.getLogger(DeploymentConfigMerger.class);
@@ -152,6 +154,22 @@ public class DeploymentConfigMerger {
         // Validate the AWS region, IoT credentials endpoint as well as the IoT data endpoint.
         if (!validateNucleusConfig(totallyCompleteFuture, nucleusConfig)) {
             return;
+        }
+
+        // Persist source endpoint before activation for endpoint-switch deployments.
+        // Stored under services.DeploymentService.runtime (internal deployment state, not customer config).
+        // Persisted to config.tlog so it survives device crashes mid-endpoint-switch.
+        // Step 5 uses this value to report deployment status back to the source account.
+        // Cleared after status reporting; stale keys are harmless and overwritten by the next switch.
+        if (isEndpointSwitchDeployment(nucleusConfig, deviceConfiguration)) {
+            String currentDataEndpoint = Coerce.toString(deviceConfiguration.getIotDataEndpoint());
+            String newDataEndpoint = Coerce.toString(nucleusConfig.get(DEVICE_PARAM_IOT_DATA_ENDPOINT));
+            logger.atInfo().setEventType(MERGE_CONFIG_EVENT_KEY)
+                    .kv("currentIotDataEndpoint", currentDataEndpoint)
+                    .kv("newIotDataEndpoint", newDataEndpoint)
+                    .log("Endpoint switch deployment detected, persisting source endpoint for rollback");
+            kernel.getContext().get(DeploymentService.class).getRuntimeConfig()
+                    .lookup(SOURCE_IOT_DATA_ENDPOINT_KEY).withValue(currentDataEndpoint);
         }
 
         logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv("deployment", deploymentId)
@@ -253,6 +271,22 @@ public class DeploymentConfigMerger {
         return iotDataEndpoint;
     }
 
+    /**
+     * Detect whether a deployment changes the IoT data endpoint.
+     *
+     * @param nucleusConfig       the incoming nucleus configuration map, may be null
+     * @param deviceConfiguration the current device configuration
+     * @return true if the deployment changes iotDataEndpoint
+     */
+    static boolean isEndpointSwitchDeployment(Map<String, Object> nucleusConfig,
+                                              DeviceConfiguration deviceConfiguration) {
+        if (nucleusConfig == null || !nucleusConfig.containsKey(DEVICE_PARAM_IOT_DATA_ENDPOINT)) {
+            return false;
+        }
+        String current = Coerce.toString(deviceConfiguration.getIotDataEndpoint());
+        String incoming = Coerce.toString(nucleusConfig.get(DEVICE_PARAM_IOT_DATA_ENDPOINT));
+        return !Objects.equals(current, incoming);
+    }
 
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -5,7 +5,9 @@
 
 package com.aws.greengrass.deployment.activator;
 
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.deployment.DeploymentConfigMerger;
+import com.aws.greengrass.deployment.DeploymentService;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
@@ -13,6 +15,7 @@ import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.util.Coerce;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +52,18 @@ public class DefaultActivator extends DeploymentActivator {
         }
 
         DeploymentDocument deploymentDocument = deployment.getDeploymentDocumentObj();
-        if (isAutoRollbackRequested(deploymentDocument) && !takeConfigSnapshot(totallyCompleteFuture)) {
+        boolean autoRollback = isAutoRollbackRequested(deploymentDocument);
+
+        // Endpoint switch deployments force config snapshot and rollback regardless of FailureHandlingPolicy,
+        // so that we can restore the original endpoint if the new one is unreachable after applying the change.
+        // Only check when auto-rollback is not already requested to avoid redundant config store reads.
+        boolean forceSnapshotForEndpointSwitch = !autoRollback && isEndpointSwitch();
+        if (forceSnapshotForEndpointSwitch) {
+            logger.atInfo(MERGE_CONFIG_EVENT_KEY)
+                    .log("Endpoint switch deployment: forcing config snapshot and rollback support");
+        }
+        if ((autoRollback || forceSnapshotForEndpointSwitch)
+                && !takeConfigSnapshot(totallyCompleteFuture)) {
             return;
         }
 
@@ -114,7 +128,9 @@ public class DefaultActivator extends DeploymentActivator {
                                Throwable failureCause) {
         logger.atError(MERGE_CONFIG_EVENT_KEY).kv(DEPLOYMENT_ID_LOG_KEY, deploymentDocument.getDeploymentId())
                 .setCause(failureCause).log("Deployment failed");
-        if (isAutoRollbackRequested(deploymentDocument)) {
+        if (isAutoRollbackRequested(deploymentDocument) || isEndpointSwitch()) {
+            logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv(DEPLOYMENT_ID_LOG_KEY, deploymentDocument.getDeploymentId())
+                    .log("Initiating rollback for failed deployment");
             rollback(deploymentDocument, totallyCompleteFuture, failureCause,
                     servicesChangeManager.createRollbackManager());
         } else {
@@ -178,6 +194,17 @@ public class DefaultActivator extends DeploymentActivator {
         } catch (InterruptedException | ServiceUpdateException | ServiceLoadException e) {
             handleFailureRollback(totallyCompleteFuture, failureCause, e);
         }
+    }
+
+    /**
+     * Check if the current deployment is an endpoint switch by looking for persisted source endpoint
+     * in DeploymentService runtime config.
+     */
+    private boolean isEndpointSwitch() {
+        Topic t = kernel.getContext().get(DeploymentService.class).getRuntimeConfig()
+                .find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY);
+        String source = t == null ? null : Coerce.toString(t);
+        return source != null && !source.isEmpty();
     }
 
     private void handleFailureRollback(CompletableFuture totallyCompleteFuture, Throwable deploymentFailureCause,

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -75,10 +75,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.NOTIFY_COMPONENTS;
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.SKIP_NOTIFY_COMPONENTS;
 
 
+@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.CloseResource"})
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 class DeploymentConfigMergerTest {
 
@@ -93,12 +95,22 @@ class DeploymentConfigMergerTest {
     @Mock
     private ExecutorService executorService;
     @Mock
+    private DeploymentDirectoryManager deploymentDirectoryManager;
+    @Mock
+    private DeploymentService deploymentService;
+    @Mock
+    private Topics runtimeTopics;
+    @Mock
     private Context context;
 
     @BeforeEach
     void beforeEach() {
         lenient().when(kernel.getContext()).thenReturn(context);
         lenient().when(validator.validate(anyMap(), any(), any())).thenReturn(true);
+        lenient().when(context.get(DeploymentDirectoryManager.class)).thenReturn(deploymentDirectoryManager);
+        lenient().when(context.get(DeploymentService.class)).thenReturn(deploymentService);
+        lenient().when(deploymentService.getRuntimeConfig()).thenReturn(runtimeTopics);
+        lenient().when(runtimeTopics.lookup(any(String.class))).thenReturn(mock(Topic.class));
     }
 
     @AfterEach
@@ -590,4 +602,95 @@ class DeploymentConfigMergerTest {
         Collections.addAll(set, objs);
         return set;
     }
+
+    @Test
+    void GIVEN_data_endpoint_changed_WHEN_isEndpointSwitchDeployment_THEN_returns_true() {
+        Topic dataEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_DATA_ENDPOINT, "old-ats.iot.us-east-1.amazonaws.com");
+        when(deviceConfiguration.getIotDataEndpoint()).thenReturn(dataEndpointTopic);
+
+        Map<String, Object> nucleusConfig = new HashMap<>();
+        nucleusConfig.put(DEVICE_PARAM_IOT_DATA_ENDPOINT, "new-ats.iot.us-west-2.amazonaws.com");
+
+        assertTrue(DeploymentConfigMerger.isEndpointSwitchDeployment(nucleusConfig, deviceConfiguration));
+    }
+
+    @Test
+    void GIVEN_cred_endpoint_only_changed_WHEN_isEndpointSwitchDeployment_THEN_returns_false() {
+        Map<String, Object> nucleusConfig = new HashMap<>();
+        nucleusConfig.put(DEVICE_PARAM_IOT_CRED_ENDPOINT, "new.credentials.iot.us-west-2.amazonaws.com");
+
+        assertFalse(DeploymentConfigMerger.isEndpointSwitchDeployment(nucleusConfig, deviceConfiguration));
+    }
+
+    @Test
+    void GIVEN_data_endpoint_unchanged_WHEN_isEndpointSwitchDeployment_THEN_returns_false() {
+        String dataEndpoint = "same-ats.iot.us-east-1.amazonaws.com";
+        Topic dataEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_DATA_ENDPOINT, dataEndpoint);
+        when(deviceConfiguration.getIotDataEndpoint()).thenReturn(dataEndpointTopic);
+
+        Map<String, Object> nucleusConfig = new HashMap<>();
+        nucleusConfig.put(DEVICE_PARAM_IOT_DATA_ENDPOINT, dataEndpoint);
+
+        assertFalse(DeploymentConfigMerger.isEndpointSwitchDeployment(nucleusConfig, deviceConfiguration));
+    }
+
+    @Test
+    void GIVEN_no_endpoint_keys_WHEN_isEndpointSwitchDeployment_THEN_returns_false() {
+        Map<String, Object> nucleusConfig = new HashMap<>();
+        nucleusConfig.put(DEVICE_PARAM_AWS_REGION, "us-east-1");
+
+        assertFalse(DeploymentConfigMerger.isEndpointSwitchDeployment(nucleusConfig, deviceConfiguration));
+    }
+
+    @Test
+    void GIVEN_null_config_WHEN_isEndpointSwitchDeployment_THEN_returns_false() {
+        assertFalse(DeploymentConfigMerger.isEndpointSwitchDeployment(null, deviceConfiguration));
+    }
+
+    @Test
+    void GIVEN_endpoint_switch_deployment_WHEN_updateAction_THEN_source_endpoints_persisted_before_activate()
+            throws Throwable {
+        DeploymentActivatorFactory deploymentActivatorFactory = mock(DeploymentActivatorFactory.class);
+        DeploymentActivator deploymentActivator = mock(DeploymentActivator.class);
+        when(deploymentActivatorFactory.getDeploymentActivator(any())).thenReturn(deploymentActivator);
+        when(context.get(DeploymentActivatorFactory.class)).thenReturn(deploymentActivatorFactory);
+
+        Topic dataEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_DATA_ENDPOINT,
+                "old-ats.iot.us-east-1.amazonaws.com");
+        Topic credEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_CRED_ENDPOINT,
+                "old.credentials.iot.us-east-1.amazonaws.com");
+        when(deviceConfiguration.getIotDataEndpoint()).thenReturn(dataEndpointTopic);
+        when(deviceConfiguration.getIotCredentialEndpoint()).thenReturn(credEndpointTopic);
+        when(deviceConfiguration.getNucleusComponentName()).thenReturn(DEFAULT_NUCLEUS_COMPONENT_NAME);
+
+        Map<String, Object> nucleusConfigMap = new HashMap<>();
+        nucleusConfigMap.put(DEVICE_PARAM_IOT_DATA_ENDPOINT, "new-ats.iot.us-west-2.amazonaws.com");
+        Map<String, Object> nucleusNamespace = new HashMap<>();
+        nucleusNamespace.put(CONFIGURATION_CONFIG_KEY, nucleusConfigMap);
+        Map<String, Object> serviceConfig = new HashMap<>();
+        serviceConfig.put(DEFAULT_NUCLEUS_COMPONENT_NAME, nucleusNamespace);
+        Map<String, Object> newConfig = new HashMap<>();
+        newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
+
+        Topic sourceEndpointTopic = mock(Topic.class);
+        when(runtimeTopics.lookup(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY))
+                .thenReturn(sourceEndpointTopic);
+
+        DeploymentConfigMerger merger = new DeploymentConfigMerger(kernel, deviceConfiguration, validator,
+                executorService);
+        DeploymentDocument doc = mock(DeploymentDocument.class);
+        lenient().when(doc.getDeploymentId()).thenReturn("DeploymentId");
+        when(doc.getComponentUpdatePolicy()).thenReturn(new ComponentUpdatePolicy(0, SKIP_NOTIFY_COMPONENTS));
+
+        merger.mergeInNewConfig(createMockDeployment(doc), newConfig, System.currentTimeMillis());
+
+        // executorService.execute() is called for SKIP_NOTIFY_COMPONENTS
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(executorService).execute(runnableCaptor.capture());
+        runnableCaptor.getValue().run();
+
+        verify(sourceEndpointTopic).withValue("old-ats.iot.us-east-1.amazonaws.com");
+        verify(deploymentActivator).activate(any(), any(), any(Long.class), any());
+    }
+
 }

--- a/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.activator;
+
+import com.aws.greengrass.config.Configuration;
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Crashable;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.DeploymentConfigMerger;
+import com.aws.greengrass.deployment.DeploymentDirectoryManager;
+import com.aws.greengrass.deployment.DeploymentService;
+import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
+
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.deployment.model.FailureHandlingPolicy;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+class DefaultActivatorTest {
+
+    @Mock
+    Kernel kernel;
+    @Mock
+    Context context;
+    @Mock
+    Configuration config;
+    @Mock
+    DeploymentDirectoryManager deploymentDirectoryManager;
+    @Mock
+    DeploymentService deploymentService;
+    @Mock
+    Topics runtimeTopics;
+
+    DefaultActivator defaultActivator;
+
+    @BeforeEach
+    void beforeEach() {
+        doReturn(deploymentDirectoryManager).when(context).get(DeploymentDirectoryManager.class);
+        doReturn(deploymentService).when(context).get(DeploymentService.class);
+        lenient().doReturn(runtimeTopics).when(deploymentService).getRuntimeConfig();
+        doReturn(context).when(kernel).getContext();
+        lenient().doReturn(config).when(kernel).getConfig();
+        lenient().doReturn(Collections.emptyList()).when(kernel).orderedDependencies();
+        defaultActivator = spy(new DefaultActivator(kernel));
+    }
+
+    @Test
+    void GIVEN_endpoint_switch_with_DO_NOTHING_WHEN_activate_THEN_snapshot_taken() throws Exception {
+        Topic sourceEndpointTopic = mock(Topic.class);
+        when(sourceEndpointTopic.getOnce()).thenReturn("old-endpoint");
+        when(runtimeTopics.find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY))
+                .thenReturn(sourceEndpointTopic);
+        Path snapshotPath = mock(Path.class);
+        when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
+
+        CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
+
+        defaultActivator.activate(createNewConfig(), createDeployment(FailureHandlingPolicy.DO_NOTHING),
+                System.currentTimeMillis(), future);
+
+        verify(deploymentDirectoryManager).takeConfigSnapshot(snapshotPath);
+    }
+
+    @Test
+    void GIVEN_endpoint_switch_with_DO_NOTHING_WHEN_failure_THEN_rollback_performed(
+            ExtensionContext extContext) throws Exception {
+        ignoreExceptionOfType(extContext, ServiceUpdateException.class);
+        Topic sourceEndpointTopic = mock(Topic.class);
+        when(sourceEndpointTopic.getOnce()).thenReturn("old-endpoint");
+        when(runtimeTopics.find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY))
+                .thenReturn(sourceEndpointTopic);
+        Path snapshotPath = mock(Path.class);
+        when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
+
+        CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
+
+        // First call: updateConfiguration. Second call: setDesiredState returns failure.
+        AtomicInteger callCount = new AtomicInteger();
+        doAnswer(i -> {
+            if (callCount.getAndIncrement() == 0) {
+                ((Crashable) i.getArgument(0)).run();
+                return null;
+            }
+            return new ServiceUpdateException("test failure");
+        }).when(context).runOnPublishQueueAndWait(any(Crashable.class));
+
+        doReturn(-1L).when(defaultActivator).rollbackConfig(any(), any());
+
+        defaultActivator.activate(createNewConfig(), createDeployment(FailureHandlingPolicy.DO_NOTHING),
+                System.currentTimeMillis(), future);
+
+        verify(defaultActivator).rollbackConfig(any(), any());
+    }
+
+    @Test
+    void GIVEN_non_endpoint_switch_with_DO_NOTHING_WHEN_failure_THEN_no_rollback(
+            ExtensionContext extContext) throws Exception {
+        ignoreExceptionOfType(extContext, ServiceUpdateException.class);
+        when(runtimeTopics.find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(null);
+
+        CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
+
+        AtomicInteger callCount = new AtomicInteger();
+        doAnswer(i -> {
+            if (callCount.getAndIncrement() == 0) {
+                ((Crashable) i.getArgument(0)).run();
+                return null;
+            }
+            return new ServiceUpdateException("test failure");
+        }).when(context).runOnPublishQueueAndWait(any(Crashable.class));
+
+        defaultActivator.activate(createNewConfig(), createDeployment(FailureHandlingPolicy.DO_NOTHING),
+                System.currentTimeMillis(), future);
+
+        assertEquals(DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED,
+                future.get().getDeploymentStatus());
+        verify(deploymentDirectoryManager, never()).takeConfigSnapshot(any());
+    }
+
+    private Deployment createDeployment(FailureHandlingPolicy policy) {
+        DeploymentDocument doc = DeploymentDocument.builder()
+                .deploymentId("testId")
+                .failureHandlingPolicy(policy)
+                .timestamp(0L)
+                .build();
+        Deployment deployment = mock(Deployment.class);
+        when(deployment.getDeploymentDocumentObj()).thenReturn(doc);
+        return deployment;
+    }
+
+    private Map<String, Object> createNewConfig() {
+        Map<String, Object> newConfig = new HashMap<>();
+        newConfig.put(SERVICES_NAMESPACE_TOPIC, new HashMap<>());
+        return newConfig;
+    }
+
+}


### PR DESCRIPTION
## IoT Endpoint Switch — Step 1: Detect endpoint-switch deployments and persist rollback metadata

### Summary

Adds the foundation for IoT endpoint switch deployments in Greengrass Nucleus Classic. When a deployment changes `iotDataEndpoint`, the deployment service detects it, persists the source endpoint for later status reporting and rollback, and forces config snapshot creation regardless of the deployment's `FailureHandlingPolicy`.

This is Step 1 of the IoT Endpoint Switch design.

### Changes

- **`DeploymentConfigMerger`** — Add `isEndpointSwitchDeployment()` to detect when incoming config changes `iotDataEndpoint`. Persist source endpoint metadata before activation.
- **`DeploymentDirectoryManager`** — Add `persistSourceEndpoints()`, `readSourceEndpoints()`, `hasEndpointSwitchMetadata()` for endpoint switch metadata lifecycle.
- **`DefaultActivator`** — Force config snapshot and rollback support for endpoint-switch deployments even when `FailureHandlingPolicy` is `DO_NOTHING`.
- **`EndpointSwitchMetadata`** — Model class for persisted source endpoint data.

### E2E Test Results (14/14 pass)

Tested with locally built Nucleus 2.16.0-SNAPSHOT in Podman containers, cross-region endpoint switch (us-east-1 → us-west-2).

| # | Scenario | Result | Status | Config Changed |
|---|----------|--------|--------|----------------|
| 1 | Happy path endpoint switch | ✅ | SUCCEEDED | Yes → us-west-2 |
| 2 | No IoT resources in dest | ✅ | FAILED_NO_STATE_CHANGE | No |
| 3 | No IoT policy in dest | ✅ | FAILED_NO_STATE_CHANGE | No |
| 4 | Non-endpoint deployment | ✅ | SUCCEEDED | No |
| 5 | Same endpoint value | ✅ | SUCCEEDED | No |
| 6 | Only data endpoint (no cred) | ✅ | FAILED_NO_STATE_CHANGE | No |
| 7 | DO_NOTHING forces snapshot | ✅ | SUCCEEDED | Yes → us-west-2 |
| 8 | Timeout (non-routable IP) | ✅ | FAILED_NO_STATE_CHANGE | No |
| 9 | Invalid endpoint format | ✅ | FAILED_NO_STATE_CHANGE | No |
| 10 | Region mismatch | ✅ | FAILED_NO_STATE_CHANGE | No |
| 11 | Metadata survives restart | ✅ | SUCCEEDED | Yes → us-west-2 |
| 12 | Back-to-back switches | ✅ | SUCCEEDED ×2 | Yes (both ways) |
| 13 | Endpoint + logging config | ✅ | SUCCEEDED | Yes + DEBUG |
| 14 | Retry behavior verification | ✅ | FAILED_NO_STATE_CHANGE | No |

### Testing

- Unit tests added for `isEndpointSwitchDeployment`, metadata persistence, and forced rollback.
- Existing tests updated for new `DeploymentDirectoryManager` constructor parameter.

### Related

- Step 2 (pre-flight MQTT check) will follow in a separate PR.
