### PR TITLE
feat: standalone MQTT connection and pre-flight connectivity check

### DIFF
--- a/README_CONFIG_SCHEMA.md
+++ b/README_CONFIG_SCHEMA.md
@@ -177,6 +177,7 @@ services:
         pingTimeoutMs: 30000
         operationTimeoutMs: 30000
         maxInFlightPublishes: 5
+        standaloneMqttTimeoutMs: 60000
         spooler:
           keepQos0WhenOffline: false
           maxSizeInBytes: 2621440
@@ -195,6 +196,22 @@ services:
         periodicAggregateMetricsIntervalSeconds: 3600
         periodicPublishMetricsIntervalSeconds: 86400
 ```
+
+### Endpoint Switch Configuration
+
+`mqtt.standaloneMqttTimeoutMs` (default: `60000`) — Timeout budget in milliseconds for the pre-flight
+MQTT connectivity check during endpoint-switch deployments. Controls the number of connection attempts
+(timeoutMs / 10s per attempt) with exponential backoff between retries. Actual elapsed time may exceed
+this value due to backoff sleep between attempts. Values ≤ 0 are ignored and the default is used.
+
+**IoT policy requirement:** The pre-flight check connects to the target endpoint using the MQTT client ID
+`<thingName>#endpoint-switch`. If your IoT policy restricts `iot:Connect` to an exact thing name match
+(e.g., `client/${iot:Connection.Thing.ThingName}`), you must update it to allow the suffix pattern:
+```
+"Resource": "arn:aws:iot:*:*:client/${iot:Connection.Thing.ThingName}*"
+```
+This is the same wildcard pattern required by IoT Device Shadow and IoT Jobs clients. Without this,
+endpoint-switch deployments will fail with `MISSING_MQTT_CONNECT_POLICY`.
 
 Setting a custom path to relocate the $GG_ROOT/ipc.socket to another location
  on the filesystem, and it doesn't apply to Windows.

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.deployment.activator.KernelUpdateActivator;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorCodeUtils;
 import com.aws.greengrass.deployment.exceptions.ComponentConfigurationValidationException;
