### PR TITLE
fix: stabilize flaky ERRORED-state uninstall lifecycle test

### DIFF
--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -728,16 +728,37 @@ class LifecycleTest {
         TestService testService = new TestService(testServiceTopics);
 
         CountDownLatch uninstallCalled = new CountDownLatch(1);
-        testService.setStartupRunnable(() -> testService.reportState(State.ERRORED));
+        CountDownLatch reachedErrored = new CountDownLatch(1);
+        CountDownLatch blockRetry = new CountDownLatch(1);
+        AtomicBoolean firstAttempt = new AtomicBoolean(true);
+        testService.setStartupRunnable(() -> {
+            if (firstAttempt.compareAndSet(true, false)) {
+                testService.reportState(State.ERRORED);
+                return;
+            }
+            // Block retry attempts so the service cannot cycle to BROKEN before
+            // requestUninstall() is called.
+            try {
+                blockRetry.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // interrupted by uninstall — expected
+            }
+        });
         testService.setUninstallRunnable(() -> uninstallCalled.countDown());
+        context.addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (newState.equals(State.ERRORED)) {
+                reachedErrored.countDown();
+            }
+        });
 
         testService.postInject();
         testService.requestStart();
-        assertThat(testService::getState, eventuallyEval(is(State.ERRORED)));
+        assertTrue(reachedErrored.await(5, TimeUnit.SECONDS), "Service should reach ERRORED");
 
         testService.requestUninstall();
-        
-        assertTrue(uninstallCalled.await(2, TimeUnit.SECONDS), "Uninstall should be called");
+        blockRetry.countDown();
+
+        assertTrue(uninstallCalled.await(5, TimeUnit.SECONDS), "Uninstall should be called");
         assertThat(testService::getState, eventuallyEval(is(State.UNINSTALLED)));
     }
 


### PR DESCRIPTION
**Description of changes:**

The test `GIVEN_service_in_ERRORED_state_WHEN_requestUninstall_THEN_transitions_to_UNINSTALLED` in `LifecycleTest` is flaky on CI. It uses `eventuallyEval(is(ERRORED))` to poll for the ERRORED state, but the lifecycle state machine immediately retries after ERRORED (cycling STOPPING → INSTALLED → STARTING → ERRORED). After 3 consecutive errors it transitions to BROKEN. On slow CI runners the polling matcher observes BROKEN instead of ERRORED, causing the assertion to fail.

**Fix:**

- Use a `GlobalStateChangeListener` with a `CountDownLatch` to observe the ERRORED transition directly instead of polling.
- Block the retry loop on a second latch so the service cannot race through 3 retries to BROKEN before `requestUninstall()` is called.
- Release the retry latch after `requestUninstall()` so the lifecycle can proceed to UNINSTALLED.

**How was this change tested:**

- [x] Ran the specific test — passes reliably.
- [x] Ran all 14 `LifecycleTest` tests — all pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.