### PR TITLE
fix: download all root CAs during auto provisioning

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -385,6 +385,10 @@ public class DeviceConfiguration {
         };
     }
 
+    public void setRootCA3Downloaded(boolean downloaded) {
+        rootCA3Downloaded.set(downloaded);
+    }
+
     public Topics getRunWithTopic() {
         return getTopics(RUN_WITH_TOPIC);
     }

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -311,9 +311,7 @@ public class DeviceProvisioningHelper {
         DeviceConfiguration deviceConfig = new DeviceConfiguration(kernel.getConfig(), kernel.getKernelCommandLine(),
                 thing.thingName, thing.dataEndpoint, thing.credEndpoint, privKeyFilePath.toString(),
                 certFilePath.toString(), caFilePath.toString(), awsRegion, roleAliasName);
-        if (allCAsDownloaded) {
-            deviceConfig.setRootCA3Downloaded(true);
-        }
+        deviceConfig.setRootCA3Downloaded(allCAsDownloaded);
         // Make sure tlog persists the device configuration
         kernel.getContext().waitForPublishQueueToClear();
         outStream.println("Created device configuration");

--- a/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
+++ b/src/main/java/com/aws/greengrass/easysetup/DeviceProvisioningHelper.java
@@ -285,9 +285,16 @@ public class DeviceProvisioningHelper {
 
         Path caFilePath = certPath.resolve("rootCA.pem");
 
+        boolean allCAsDownloaded = false;
         try {
-            outStream.printf("Downloading CA from \"%s\"%n", RootCAUtils.AMAZON_ROOT_CA_1_URL);
-            RootCAUtils.downloadRootCAToFile(caFilePath.toFile(), RootCAUtils.AMAZON_ROOT_CA_1_URL);
+            outStream.println("Downloading Amazon Root CAs");
+            RootCAUtils.downloadRootCAToFile(caFilePath.toFile(),
+                    RootCAUtils.AMAZON_ROOT_CA_1_URL,
+                    RootCAUtils.AMAZON_ROOT_CA_2_URL,
+                    RootCAUtils.AMAZON_ROOT_CA_3_URL,
+                    RootCAUtils.AMAZON_ROOT_CA_4_URL,
+                    RootCAUtils.SFS_ROOT_CA_G2_URL);
+            allCAsDownloaded = true;
         } catch (IOException e) {
             // Do not block as the root CA file may have been manually provisioned
             outStream.printf("Failed to download CA from path - %s%n", e);
@@ -301,9 +308,12 @@ public class DeviceProvisioningHelper {
         Path certFilePath = certPath.resolve("thingCert.crt");
         Files.write(certFilePath, thing.certificatePem.getBytes(StandardCharsets.UTF_8));
 
-        new DeviceConfiguration(kernel.getConfig(), kernel.getKernelCommandLine(),
+        DeviceConfiguration deviceConfig = new DeviceConfiguration(kernel.getConfig(), kernel.getKernelCommandLine(),
                 thing.thingName, thing.dataEndpoint, thing.credEndpoint, privKeyFilePath.toString(),
                 certFilePath.toString(), caFilePath.toString(), awsRegion, roleAliasName);
+        if (allCAsDownloaded) {
+            deviceConfig.setRootCA3Downloaded(true);
+        }
         // Make sure tlog persists the device configuration
         kernel.getContext().waitForPublishQueueToClear();
         outStream.println("Created device configuration");

--- a/src/main/java/com/aws/greengrass/util/RootCAUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RootCAUtils.java
@@ -35,6 +35,7 @@ public final class RootCAUtils {
     public static final String AMAZON_ROOT_CA_2_URL = "https://www.amazontrust.com/repository/AmazonRootCA2.pem";
     public static final String AMAZON_ROOT_CA_3_URL = "https://www.amazontrust.com/repository/AmazonRootCA3.pem";
     public static final String AMAZON_ROOT_CA_4_URL = "https://www.amazontrust.com/repository/AmazonRootCA4.pem";
+    public static final String SFS_ROOT_CA_G2_URL = "https://www.amazontrust.com/repository/SFSRootCAG2.pem";
     private static final Logger logger = LogManager.getLogger(ProxyUtils.class);
 
     private RootCAUtils() {

--- a/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
+++ b/src/test/java/com/aws/greengrass/easysetup/DeviceProvisioningHelperTest.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.EncryptionUtils;
 import com.aws.greengrass.util.IamSdkClientFactory;
 import com.aws.greengrass.util.IotSdkClientFactory;
-import com.aws.greengrass.util.RootCAUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -441,12 +440,10 @@ class DeviceProvisioningHelperTest {
         Path caFilePath = certPath.resolve("rootCA.pem");
         File caFile = caFilePath.toFile();
 
-        RootCAUtils.downloadRootCAToFile(caFile, RootCAUtils.AMAZON_ROOT_CA_3_URL);
-
         String certificates = new String(Files.readAllBytes(caFile.toPath()), StandardCharsets.UTF_8);
         List<String> certificateArray = Arrays.stream(certificates.split(EncryptionUtils.CERTIFICATE_PEM_HEADER)).filter(s -> !s.isEmpty()).collect(Collectors.toList());
 
-        assertEquals(2, certificateArray.size());
+        assertEquals(5, certificateArray.size());
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updated DeviceProvisioningHelper to download all 5 ATS root CAs (AmazonRootCA1-4 + SFSRootCAG2) during auto-provisioning instead of only CA1. Added a setter for rootCA3Downloaded on DeviceConfiguration so the FIPS fallback skips re-downloading CA3 when all CAs were already downloaded during provisioning. Updated existing tests to reflect the new behavior.

**Why is this change necessary:**
IoT Core changed TLS behavior in govcloud regions to prioritize ECDSA (CA3) over RSA (CA1). New customer devices provisioned with only CA1 in their trust store fail to connect because Greengrass advertises both RSA and ECDSA support. This change aligns Greengrass auto-provisioning with ATS guidance to trust all five root CAs by default, preventing connection failures for new govcloud customers.

**How was this change tested:**
- [ *] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