+import com.aws.greengrass.deployment.exceptions.DeploymentException;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
@@ -27,6 +28,9 @@ import com.aws.greengrass.lifecyclemanager.UpdateSystemPolicyService;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.mqttclient.StandaloneMqttConnector;
+import com.aws.greengrass.security.SecurityService;
+import com.aws.greengrass.security.exceptions.MqttConnectionProviderException;
 import com.aws.greengrass.util.Coerce;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -61,8 +65,11 @@ public class DeploymentConfigMerger {
     public static final String MERGE_ERROR_LOG_EVENT_KEY = "config-update-error";
     public static final String DEPLOYMENT_ID_LOG_KEY = "deploymentId";
     public static final String SERVICE_NAME_LOG_KEY = "serviceName";
-    public static final String SOURCE_IOT_DATA_ENDPOINT_KEY = "sourceIotDataEndpoint";
     protected static final int WAIT_SVC_START_POLL_INTERVAL_MILLISEC = 1000;
+    static final long DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS = 60_000;
+    static final String STANDALONE_MQTT_TIMEOUT_KEY = "standaloneMqttTimeoutMs";
+    private static final String ENDPOINT_LOG_KEY = "endpoint";
+    private static final String ENDPOINT_SWITCH_CLIENT_SUFFIX = "#endpoint-switch";
 
     private static final Logger logger = LogManager.getLogger(DeploymentConfigMerger.class);
 
@@ -156,9 +163,10 @@ public class DeploymentConfigMerger {
             return;
         }
 
-        // Persist source endpoint before activation for endpoint-switch deployments.
-        // Stored under services.DeploymentService.runtime (internal deployment state, not customer config).
-        // Persisted to config.tlog so it survives device crashes mid-endpoint-switch.
+        // Endpoint-switch deployments: pre-flight connectivity check, then persist source endpoint.
+        // Pre-flight runs BEFORE persisting so that on failure, no device state has changed.
+        // Source endpoint is stored under services.DeploymentService.runtime (internal deployment state,
+        // not customer config). Persisted to config.tlog so it survives device crashes mid-endpoint-switch.
         // Step 5 uses this value to report deployment status back to the source account.
         // Cleared after status reporting; stale keys are harmless and overwritten by the next switch.
         if (isEndpointSwitchDeployment(nucleusConfig, deviceConfiguration)) {
@@ -167,9 +175,31 @@ public class DeploymentConfigMerger {
             logger.atInfo().setEventType(MERGE_CONFIG_EVENT_KEY)
                     .kv("currentIotDataEndpoint", currentDataEndpoint)
                     .kv("newIotDataEndpoint", newDataEndpoint)
-                    .log("Endpoint switch deployment detected, persisting source endpoint for rollback");
+                    .log("Endpoint switch deployment detected");
+
+            // Pre-flight MQTT connectivity check to new endpoint
+            logger.atInfo().setEventType(MERGE_CONFIG_EVENT_KEY)
+                    .kv(ENDPOINT_LOG_KEY, newDataEndpoint)
+                    .log("Starting pre-flight MQTT connectivity check");
+            long preflightTimeout = Coerce.toLong(deviceConfiguration.getMQTTNamespace()
+                    .findOrDefault(DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS, STANDALONE_MQTT_TIMEOUT_KEY));
+            if (preflightTimeout <= 0) {
+                logger.atWarn().kv("configured", preflightTimeout)
+                        .kv("using", DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS)
+                        .log("Invalid standaloneMqttTimeoutMs, using default");
+                preflightTimeout = DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS;
+            }
+            if (!verifyMqttConnectivity(totallyCompleteFuture, newDataEndpoint, ENDPOINT_SWITCH_CLIENT_SUFFIX,
+                    preflightTimeout)) {
+                return;
+            }
+            logger.atInfo().setEventType(MERGE_CONFIG_EVENT_KEY)
+                    .kv(ENDPOINT_LOG_KEY, newDataEndpoint)
+                    .log("Pre-flight MQTT connectivity check passed");
+
+            // Persist source endpoint only after pre-flight succeeds — no state change on failure
             kernel.getContext().get(DeploymentService.class).getRuntimeConfig()
-                    .lookup(SOURCE_IOT_DATA_ENDPOINT_KEY).withValue(currentDataEndpoint);
+                    .lookup(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY).withValue(currentDataEndpoint);
         }
 
         logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv("deployment", deploymentId)
@@ -193,6 +223,55 @@ public class DeploymentConfigMerger {
             }
         }
         return true;
+    }
+
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "REC_CATCH_EXCEPTION",
+            justification = "Defensive catch for unexpected errors from CRT builder and proxy config")
+    boolean verifyMqttConnectivity(CompletableFuture<DeploymentResult> totallyCompleteFuture,
+                                   String endpoint, String clientIdSuffix, long timeoutMs) {
+        try (StandaloneMqttConnector conn = StandaloneMqttConnector.of(
+                kernel.getContext().get(SecurityService.class), deviceConfiguration,
+                endpoint, clientIdSuffix)) {
+            conn.connect(timeoutMs);
+            return true;
+        } catch (MqttConnectionProviderException e) {
+            logger.atError().setEventType(MERGE_ERROR_LOG_EVENT_KEY).setCause(e)
+                    .kv(ENDPOINT_LOG_KEY, endpoint)
+                    .log("Pre-flight MQTT connectivity check failed: device identity configuration error");
+            totallyCompleteFuture.complete(
+                    new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE,
+                            new DeploymentException("Device identity configuration error", e,
+                                    DeploymentErrorCode.TLS_HANDSHAKE_FAILURE)));
+            return false;
+        } catch (DeploymentException e) {
+            if (e.getErrorCodes().contains(DeploymentErrorCode.MISSING_MQTT_CONNECT_POLICY)) {
+                String thingName = Coerce.toString(deviceConfiguration.getThingName());
+                logger.atError().setEventType(MERGE_ERROR_LOG_EVENT_KEY).setCause(e)
+                        .kv(ENDPOINT_LOG_KEY, endpoint)
+                        .log("Pre-flight MQTT connectivity check failed: MQTT CONNECT rejected. "
+                                + "Possible causes: (1) IoT policy does not allow client ID \""
+                                + thingName + clientIdSuffix + "\" — update iot:Connect resource to "
+                                + "\"arn:aws:iot:*:*:client/" + thingName + "*\", or "
+                                + "(2) device certificate is not authorized in the target account");
+            } else {
+                logger.atError().setEventType(MERGE_ERROR_LOG_EVENT_KEY).setCause(e)
+                        .kv(ENDPOINT_LOG_KEY, endpoint)
+                        .log("Pre-flight MQTT connectivity check failed");
+            }
+            totallyCompleteFuture.complete(
+                    new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE, e));
+            return false;
+        } catch (Exception e) {
+            logger.atError().setEventType(MERGE_ERROR_LOG_EVENT_KEY).setCause(e)
+                    .kv(ENDPOINT_LOG_KEY, endpoint)
+                    .log("Pre-flight MQTT connectivity check failed");
+            totallyCompleteFuture.complete(
+                    new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE,
+                            new DeploymentException("MQTT pre-flight connection to " + endpoint + " failed",
+                                    e, DeploymentErrorCode.MQTT_CONNECTION_FAILED)));
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -98,6 +98,7 @@ public class DeploymentService extends GreengrassService {
     public static final String GROUP_TO_LAST_DEPLOYMENT_CONFIG_ARN_KEY = "configArn";
     public static final String GROUP_TO_ROOT_COMPONENTS_VERSION_KEY = "version";
     public static final String GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN = "groupConfigArn";
+    public static final String SOURCE_IOT_DATA_ENDPOINT_KEY = "sourceIotDataEndpoint";
     public static final String GROUP_TO_ROOT_COMPONENTS_GROUP_NAME = "groupConfigName";
     public static final String DEPLOYMENT_DETAILED_STATUS_KEY = "detailed-deployment-status";
     public static final String DEPLOYMENT_FAILURE_CAUSE_KEY = "deployment-failure-cause";

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -140,6 +140,17 @@ public class DefaultActivator extends DeploymentActivator {
         }
     }
 
