### PR TITLE
test: fix bug a metadata invariant to assert on main thread

### DIFF
--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.deployment.exceptions.DeploymentTaskFailureException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus;
+import com.aws.greengrass.deployment.model.DeploymentTaskMetadata;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.GreengrassLogMessage;
@@ -54,6 +55,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -790,12 +792,14 @@ class DeploymentServiceTest extends GGServiceTestUtil {
 
         String deploymentDocument = getTestDeploymentDocument();
 
+        // The deployment service runs on its own thread; an AssertionError thrown from
+        // inside this Answer executes on that thread and is swallowed by the deployment
+        // loop, so the main thread never sees the failure. Capture the service-side view
+        // of metadata into an AtomicReference and assert on the main thread after the
+        // submit() call has been observed.
+        AtomicReference<DeploymentTaskMetadata> metadataAtSubmit = new AtomicReference<>();
         when(mockExecutorService.submit(any(DefaultDeploymentTask.class))).thenAnswer(invocation -> {
-            // At the point the task is submitted, metadata must already be non-null.
-            // This is the Bug A invariant: any observer of deployment processing side-effects
-            // must see currentDeploymentTaskMetadata != null.
-            assertThat("currentDeploymentTaskMetadata must be non-null when task is submitted",
-                    deploymentService.getCurrentDeploymentTaskMetadata(), is(IsNull.notNullValue()));
+            metadataAtSubmit.set(deploymentService.getCurrentDeploymentTaskMetadata());
             return mockFuture;
         });
 
@@ -803,12 +807,17 @@ class DeploymentServiceTest extends GGServiceTestUtil {
                 Deployment.DeploymentType.SHADOW, TEST_JOB_ID_1));
         startDeploymentServiceInAnotherThread();
 
-        // Verify the task was submitted (which triggers the assertion above)
+        // Verify the task was submitted (which populates metadataAtSubmit)
         verify(mockExecutorService, WAIT_FOUR_SECONDS).submit(any(DefaultDeploymentTask.class));
         // Verify IN_PROGRESS was persisted
         verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
                 eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.SHADOW),
                 eq(JobStatus.IN_PROGRESS.toString()), any(), any());
+        // Bug A invariant: metadata must already be populated at the moment submit() is called,
+        // otherwise concurrent readers (ShadowDeploymentListener, IotJobsHelper) observe null
+        // and can take the wrong branch.
+        assertThat("currentDeploymentTaskMetadata must be non-null when task is submitted",
+                metadataAtSubmit.get(), is(IsNull.notNullValue()));
     }
 
     String getTestDeploymentDocument() {


### PR DESCRIPTION
**Issue #, if available:**

Follow-up to #1782.

**Description of changes:**

The Bug A metadata-ordering test added in #1782 does not actually validate its invariant. The test wraps an `assertThat` call inside a Mockito `Answer` for `executorService.submit(...)`. That Answer executes on the `deploymentServiceThread` started by `startDeploymentServiceInAnotherThread()`, not on the JUnit main thread. An `AssertionFailedError` thrown there is swallowed by the deployment loop, so the main thread never observes the failure and the test passes even when the invariant is violated.

I verified this by running the PR #1782 tests unmodified against the parent commit of that PR (`e9d5e314`, which has both bugs present). Expected: Bug A test fails. Actual: Bug A test passes. Only the Bug B skip-path test correctly fails on pre-fix code.

With this patch applied, pre-fix source produces:

```
Tests run: 3, Failures: 2, Errors: 0
  - GIVEN_new_deployment_WHEN_createNewDeployment_THEN_metadata_assigned_before_submit <<< FAILURE
      "currentDeploymentTaskMetadata must be non-null when task is submitted"
      Expected: is not null
           but: was null
  - GIVEN_shadow_deployment_in_progress_WHEN_duplicate_shadow_deployment_offered_THEN_skip_not_cancel <<< FAILURE
```

Both defects are now observable by the main test thread.

**Why is this change necessary:**

Without it, any future regression of the Bug A ordering in `createNewDeployment()` would not be caught by the test suite. The test would continue to pass silently.

**Fix:**

Capture `deploymentService.getCurrentDeploymentTaskMetadata()` into an `AtomicReference` inside the Answer, then assert on the main thread after `verify(...submit...)` confirms the Answer ran. The `AtomicReference` provides the necessary visibility guarantee across threads, and any assertion failure now reaches the JUnit runner.

**How was this change tested:**

- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Verification matrix, all runs against `DeploymentServiceTest`:

| Scenario | Result |
|---|---|
| Pre-fix source (`e9d5e314`) + patched test | 2 failures (Bug A + Bug B skip) — correct, matches the two real defects |
| Post-fix source (#1782 merged) + patched test | 3 passes, plus all 17 tests in the class pass |

**Any additional information or context required to review the change:**

The production-source fix from #1782 is unchanged. This PR only corrects the test that validates it.

**Documentation Checklist:**

 - [x] Updated the README if applicable. (N/A — test-only change)

**Compatibility Checklist:**

- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [x] For external library version updates, I have reviewed its change logs and Nucleus does not consume any deprecated method or type. (N/A)

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
