### PR TITLE
chore: bump logging dependency to 2.4.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>logging</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Bump `aws-greengrass-logging-java` dependency from `2.3.0-SNAPSHOT` to `2.4.0-SNAPSHOT`.

**Why is this change necessary:**

`2.4.0-SNAPSHOT` adds `LogFormat.RAW` and `LogManager.getRawLogger(name, outputDir)` — a raw/passthrough log format that writes messages without the TEXT/JSON envelope. The `aws-greengrass-telemetry-nucleus-emitter` component needs this to write CloudWatch EMF JSON to files managed by the GG logging framework, where CloudWatch Logs auto-parses EMF into CloudWatch Metrics.

Logging-java PR: https://github.com/aws-greengrass/aws-greengrass-logging-java/pull/215

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

No new tests needed — this is a dependency version bump only. The logging library's own test suite (3 new unit tests for `getRawLogger`) passed in PR #215. No Nucleus code changes.

**Any additional information or context required to review the change:**

Consumer PRs that depend on this:
- https://github.com/aws-greengrass/aws-greengrass-telemetry-nucleus-emitter/pull/21
- https://github.com/aws-greengrass/aws-greengrass-telemetry-nucleus-emitter/pull/22

**Documentation Checklist:**
 - [x] Updated the README if applicable. (N/A — no README changes needed)

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [x] For external library version updates, I have reviewed its change logs and Nucleus does not consume any deprecated method or type.

The `2.4.0-SNAPSHOT` release adds one new enum value (`LogFormat.RAW`) and one new factory method (`LogManager.getRawLogger`). No existing APIs were modified or deprecated. All existing Nucleus code continues to use `TEXT`/`JSON` formats unchanged.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.