+    /**
+     * Check if the current deployment is an endpoint switch by looking for persisted source endpoint
+     * in DeploymentService runtime config.
+     */
+    private boolean isEndpointSwitch() {
+        Topic t = kernel.getContext().get(DeploymentService.class).getRuntimeConfig()
+                .find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY);
+        String source = t == null ? null : Coerce.toString(t);
+        return source != null && !source.isEmpty();
+    }
+
     void rollback(DeploymentDocument deploymentDocument, CompletableFuture<DeploymentResult> totallyCompleteFuture,
                   Throwable failureCause, DeploymentConfigMerger.AggregateServicesChangeManager rollbackManager) {
         String deploymentId = deploymentDocument.getDeploymentId();
@@ -194,17 +205,6 @@ public class DefaultActivator extends DeploymentActivator {
         } catch (InterruptedException | ServiceUpdateException | ServiceLoadException e) {
             handleFailureRollback(totallyCompleteFuture, failureCause, e);
         }
-    }
-
-    /**
-     * Check if the current deployment is an endpoint switch by looking for persisted source endpoint
-     * in DeploymentService runtime config.
-     */
-    private boolean isEndpointSwitch() {
-        Topic t = kernel.getContext().get(DeploymentService.class).getRuntimeConfig()
-                .find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY);
-        String source = t == null ? null : Coerce.toString(t);
-        return source != null && !source.isEmpty();
     }
 
     private void handleFailureRollback(CompletableFuture totallyCompleteFuture, Throwable deploymentFailureCause,

--- a/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
+++ b/src/main/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCode.java
@@ -41,6 +41,9 @@ public enum DeploymentErrorCode {
 
     /* Network / http */
     NETWORK_ERROR(DeploymentErrorType.NETWORK_ERROR),
+    MQTT_CONNECTION_FAILED(DeploymentErrorType.NETWORK_ERROR),
+    TLS_HANDSHAKE_FAILURE(DeploymentErrorType.NETWORK_ERROR),
+    MISSING_MQTT_CONNECT_POLICY(DeploymentErrorType.PERMISSION_ERROR),
     HTTP_REQUEST_ERROR(DeploymentErrorType.HTTP_ERROR),
     DOWNLOAD_DEPLOYMENT_DOCUMENT_ERROR(DeploymentErrorType.HTTP_ERROR),
     GET_GREENGRASS_ARTIFACT_SIZE_ERROR(DeploymentErrorType.HTTP_ERROR),

--- a/src/main/java/com/aws/greengrass/mqttclient/StandaloneMqttConnector.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/StandaloneMqttConnector.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient;
+
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
+import com.aws.greengrass.deployment.exceptions.DeploymentException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.security.SecurityService;
+import com.aws.greengrass.security.exceptions.MqttConnectionProviderException;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.ProxyUtils;
+import com.aws.greengrass.util.RetryUtils;
+import com.aws.greengrass.util.Utils;
+import software.amazon.awssdk.crt.http.HttpProxyOptions;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A standalone MQTT connection for one-shot operations (pre-flight checks, status reporting)
+ * independent of the main MqttClient. Not thread-safe — callers must not share instances across threads.
+ */
+@SuppressWarnings({"PMD.NullAssignment"})
+public class StandaloneMqttConnector implements Closeable {
+    private static final Logger logger = LogManager.getLogger(StandaloneMqttConnector.class);
+    private static final long DISCONNECT_TIMEOUT_MS = 5000;
+    private static final long PER_ATTEMPT_TIMEOUT_MS = 10_000;
+
+    private final AwsIotMqttConnectionBuilder builder;
+    private final String clientId;
+    private MqttClientConnection connection;
+
+    /**
+     * Create a standalone MQTT connection.
+     *
+     * @param builder  configured MQTT connection builder (with certs, CA, endpoint)
+     * @param clientId MQTT client ID
+     */
+    public StandaloneMqttConnector(AwsIotMqttConnectionBuilder builder, String clientId) {
+        this.builder = builder;
+        this.clientId = clientId;
+    }
+
+    /**
+     * Build a StandaloneMqttConnector configured with device identity, proxy, and the given endpoint.
+     * Extracts builder setup from the deployment layer so callers don't need to know about proxy/TLS details.
+     *
+     * <p>Proxy options are built directly rather than via {@code ProxyUtils.getHttpProxyOptions()} because
+     * that method requires a {@code @NonNull ClientTlsContext} for HTTPS proxy tunneling. Standalone
+     * connections use HTTP CONNECT tunneling (the common case for MQTT) which works without a TLS context.</p>
+     *
+     * @param securityService     provides the MQTT connection builder with device certs
+     * @param deviceConfiguration provides endpoint, proxy, port, and CA configuration
+     * @param endpoint            the IoT data endpoint to connect to
+     * @param clientIdSuffix      suffix appended to thing name for the MQTT client ID
+     * @return a configured StandaloneMqttConnector ready to call {@link #connect(long)}
+     * @throws MqttConnectionProviderException if the device identity builder cannot be created
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public static StandaloneMqttConnector of(SecurityService securityService,
+                                              DeviceConfiguration deviceConfiguration,
+                                              String endpoint, String clientIdSuffix)
+            throws MqttConnectionProviderException {
+        String thingName = Coerce.toString(deviceConfiguration.getThingName());
+        String clientId = thingName + clientIdSuffix;
+        AwsIotMqttConnectionBuilder mqttBuilder = securityService.getDeviceIdentityMqttConnectionBuilder();
+        int mqttPort = Coerce.toInt(deviceConfiguration.getMQTTNamespace()
+                .findOrDefault(MqttClient.DEFAULT_MQTT_PORT, MqttClient.MQTT_PORT_KEY));
+        mqttBuilder.withEndpoint(endpoint)
+                .withCertificateAuthorityFromPath(null,
+                        Coerce.toString(deviceConfiguration.getRootCAFilePath()))
+                .withPort((short) mqttPort)
+                .withCleanSession(true);
+        configureProxy(mqttBuilder, deviceConfiguration, endpoint);
+        return new StandaloneMqttConnector(mqttBuilder, clientId);
+    }
+
+    private static void configureProxy(AwsIotMqttConnectionBuilder mqttBuilder,
+                                       DeviceConfiguration deviceConfiguration, String endpoint) {
+        String proxyUrl = deviceConfiguration.getProxyUrl();
+        if (Utils.isEmpty(proxyUrl)) {
+            return;
+        }
+        HttpProxyOptions httpProxyOptions = new HttpProxyOptions();
+        httpProxyOptions.setHost(ProxyUtils.getHostFromProxyUrl(proxyUrl));
+        httpProxyOptions.setPort(ProxyUtils.getPortFromProxyUrl(proxyUrl));
+        httpProxyOptions.setConnectionType(HttpProxyOptions.HttpProxyConnectionType.Tunneling);
+        String proxyUsername = deviceConfiguration.getProxyUsername();
+        if (Utils.isNotEmpty(proxyUsername)) {
+            httpProxyOptions.setAuthorizationType(HttpProxyOptions.HttpProxyAuthorizationType.Basic);
+            httpProxyOptions.setAuthorizationUsername(proxyUsername);
+            httpProxyOptions.setAuthorizationPassword(deviceConfiguration.getProxyPassword());
+        }
+        String noProxy = Coerce.toString(deviceConfiguration.getNoProxyAddresses());
+        if (Utils.isNotEmpty(noProxy) && Utils.isNotEmpty(endpoint)
+                && Arrays.stream(noProxy.split(",")).anyMatch(endpoint::matches)) {
+            return;
+        }
+        mqttBuilder.withHttpProxyOptions(httpProxyOptions);
+    }
+
+    /**
+     * Connect to the MQTT endpoint with retries using exponential backoff.
+     * The timeout controls the number of attempts (timeoutMs / perAttemptTimeout), not a hard wall-clock
+     * deadline — actual elapsed time may exceed timeoutMs due to backoff sleep between attempts.
+     *
+     * <p>All exceptions are retryable to support JITR/JITP provisioning flows where the first connection
+     * attempt fails and triggers provisioning, then subsequent retries succeed.</p>
+     *
+     * @param timeoutMs timeout budget in milliseconds used to derive the number of connection attempts
+     * @throws DeploymentException with appropriate error code if all attempts fail
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public void connect(long timeoutMs) throws DeploymentException {
+        if (timeoutMs <= 0) {
+            throw new DeploymentException("MQTT connection timeout must be positive, got " + timeoutMs,
+                    DeploymentErrorCode.MQTT_CONNECTION_FAILED);
+        }
+        long perAttemptTimeout = Math.min(timeoutMs, PER_ATTEMPT_TIMEOUT_MS);
+        int maxAttempts = Math.max(1, (int) (timeoutMs / perAttemptTimeout));
+        RetryUtils.RetryConfig retryConfig = RetryUtils.RetryConfig.builder()
+                .initialRetryInterval(Duration.ofSeconds(1))
+                .maxRetryInterval(Duration.ofSeconds(10))
+                .maxAttempt(maxAttempts)
+                // All exceptions are retryable — supports JITR/JITP where first connect triggers provisioning
+                .retryableExceptions(Collections.singletonList(Exception.class))
+                .build();
+        try {
+            RetryUtils.runWithRetry(retryConfig, () -> {
+                connectionCleanup();
+                builder.withClientId(clientId);
+                connection = builder.build();
+                try {
+                    connection.connect().get(perAttemptTimeout, TimeUnit.MILLISECONDS);
+                } catch (Exception e) {
+                    connectionCleanup();
+                    throw e;
+                }
+                logger.atInfo().kv("clientId", clientId).log("Standalone MQTT connection established");
+                return null;
+            }, "standalone-mqtt-connect", logger);
+        } catch (InterruptedException e) {
+            connectionCleanup();
+            Thread.currentThread().interrupt();
+            throw new DeploymentException("MQTT connection interrupted", e,
+                    DeploymentErrorCode.MQTT_CONNECTION_FAILED);
+        } catch (Exception e) {
+            connectionCleanup();
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            throw new DeploymentException("MQTT connection failed", e,
+                    mapExceptionToErrorCode(cause));
+        }
+    }
+
+    @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public void close() {
+        if (connection != null) {
+            try {
+                connection.disconnect().get(DISCONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                logger.atDebug().setCause(e).log("Error disconnecting standalone MQTT connection");
+            } finally {
+                connectionCleanup();
+            }
+        }
+    }
+
+    private void connectionCleanup() {
+        if (connection != null) {
+            connection.close();
+            connection = null;
+        }
+    }
+
+    static DeploymentErrorCode mapExceptionToErrorCode(Throwable cause) {
+        if (cause == null) {
+            return DeploymentErrorCode.MQTT_CONNECTION_FAILED;
+        }
+        // Unwrap ExecutionException from CompletableFuture.get()
+        Throwable actual = cause instanceof ExecutionException && cause.getCause() != null
+                ? cause.getCause() : cause;
+        String message = actual.getMessage() == null ? "" : actual.getMessage().toLowerCase(Locale.ROOT);
+        if (message.contains("tls") || message.contains("ssl") || message.contains("handshake")
+                || message.contains("certificate")) {
+            return DeploymentErrorCode.TLS_HANDSHAKE_FAILURE;
+        }
+        if (message.contains("not authorized") || message.contains("policy")
+                || message.contains("connack")) {
+            return DeploymentErrorCode.MISSING_MQTT_CONNECT_POLICY;
+        }
+        return DeploymentErrorCode.MQTT_CONNECTION_FAILED;
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -15,6 +15,10 @@ import com.aws.greengrass.deployment.activator.DeploymentActivatorFactory;
 import com.aws.greengrass.deployment.activator.KernelUpdateActivator;
 import com.aws.greengrass.deployment.bootstrap.BootstrapManager;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
+import com.aws.greengrass.security.SecurityService;
+import com.aws.greengrass.security.exceptions.MqttConnectionProviderException;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 import com.aws.greengrass.deployment.model.ComponentUpdatePolicy;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
@@ -26,6 +30,7 @@ import com.aws.greengrass.lifecyclemanager.UpdateSystemPolicyService;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,10 +77,12 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.NOTIFY_COMPONENTS;
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.SKIP_NOTIFY_COMPONENTS;
 
@@ -107,6 +114,7 @@ class DeploymentConfigMergerTest {
     void beforeEach() {
         lenient().when(kernel.getContext()).thenReturn(context);
         lenient().when(validator.validate(anyMap(), any(), any())).thenReturn(true);
+        lenient().when(deviceConfiguration.getProxyUrl()).thenReturn("");
         lenient().when(context.get(DeploymentDirectoryManager.class)).thenReturn(deploymentDirectoryManager);
         lenient().when(context.get(DeploymentService.class)).thenReturn(deploymentService);
         lenient().when(deploymentService.getRuntimeConfig()).thenReturn(runtimeTopics);
@@ -461,6 +469,7 @@ class DeploymentConfigMergerTest {
         when(context.get(BootstrapManager.class)).thenReturn(bootstrapManager);
         DefaultActivator defaultActivator = mock(DefaultActivator.class);
         when(context.get(DefaultActivator.class)).thenReturn(defaultActivator);
+        setupPreflightMocks();
 
         Topic regionTopic = Topic.of(context, DEVICE_PARAM_AWS_REGION, "us-west-2");
         when(deviceConfiguration.getAWSRegion()).thenReturn(regionTopic);
@@ -582,6 +591,24 @@ class DeploymentConfigMergerTest {
         return deployment;
     }
 
+    private void setupPreflightMocks() throws Exception {
+        SecurityService securityService = mock(SecurityService.class);
+        lenient().when(context.get(SecurityService.class)).thenReturn(securityService);
+        AwsIotMqttConnectionBuilder mqttBuilder = mock(AwsIotMqttConnectionBuilder.class, RETURNS_DEEP_STUBS);
+        lenient().when(securityService.getDeviceIdentityMqttConnectionBuilder()).thenReturn(mqttBuilder);
+        MqttClientConnection mqttConn = mock(MqttClientConnection.class);
+        lenient().when(mqttBuilder.build()).thenReturn(mqttConn);
+        lenient().when(mqttConn.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        lenient().when(mqttConn.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
+        Topics mqttTopics = mock(Topics.class);
+        lenient().when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttTopics);
+        lenient().when(mqttTopics.findOrDefault(any(), any())).thenReturn(MqttClient.DEFAULT_MQTT_PORT);
+        Topic thingNameTopic = Topic.of(context, "thingName", "myThing");
+        Topic rootCaTopic = Topic.of(context, "rootCA", "/path/to/ca.pem");
+        lenient().when(deviceConfiguration.getThingName()).thenReturn(thingNameTopic);
+        lenient().when(deviceConfiguration.getRootCAFilePath()).thenReturn(rootCaTopic);
+    }
+
     private GreengrassService createMockGreengrassService(String name) {
         GreengrassService service = mock(GreengrassService.class);
         lenient().when(service.getName()).thenReturn(name);
@@ -654,6 +681,7 @@ class DeploymentConfigMergerTest {
         DeploymentActivator deploymentActivator = mock(DeploymentActivator.class);
         when(deploymentActivatorFactory.getDeploymentActivator(any())).thenReturn(deploymentActivator);
         when(context.get(DeploymentActivatorFactory.class)).thenReturn(deploymentActivatorFactory);
+        setupPreflightMocks();
 
         Topic dataEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_DATA_ENDPOINT,
                 "old-ats.iot.us-east-1.amazonaws.com");
@@ -673,7 +701,7 @@ class DeploymentConfigMergerTest {
         newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
 
         Topic sourceEndpointTopic = mock(Topic.class);
-        when(runtimeTopics.lookup(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY))
+        when(runtimeTopics.lookup(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
                 .thenReturn(sourceEndpointTopic);
 
         DeploymentConfigMerger merger = new DeploymentConfigMerger(kernel, deviceConfiguration, validator,
@@ -693,4 +721,105 @@ class DeploymentConfigMergerTest {
         verify(deploymentActivator).activate(any(), any(), any(Long.class), any());
     }
 
+    @Test
+    void GIVEN_endpoint_switch_WHEN_preflight_succeeds_THEN_activate_called(
+            ExtensionContext extensionContext) throws Throwable {
+        ignoreExceptionOfType(extensionContext, IOException.class);
+
+        DeploymentActivatorFactory deploymentActivatorFactory = mock(DeploymentActivatorFactory.class);
+        DeploymentActivator deploymentActivator = mock(DeploymentActivator.class);
+        when(deploymentActivatorFactory.getDeploymentActivator(any())).thenReturn(deploymentActivator);
+        when(context.get(DeploymentActivatorFactory.class)).thenReturn(deploymentActivatorFactory);
+        setupPreflightMocks();
+
+        Topic dataEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_DATA_ENDPOINT,
+                "old-ats.iot.us-east-1.amazonaws.com");
+        Topic credEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_CRED_ENDPOINT,
+                "old.credentials.iot.us-east-1.amazonaws.com");
+        when(deviceConfiguration.getIotDataEndpoint()).thenReturn(dataEndpointTopic);
+        when(deviceConfiguration.getIotCredentialEndpoint()).thenReturn(credEndpointTopic);
+        when(deviceConfiguration.getNucleusComponentName()).thenReturn(DEFAULT_NUCLEUS_COMPONENT_NAME);
+
+        Map<String, Object> nucleusConfigMap = new HashMap<>();
+        nucleusConfigMap.put(DEVICE_PARAM_IOT_DATA_ENDPOINT, "new-ats.iot.us-west-2.amazonaws.com");
+        Map<String, Object> nucleusNamespace = new HashMap<>();
+        nucleusNamespace.put(CONFIGURATION_CONFIG_KEY, nucleusConfigMap);
+        Map<String, Object> serviceConfig = new HashMap<>();
+        serviceConfig.put(DEFAULT_NUCLEUS_COMPONENT_NAME, nucleusNamespace);
+        Map<String, Object> newConfig = new HashMap<>();
+        newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
+
+        DeploymentConfigMerger merger = new DeploymentConfigMerger(kernel, deviceConfiguration, validator,
+                executorService);
+        DeploymentDocument doc = mock(DeploymentDocument.class);
+        lenient().when(doc.getDeploymentId()).thenReturn("DeploymentId");
+        when(doc.getComponentUpdatePolicy()).thenReturn(new ComponentUpdatePolicy(0, SKIP_NOTIFY_COMPONENTS));
+
+        merger.mergeInNewConfig(createMockDeployment(doc), newConfig, System.currentTimeMillis());
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(executorService).execute(runnableCaptor.capture());
+        runnableCaptor.getValue().run();
+
+        verify(deploymentActivator).activate(any(), any(), any(Long.class), any());
+    }
+
+    @Test
+    void GIVEN_endpoint_switch_WHEN_preflight_fails_THEN_deployment_fails_no_state_change(
+            ExtensionContext extensionContext) throws Throwable {
+        ignoreExceptionOfType(extensionContext, IOException.class);
+        ignoreExceptionOfType(extensionContext, MqttConnectionProviderException.class);
+
+        DeploymentActivatorFactory deploymentActivatorFactory = mock(DeploymentActivatorFactory.class);
+        DeploymentActivator deploymentActivator = mock(DeploymentActivator.class);
+        when(deploymentActivatorFactory.getDeploymentActivator(any())).thenReturn(deploymentActivator);
+        when(context.get(DeploymentActivatorFactory.class)).thenReturn(deploymentActivatorFactory);
+
+        SecurityService securityService = mock(SecurityService.class);
+        when(context.get(SecurityService.class)).thenReturn(securityService);
+        when(securityService.getDeviceIdentityMqttConnectionBuilder())
+                .thenThrow(new MqttConnectionProviderException("builder failed"));
+
+        Topic dataEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_DATA_ENDPOINT,
+                "old-ats.iot.us-east-1.amazonaws.com");
+        Topic credEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_CRED_ENDPOINT,
+                "old.credentials.iot.us-east-1.amazonaws.com");
+        Topic thingNameTopic = Topic.of(context, "thingName", "myThing");
+        Topic rootCaTopic = Topic.of(context, "rootCA", "/path/to/ca.pem");
+        when(deviceConfiguration.getIotDataEndpoint()).thenReturn(dataEndpointTopic);
+        when(deviceConfiguration.getIotCredentialEndpoint()).thenReturn(credEndpointTopic);
+        when(deviceConfiguration.getThingName()).thenReturn(thingNameTopic);
+        lenient().when(deviceConfiguration.getRootCAFilePath()).thenReturn(rootCaTopic);
+        when(deviceConfiguration.getNucleusComponentName()).thenReturn(DEFAULT_NUCLEUS_COMPONENT_NAME);
+        Topics mqttTopics = mock(Topics.class);
+        lenient().when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttTopics);
+        lenient().when(mqttTopics.findOrDefault(any(), any())).thenReturn(60_000L);
+
+        Map<String, Object> nucleusConfigMap = new HashMap<>();
+        nucleusConfigMap.put(DEVICE_PARAM_IOT_DATA_ENDPOINT, "new-ats.iot.us-west-2.amazonaws.com");
+        Map<String, Object> nucleusNamespace = new HashMap<>();
+        nucleusNamespace.put(CONFIGURATION_CONFIG_KEY, nucleusConfigMap);
+        Map<String, Object> serviceConfig = new HashMap<>();
+        serviceConfig.put(DEFAULT_NUCLEUS_COMPONENT_NAME, nucleusNamespace);
+        Map<String, Object> newConfig = new HashMap<>();
+        newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
+
+        DeploymentConfigMerger merger = new DeploymentConfigMerger(kernel, deviceConfiguration, validator,
+                executorService);
+        DeploymentDocument doc = mock(DeploymentDocument.class);
+        lenient().when(doc.getDeploymentId()).thenReturn("DeploymentId");
+        when(doc.getComponentUpdatePolicy()).thenReturn(new ComponentUpdatePolicy(0, SKIP_NOTIFY_COMPONENTS));
+
+        CompletableFuture<DeploymentResult> future = (CompletableFuture<DeploymentResult>)
+                merger.mergeInNewConfig(createMockDeployment(doc), newConfig, System.currentTimeMillis());
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(executorService).execute(runnableCaptor.capture());
+        runnableCaptor.getValue().run();
+
+        assertTrue(future.isDone());
+        assertEquals(DeploymentResult.DeploymentStatus.FAILED_NO_STATE_CHANGE,
+                future.get().getDeploymentStatus());
+        verify(deploymentActivator, never()).activate(any(), any(), any(Long.class), any());
+    }
 }

--- a/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Crashable;
 import com.aws.greengrass.dependency.Context;
-import com.aws.greengrass.deployment.DeploymentConfigMerger;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
 import com.aws.greengrass.deployment.DeploymentService;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
@@ -81,7 +80,7 @@ class DefaultActivatorTest {
     void GIVEN_endpoint_switch_with_DO_NOTHING_WHEN_activate_THEN_snapshot_taken() throws Exception {
         Topic sourceEndpointTopic = mock(Topic.class);
         when(sourceEndpointTopic.getOnce()).thenReturn("old-endpoint");
-        when(runtimeTopics.find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY))
+        when(runtimeTopics.find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
                 .thenReturn(sourceEndpointTopic);
         Path snapshotPath = mock(Path.class);
         when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
@@ -100,7 +99,7 @@ class DefaultActivatorTest {
         ignoreExceptionOfType(extContext, ServiceUpdateException.class);
         Topic sourceEndpointTopic = mock(Topic.class);
         when(sourceEndpointTopic.getOnce()).thenReturn("old-endpoint");
-        when(runtimeTopics.find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY))
+        when(runtimeTopics.find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
                 .thenReturn(sourceEndpointTopic);
         Path snapshotPath = mock(Path.class);
         when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
@@ -129,7 +128,7 @@ class DefaultActivatorTest {
     void GIVEN_non_endpoint_switch_with_DO_NOTHING_WHEN_failure_THEN_no_rollback(
             ExtensionContext extContext) throws Exception {
         ignoreExceptionOfType(extContext, ServiceUpdateException.class);
-        when(runtimeTopics.find(DeploymentConfigMerger.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(null);
+        when(runtimeTopics.find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(null);
 
         CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
 

--- a/src/test/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/errorcode/DeploymentErrorCodeTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment.errorcode;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DeploymentErrorCodeTest {
+
+    @Test
+    void GIVEN_MQTT_CONNECTION_FAILED_WHEN_getErrorType_THEN_returns_NETWORK_ERROR() {
+        assertEquals(DeploymentErrorType.NETWORK_ERROR, DeploymentErrorCode.MQTT_CONNECTION_FAILED.getErrorType());
+    }
+
+    @Test
+    void GIVEN_TLS_HANDSHAKE_FAILURE_WHEN_getErrorType_THEN_returns_NETWORK_ERROR() {
+        assertEquals(DeploymentErrorType.NETWORK_ERROR, DeploymentErrorCode.TLS_HANDSHAKE_FAILURE.getErrorType());
+    }
+
+    @Test
+    void GIVEN_MISSING_MQTT_CONNECT_POLICY_WHEN_getErrorType_THEN_returns_PERMISSION_ERROR() {
+        assertEquals(DeploymentErrorType.PERMISSION_ERROR, DeploymentErrorCode.MISSING_MQTT_CONNECT_POLICY.getErrorType());
+    }
+}

--- a/src/test/java/com/aws/greengrass/mqttclient/StandaloneMqttConnectorTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/StandaloneMqttConnectorTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient;
+
+import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
+import com.aws.greengrass.deployment.exceptions.DeploymentException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("PMD.CloseResource")
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+class StandaloneMqttConnectorTest {
+
+    @Mock
+    AwsIotMqttConnectionBuilder builder;
+    @Mock
+    MqttClientConnection mqttConnection;
+
+    @BeforeEach
+    void beforeEach() {
+        lenient().when(builder.withClientId(any())).thenReturn(builder);
+        lenient().when(builder.build()).thenReturn(mqttConnection);
+    }
+
+    @Test
+    void GIVEN_valid_endpoint_WHEN_connect_and_close_THEN_succeeds() throws Exception {
+        when(mqttConnection.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mqttConnection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-preflight");
+        conn.connect(5000);
+        conn.close();
+
+        verify(mqttConnection).connect();
+        verify(mqttConnection).disconnect();
+    }
+
+    @Test
+    void GIVEN_timeout_WHEN_connect_THEN_throws_MQTT_CONNECTION_FAILED() {
+        // Each attempt hangs (never completes), bounded by PER_ATTEMPT_TIMEOUT_MS
+        when(mqttConnection.connect()).thenReturn(new CompletableFuture<>());
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-preflight");
+        DeploymentException ex = assertThrows(DeploymentException.class, () -> conn.connect(3000));
+
+        assertTrue(ex.getErrorCodes().contains(DeploymentErrorCode.MQTT_CONNECTION_FAILED));
+    }
+
+    @Test
+    void GIVEN_tls_error_WHEN_connect_THEN_throws_TLS_HANDSHAKE_FAILURE() {
+        CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new Exception("TLS handshake failed"));
+        when(mqttConnection.connect()).thenReturn(failedFuture);
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-preflight");
+        DeploymentException ex = assertThrows(DeploymentException.class, () -> conn.connect(5000));
+
+        assertTrue(ex.getErrorCodes().contains(DeploymentErrorCode.TLS_HANDSHAKE_FAILURE));
+    }
+
+    @Test
+    void GIVEN_auth_rejection_WHEN_connect_THEN_throws_MISSING_MQTT_CONNECT_POLICY() {
+        CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new Exception("Not authorized, connection refused"));
+        when(mqttConnection.connect()).thenReturn(failedFuture);
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-preflight");
+        DeploymentException ex = assertThrows(DeploymentException.class, () -> conn.connect(5000));
+
+        assertTrue(ex.getErrorCodes().contains(DeploymentErrorCode.MISSING_MQTT_CONNECT_POLICY));
+    }
+
+    @Test
+    void GIVEN_connection_WHEN_close_called_twice_THEN_no_exception() throws Exception {
+        when(mqttConnection.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mqttConnection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-preflight");
+        conn.connect(5000);
+        conn.close();
+        assertDoesNotThrow(conn::close);
+    }
+
+    @Test
+    void GIVEN_thing_name_and_suffix_WHEN_connect_THEN_client_id_is_correct() throws Exception {
+        when(mqttConnection.connect()).thenReturn(CompletableFuture.completedFuture(true));
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "myThing-preflight");
+        conn.connect(5000);
+
+        verify(builder).withClientId("myThing-preflight");
+    }
+
+    @Test
+    void GIVEN_error_code_mapping_WHEN_tls_message_THEN_returns_TLS_HANDSHAKE_FAILURE() {
+        assertEquals(DeploymentErrorCode.TLS_HANDSHAKE_FAILURE,
+                StandaloneMqttConnector.mapExceptionToErrorCode(new Exception("SSL handshake error")));
+    }
+
+    @Test
+    void GIVEN_error_code_mapping_WHEN_auth_message_THEN_returns_MISSING_MQTT_CONNECT_POLICY() {
+        assertEquals(DeploymentErrorCode.MISSING_MQTT_CONNECT_POLICY,
+                StandaloneMqttConnector.mapExceptionToErrorCode(new Exception("Not authorized")));
+    }
+
+    @Test
+    void GIVEN_error_code_mapping_WHEN_generic_message_THEN_returns_MQTT_CONNECTION_FAILED() {
+        assertEquals(DeploymentErrorCode.MQTT_CONNECTION_FAILED,
+                StandaloneMqttConnector.mapExceptionToErrorCode(new Exception("some error")));
+    }
+
+    @Test
+    void GIVEN_transient_failure_WHEN_connect_THEN_retries_and_succeeds(ExtensionContext extContext) throws Exception {
+        ignoreExceptionOfType(extContext, ExecutionException.class);
+        AtomicInteger attempts = new AtomicInteger(0);
+        when(mqttConnection.connect()).thenAnswer(invocation -> {
+            if (attempts.incrementAndGet() < 3) {
+                CompletableFuture<Boolean> f = new CompletableFuture<>();
+                f.completeExceptionally(new Exception("socket operation timed out"));
+                return f;
+            }
+            return CompletableFuture.completedFuture(true);
+        });
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-retry");
+        conn.connect(60_000);
+
+        assertEquals(3, attempts.get());
+        verify(builder, atLeast(3)).build();
+    }
+
+    @Test
+    void GIVEN_persistent_failure_WHEN_connect_THEN_retries_until_timeout(ExtensionContext extContext) {
+        ignoreExceptionOfType(extContext, ExecutionException.class);
+        CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new Exception("connection refused"));
+        when(mqttConnection.connect()).thenReturn(failedFuture);
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-retry");
+        DeploymentException ex = assertThrows(DeploymentException.class, () -> conn.connect(30_000));
+
+        // With 30s timeout and 10s per-attempt, maxAttempts=3. All fail → DeploymentException.
+        verify(builder, atLeast(2)).build();
+        assertTrue(ex.getErrorCodes().contains(DeploymentErrorCode.MQTT_CONNECTION_FAILED),
+                "connection refused is a network error, not a policy error");
+    }
+
+    @Test
+    void GIVEN_error_code_mapping_WHEN_null_cause_THEN_returns_MQTT_CONNECTION_FAILED() {
+        assertEquals(DeploymentErrorCode.MQTT_CONNECTION_FAILED,
+                StandaloneMqttConnector.mapExceptionToErrorCode(null));
+    }
+}


### PR DESCRIPTION
## IoT Endpoint Switch — Step 2: Standalone MQTT connection and pre-flight connectivity check

### Summary

Adds pre-flight MQTT connectivity verification for endpoint-switch deployments. Before applying a new IoT endpoint configuration, the deployment service creates a temporary MQTT connection to the target endpoint to verify reachability. If pre-flight fails, the deployment reports `FAILED_NO_STATE_CHANGE` — no device state is modified.

Also addresses Step 1 PR #1776 review comments from Siddhant and Mitchell.

This is Step 2 of the IoT Endpoint Switch design.

### Changes

- **StandaloneMqttConnection** — New reusable standalone MQTT connection class in `mqttclient` package. Supports connect with retries/exponential backoff, publish, and close. Maps CRT exceptions to deployment error codes (`MQTT_CONNECTION_FAILED`, `TLS_HANDSHAKE_FAILURE`, `MISSING_MQTT_CONNECT_POLICY`). Not thread-safe — designed for single-use one-shot operations.
- **DeploymentConfigMerger** — Add `verifyMqttConnectivity()` pre-flight check using device certs. Respects proxy config (same pattern as MqttClient with noProxy filtering). Configurable timeout via `mqtt.standaloneMqttTimeoutMs` (default 60s). Pre-flight runs BEFORE persisting source endpoint so failure leaves zero state change.
- **DeploymentService** — `SOURCE_IOT_DATA_ENDPOINT_KEY` constant moved here from `DeploymentConfigMerger` (Siddhant review: constant belongs with the service that owns the runtime config).
- **DefaultActivator** — `isEndpointSwitch()` updated to reference `DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY`.
- **DeploymentErrorCode** — 3 new error codes: `MQTT_CONNECTION_FAILED` (NETWORK_ERROR), `TLS_HANDSHAKE_FAILURE` (NETWORK_ERROR), `MISSING_MQTT_CONNECT_POLICY` (PERMISSION_ERROR).
- **README_CONFIG_SCHEMA.md** — Document `mqtt.standaloneMqttTimeoutMs` config key.

### Step 1 PR Review Comments Addressed

- Siddhant: Moved `SOURCE_IOT_DATA_ENDPOINT_KEY` from `DeploymentConfigMerger` to `DeploymentService`
- Mitchell: Confirmed we only persist `sourceIotDataEndpoint`, not `sourceIotCredEndpoint`

### E2E Test Results (22/22 pass)

Tested with locally built Nucleus 2.16.0-SNAPSHOT in Podman containers, fresh device per test.

| # | Scenario | Result | Status | Config Changed |
|---|---|---|---|---|
| 1 | Happy path us-east-1 → us-west-2 | ✅ | SUCCEEDED | Yes → us-west-2 |
| 2 | Reverse us-west-2 → us-east-1 | ✅ | SUCCEEDED | Yes → us-east-1 |
| 3 | Non-ATS endpoint fails at pre-flight DNS | ✅ | FAILED_NO_STATE_CHANGE | No |
| 4 | Unreachable fake endpoint | ✅ | FAILED_NO_STATE_CHANGE | No |
| 5 | DO_NOTHING policy forces snapshot | ✅ | SUCCEEDED | Yes → us-west-2 |
| 6 | Back-to-back switch (W2→E1→W2) | ✅ | SUCCEEDED ×2 | Yes (both ways) |
| 7 | Non-endpoint deployment unaffected | ✅ | SUCCEEDED | No |
| 8 | Endpoint + component config change | ✅ | SUCCEEDED | Yes → us-west-2 |
| 9 | Cred-only change not detected as switch | ✅ | SUCCEEDED | No |
| 10 | Same endpoint redeployed not detected | ✅ | SUCCEEDED | No |
| 11 | sourceIotDataEndpoint persisted in config.tlog | ✅ | SUCCEEDED | Yes → us-west-2 |
| 12 | Empty iotDataEndpoint is no-op | ✅ | SUCCEEDED | No |
| 13 | Malformed URL device unchanged | ✅ | SUCCEEDED | No |
| 14 | Cross-region cert in both regions | ✅ | SUCCEEDED | Yes → us-west-2 |
| 15 | Pre-flight: unreachable endpoint | ✅ | FAILED_NO_STATE_CHANGE | No |
| 16 | Pre-flight: cert not registered (validation catches) | ✅ | FAILED_NO_STATE_CHANGE | No |
| 17 | Custom standaloneMqttTimeoutMs=5s | ✅ | FAILED_NO_STATE_CHANGE | No |
| 18 | Cloud-side FAILED status visible | ✅ | FAILED | No |
| 19 | Custom MQTT port 443 | ✅ | SUCCEEDED | Yes → us-west-2 |
| 20 | Bad component fails at resolution before pre-flight | ✅ | FAILED_NO_STATE_CHANGE | No |
| 21 | Concurrent deployment queued correctly | ✅ | SUCCEEDED | No |
| 22 | Network disconnect mid-pre-flight | ✅ | FAILED_NO_STATE_CHANGE | No |

### Testing

- Unit tests: 38/38 pass (StandaloneMqttConnectionTest 13, DeploymentConfigMergerTest 19, DefaultActivatorTest 3, DeploymentErrorCodeTest 3)
- Checkstyle clean, japicmp clean (no backward compatibility breaks)
- E2E: 22/22 pass (Podman, fresh device per test, account 986036454283)

### Related

- Step 1: PR #1776 (merged)
- Step 3 (credential endpoint validation) will follow in a separate PR
- Design: [Detailed Design — Section F.1 Step 4](https://quip-amazon.com/B49kAM8Mb4xI)