### PR TITLE
PoC: Replace aws-c-mqtt with coreMQTT via channel handler adapter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "coremqtt-jni/coreMQTT"]
+	path = coremqtt-jni/coreMQTT
+	url = https://github.com/FreeRTOS/coreMQTT.git

--- a/coremqtt-jni/CMakeLists.txt
+++ b/coremqtt-jni/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.12)
+project(coremqtt-jni C)
+
+# Find JNI - use JAVA_HOME hint
+set(JAVA_HOME $ENV{JAVA_HOME})
+if(NOT JAVA_HOME)
+    execute_process(COMMAND /usr/libexec/java_home OUTPUT_VARIABLE JAVA_HOME OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+endif()
+if(NOT JAVA_HOME)
+    set(JAVA_HOME "/opt/homebrew/Cellar/openjdk@17/17.0.16/libexec/openjdk.jdk/Contents/Home")
+endif()
+set(JNI_INCLUDE_DIRS "${JAVA_HOME}/include")
+if(APPLE)
+    list(APPEND JNI_INCLUDE_DIRS "${JAVA_HOME}/include/darwin")
+elseif(UNIX)
+    list(APPEND JNI_INCLUDE_DIRS "${JAVA_HOME}/include/linux")
+endif()
+
+# Paths to dependencies (adjust if needed)
+set(COREMQTT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/coreMQTT")
+set(AWS_CRT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../aws-crt-java")
+
+# coreMQTT sources
+set(COREMQTT_SOURCES
+    ${COREMQTT_DIR}/source/core_mqtt.c
+    ${COREMQTT_DIR}/source/core_mqtt_serializer.c
+    ${COREMQTT_DIR}/source/core_mqtt_state.c
+    ${COREMQTT_DIR}/source/core_mqtt_serializer_private.c
+    ${COREMQTT_DIR}/source/core_mqtt_prop_serializer.c
+    ${COREMQTT_DIR}/source/core_mqtt_prop_deserializer.c
+)
+
+# Our adapter sources
+set(ADAPTER_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/coremqtt_channel_handler.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/coremqtt_jni.c
+)
+
+add_library(coremqtt_jni SHARED ${COREMQTT_SOURCES} ${ADAPTER_SOURCES})
+
+target_include_directories(coremqtt_jni PRIVATE
+    # Our config header (must come first so coreMQTT picks it up)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    # coreMQTT headers
+    ${COREMQTT_DIR}/source/include
+    ${COREMQTT_DIR}/source/include/private
+    ${COREMQTT_DIR}/source/interface
+    # JNI headers
+    ${JNI_INCLUDE_DIRS}
+    # Installed CRT headers
+    /tmp/aws-crt-install/include
+)
+
+# Link against installed CRT libraries
+target_link_directories(coremqtt_jni PRIVATE /tmp/aws-crt-install/lib)
+target_link_libraries(coremqtt_jni PRIVATE aws-c-io aws-c-common aws-c-cal)
+
+# On macOS, link frameworks
+if(APPLE)
+    target_link_libraries(coremqtt_jni PRIVATE "-framework Security" "-framework CoreFoundation" "-framework Network")
+endif()
+
+set_target_properties(coremqtt_jni PROPERTIES
+    C_STANDARD 99
+    POSITION_INDEPENDENT_CODE ON
+)

--- a/coremqtt-jni/include/core_mqtt_config.h
+++ b/coremqtt-jni/include/core_mqtt_config.h
@@ -1,0 +1,47 @@
+/*
+ * coreMQTT compile-time configuration for Greengrass Nucleus PoC.
+ * Transport is non-blocking: recv returns 0 when no data, send is immediate via channel.
+ * All coreMQTT calls happen on the aws-c-io event loop thread (single-threaded).
+ */
+#ifndef CORE_MQTT_CONFIG_H
+#define CORE_MQTT_CONFIG_H
+
+#include <stdint.h>
+
+/* Non-blocking recv. Data arrives via channel read callback, not polling. */
+#define MQTT_RECV_POLLING_TIMEOUT_MS    ( 0U )
+
+/* Non-blocking send. Channel slot send is immediate. */
+#define MQTT_SEND_TIMEOUT_MS            ( 0U )
+
+/* Wait 30s for PINGRESP before declaring keep-alive timeout. */
+#define MQTT_PINGRESP_TIMEOUT_MS        ( 30000U )
+
+/* Send PINGREQ after 30s of TX inactivity. */
+#define PACKET_TX_TIMEOUT_MS            ( 30000U )
+
+/* Send PINGREQ after 30s of RX inactivity. */
+#define PACKET_RX_TIMEOUT_MS            ( 30000U )
+
+/* CONNACK receive retries. */
+#define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT ( 5U )
+
+/* Max vectors for subscribe/unsubscribe packets. */
+#define MQTT_SUB_UNSUB_MAX_VECTORS      ( 4U )
+
+/*
+ * Threading: All coreMQTT calls happen on the single aws-c-io event loop thread.
+ * No mutex needed. Assert correct thread in debug builds.
+ */
+#define MQTT_PRE_STATE_UPDATE_HOOK( pContext )   /* single-threaded, no-op */
+#define MQTT_POST_STATE_UPDATE_HOOK( pContext )  /* single-threaded, no-op */
+
+/* Logging - disabled for PoC build. coreMQTT uses double-parenthesis style:
+ * LogError( ( "format %d", arg ) ) which requires custom printf-like macros. */
+#define LogError( message )
+#define LogWarn( message )
+#define LogInfo( message )
+#define LogDebug( message )
+#define LogTrace( message )
+
+#endif /* CORE_MQTT_CONFIG_H */

--- a/coremqtt-jni/src/coremqtt_channel_handler.c
+++ b/coremqtt-jni/src/coremqtt_channel_handler.c
@@ -1,0 +1,753 @@
+/*
+ * coreMQTT Channel Handler Adapter.
+ * Plugs coreMQTT into the aws-c-io channel pipeline, replacing aws-c-mqtt.
+ */
+#include "coremqtt_channel_handler.h"
+
+#include <aws/common/allocator.h>
+#include <aws/common/clock.h>
+#include <aws/io/channel.h>
+#include <aws/io/event_loop.h>
+#include <aws/io/socket.h>
+#include <string.h>
+
+/* ─── Forward declarations ─────────────────────────────────────────────── */
+
+static int s_process_read_message(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    struct aws_io_message *message);
+
+static int s_shutdown(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    enum aws_channel_direction dir,
+    int error_code,
+    bool free_scarce_resources_immediately);
+
+static size_t s_initial_window_size(struct aws_channel_handler *handler);
+static size_t s_message_overhead(struct aws_channel_handler *handler);
+static void s_destroy_handler(struct aws_channel_handler *handler);
+
+static struct aws_channel_handler_vtable s_vtable = {
+    .process_read_message = s_process_read_message,
+    .process_write_message = NULL, /* We don't receive write messages from upstream */
+    .increment_read_window = NULL,
+    .shutdown = s_shutdown,
+    .initial_window_size = s_initial_window_size,
+    .message_overhead = s_message_overhead,
+    .destroy = s_destroy_handler,
+};
+
+/* ─── Time function for coreMQTT ──────────────────────────────────────── */
+
+static uint32_t s_get_time_ms(void) {
+    uint64_t now_ns = 0;
+    aws_high_res_clock_get_ticks(&now_ns);
+    return (uint32_t)(now_ns / 1000000ULL);
+}
+
+/* ─── Transport Interface: recv (reads from ring buffer) ───────────────── */
+
+static int32_t s_transport_recv(
+    NetworkContext_t *pNetworkContext,
+    void *pBuffer,
+    size_t bytesToRecv) {
+
+    struct coremqtt_channel_handler *h = (struct coremqtt_channel_handler *)pNetworkContext;
+
+    size_t available = h->recv_write_pos - h->recv_read_pos;
+    if (available == 0) {
+        return 0; /* No data available - coreMQTT will return MQTTNoDataAvailable */
+    }
+
+    size_t to_copy = (available < bytesToRecv) ? available : bytesToRecv;
+    memcpy(pBuffer, h->recv_buffer_storage + h->recv_read_pos, to_copy);
+    h->recv_read_pos += to_copy;
+
+    /* Compact buffer when fully consumed */
+    if (h->recv_read_pos == h->recv_write_pos) {
+        h->recv_read_pos = 0;
+        h->recv_write_pos = 0;
+    }
+
+    return (int32_t)to_copy;
+}
+
+/* ─── Transport Interface: send (writes to channel pipeline) ───────────── */
+
+static int32_t s_transport_send(
+    NetworkContext_t *pNetworkContext,
+    const void *pBuffer,
+    size_t bytesToSend) {
+
+    struct coremqtt_channel_handler *h = (struct coremqtt_channel_handler *)pNetworkContext;
+
+    if (h->slot == NULL || h->slot->channel == NULL) {
+        return -1;
+    }
+
+    struct aws_io_message *msg = aws_channel_acquire_message_from_pool(
+        h->slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, bytesToSend);
+    if (msg == NULL) {
+        return -1;
+    }
+
+    struct aws_byte_cursor data = aws_byte_cursor_from_array(pBuffer, bytesToSend);
+    if (!aws_byte_buf_write_from_whole_cursor(&msg->message_data, data)) {
+        aws_mem_release(msg->allocator, msg);
+        return -1;
+    }
+
+    if (aws_channel_slot_send_message(h->slot, msg, AWS_CHANNEL_DIR_WRITE)) {
+        aws_mem_release(msg->allocator, msg);
+        return -1;
+    }
+
+    return (int32_t)bytesToSend;
+}
+
+/* ─── Channel handler vtable implementations ──────────────────────────── */
+
+static int s_process_read_message(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    struct aws_io_message *message) {
+
+    struct coremqtt_channel_handler *h = handler->impl;
+
+    /* Append decrypted bytes to recv ring buffer */
+    size_t incoming_len = message->message_data.len;
+    size_t space = COREMQTT_RECV_BUFFER_SIZE - h->recv_write_pos;
+
+    if (incoming_len > space) {
+        /* Compact first */
+        if (h->recv_read_pos > 0) {
+            size_t unread = h->recv_write_pos - h->recv_read_pos;
+            memmove(h->recv_buffer_storage, h->recv_buffer_storage + h->recv_read_pos, unread);
+            h->recv_write_pos = unread;
+            h->recv_read_pos = 0;
+            space = COREMQTT_RECV_BUFFER_SIZE - h->recv_write_pos;
+        }
+        if (incoming_len > space) {
+            /* Buffer overflow - shouldn't happen with 256KB buffer */
+            aws_mem_release(message->allocator, message);
+            return AWS_OP_ERR;
+        }
+    }
+
+    memcpy(h->recv_buffer_storage + h->recv_write_pos, message->message_data.buffer, incoming_len);
+    h->recv_write_pos += incoming_len;
+
+    aws_channel_slot_increment_read_window(slot, incoming_len);
+    aws_mem_release(message->allocator, message);
+
+    /* Trigger coreMQTT to process the received data */
+    MQTT_ProcessLoop(&h->mqtt_ctx);
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_shutdown(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    enum aws_channel_direction dir,
+    int error_code,
+    bool free_scarce_resources_immediately) {
+
+    (void)handler;
+    return aws_channel_slot_on_handler_shutdown_complete(slot, dir, error_code, free_scarce_resources_immediately);
+}
+
+static size_t s_initial_window_size(struct aws_channel_handler *handler) {
+    (void)handler;
+    return COREMQTT_RECV_BUFFER_SIZE;
+}
+
+static size_t s_message_overhead(struct aws_channel_handler *handler) {
+    (void)handler;
+    return 0;
+}
+
+static void s_destroy_handler(struct aws_channel_handler *handler) {
+    (void)handler;
+    /* Actual cleanup done in coremqtt_channel_handler_destroy */
+}
+
+/* ─── Pending ACK helpers ─────────────────────────────────────────────── */
+
+struct pending_ack_data {
+    jobject java_future; /* global ref */
+    JavaVM *jvm;
+};
+
+static void s_pending_ack_destroy(void *value) {
+    /* Note: java_future global ref must be deleted by caller before removing */
+    struct pending_ack_data *data = value;
+    /* We don't free here - freed after completing the future */
+    (void)data;
+}
+
+static void s_complete_java_future(JavaVM *jvm, jobject future, int reason_code, bool success) {
+    JNIEnv *env = NULL;
+    (*jvm)->AttachCurrentThread(jvm, (void **)&env, NULL);
+    if (env == NULL) return;
+
+    jclass future_class = (*env)->GetObjectClass(env, future);
+    if (success) {
+        jmethodID complete_mid = (*env)->GetMethodID(env, future_class, "complete", "(Ljava/lang/Object;)Z");
+        /* Complete with Integer reason code */
+        jclass int_class = (*env)->FindClass(env, "java/lang/Integer");
+        jmethodID int_valueof = (*env)->GetStaticMethodID(env, int_class, "valueOf", "(I)Ljava/lang/Integer;");
+        jobject boxed = (*env)->CallStaticObjectMethod(env, int_class, int_valueof, reason_code);
+        (*env)->CallBooleanMethod(env, future, complete_mid, boxed);
+        (*env)->DeleteLocalRef(env, boxed);
+        (*env)->DeleteLocalRef(env, int_class);
+    } else {
+        jmethodID fail_mid = (*env)->GetMethodID(env, future_class, "completeExceptionally", "(Ljava/lang/Throwable;)Z");
+        jclass exc_class = (*env)->FindClass(env, "java/lang/RuntimeException");
+        jmethodID exc_init = (*env)->GetMethodID(env, exc_class, "<init>", "(Ljava/lang/String;)V");
+        jstring msg = (*env)->NewStringUTF(env, "MQTT operation failed");
+        jobject exc = (*env)->NewObject(env, exc_class, exc_init, msg);
+        (*env)->CallBooleanMethod(env, future, fail_mid, exc);
+        (*env)->DeleteLocalRef(env, exc);
+        (*env)->DeleteLocalRef(env, msg);
+        (*env)->DeleteLocalRef(env, exc_class);
+    }
+    (*env)->DeleteLocalRef(env, future_class);
+}
+
+/* ─── coreMQTT Event Callback ─────────────────────────────────────────── */
+
+static bool s_mqtt_event_callback(
+    MQTTContext_t *pContext,
+    MQTTPacketInfo_t *pPacketInfo,
+    MQTTDeserializedInfo_t *pDeserializedInfo,
+    MQTTSuccessFailReasonCode_t *pReasonCode,
+    MQTTPropBuilder_t *pSendPropsBuffer,
+    MQTTPropBuilder_t *pGetPropsBuffer) {
+
+    (void)pReasonCode;
+    (void)pSendPropsBuffer;
+    (void)pGetPropsBuffer;
+
+    struct coremqtt_channel_handler *h =
+        (struct coremqtt_channel_handler *)pContext->transportInterface.pNetworkContext;
+
+    uint16_t packet_id = pDeserializedInfo->packetIdentifier;
+    uint8_t packet_type = pPacketInfo->type & 0xF0U;
+
+    switch (packet_type) {
+        case MQTT_PACKET_TYPE_PUBACK:
+        case MQTT_PACKET_TYPE_SUBACK:
+        case MQTT_PACKET_TYPE_UNSUBACK: {
+            /* Look up and complete the pending future */
+            struct aws_hash_element *elem = NULL;
+            uint64_t key = (uint64_t)packet_id;
+            aws_hash_table_find(&h->pending_acks, (void *)key, &elem);
+            if (elem != NULL && elem->value != NULL) {
+                struct pending_ack_data *ack_data = elem->value;
+                int rc = 0;
+                if (pDeserializedInfo->pReasonCode != NULL) {
+                    rc = (int)pDeserializedInfo->pReasonCode->reasonCode[0];
+                }
+                s_complete_java_future(h->jvm, ack_data->java_future, rc, true);
+                JNIEnv *env = NULL;
+                (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+                if (env) {
+                    (*env)->DeleteGlobalRef(env, ack_data->java_future);
+                }
+                aws_mem_release(h->allocator, ack_data);
+                aws_hash_table_remove(&h->pending_acks, (void *)key, NULL, NULL);
+            }
+            break;
+        }
+
+        case MQTT_PACKET_TYPE_PUBLISH: {
+            /* Incoming publish → JNI upcall to Java */
+            if (pDeserializedInfo->pPublishInfo != NULL && h->java_callback != NULL) {
+                MQTTPublishInfo_t *pub = pDeserializedInfo->pPublishInfo;
+                JNIEnv *env = NULL;
+                (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+                if (env != NULL) {
+                    jstring jtopic = (*env)->NewStringUTF(env, pub->pTopicName);
+                    jbyteArray jpayload = (*env)->NewByteArray(env, (jsize)pub->payloadLength);
+                    (*env)->SetByteArrayRegion(env, jpayload, 0, (jsize)pub->payloadLength,
+                                              (const jbyte *)pub->pPayload);
+                    (*env)->CallVoidMethod(env, h->java_callback, h->on_publish_received_mid,
+                                          jtopic, jpayload, (jint)pub->qos, (jboolean)pub->retain);
+                    (*env)->DeleteLocalRef(env, jtopic);
+                    (*env)->DeleteLocalRef(env, jpayload);
+                }
+            }
+            break;
+        }
+
+        case MQTT_PACKET_TYPE_DISCONNECT: {
+            h->is_connected = false;
+            if (h->java_callback != NULL) {
+                JNIEnv *env = NULL;
+                (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+                if (env != NULL) {
+                    (*env)->CallVoidMethod(env, h->java_callback, h->on_disconnection_mid, (jint)0);
+                }
+            }
+            break;
+        }
+
+        default:
+            break;
+    }
+
+    return true;
+}
+
+/* ─── Keep-alive timer task ───────────────────────────────────────────── */
+
+static void s_keepalive_task_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
+    (void)task;
+    struct coremqtt_channel_handler *h = arg;
+
+    if (status != AWS_TASK_STATUS_RUN_READY || !h->is_connected) {
+        h->keepalive_scheduled = false;
+        return;
+    }
+
+    /* ProcessLoop with no new data: checks timers, sends PINGREQ if needed */
+    MQTTStatus_t mqtt_status = MQTT_ProcessLoop(&h->mqtt_ctx);
+
+    if (mqtt_status == MQTTKeepAliveTimeout) {
+        h->is_connected = false;
+        if (h->slot && h->slot->channel) {
+            aws_channel_shutdown(h->slot->channel, AWS_ERROR_INVALID_STATE);
+        }
+        h->keepalive_scheduled = false;
+        return;
+    }
+
+    /* Reschedule: run at half the keep-alive interval */
+    uint64_t now_ns = 0;
+    aws_high_res_clock_get_ticks(&now_ns);
+    uint64_t interval_ns = (uint64_t)h->keep_alive_sec * 500000000ULL; /* half interval */
+    if (interval_ns == 0) interval_ns = 15000000000ULL; /* default 15s if keepalive is 0 */
+    aws_event_loop_schedule_task_future(h->loop, &h->keepalive_task, now_ns + interval_ns);
+}
+
+static void s_schedule_keepalive(struct coremqtt_channel_handler *h) {
+    if (h->keepalive_scheduled) return;
+    h->keepalive_scheduled = true;
+    aws_task_init(&h->keepalive_task, s_keepalive_task_fn, h, "CoreMqttKeepAlive");
+    uint64_t now_ns = 0;
+    aws_high_res_clock_get_ticks(&now_ns);
+    uint64_t interval_ns = (uint64_t)h->keep_alive_sec * 500000000ULL;
+    if (interval_ns == 0) interval_ns = 15000000000ULL;
+    aws_event_loop_schedule_task_future(h->loop, &h->keepalive_task, now_ns + interval_ns);
+}
+
+/* ─── Operation task data structures ──────────────────────────────────── */
+
+struct publish_task_data {
+    struct aws_task task;
+    struct coremqtt_channel_handler *handler;
+    char *topic;
+    uint8_t *payload;
+    size_t payload_len;
+    MQTTQoS_t qos;
+    bool retain;
+    jobject java_future; /* global ref */
+};
+
+struct subscribe_task_data {
+    struct aws_task task;
+    struct coremqtt_channel_handler *handler;
+    char *topic;
+    MQTTQoS_t qos;
+    jobject java_future; /* global ref */
+};
+
+struct unsubscribe_task_data {
+    struct aws_task task;
+    struct coremqtt_channel_handler *handler;
+    char *topic;
+    jobject java_future; /* global ref */
+};
+
+/* ─── Publish task (runs on event loop thread) ────────────────────────── */
+
+static void s_publish_task_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
+    (void)task;
+    struct publish_task_data *data = arg;
+    struct coremqtt_channel_handler *h = data->handler;
+
+    if (status != AWS_TASK_STATUS_RUN_READY || !h->is_connected) {
+        s_complete_java_future(h->jvm, data->java_future, 0, false);
+        goto cleanup;
+    }
+
+    MQTTPublishInfo_t pub_info = {
+        .qos = data->qos,
+        .retain = data->retain,
+        .dup = false,
+        .pTopicName = data->topic,
+        .topicNameLength = strlen(data->topic),
+        .pPayload = data->payload,
+        .payloadLength = data->payload_len,
+    };
+
+    uint16_t packet_id = 0;
+    if (data->qos > MQTTQoS0) {
+        packet_id = MQTT_GetPacketId(&h->mqtt_ctx);
+        /* Store pending ACK */
+        struct pending_ack_data *ack_data = aws_mem_calloc(h->allocator, 1, sizeof(struct pending_ack_data));
+        ack_data->java_future = data->java_future;
+        ack_data->jvm = h->jvm;
+        uint64_t key = (uint64_t)packet_id;
+        aws_hash_table_put(&h->pending_acks, (void *)key, ack_data, NULL);
+    }
+
+    MQTTStatus_t result = MQTT_Publish(&h->mqtt_ctx, &pub_info, packet_id, NULL);
+
+    if (result != MQTTSuccess) {
+        if (packet_id != 0) {
+            uint64_t key = (uint64_t)packet_id;
+            struct aws_hash_element *elem = NULL;
+            aws_hash_table_find(&h->pending_acks, (void *)key, &elem);
+            if (elem) {
+                aws_mem_release(h->allocator, elem->value);
+                aws_hash_table_remove(&h->pending_acks, (void *)key, NULL, NULL);
+            }
+        }
+        s_complete_java_future(h->jvm, data->java_future, 0, false);
+        goto cleanup;
+    }
+
+    /* QoS 0: complete immediately (no PUBACK expected) */
+    if (data->qos == MQTTQoS0) {
+        s_complete_java_future(h->jvm, data->java_future, 0, true);
+    }
+    /* QoS 1: future will be completed when PUBACK arrives in event callback */
+
+cleanup:
+    if (data->qos == MQTTQoS0 || result != MQTTSuccess) {
+        JNIEnv *env = NULL;
+        (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+        if (env) (*env)->DeleteGlobalRef(env, data->java_future);
+    }
+    aws_mem_release(h->allocator, data->topic);
+    aws_mem_release(h->allocator, data->payload);
+    aws_mem_release(h->allocator, data);
+}
+
+/* ─── Subscribe task (runs on event loop thread) ──────────────────────── */
+
+static void s_subscribe_task_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
+    (void)task;
+    struct subscribe_task_data *data = arg;
+    struct coremqtt_channel_handler *h = data->handler;
+
+    if (status != AWS_TASK_STATUS_RUN_READY || !h->is_connected) {
+        s_complete_java_future(h->jvm, data->java_future, 0, false);
+        goto cleanup;
+    }
+
+    MQTTSubscribeInfo_t sub_info = {
+        .qos = data->qos,
+        .pTopicFilter = data->topic,
+        .topicFilterLength = strlen(data->topic),
+    };
+
+    uint16_t packet_id = MQTT_GetPacketId(&h->mqtt_ctx);
+
+    /* Store pending ACK */
+    struct pending_ack_data *ack_data = aws_mem_calloc(h->allocator, 1, sizeof(struct pending_ack_data));
+    ack_data->java_future = data->java_future;
+    ack_data->jvm = h->jvm;
+    uint64_t key = (uint64_t)packet_id;
+    aws_hash_table_put(&h->pending_acks, (void *)key, ack_data, NULL);
+
+    MQTTStatus_t result = MQTT_Subscribe(&h->mqtt_ctx, &sub_info, 1, packet_id, NULL);
+
+    if (result != MQTTSuccess) {
+        aws_mem_release(h->allocator, ack_data);
+        aws_hash_table_remove(&h->pending_acks, (void *)key, NULL, NULL);
+        s_complete_java_future(h->jvm, data->java_future, 0, false);
+        JNIEnv *env = NULL;
+        (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+        if (env) (*env)->DeleteGlobalRef(env, data->java_future);
+    }
+    /* Otherwise future completed when SUBACK arrives */
+
+cleanup:
+    aws_mem_release(h->allocator, data->topic);
+    aws_mem_release(h->allocator, data);
+}
+
+/* ─── Unsubscribe task (runs on event loop thread) ────────────────────── */
+
+static void s_unsubscribe_task_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
+    (void)task;
+    struct unsubscribe_task_data *data = arg;
+    struct coremqtt_channel_handler *h = data->handler;
+
+    if (status != AWS_TASK_STATUS_RUN_READY || !h->is_connected) {
+        s_complete_java_future(h->jvm, data->java_future, 0, false);
+        goto cleanup;
+    }
+
+    MQTTSubscribeInfo_t unsub_info = {
+        .pTopicFilter = data->topic,
+        .topicFilterLength = strlen(data->topic),
+    };
+
+    uint16_t packet_id = MQTT_GetPacketId(&h->mqtt_ctx);
+
+    struct pending_ack_data *ack_data = aws_mem_calloc(h->allocator, 1, sizeof(struct pending_ack_data));
+    ack_data->java_future = data->java_future;
+    ack_data->jvm = h->jvm;
+    uint64_t key = (uint64_t)packet_id;
+    aws_hash_table_put(&h->pending_acks, (void *)key, ack_data, NULL);
+
+    MQTTStatus_t result = MQTT_Unsubscribe(&h->mqtt_ctx, &unsub_info, 1, packet_id, NULL);
+
+    if (result != MQTTSuccess) {
+        aws_mem_release(h->allocator, ack_data);
+        aws_hash_table_remove(&h->pending_acks, (void *)key, NULL, NULL);
+        s_complete_java_future(h->jvm, data->java_future, 0, false);
+        JNIEnv *env = NULL;
+        (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+        if (env) (*env)->DeleteGlobalRef(env, data->java_future);
+    }
+
+cleanup:
+    aws_mem_release(h->allocator, data->topic);
+    aws_mem_release(h->allocator, data);
+}
+
+/* ─── Public API: submit operations (called from JNI thread) ──────────── */
+
+void coremqtt_publish(
+    struct coremqtt_channel_handler *handler,
+    const char *topic,
+    const uint8_t *payload,
+    size_t payload_len,
+    MQTTQoS_t qos,
+    bool retain,
+    jobject java_future) {
+
+    struct publish_task_data *data = aws_mem_calloc(handler->allocator, 1, sizeof(struct publish_task_data));
+    data->handler = handler;
+    data->topic = aws_mem_calloc(handler->allocator, 1, strlen(topic) + 1);
+    memcpy(data->topic, topic, strlen(topic) + 1);
+    if (payload_len > 0) {
+        data->payload = aws_mem_calloc(handler->allocator, 1, payload_len);
+        memcpy(data->payload, payload, payload_len);
+    }
+    data->payload_len = payload_len;
+    data->qos = qos;
+    data->retain = retain;
+    data->java_future = java_future; /* already a global ref */
+
+    aws_task_init(&data->task, s_publish_task_fn, data, "CoreMqttPublish");
+    aws_event_loop_schedule_task_now(handler->loop, &data->task);
+}
+
+void coremqtt_subscribe(
+    struct coremqtt_channel_handler *handler,
+    const char *topic,
+    MQTTQoS_t qos,
+    jobject java_future) {
+
+    struct subscribe_task_data *data = aws_mem_calloc(handler->allocator, 1, sizeof(struct subscribe_task_data));
+    data->handler = handler;
+    data->topic = aws_mem_calloc(handler->allocator, 1, strlen(topic) + 1);
+    memcpy(data->topic, topic, strlen(topic) + 1);
+    data->qos = qos;
+    data->java_future = java_future;
+
+    aws_task_init(&data->task, s_subscribe_task_fn, data, "CoreMqttSubscribe");
+    aws_event_loop_schedule_task_now(handler->loop, &data->task);
+}
+
+void coremqtt_unsubscribe(
+    struct coremqtt_channel_handler *handler,
+    const char *topic,
+    jobject java_future) {
+
+    struct unsubscribe_task_data *data = aws_mem_calloc(handler->allocator, 1, sizeof(struct unsubscribe_task_data));
+    data->handler = handler;
+    data->topic = aws_mem_calloc(handler->allocator, 1, strlen(topic) + 1);
+    memcpy(data->topic, topic, strlen(topic) + 1);
+    data->java_future = java_future;
+
+    aws_task_init(&data->task, s_unsubscribe_task_fn, data, "CoreMqttUnsubscribe");
+    aws_event_loop_schedule_task_now(handler->loop, &data->task);
+}
+
+/* ─── Channel setup/shutdown callbacks ────────────────────────────────── */
+
+void coremqtt_on_channel_setup(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data) {
+
+    (void)bootstrap;
+    struct coremqtt_channel_handler *h = user_data;
+
+    if (error_code != 0 || channel == NULL) {
+        if (h->java_callback != NULL) {
+            JNIEnv *env = NULL;
+            (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+            if (env) {
+                (*env)->CallVoidMethod(env, h->java_callback, h->on_connection_failure_mid, (jint)error_code);
+            }
+        }
+        return;
+    }
+
+    /* Insert ourselves at the end of the channel pipeline (after TLS) */
+    h->slot = aws_channel_slot_new(channel);
+    aws_channel_slot_insert_end(channel, h->slot);
+    aws_channel_slot_set_handler(h->slot, &h->base);
+    h->loop = aws_channel_get_event_loop(channel);
+
+    /* Send MQTT CONNECT */
+    MQTTConnectInfo_t connect_info = {
+        .cleanSession = false, /* persistent session */
+        .keepAliveSeconds = h->keep_alive_sec,
+        .pClientIdentifier = NULL, /* set by caller before setup */
+        .clientIdentifierLength = 0,
+    };
+
+    /* TODO: client ID and session expiry will be set from JNI before connection */
+
+    bool session_present = false;
+    MQTTStatus_t status = MQTT_Connect(&h->mqtt_ctx, &connect_info, NULL, 30000,
+                                        &session_present, NULL, NULL);
+
+    if (status == MQTTSuccess) {
+        h->is_connected = true;
+        s_schedule_keepalive(h);
+        if (h->java_callback != NULL) {
+            JNIEnv *env = NULL;
+            (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+            if (env) {
+                (*env)->CallVoidMethod(env, h->java_callback, h->on_connection_success_mid,
+                                      (jboolean)session_present);
+            }
+        }
+    } else {
+        if (h->java_callback != NULL) {
+            JNIEnv *env = NULL;
+            (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+            if (env) {
+                (*env)->CallVoidMethod(env, h->java_callback, h->on_connection_failure_mid, (jint)status);
+            }
+        }
+        aws_channel_shutdown(channel, AWS_ERROR_INVALID_STATE);
+    }
+}
+
+void coremqtt_on_channel_shutdown(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data) {
+
+    (void)bootstrap;
+    (void)channel;
+    struct coremqtt_channel_handler *h = user_data;
+
+    h->is_connected = false;
+    h->slot = NULL;
+    h->keepalive_scheduled = false;
+
+    if (h->java_callback != NULL) {
+        JNIEnv *env = NULL;
+        (*h->jvm)->AttachCurrentThread(h->jvm, (void **)&env, NULL);
+        if (env) {
+            (*env)->CallVoidMethod(env, h->java_callback, h->on_disconnection_mid, (jint)error_code);
+        }
+    }
+}
+
+/* ─── Create / Destroy ────────────────────────────────────────────────── */
+
+static uint64_t s_hash_uint64(const void *key) {
+    return (uint64_t)key;
+}
+
+static bool s_eq_uint64(const void *a, const void *b) {
+    return a == b;
+}
+
+struct coremqtt_channel_handler *coremqtt_channel_handler_new(
+    struct aws_allocator *allocator,
+    JavaVM *jvm,
+    jobject java_callback,
+    uint16_t keep_alive_sec) {
+
+    struct coremqtt_channel_handler *h = aws_mem_calloc(allocator, 1, sizeof(struct coremqtt_channel_handler));
+    h->allocator = allocator;
+    h->jvm = jvm;
+    h->java_callback = java_callback; /* already a global ref */
+    h->keep_alive_sec = keep_alive_sec;
+
+    /* Set up channel handler vtable */
+    h->base.vtable = &s_vtable;
+    h->base.alloc = allocator;
+    h->base.impl = h;
+
+    /* Initialize coreMQTT */
+    TransportInterface_t transport = {
+        .recv = s_transport_recv,
+        .send = s_transport_send,
+        .writev = NULL,
+        .pNetworkContext = (NetworkContext_t *)h,
+    };
+
+    MQTTFixedBuffer_t network_buf = {
+        .pBuffer = h->network_buffer,
+        .size = COREMQTT_NETWORK_BUFFER_SIZE,
+    };
+
+    MQTT_Init(&h->mqtt_ctx, &transport, s_get_time_ms, s_mqtt_event_callback, &network_buf);
+    MQTT_InitStatefulQoS(&h->mqtt_ctx,
+                         h->outgoing_records, COREMQTT_MAX_OUTGOING_PUBLISHES,
+                         h->incoming_records, COREMQTT_MAX_INCOMING_PUBLISHES,
+                         h->ack_props_buffer, COREMQTT_ACK_PROPS_BUF_SIZE);
+
+    /* Initialize pending ACK hash table */
+    aws_hash_table_init(&h->pending_acks, allocator, 64, s_hash_uint64, s_eq_uint64, NULL, NULL);
+
+    /* Cache JNI method IDs */
+    JNIEnv *env = NULL;
+    (*jvm)->AttachCurrentThread(jvm, (void **)&env, NULL);
+    if (env && java_callback) {
+        jclass cls = (*env)->GetObjectClass(env, java_callback);
+        h->on_publish_received_mid = (*env)->GetMethodID(env, cls, "onPublishReceived", "(Ljava/lang/String;[BIZ)V");
+        h->on_connection_success_mid = (*env)->GetMethodID(env, cls, "onConnectionSuccess", "(Z)V");
+        h->on_connection_failure_mid = (*env)->GetMethodID(env, cls, "onConnectionFailure", "(I)V");
+        h->on_disconnection_mid = (*env)->GetMethodID(env, cls, "onDisconnection", "(I)V");
+        h->on_ack_received_mid = (*env)->GetMethodID(env, cls, "onAckReceived", "(II)V");
+        (*env)->DeleteLocalRef(env, cls);
+    }
+
+    return h;
+}
+
+void coremqtt_channel_handler_destroy(struct coremqtt_channel_handler *handler) {
+    if (handler == NULL) return;
+
+    aws_hash_table_clean_up(&handler->pending_acks);
+
+    if (handler->java_callback != NULL) {
+        JNIEnv *env = NULL;
+        (*handler->jvm)->AttachCurrentThread(handler->jvm, (void **)&env, NULL);
+        if (env) {
+            (*env)->DeleteGlobalRef(env, handler->java_callback);
+        }
+    }
+
+    aws_mem_release(handler->allocator, handler);
+}

--- a/coremqtt-jni/src/coremqtt_channel_handler.h
+++ b/coremqtt-jni/src/coremqtt_channel_handler.h
@@ -1,0 +1,119 @@
+/*
+ * coreMQTT Channel Handler Adapter for aws-c-io pipeline.
+ * Replaces aws-c-mqtt as the MQTT protocol handler in the channel.
+ */
+#ifndef COREMQTT_CHANNEL_HANDLER_H
+#define COREMQTT_CHANNEL_HANDLER_H
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/hash_table.h>
+#include <aws/common/task_scheduler.h>
+#include <aws/io/channel.h>
+#include <aws/io/channel_bootstrap.h>
+#include <aws/io/event_loop.h>
+#include <jni.h>
+
+#include "core_mqtt.h"
+#include "core_mqtt_serializer.h"
+
+/* Network buffer size: 130KB (IoT Core max payload is 128KB + headers/properties) */
+#define COREMQTT_NETWORK_BUFFER_SIZE    ( 130U * 1024U )
+
+/* Max in-flight QoS 1 publishes tracked */
+#define COREMQTT_MAX_OUTGOING_PUBLISHES ( 100U )
+#define COREMQTT_MAX_INCOMING_PUBLISHES ( 100U )
+
+/* Receive ring buffer size */
+#define COREMQTT_RECV_BUFFER_SIZE       ( 256U * 1024U )
+
+/* Ack properties buffer size */
+#define COREMQTT_ACK_PROPS_BUF_SIZE     ( 1024U )
+
+struct coremqtt_channel_handler {
+    /* aws-c-io channel handler base */
+    struct aws_channel_handler base;
+    struct aws_channel_slot *slot;
+    struct aws_event_loop *loop;
+    struct aws_allocator *allocator;
+
+    /* coreMQTT context and buffers */
+    MQTTContext_t mqtt_ctx;
+    uint8_t network_buffer[COREMQTT_NETWORK_BUFFER_SIZE];
+    MQTTPubAckInfo_t outgoing_records[COREMQTT_MAX_OUTGOING_PUBLISHES];
+    MQTTPubAckInfo_t incoming_records[COREMQTT_MAX_INCOMING_PUBLISHES];
+    uint8_t ack_props_buffer[COREMQTT_ACK_PROPS_BUF_SIZE];
+
+    /* Receive ring buffer: filled by channel read, drained by TransportRecv */
+    uint8_t recv_buffer_storage[COREMQTT_RECV_BUFFER_SIZE];
+    size_t recv_write_pos;
+    size_t recv_read_pos;
+
+    /* Pending ACK tracking: packetId -> callback user_data */
+    struct aws_hash_table pending_acks;
+
+    /* Keep-alive timer */
+    struct aws_task keepalive_task;
+    bool keepalive_scheduled;
+
+    /* Connection state */
+    bool is_connected;
+    uint16_t keep_alive_sec;
+
+    /* JNI callback references */
+    JavaVM *jvm;
+    jobject java_callback;   /* global ref to CoreMqttCallbackHandler */
+    jmethodID on_publish_received_mid;
+    jmethodID on_connection_success_mid;
+    jmethodID on_connection_failure_mid;
+    jmethodID on_disconnection_mid;
+    jmethodID on_ack_received_mid;
+};
+
+/* Create a new channel handler. Call before initiating connection. */
+struct coremqtt_channel_handler *coremqtt_channel_handler_new(
+    struct aws_allocator *allocator,
+    JavaVM *jvm,
+    jobject java_callback,
+    uint16_t keep_alive_sec);
+
+/* Destroy and free. */
+void coremqtt_channel_handler_destroy(struct coremqtt_channel_handler *handler);
+
+/* Submit a publish operation (called from JNI, schedules event loop task). */
+void coremqtt_publish(
+    struct coremqtt_channel_handler *handler,
+    const char *topic,
+    const uint8_t *payload,
+    size_t payload_len,
+    MQTTQoS_t qos,
+    bool retain,
+    jobject java_future);
+
+/* Submit a subscribe operation. */
+void coremqtt_subscribe(
+    struct coremqtt_channel_handler *handler,
+    const char *topic,
+    MQTTQoS_t qos,
+    jobject java_future);
+
+/* Submit an unsubscribe operation. */
+void coremqtt_unsubscribe(
+    struct coremqtt_channel_handler *handler,
+    const char *topic,
+    jobject java_future);
+
+/* Channel setup callback - to be used with aws_client_bootstrap_new_socket_channel. */
+void coremqtt_on_channel_setup(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data);
+
+/* Channel shutdown callback. */
+void coremqtt_on_channel_shutdown(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data);
+
+#endif /* COREMQTT_CHANNEL_HANDLER_H */

--- a/coremqtt-jni/src/coremqtt_jni.c
+++ b/coremqtt-jni/src/coremqtt_jni.c
@@ -1,0 +1,250 @@
+/*
+ * JNI entry points for the coreMQTT channel handler adapter.
+ * These are called from Java CoreMqttNative class.
+ */
+#include "coremqtt_channel_handler.h"
+
+#include <aws/common/allocator.h>
+#include <aws/io/channel_bootstrap.h>
+#include <aws/io/socket.h>
+#include <aws/io/tls_channel_handler.h>
+#include <jni.h>
+#include <string.h>
+
+/* Helper: get C string from jstring (caller must free) */
+static char *s_jstring_to_cstr(JNIEnv *env, jstring jstr, struct aws_allocator *alloc) {
+    if (jstr == NULL) return NULL;
+    const char *utf = (*env)->GetStringUTFChars(env, jstr, NULL);
+    size_t len = strlen(utf);
+    char *copy = aws_mem_calloc(alloc, 1, len + 1);
+    memcpy(copy, utf, len + 1);
+    (*env)->ReleaseStringUTFChars(env, jstr, utf);
+    return copy;
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    create
+ * Signature: (ILjava/lang/Object;)J
+ *
+ * Creates the channel handler. Does NOT connect yet.
+ */
+JNIEXPORT jlong JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_create(
+    JNIEnv *env,
+    jclass cls,
+    jint keep_alive_sec,
+    jobject java_callback) {
+
+    (void)cls;
+    struct aws_allocator *alloc = aws_default_allocator();
+    JavaVM *jvm = NULL;
+    (*env)->GetJavaVM(env, &jvm);
+
+    jobject callback_ref = (*env)->NewGlobalRef(env, java_callback);
+
+    struct coremqtt_channel_handler *handler = coremqtt_channel_handler_new(
+        alloc, jvm, callback_ref, (uint16_t)keep_alive_sec);
+
+    return (jlong)(uintptr_t)handler;
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    destroy
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_destroy(
+    JNIEnv *env,
+    jclass cls,
+    jlong handle) {
+
+    (void)env;
+    (void)cls;
+    struct coremqtt_channel_handler *handler = (struct coremqtt_channel_handler *)(uintptr_t)handle;
+    coremqtt_channel_handler_destroy(handler);
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    connect
+ * Signature: (JLjava/lang/String;IJJLjava/lang/String;)V
+ *
+ * Initiates TCP+TLS connection via aws-c-io bootstrap, then sends MQTT CONNECT.
+ */
+JNIEXPORT void JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_connect(
+    JNIEnv *env,
+    jclass cls,
+    jlong handle,
+    jstring jendpoint,
+    jint port,
+    jlong bootstrap_handle,
+    jlong tls_ctx_handle,
+    jstring jclient_id) {
+
+    (void)cls;
+    struct aws_allocator *alloc = aws_default_allocator();
+    struct coremqtt_channel_handler *handler = (struct coremqtt_channel_handler *)(uintptr_t)handle;
+
+    const char *endpoint = (*env)->GetStringUTFChars(env, jendpoint, NULL);
+    const char *client_id = (*env)->GetStringUTFChars(env, jclient_id, NULL);
+
+    /* Store client ID in the MQTT context for CONNECT */
+    /* TODO: store client_id in handler struct for use in channel_setup */
+
+    struct aws_client_bootstrap *bootstrap = (struct aws_client_bootstrap *)(uintptr_t)bootstrap_handle;
+    struct aws_tls_ctx *tls_ctx = (struct aws_tls_ctx *)(uintptr_t)tls_ctx_handle;
+
+    /* Set up TLS connection options */
+    struct aws_tls_connection_options tls_options;
+    AWS_ZERO_STRUCT(tls_options);
+    aws_tls_connection_options_init_from_ctx(&tls_options, tls_ctx);
+    struct aws_byte_cursor host_cursor = aws_byte_cursor_from_c_str(endpoint);
+    aws_tls_connection_options_set_server_name(&tls_options, alloc, &host_cursor);
+
+    /* Socket options */
+    struct aws_socket_options socket_options = {
+        .type = AWS_SOCKET_STREAM,
+        .domain = AWS_SOCKET_IPV4,
+        .connect_timeout_ms = 10000,
+    };
+
+    /* Initiate connection through aws-c-io bootstrap */
+    struct aws_socket_channel_bootstrap_options channel_options = {
+        .bootstrap = bootstrap,
+        .host_name = endpoint,
+        .port = (uint32_t)port,
+        .socket_options = &socket_options,
+        .tls_options = &tls_options,
+        .setup_callback = coremqtt_on_channel_setup,
+        .shutdown_callback = coremqtt_on_channel_shutdown,
+        .user_data = handler,
+    };
+
+    int result = aws_client_bootstrap_new_socket_channel(&channel_options);
+    if (result != AWS_OP_SUCCESS) {
+        JNIEnv *cb_env = env;
+        if (handler->java_callback) {
+            (*cb_env)->CallVoidMethod(cb_env, handler->java_callback,
+                                     handler->on_connection_failure_mid, (jint)aws_last_error());
+        }
+    }
+
+    (*env)->ReleaseStringUTFChars(env, jendpoint, endpoint);
+    (*env)->ReleaseStringUTFChars(env, jclient_id, client_id);
+    aws_tls_connection_options_clean_up(&tls_options);
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    disconnect
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_disconnect(
+    JNIEnv *env,
+    jclass cls,
+    jlong handle) {
+
+    (void)env;
+    (void)cls;
+    struct coremqtt_channel_handler *handler = (struct coremqtt_channel_handler *)(uintptr_t)handle;
+
+    if (handler->is_connected && handler->slot && handler->slot->channel) {
+        MQTTSuccessFailReasonCode_t reason = 0; /* Normal disconnection */
+        MQTT_Disconnect(&handler->mqtt_ctx, NULL, &reason);
+        aws_channel_shutdown(handler->slot->channel, 0);
+    }
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    publish
+ * Signature: (JLjava/lang/String;[BIZLjava/lang/Object;)V
+ */
+JNIEXPORT void JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_publish(
+    JNIEnv *env,
+    jclass cls,
+    jlong handle,
+    jstring jtopic,
+    jbyteArray jpayload,
+    jint qos,
+    jboolean retain,
+    jobject jfuture) {
+
+    (void)cls;
+    struct coremqtt_channel_handler *handler = (struct coremqtt_channel_handler *)(uintptr_t)handle;
+
+    const char *topic = (*env)->GetStringUTFChars(env, jtopic, NULL);
+    jsize payload_len = jpayload ? (*env)->GetArrayLength(env, jpayload) : 0;
+    jbyte *payload = payload_len > 0 ? (*env)->GetByteArrayElements(env, jpayload, NULL) : NULL;
+
+    jobject future_ref = (*env)->NewGlobalRef(env, jfuture);
+
+    coremqtt_publish(handler, topic, (const uint8_t *)payload, (size_t)payload_len,
+                     (MQTTQoS_t)qos, (bool)retain, future_ref);
+
+    if (payload) (*env)->ReleaseByteArrayElements(env, jpayload, payload, JNI_ABORT);
+    (*env)->ReleaseStringUTFChars(env, jtopic, topic);
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    subscribe
+ * Signature: (JLjava/lang/String;ILjava/lang/Object;)V
+ */
+JNIEXPORT void JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_subscribe(
+    JNIEnv *env,
+    jclass cls,
+    jlong handle,
+    jstring jtopic,
+    jint qos,
+    jobject jfuture) {
+
+    (void)cls;
+    struct coremqtt_channel_handler *handler = (struct coremqtt_channel_handler *)(uintptr_t)handle;
+
+    const char *topic = (*env)->GetStringUTFChars(env, jtopic, NULL);
+    jobject future_ref = (*env)->NewGlobalRef(env, jfuture);
+
+    coremqtt_subscribe(handler, topic, (MQTTQoS_t)qos, future_ref);
+
+    (*env)->ReleaseStringUTFChars(env, jtopic, topic);
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    unsubscribe
+ * Signature: (JLjava/lang/String;Ljava/lang/Object;)V
+ */
+JNIEXPORT void JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_unsubscribe(
+    JNIEnv *env,
+    jclass cls,
+    jlong handle,
+    jstring jtopic,
+    jobject jfuture) {
+
+    (void)cls;
+    struct coremqtt_channel_handler *handler = (struct coremqtt_channel_handler *)(uintptr_t)handle;
+
+    const char *topic = (*env)->GetStringUTFChars(env, jtopic, NULL);
+    jobject future_ref = (*env)->NewGlobalRef(env, jfuture);
+
+    coremqtt_unsubscribe(handler, topic, future_ref);
+
+    (*env)->ReleaseStringUTFChars(env, jtopic, topic);
+}
+
+/*
+ * Class:     com_aws_greengrass_mqttclient_CoreMqttNative
+ * Method:    isConnected
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_aws_greengrass_mqttclient_CoreMqttNative_isConnected(
+    JNIEnv *env,
+    jclass cls,
+    jlong handle) {
+
+    (void)env;
+    (void)cls;
+    struct coremqtt_channel_handler *handler = (struct coremqtt_channel_handler *)(uintptr_t)handle;
+    return (jboolean)handler->is_connected;
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/CoreMqttJniClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/CoreMqttJniClient.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.mqttclient.v5.PubAck;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.QOS;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
+import com.aws.greengrass.mqttclient.v5.SubscribeResponse;
+import com.aws.greengrass.mqttclient.v5.UnsubscribeResponse;
+import com.aws.greengrass.util.Coerce;
+import lombok.Getter;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.ClientTlsContext;
+import vendored.com.google.common.util.concurrent.RateLimiter;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.aws.greengrass.mqttclient.MqttClient.DEFAULT_MQTT_KEEP_ALIVE_TIMEOUT;
+import static com.aws.greengrass.mqttclient.MqttClient.MQTT_KEEP_ALIVE_TIMEOUT_KEY;
+
+/**
+ * IndividualMqttClient implementation backed by coreMQTT via JNI.
+ * Replaces AwsIotMqtt5Client for the "coremqtt" version config.
+ */
+class CoreMqttJniClient implements IndividualMqttClient {
+
+    private static final Logger logger = LogManager.getLogger(CoreMqttJniClient.class);
+    private static final Random RANDOM = new Random();
+
+    private long nativeHandle;
+    @Getter
+    private final String clientId;
+    @Getter
+    private final int clientIdNum;
+    private final Topics mqttTopics;
+    private final CallbackEventManager callbackEventManager;
+    private final ExecutorService executorService;
+    private final ScheduledExecutorService ses;
+    private final Consumer<Publish> messageHandler;
+    private final Supplier<ClientBootstrap> bootstrapSupplier;
+    private final Supplier<ClientTlsContext> tlsContextSupplier;
+    private final Supplier<String> endpointSupplier;
+    private final Supplier<Integer> portSupplier;
+
+    private final Set<Subscribe> subscriptionTopics = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<Subscribe> droppedSubscriptionTopics = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    @Getter
+    private final AtomicInteger inprogressSubscriptions = new AtomicInteger();
+    private final AtomicBoolean hasConnectedOnce = new AtomicBoolean(false);
+    private CompletableFuture<Object> connectFuture;
+
+    // Rate limiters (same as AwsIotMqtt5Client)
+    private final RateLimiter transactionLimiter = RateLimiter.create(100.0);
+    private final RateLimiter bandwidthLimiter = RateLimiter.create(512.0 * 1024);
+
+    /**
+     * Callback handler invoked from native code via JNI.
+     */
+    @SuppressWarnings("unused") // Called from JNI
+    private final Object callbackHandler = new Object() {
+        public void onPublishReceived(String topic, byte[] payload, int qos, boolean retain) {
+            Publish pub = Publish.builder()
+                    .topic(topic)
+                    .payload(payload)
+                    .qos(QOS.fromInt(qos))
+                    .retain(retain)
+                    .build();
+            messageHandler.accept(pub);
+        }
+
+        public void onConnectionSuccess(boolean sessionPresent) {
+            logger.atInfo().kv("sessionPresent", sessionPresent).log("coreMQTT connected to AWS IoT Core");
+            if (hasConnectedOnce.compareAndSet(false, true)) {
+                callbackEventManager.runOnInitialConnect(sessionPresent);
+            } else {
+                callbackEventManager.runOnConnectionResumed(sessionPresent);
+            }
+            if (connectFuture != null && !connectFuture.isDone()) {
+                connectFuture.complete(null);
+            }
+            resubscribe(sessionPresent);
+        }
+
+        public void onConnectionFailure(int errorCode) {
+            logger.atError().kv("errorCode", errorCode).log("coreMQTT connection failed");
+            if (connectFuture != null && !connectFuture.isDone()) {
+                connectFuture.completeExceptionally(
+                        new RuntimeException("Connection failed with error: " + errorCode));
+            }
+        }
+
+        public void onDisconnection(int errorCode) {
+            logger.atWarn().kv("errorCode", errorCode).log("coreMQTT connection interrupted");
+            callbackEventManager.runOnConnectionInterrupted(errorCode);
+        }
+    };
+
+    CoreMqttJniClient(
+            Function<CoreMqttJniClient, Consumer<Publish>> messageHandlerFactory,
+            String clientId,
+            int clientIdNum,
+            Topics mqttTopics,
+            CallbackEventManager callbackEventManager,
+            ExecutorService executorService,
+            ScheduledExecutorService ses,
+            Supplier<ClientBootstrap> bootstrapSupplier,
+            Supplier<ClientTlsContext> tlsContextSupplier,
+            Supplier<String> endpointSupplier,
+            Supplier<Integer> portSupplier) {
+
+        this.clientId = clientId;
+        this.clientIdNum = clientIdNum;
+        this.mqttTopics = mqttTopics;
+        this.callbackEventManager = callbackEventManager;
+        this.executorService = executorService;
+        this.ses = ses;
+        this.messageHandler = messageHandlerFactory.apply(this);
+        this.bootstrapSupplier = bootstrapSupplier;
+        this.tlsContextSupplier = tlsContextSupplier;
+        this.endpointSupplier = endpointSupplier;
+        this.portSupplier = portSupplier;
+
+        int keepAliveMs = Coerce.toInt(
+                mqttTopics.findOrDefault(DEFAULT_MQTT_KEEP_ALIVE_TIMEOUT, MQTT_KEEP_ALIVE_TIMEOUT_KEY));
+        int keepAliveSec = keepAliveMs / 1000;
+
+        this.nativeHandle = CoreMqttNative.create(keepAliveSec, callbackHandler);
+    }
+
+    @Override
+    public CompletableFuture<?> connect() {
+        if (connectFuture != null && !connectFuture.isDone()) {
+            return connectFuture;
+        }
+        connectFuture = new CompletableFuture<>();
+
+        String endpoint = endpointSupplier.get();
+        int port = portSupplier.get();
+        long bootstrapHandle = bootstrapSupplier.get().getNativeHandle();
+        long tlsCtxHandle = tlsContextSupplier.get().getNativeHandle();
+
+        CoreMqttNative.connect(nativeHandle, endpoint, port, bootstrapHandle, tlsCtxHandle, clientId);
+        return connectFuture;
+    }
+
+    @Override
+    public CompletableFuture<SubscribeResponse> subscribe(Subscribe subscribe) {
+        CompletableFuture<SubscribeResponse> future = new CompletableFuture<>();
+        inprogressSubscriptions.incrementAndGet();
+
+        CompletableFuture<Integer> nativeFuture = new CompletableFuture<>();
+        CoreMqttNative.subscribe(nativeHandle, subscribe.getTopic(), subscribe.getQos().getValue(), nativeFuture);
+
+        nativeFuture.whenComplete((rc, error) -> {
+            inprogressSubscriptions.decrementAndGet();
+            if (error == null) {
+                subscriptionTopics.add(subscribe);
+                int reasonCode = (rc != null) ? rc : 0;
+                future.complete(new SubscribeResponse(null, reasonCode, null));
+            } else {
+                future.completeExceptionally(error);
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<UnsubscribeResponse> unsubscribe(String topic) {
+        CompletableFuture<UnsubscribeResponse> future = new CompletableFuture<>();
+
+        CompletableFuture<Integer> nativeFuture = new CompletableFuture<>();
+        CoreMqttNative.unsubscribe(nativeHandle, topic, nativeFuture);
+
+        nativeFuture.whenComplete((rc, error) -> {
+            if (error == null) {
+                subscriptionTopics.removeIf(s -> s.getTopic().equals(topic));
+                future.complete(new UnsubscribeResponse(null, null, null));
+            } else {
+                future.completeExceptionally(error);
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<PubAck> publish(Publish publish) {
+        CompletableFuture<PubAck> future = new CompletableFuture<>();
+
+        transactionLimiter.acquire();
+        bandwidthLimiter.acquire(publish.getPayload() != null ? publish.getPayload().length : 0);
+
+        CompletableFuture<Integer> nativeFuture = new CompletableFuture<>();
+        CoreMqttNative.publish(nativeHandle, publish.getTopic(),
+                publish.getPayload() != null ? publish.getPayload() : new byte[0],
+                publish.getQos().getValue(), publish.isRetain(), nativeFuture);
+
+        nativeFuture.whenComplete((rc, error) -> {
+            if (error == null) {
+                int reasonCode = (rc != null) ? rc : 0;
+                future.complete(new PubAck(reasonCode, null, null));
+            } else {
+                future.completeExceptionally(error);
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public long getThrottlingWaitTimeMicros() {
+        return Math.max(bandwidthLimiter.microTimeToNextPermit(), transactionLimiter.microTimeToNextPermit());
+    }
+
+    @Override
+    public boolean canAddNewSubscription() {
+        return (subscriptionTopics.size() + inprogressSubscriptions.get())
+                < MqttClient.MAX_SUBSCRIPTIONS_PER_CONNECTION;
+    }
+
+    @Override
+    public int subscriptionCount() {
+        return subscriptionTopics.size();
+    }
+
+    @Override
+    public boolean isConnectionClosable() {
+        return subscriptionTopics.size() + inprogressSubscriptions.get() == 0;
+    }
+
+    @Override
+    public boolean connected() {
+        return nativeHandle != 0 && CoreMqttNative.isConnected(nativeHandle);
+    }
+
+    @Override
+    public void close() {
+        closeOnShutdown();
+    }
+
+    @Override
+    public void closeOnShutdown() {
+        if (nativeHandle != 0) {
+            CoreMqttNative.disconnect(nativeHandle);
+            CoreMqttNative.destroy(nativeHandle);
+            nativeHandle = 0;
+        }
+    }
+
+    @Override
+    public void reconnect(long operationTimeoutMs) throws TimeoutException, ExecutionException, InterruptedException {
+        logger.atInfo().log("Reconnecting coreMQTT client");
+        CoreMqttNative.disconnect(nativeHandle);
+        connect().get(operationTimeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void resubscribe(boolean sessionPresent) {
+        if (!subscriptionTopics.isEmpty() && !sessionPresent) {
+            droppedSubscriptionTopics.addAll(subscriptionTopics);
+        }
+        if (!droppedSubscriptionTopics.isEmpty()) {
+            executorService.submit(this::resubscribeDroppedTopics);
+        }
+    }
+
+    private void resubscribeDroppedTopics() {
+        long delayMs = 0;
+        while (connected() && !droppedSubscriptionTopics.isEmpty()) {
+            if (delayMs > 0) {
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+            for (Subscribe sub : droppedSubscriptionTopics) {
+                try {
+                    subscribe(sub).get(30, TimeUnit.SECONDS);
+                    droppedSubscriptionTopics.remove(sub);
+                } catch (Exception e) {
+                    logger.atError().kv("topic", sub.getTopic()).log("Failed to resubscribe, will retry", e);
+                }
+            }
+            delayMs = Duration.ofMinutes(2).toMillis() + RANDOM.nextInt(10_000);
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/CoreMqttNative.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/CoreMqttNative.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * JNI bridge to the coreMQTT channel handler native library.
+ * All native methods delegate to coremqtt_jni.c.
+ */
+final class CoreMqttNative {
+
+    static {
+        System.loadLibrary("coremqtt_jni");
+    }
+
+    private CoreMqttNative() {
+    }
+
+    /**
+     * Create a new coreMQTT channel handler instance.
+     *
+     * @param keepAliveSec keep-alive interval in seconds
+     * @param callback     callback handler for events (implements CoreMqttCallbackHandler)
+     * @return native handle (pointer)
+     */
+    static native long create(int keepAliveSec, Object callback);
+
+    /**
+     * Destroy the native handler and free resources.
+     */
+    static native void destroy(long handle);
+
+    /**
+     * Initiate TCP+TLS connection and send MQTT CONNECT.
+     *
+     * @param handle          native handle
+     * @param endpoint        IoT Core endpoint
+     * @param port            port (typically 8883)
+     * @param bootstrapHandle native handle to aws_client_bootstrap
+     * @param tlsCtxHandle    native handle to aws_tls_ctx
+     * @param clientId        MQTT client ID
+     */
+    static native void connect(long handle, String endpoint, int port,
+                               long bootstrapHandle, long tlsCtxHandle, String clientId);
+
+    /**
+     * Send MQTT DISCONNECT and shut down the channel.
+     */
+    static native void disconnect(long handle);
+
+    /**
+     * Publish a message. Future is completed when PUBACK is received (QoS 1)
+     * or immediately after send (QoS 0).
+     */
+    static native void publish(long handle, String topic, byte[] payload,
+                               int qos, boolean retain, Object future);
+
+    /**
+     * Subscribe to a topic. Future is completed when SUBACK is received.
+     */
+    static native void subscribe(long handle, String topic, int qos, Object future);
+
+    /**
+     * Unsubscribe from a topic. Future is completed when UNSUBACK is received.
+     */
+    static native void unsubscribe(long handle, String topic, Object future);
+
+    /**
+     * Check if the MQTT connection is currently active.
+     */
+    static native boolean isConnected(long handle);
+}

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -987,6 +987,16 @@ public class MqttClient implements Closeable {
                 : "#" + (clientIdNum + 1));
         logger.atDebug().kv("clientId", clientId).log("Getting new MQTT connection");
 
+        if ("coremqtt".equalsIgnoreCase(getMqttVersion())) {
+            return new CoreMqttJniClient(
+                    this::getMessageHandlerForClient, clientId, clientIdNum, mqttTopics,
+                    callbackEventManager, executorService, ses,
+                    () -> clientBootstrap,
+                    () -> proxyTlsContext,
+                    () -> Coerce.toString(deviceConfiguration.getIotDataEndpoint()),
+                    () -> Coerce.toInt(mqttTopics.findOrDefault(DEFAULT_MQTT_PORT, MQTT_PORT_KEY)));
+        }
+
         if (MQTT_VERSION_5.equalsIgnoreCase(getMqttVersion())) {
             return new AwsIotMqtt5Client(() -> {
                 try {


### PR DESCRIPTION
- Add coremqtt-jni/ native adapter that plugs coreMQTT into the aws-c-io channel pipeline, replacing aws-c-mqtt as the MQTT protocol handler while keeping TLS/sockets/event loops intact.
- Add CoreMqttJniClient implementing IndividualMqttClient interface.
- Selectable via mqtt.version: "coremqtt" in device config.
- coreMQTT added as git submodule under coremqtt-jni/coreMQTT.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
