### PR TITLE
fix: ignore wrapped ClosedByInterruptException in test log protector

### DIFF
--- a/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
+++ b/src/test/java/com/aws/greengrass/testcommons/testutilities/ExceptionLogProtector.java
@@ -144,7 +144,7 @@ public class ExceptionLogProtector implements BeforeEachCallback, AfterEachCallb
         ignoreExceptionUltimateCauseWithMessage(context, "Channel not found for given connection context");
 
         ignoreExceptionOfType(context, RejectedExecutionException.class);
-        ignoreExceptionOfType(context, ClosedByInterruptException.class);
+        ignoreExceptionUltimateCauseOfType(context, ClosedByInterruptException.class);
         ignoreExceptionWithStackTraceContaining(context, IllegalAccessException.class,
                 ProvisioningPluginFactory.class.getName());
         ignoreExceptionWithStackTraceContaining(context, NullPointerException.class,


### PR DESCRIPTION
## Summary

`ExceptionLogProtector` uses `ignoreExceptionOfType(ClosedByInterruptException.class)` which only matches when the **top-level** logged exception is `ClosedByInterruptException`. During kernel shutdown on Windows, `cleanupStaleVersions` reads recipe files via NIO `FileChannel` while the thread's interrupt flag is set. The channel throws `ClosedByInterruptException`, but `ComponentStore.findComponentRecipeContent` wraps it in `PackageLoadingException`. The protector sees the wrapper, not the root cause, and fails the test.

This changes `ignoreExceptionOfType` → `ignoreExceptionUltimateCauseOfType` so the predicate walks the cause chain.

## Testing

This is a one-line change to test infrastructure. The fix was verified by tracing the exact failure in [CI run 25131562522](https://github.com/aws-greengrass/aws-greengrass-nucleus/actions/runs/25131562522/job/73658875266) — the `PackageLoadingException` wrapping `ClosedByInterruptException` is now matched by the updated predicate.