### PR TITLE
feat(deployment): report terminal deployment status to source account after endpoint switch

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -62,10 +62,7 @@ public class DeploymentConfigMerger {
     public static final String DEPLOYMENT_ID_LOG_KEY = "deploymentId";
     public static final String SERVICE_NAME_LOG_KEY = "serviceName";
     protected static final int WAIT_SVC_START_POLL_INTERVAL_MILLISEC = 1000;
-    static final long DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS = 60_000;
-    static final String STANDALONE_MQTT_TIMEOUT_KEY = "standaloneMqttTimeoutMs";
     private static final String ENDPOINT_LOG_KEY = "endpoint";
-    private static final String ENDPOINT_SWITCH_CLIENT_SUFFIX = "#endpoint-switch";
 
     private static final Logger logger = LogManager.getLogger(DeploymentConfigMerger.class);
 
@@ -161,10 +158,20 @@ public class DeploymentConfigMerger {
 
         // Endpoint-switch deployments: pre-flight connectivity check, then persist source endpoint.
         // Pre-flight runs BEFORE persisting so that on failure, no device state has changed.
-        // Source endpoint is stored under services.DeploymentService.runtime (internal deployment state,
-        // not customer config). Persisted to config.tlog so it survives device crashes mid-endpoint-switch.
-        // Step 5 uses this value to report deployment status back to the source account.
-        // Cleared after status reporting; stale keys are harmless and overwritten by the next switch.
+        //
+        // Before switching the IoT endpoint, save two values to runtime config:
+        //
+        // 1. sourceIotDataEndpoint — the current IoT data endpoint (where the device is connected
+        //    now). After the switch, the status consumer uses this to publish the deployment result
+        //    back to the originating account via a standalone MQTT connection.
+        //
+        // 2. sourceDeploymentId — this deployment's ID (job ID, config ARN, or UUID depending on
+        //    type). The status consumer matches this against the persisted status entry to identify
+        //    which entry belongs to the endpoint-switch deployment.
+        //
+        // Both are stored under services.DeploymentService.runtime (internal deployment state, not
+        // customer config) and persisted to config.tlog (survives crashes). Removed by the status
+        // consumer after it successfully publishes the deployment result to the source endpoint.
         EndpointSwitchPreflightValidator preflightValidator =
                 kernel.getContext().get(EndpointSwitchPreflightValidator.class);
         if (isEndpointSwitchDeployment(nucleusConfig, deviceConfiguration)) {
@@ -179,16 +186,9 @@ public class DeploymentConfigMerger {
             logger.atInfo().setEventType(MERGE_CONFIG_EVENT_KEY)
                     .kv(ENDPOINT_LOG_KEY, newDataEndpoint)
                     .log("Starting pre-flight MQTT connectivity check");
-            long preflightTimeout = Coerce.toLong(deviceConfiguration.getMQTTNamespace()
-                    .findOrDefault(DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS, STANDALONE_MQTT_TIMEOUT_KEY));
-            if (preflightTimeout <= 0) {
-                logger.atWarn().kv("configured", preflightTimeout)
-                        .kv("using", DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS)
-                        .log("Invalid standaloneMqttTimeoutMs, using default");
-                preflightTimeout = DEFAULT_PREFLIGHT_MQTT_TIMEOUT_MS;
-            }
+            long preflightTimeout = deviceConfiguration.getStandaloneMqttTimeout();
             if (!preflightValidator.verifyMqttConnectivity(totallyCompleteFuture, newDataEndpoint,
-                    ENDPOINT_SWITCH_CLIENT_SUFFIX, preflightTimeout)) {
+                    preflightTimeout)) {
                 return;
             }
             logger.atInfo().setEventType(MERGE_CONFIG_EVENT_KEY)
@@ -196,8 +196,7 @@ public class DeploymentConfigMerger {
                     .log("Pre-flight MQTT connectivity check passed");
 
             // Persist source endpoint only after pre-flight succeeds — no state change on failure
-            kernel.getContext().get(DeploymentService.class).getRuntimeConfig()
-                    .lookup(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY).withValue(currentDataEndpoint);
+            kernel.getContext().get(EndpointSwitchState.class).persist(currentDataEndpoint, deployment.getId());
         }
 
         // Pre-flight credential endpoint check — uses the device certificate for mTLS authentication,

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -98,7 +98,6 @@ public class DeploymentService extends GreengrassService {
     public static final String GROUP_TO_LAST_DEPLOYMENT_CONFIG_ARN_KEY = "configArn";
     public static final String GROUP_TO_ROOT_COMPONENTS_VERSION_KEY = "version";
     public static final String GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN = "groupConfigArn";
-    public static final String SOURCE_IOT_DATA_ENDPOINT_KEY = "sourceIotDataEndpoint";
     public static final String GROUP_TO_ROOT_COMPONENTS_GROUP_NAME = "groupConfigName";
     public static final String DEPLOYMENT_DETAILED_STATUS_KEY = "detailed-deployment-status";
     public static final String DEPLOYMENT_FAILURE_CAUSE_KEY = "deployment-failure-cause";

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -506,6 +506,25 @@ public class DeviceConfiguration {
         return getTopics(DEVICE_MQTT_NAMESPACE);
     }
 
+    /**
+     * Get the standalone MQTT timeout for endpoint-switch operations, falling back to the default
+     * if the configured value is invalid (≤ 0).
+     *
+     * @return timeout in milliseconds (always positive)
+     */
+    public long getStandaloneMqttTimeout() {
+        long timeout = Coerce.toLong(getMQTTNamespace()
+                .findOrDefault(EndpointSwitchState.DEFAULT_STANDALONE_MQTT_TIMEOUT_MS,
+                        EndpointSwitchState.STANDALONE_MQTT_TIMEOUT_KEY));
+        if (timeout <= 0) {
+            logger.atWarn().kv("configured", timeout)
+                    .kv("using", EndpointSwitchState.DEFAULT_STANDALONE_MQTT_TIMEOUT_MS)
+                    .log("Invalid standaloneMqttTimeoutMs, using default");
+            return EndpointSwitchState.DEFAULT_STANDALONE_MQTT_TIMEOUT_MS;
+        }
+        return timeout;
+    }
+
     public Topics getSpoolerNamespace() {
         return getMQTTNamespace().lookupTopics(DEVICE_SPOOLER_NAMESPACE);
     }

--- a/src/main/java/com/aws/greengrass/deployment/EndpointSwitchPreflightValidator.java
+++ b/src/main/java/com/aws/greengrass/deployment/EndpointSwitchPreflightValidator.java
@@ -62,10 +62,9 @@ class EndpointSwitchPreflightValidator {
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "REC_CATCH_EXCEPTION",
             justification = "Defensive catch for unexpected errors from CRT builder and proxy config")
     boolean verifyMqttConnectivity(CompletableFuture<DeploymentResult> totallyCompleteFuture,
-                                   String endpoint, String clientIdSuffix, long timeoutMs) {
-        try (StandaloneMqttConnector conn = StandaloneMqttConnector.of(
-                kernel.getContext().get(SecurityService.class), deviceConfiguration,
-                endpoint, clientIdSuffix)) {
+                                   String endpoint, long timeoutMs) {
+        try (StandaloneMqttConnector conn = StandaloneMqttConnector.forEndpointSwitch(
+                kernel.getContext().get(SecurityService.class), deviceConfiguration, endpoint)) {
             conn.connect(timeoutMs);
             return true;
         } catch (MqttConnectionProviderException e) {
@@ -84,7 +83,7 @@ class EndpointSwitchPreflightValidator {
                         .kv(ENDPOINT_LOG_KEY, endpoint)
                         .log("Pre-flight MQTT connectivity check failed: MQTT CONNECT rejected. "
                                 + "Possible causes: (1) IoT policy does not allow client ID \""
-                                + thingName + clientIdSuffix + "\" — update iot:Connect resource to "
+                                + thingName + "#endpoint-switch\" — update iot:Connect resource to "
                                 + "\"arn:aws:iot:*:*:client/" + thingName + "*\", or "
                                 + "(2) device certificate is not authorized in the target account");
             } else {

--- a/src/main/java/com/aws/greengrass/deployment/EndpointSwitchState.java
+++ b/src/main/java/com/aws/greengrass/deployment/EndpointSwitchState.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.Utils;
+
+import javax.inject.Inject;
+
+/**
+ * Manages persisted state for in-flight endpoint-switch deployments.
+ *
+ * <p>Before an endpoint switch, {@link DeploymentConfigMerger} persists the source IoT data endpoint and
+ * deployment ID into DeploymentService's runtime config. After the switch completes, the status consumers
+ * ({@link IotJobsHelper}, {@link ShadowDeploymentListener}) use this class to identify the endpoint-switch
+ * deployment and report terminal status back to the source endpoint via a standalone MQTT connection.</p>
+ *
+ * <p>Keys are stored under {@code services.DeploymentService.runtime} and persisted to config.tlog
+ * (survives crashes). Cleared after terminal status is reported.</p>
+ */
+public class EndpointSwitchState {
+
+    static final String SOURCE_IOT_DATA_ENDPOINT_KEY = "sourceIotDataEndpoint";
+    static final String SOURCE_DEPLOYMENT_ID_KEY = "sourceDeploymentId";
+    static final String ENDPOINT_SWITCH_CLIENT_SUFFIX = "#endpoint-switch";
+    static final long DEFAULT_STANDALONE_MQTT_TIMEOUT_MS = 60_000;
+    static final String STANDALONE_MQTT_TIMEOUT_KEY = "standaloneMqttTimeoutMs";
+
+    private final DeploymentService deploymentService;
+
+    @Inject
+    EndpointSwitchState(DeploymentService deploymentService) {
+        this.deploymentService = deploymentService;
+    }
+
+    /**
+     * Check if the given deployment is the in-flight endpoint-switch deployment by matching
+     * the deployment ID against the persisted source deployment ID.
+     *
+     * @param deploymentId the deployment ID to check (job ID for IoT Jobs, config ARN for Shadow)
+     * @return true if this is the endpoint-switch deployment
+     */
+    public boolean isEndpointSwitchDeployment(String deploymentId) {
+        String sourceEndpoint = getSourceIotDataEndpoint();
+        if (sourceEndpoint == null) {
+            return false;
+        }
+        String sourceDepId = getSourceDeploymentId();
+        return deploymentId != null && deploymentId.equals(sourceDepId);
+    }
+
+    /**
+     * Read the IoT data endpoint where the endpoint-switch deployment originated.
+     * This is the endpoint the device was connected to before the switch, used to report terminal
+     * deployment status back to the source endpoint via a standalone MQTT connection.
+     *
+     * @return the source IoT data endpoint, or null if no endpoint switch is in progress
+     */
+    public String getSourceIotDataEndpoint() {
+        String sourceEndpoint = Coerce.toString(getRuntimeConfig().find(SOURCE_IOT_DATA_ENDPOINT_KEY));
+        if (Utils.isEmpty(sourceEndpoint)) {
+            return null;
+        }
+        return sourceEndpoint;
+    }
+
+    /**
+     * Persist the source endpoint and deployment ID before applying the endpoint switch.
+     * Called by {@link DeploymentConfigMerger} after pre-flight passes.
+     *
+     * @param sourceEndpoint the current IoT data endpoint (before switch)
+     * @param deploymentId   the deployment ID initiating the switch
+     */
+    public void persist(String sourceEndpoint, String deploymentId) {
+        getRuntimeConfig().lookup(SOURCE_IOT_DATA_ENDPOINT_KEY).withValue(sourceEndpoint);
+        getRuntimeConfig().lookup(SOURCE_DEPLOYMENT_ID_KEY).withValue(deploymentId);
+    }
+
+    /**
+     * Remove the persisted source IoT data endpoint and deployment ID from runtime config.
+     * Called after the endpoint-switch deployment's terminal status has been published to the
+     * source endpoint (or publish failed — keys are cleared regardless to avoid stale state).
+     */
+    public void clear() {
+        Topic sourceEndpointTopic = getRuntimeConfig().find(SOURCE_IOT_DATA_ENDPOINT_KEY);
+        if (sourceEndpointTopic != null) {
+            sourceEndpointTopic.remove();
+        }
+        Topic sourceDeploymentIdTopic = getRuntimeConfig().find(SOURCE_DEPLOYMENT_ID_KEY);
+        if (sourceDeploymentIdTopic != null) {
+            sourceDeploymentIdTopic.remove();
+        }
+    }
+
+    private String getSourceDeploymentId() {
+        return Coerce.toString(getRuntimeConfig().find(SOURCE_DEPLOYMENT_ID_KEY));
+    }
+
+    private Topics getRuntimeConfig() {
+        return deploymentService.getRuntimeConfig();
+    }
+}

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsClientWrapper.java
@@ -40,7 +40,7 @@ import java.util.function.Consumer;
 @SuppressWarnings("PMD.AvoidCatchingGenericException")
 @SuppressFBWarnings("NM_METHOD_NAMING_CONVENTION")
 public class IotJobsClientWrapper extends IotJobsClient {
-    private static final String UPDATE_JOB_TOPIC =
+    static final String UPDATE_JOB_TOPIC =
             "$aws/things/%s/jobs/%s/namespace-aws-gg-deployment/update";
     static final String JOB_UPDATE_ACCEPTED_TOPIC =
             "$aws/things/%s/jobs/%s/namespace-aws-gg-deployment/update/accepted";

--- a/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
+++ b/src/main/java/com/aws/greengrass/deployment/IotJobsHelper.java
@@ -17,7 +17,9 @@ import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.StandaloneMqttConnector;
 import com.aws.greengrass.mqttclient.WrapperMqttClientConnection;
+import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.util.Coerce;
@@ -26,6 +28,9 @@ import com.aws.greengrass.util.LockScope;
 import com.aws.greengrass.util.SerializerFactory;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,6 +51,7 @@ import software.amazon.awssdk.iot.iotjobs.model.RejectedError;
 import software.amazon.awssdk.iot.iotjobs.model.UpdateJobExecutionRequest;
 import software.amazon.awssdk.iot.iotjobs.model.UpdateJobExecutionSubscriptionRequest;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -97,6 +103,10 @@ public class IotJobsHelper implements InjectionActions {
             "Interrupted while subscribing to Iot jobs event notifications topic";
     private static final String JOB_ID_LOG_KEY_NAME = "JobId";
     private static final String NEXT_JOB_LITERAL = "$next";
+    /**
+     * IoT Jobs status detail values are limited to 1024 characters by the service.
+     */
+    private static final int JOB_STATUS_DETAIL_MAX_LENGTH = 1024;
     // Sometimes when we are notified that a new job is queued and request the next pending job document immediately,
     // we get an empty response. This unprocessedJobs is to track the number of new queued jobs that we are notified
     // with, and keep retrying the request until we get a non-empty response.
@@ -107,6 +117,7 @@ public class IotJobsHelper implements InjectionActions {
     private static final Logger logger = LogManager.getLogger(IotJobsHelper.class);
     private static final long WAIT_TIME_MS_TO_SUBSCRIBE_AGAIN = Duration.ofMinutes(2).toMillis();
     private static final Random RANDOM = new Random();
+    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
 
     // setter is only used for testing
     @Setter
@@ -361,20 +372,28 @@ public class IotJobsHelper implements InjectionActions {
     private Boolean deploymentStatusChanged(Map<String, Object> deploymentDetails) {
         String jobId = (String) deploymentDetails.get(DEPLOYMENT_ID_KEY_NAME);
         String status = (String) deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME);
+
+        // Endpoint-switch deployment: report SUCCEEDED to the source endpoint via standalone MQTT.
+        //
+        // After a successful switch the main MQTT client is on the destination endpoint, so the
+        // IoT Job at the source endpoint can only be updated via a standalone connection.
+        //
+        // FAILED (rollback): the device is still on the source endpoint (sourceEndpoint ==
+        // currentEndpoint), so the block clears keys and falls through — the existing
+        // updateJobStatus() below publishes FAILED via the main MQTT client which is still
+        // connected to the source endpoint.
+        //
+        // IN_PROGRESS: only reaches this block after a nucleus restart (the source endpoint
+        // already received IN_PROGRESS before the restart). Dropped to avoid publishing to the
+        // destination endpoint where the IoT Job doesn't exist.
+        if (handleEndpointSwitchStatus(jobId, status, deploymentDetails)) {
+            return true;
+        }
+
+        @SuppressWarnings("unchecked")
         Map<String, Object> statusDetails =
                 (Map<String, Object>) deploymentDetails.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
-        HashMap<String, String> jobStatusDetails = new HashMap<>();
-        statusDetails.forEach((k, v) -> {
-            if (v instanceof String) {
-                jobStatusDetails.put(k, (String) v);
-            } else {
-                try {
-                    jobStatusDetails.put(k, SerializerFactory.getFailSafeJsonObjectMapper().writeValueAsString(v));
-                } catch (JsonProcessingException e) {
-                    logger.atWarn().kv("status-detail-value", v).setCause(e).log("Failed to serialize status detail");
-                }
-            }
-        });
+        HashMap<String, String> jobStatusDetails = buildJobStatusDetails(statusDetails);
         logger.atInfo().kv(JOB_ID_LOG_KEY_NAME, jobId).kv(STATUS_LOG_KEY_NAME, status)
                 .kv("StatusDetails", statusDetails).log("Updating status of persisted deployment");
         try {
@@ -435,7 +454,8 @@ public class IotJobsHelper implements InjectionActions {
                 });
 
         // Truncate status detail map values longer than the 1024 characters limit
-        statusDetailsMap.entrySet().forEach(e -> statusDetailsMap.put(e.getKey(), Utils.truncate(e.getValue(), 1024)));
+        statusDetailsMap.entrySet().forEach(e -> statusDetailsMap.put(e.getKey(),
+                Utils.truncate(e.getValue(), JOB_STATUS_DETAIL_MAX_LENGTH)));
 
         UpdateJobExecutionRequest updateJobRequest = new UpdateJobExecutionRequest();
         updateJobRequest.jobId = jobId;
@@ -662,6 +682,90 @@ public class IotJobsHelper implements InjectionActions {
         } catch (ServiceLoadException e) {
             logger.atError().setCause(e).log("Failed to find deployment service");
         }
+    }
+
+    /**
+     * Handle endpoint-switch status reporting. If this deployment is an endpoint switch,
+     * report terminal status to the source endpoint via standalone MQTT and clear persisted state.
+     *
+     * @return true if this status update was handled (caller should return), false to continue normal path
+     */
+    private boolean handleEndpointSwitchStatus(String jobId, String status,
+                                               Map<String, Object> deploymentDetails) {
+        EndpointSwitchState endpointSwitchState = kernel.getContext().get(EndpointSwitchState.class);
+        if (!endpointSwitchState.isEndpointSwitchDeployment(jobId)) {
+            return false;
+        }
+        if (JobStatus.IN_PROGRESS.toString().equals(status)) {
+            return true;
+        }
+        String sourceEndpoint = endpointSwitchState.getSourceIotDataEndpoint();
+        if (sourceEndpoint == null) {
+            // State was cleared concurrently — fall through to normal path
+            endpointSwitchState.clear();
+            return false;
+        }
+        if (!sourceEndpoint.equals(Coerce.toString(deviceConfiguration.getIotDataEndpoint()))) {
+            publishStatusToSourceEndpoint(sourceEndpoint, jobId, deploymentDetails);
+            endpointSwitchState.clear();
+            return true;
+        }
+        endpointSwitchState.clear();
+        return false;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressFBWarnings("REC_CATCH_EXCEPTION")
+    private void publishStatusToSourceEndpoint(String sourceEndpoint, String jobId,
+                                                  Map<String, Object> deploymentDetails) {
+        String status = (String) deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> statusDetails =
+                (Map<String, Object>) deploymentDetails.get(DEPLOYMENT_STATUS_DETAILS_KEY_NAME);
+        HashMap<String, String> jobStatusDetails = buildJobStatusDetails(statusDetails);
+
+        String thing = Coerce.toString(deviceConfiguration.getThingName());
+        String topic = String.format(IotJobsClientWrapper.UPDATE_JOB_TOPIC, thing, jobId);
+        long connectTimeout = deviceConfiguration.getStandaloneMqttTimeout();
+        try (StandaloneMqttConnector connector = StandaloneMqttConnector.forEndpointSwitch(
+                kernel.getContext().get(SecurityService.class), deviceConfiguration, sourceEndpoint)) {
+            connector.connect(connectTimeout);
+            UpdateJobExecutionRequest request = new UpdateJobExecutionRequest();
+            request.status = JobStatus.valueOf(status);
+            request.statusDetails = jobStatusDetails;
+            request.thingName = thing;
+            request.jobId = jobId;
+            byte[] payload = GSON.toJson(request).getBytes(StandardCharsets.UTF_8);
+            connector.publish(topic, payload, QualityOfService.AT_LEAST_ONCE,
+                    EndpointSwitchState.DEFAULT_STANDALONE_MQTT_TIMEOUT_MS);
+            logger.atInfo().kv("jobId", jobId).kv("status", status)
+                    .kv("sourceEndpoint", sourceEndpoint)
+                    .log("Reported terminal job status to source endpoint");
+        } catch (Exception e) {
+            logger.atWarn().kv("jobId", jobId).kv("status", status).kv("sourceEndpoint", sourceEndpoint)
+                    .setCause(e).log("Failed to report terminal job status to source endpoint");
+        }
+    }
+
+    @SuppressWarnings("PMD.LooseCoupling") // UpdateJobExecutionRequest.statusDetails requires HashMap
+    private HashMap<String, String> buildJobStatusDetails(Map<String, Object> statusDetails) {
+        HashMap<String, String> jobStatusDetails = new HashMap<>();
+        if (statusDetails == null) {
+            return jobStatusDetails;
+        }
+        statusDetails.forEach((k, v) -> {
+            if (v instanceof String) {
+                jobStatusDetails.put(k, (String) v);
+            } else {
+                try {
+                    jobStatusDetails.put(k, SerializerFactory.getFailSafeJsonObjectMapper().writeValueAsString(v));
+                } catch (JsonProcessingException e) {
+                    logger.atWarn().setCause(e).log("Failed to serialize status detail");
+                }
+            }
+        });
+        jobStatusDetails.replaceAll((k, v) -> Utils.truncate(v, JOB_STATUS_DETAIL_MAX_LENGTH));
+        return jobStatusDetails;
     }
 
     public static class WrapperMqttConnectionFactory {

--- a/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
+++ b/src/main/java/com/aws/greengrass/deployment/ShadowDeploymentListener.java
@@ -17,7 +17,9 @@ import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.StandaloneMqttConnector;
 import com.aws.greengrass.mqttclient.WrapperMqttClientConnection;
+import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.LockFactory;
 import com.aws.greengrass.util.LockScope;
@@ -98,6 +100,7 @@ public class ShadowDeploymentListener implements InjectionActions {
     private static final String SHADOW_GET_TOPIC = "$aws/things/{thingName}/shadow/name/{shadowName}/get/accepted";
     private static final String SUBSCRIBE_ERROR_RETRY_MESSAGE =
             "Caught exception while subscribing to shadow topics, will retry shortly";
+    static final String SHADOW_UPDATE_TOPIC = "$aws/things/%s/shadow/name/%s/update";
 
     @Inject
     private Kernel kernel;
@@ -330,6 +333,27 @@ public class ShadowDeploymentListener implements InjectionActions {
     @SuppressFBWarnings
     private Boolean deploymentStatusChanged(Map<String, Object> deploymentDetails) {
         lastDeploymentStatus.set(deploymentDetails);
+
+        String configArn = (String) deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME);
+        String status = (String) deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME);
+
+        // Endpoint-switch deployment: report SUCCEEDED to the source endpoint via standalone MQTT.
+        //
+        // After a successful switch the main MQTT client is on the destination endpoint, so the
+        // deployment shadow at the source endpoint can only be updated via a standalone connection.
+        //
+        // FAILED (rollback): the device is still on the source endpoint (sourceEndpoint ==
+        // currentEndpoint), so the block clears keys and falls through — the existing
+        // updateReportedSectionOfShadowWithDeploymentStatus() below publishes FAILED via the
+        // main MQTT client which is still connected to the source endpoint.
+        //
+        // IN_PROGRESS: only reaches this block after a nucleus restart (the source endpoint
+        // already received IN_PROGRESS before the restart). Dropped to avoid writing stale
+        // state to the destination endpoint's deployment shadow.
+        if (handleEndpointSwitchStatus(configArn, status, deploymentDetails)) {
+            return true;
+        }
+
         return updateReportedSectionOfShadowWithDeploymentStatus();
     }
 
@@ -495,6 +519,68 @@ public class ShadowDeploymentListener implements InjectionActions {
 
     private MqttClientConnection getMqttClientConnection() {
         return new WrapperMqttClientConnection(mqttClient);
+    }
+
+    /**
+     * Handle endpoint-switch status reporting. If this deployment is an endpoint switch,
+     * report terminal status to the source endpoint via standalone MQTT and clear persisted state.
+     *
+     * @return true if this status update was handled (caller should return), false to continue normal path
+     */
+    private boolean handleEndpointSwitchStatus(String configArn, String status,
+                                               Map<String, Object> deploymentDetails) {
+        EndpointSwitchState endpointSwitchState = kernel.getContext().get(EndpointSwitchState.class);
+        if (!endpointSwitchState.isEndpointSwitchDeployment(configArn)) {
+            return false;
+        }
+        if (JobStatus.IN_PROGRESS.toString().equals(status)) {
+            return true;
+        }
+        String sourceEndpoint = endpointSwitchState.getSourceIotDataEndpoint();
+        if (sourceEndpoint == null) {
+            endpointSwitchState.clear();
+            return false;
+        }
+        if (!sourceEndpoint.equals(Coerce.toString(deviceConfiguration.getIotDataEndpoint()))) {
+            publishStatusToSourceEndpoint(sourceEndpoint, deploymentDetails);
+            endpointSwitchState.clear();
+            return true;
+        }
+        endpointSwitchState.clear();
+        return false;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressFBWarnings("REC_CATCH_EXCEPTION")
+    private void publishStatusToSourceEndpoint(String sourceEndpoint, Map<String, Object> deploymentDetails) {
+        String thing = Coerce.toString(deviceConfiguration.getThingName());
+        String topic = String.format(SHADOW_UPDATE_TOPIC, thing, DEPLOYMENT_SHADOW_NAME);
+        long connectTimeout = deviceConfiguration.getStandaloneMqttTimeout();
+        try (StandaloneMqttConnector connector = StandaloneMqttConnector.forEndpointSwitch(
+                kernel.getContext().get(SecurityService.class), deviceConfiguration, sourceEndpoint)) {
+            HashMap<String, Object> reported = populateReportedSectionOfShadow(deploymentDetails);
+
+            HashMap<String, Object> state = new HashMap<>();
+            state.put("reported", reported);
+
+            HashMap<String, Object> payload = new HashMap<>();
+            payload.put("state", state);
+
+            byte[] payloadBytes = SerializerFactory.getFailSafeJsonObjectMapper().writeValueAsBytes(payload);
+
+            connector.connect(connectTimeout);
+            connector.publish(topic, payloadBytes, QualityOfService.AT_LEAST_ONCE,
+                    EndpointSwitchState.DEFAULT_STANDALONE_MQTT_TIMEOUT_MS);
+            logger.atInfo().kv("configArn", deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME))
+                    .kv("status", deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME))
+                    .kv("sourceEndpoint", sourceEndpoint)
+                    .log("Reported terminal shadow status to source endpoint");
+        } catch (Exception e) {
+            logger.atWarn().kv("configArn", deploymentDetails.get(CONFIGURATION_ARN_KEY_NAME))
+                    .kv("status", deploymentDetails.get(DEPLOYMENT_STATUS_KEY_NAME))
+                    .kv("sourceEndpoint", sourceEndpoint)
+                    .setCause(e).log("Failed to report terminal shadow status to source endpoint");
+        }
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -5,9 +5,8 @@
 
 package com.aws.greengrass.deployment.activator;
 
-import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.deployment.DeploymentConfigMerger;
-import com.aws.greengrass.deployment.DeploymentService;
+import com.aws.greengrass.deployment.EndpointSwitchState;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
@@ -15,7 +14,6 @@ import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
-import com.aws.greengrass.util.Coerce;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,12 +50,13 @@ public class DefaultActivator extends DeploymentActivator {
         }
 
         DeploymentDocument deploymentDocument = deployment.getDeploymentDocumentObj();
+        String deploymentId = deployment.getId();
         boolean autoRollback = isAutoRollbackRequested(deploymentDocument);
 
         // Endpoint switch deployments force config snapshot and rollback regardless of FailureHandlingPolicy,
         // so that we can restore the original endpoint if the new one is unreachable after applying the change.
         // Only check when auto-rollback is not already requested to avoid redundant config store reads.
-        boolean forceSnapshotForEndpointSwitch = !autoRollback && isEndpointSwitch();
+        boolean forceSnapshotForEndpointSwitch = !autoRollback && isEndpointSwitch(deploymentId);
         if (forceSnapshotForEndpointSwitch) {
             logger.atInfo(MERGE_CONFIG_EVENT_KEY)
                     .log("Endpoint switch deployment: forcing config snapshot and rollback support");
@@ -86,7 +85,7 @@ public class DefaultActivator extends DeploymentActivator {
             servicesChangeManager.reinstallBrokenServices();
         });
         if (setDesiredStateFailureCause != null) {
-            handleFailure(servicesChangeManager, deploymentDocument, totallyCompleteFuture,
+            handleFailure(servicesChangeManager, deploymentDocument, deploymentId, totallyCompleteFuture,
                     setDesiredStateFailureCause);
             return;
         }
@@ -119,16 +118,17 @@ public class DefaultActivator extends DeploymentActivator {
                     .setCause(e).log("Deployment interrupted: will not attempt rollback, regardless of policy");
             totallyCompleteFuture.complete(null);
         } catch (ServiceUpdateException | ServiceLoadException e) {
-            handleFailure(servicesChangeManager, deploymentDocument, totallyCompleteFuture, e);
+            handleFailure(servicesChangeManager, deploymentDocument, deploymentId, totallyCompleteFuture, e);
         }
     }
 
     private void handleFailure(DeploymentConfigMerger.AggregateServicesChangeManager servicesChangeManager,
-                               DeploymentDocument deploymentDocument, CompletableFuture totallyCompleteFuture,
+                               DeploymentDocument deploymentDocument, String deploymentId,
+                               CompletableFuture totallyCompleteFuture,
                                Throwable failureCause) {
         logger.atError(MERGE_CONFIG_EVENT_KEY).kv(DEPLOYMENT_ID_LOG_KEY, deploymentDocument.getDeploymentId())
                 .setCause(failureCause).log("Deployment failed");
-        if (isAutoRollbackRequested(deploymentDocument) || isEndpointSwitch()) {
+        if (isAutoRollbackRequested(deploymentDocument) || isEndpointSwitch(deploymentId)) {
             logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv(DEPLOYMENT_ID_LOG_KEY, deploymentDocument.getDeploymentId())
                     .log("Initiating rollback for failed deployment");
             rollback(deploymentDocument, totallyCompleteFuture, failureCause,
@@ -142,13 +142,10 @@ public class DefaultActivator extends DeploymentActivator {
 
     /**
      * Check if the current deployment is an endpoint switch by looking for persisted source endpoint
-     * in DeploymentService runtime config.
+     * and matching deployment ID in EndpointSwitchState.
      */
-    private boolean isEndpointSwitch() {
-        Topic t = kernel.getContext().get(DeploymentService.class).getRuntimeConfig()
-                .find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY);
-        String source = t == null ? null : Coerce.toString(t);
-        return source != null && !source.isEmpty();
+    private boolean isEndpointSwitch(String deploymentId) {
+        return kernel.getContext().get(EndpointSwitchState.class).isEndpointSwitchDeployment(deploymentId);
     }
 
     void rollback(DeploymentDocument deploymentDocument, CompletableFuture<DeploymentResult> totallyCompleteFuture,

--- a/src/main/java/com/aws/greengrass/mqttclient/StandaloneMqttConnector.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/StandaloneMqttConnector.java
@@ -18,6 +18,8 @@ import com.aws.greengrass.util.RetryUtils;
 import com.aws.greengrass.util.Utils;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.crt.mqtt.MqttMessage;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
 import java.io.Closeable;
@@ -37,6 +39,7 @@ public class StandaloneMqttConnector implements Closeable {
     private static final Logger logger = LogManager.getLogger(StandaloneMqttConnector.class);
     private static final long DISCONNECT_TIMEOUT_MS = 5000;
     private static final long PER_ATTEMPT_TIMEOUT_MS = 10_000;
+    private static final String ENDPOINT_SWITCH_CLIENT_SUFFIX = "#endpoint-switch";
 
     private final AwsIotMqttConnectionBuilder builder;
     private final String clientId;
@@ -85,6 +88,24 @@ public class StandaloneMqttConnector implements Closeable {
                 .withCleanSession(true);
         configureProxy(mqttBuilder, deviceConfiguration, endpoint);
         return new StandaloneMqttConnector(mqttBuilder, clientId);
+    }
+
+    /**
+     * Create a StandaloneMqttConnector configured for endpoint-switch operations (pre-flight checks
+     * and source endpoint status reporting). Uses the standard endpoint-switch client ID suffix.
+     *
+     * @param securityService     provides the MQTT connection builder with device certs
+     * @param deviceConfiguration provides endpoint, proxy, port, and CA configuration
+     * @param endpoint            the IoT data endpoint to connect to
+     * @return a configured StandaloneMqttConnector ready to call {@link #connect(long)}
+     * @throws MqttConnectionProviderException if the device identity builder cannot be created
+     */
+    public static StandaloneMqttConnector forEndpointSwitch(SecurityService securityService,
+                                                            DeviceConfiguration deviceConfiguration,
+                                                            String endpoint)
+            throws MqttConnectionProviderException {
+        return of(securityService, deviceConfiguration, endpoint,
+                ENDPOINT_SWITCH_CLIENT_SUFFIX);
     }
 
     private static void configureProxy(AwsIotMqttConnectionBuilder mqttBuilder,
@@ -160,6 +181,59 @@ public class StandaloneMqttConnector implements Closeable {
             connectionCleanup();
             Throwable cause = e.getCause() == null ? e : e.getCause();
             throw new DeploymentException("MQTT connection failed", e,
+                    mapExceptionToErrorCode(cause));
+        }
+    }
+
+    /**
+     * Publish a message on the already-connected standalone connection with retries using exponential backoff.
+     * The timeout controls the number of attempts (timeoutMs / perAttemptTimeout), not a hard wall-clock
+     * deadline — actual elapsed time may exceed timeoutMs due to backoff sleep between attempts.
+     *
+     * <p>This method assumes the source IoT Thing and device certificate remain valid post-switch.
+     * If the source account deletes the Thing or deregisters the certificate after the endpoint switch,
+     * publish attempts will fail. This is non-fatal — the source IoT Job will eventually time out.</p>
+     *
+     * @param topic     MQTT topic to publish to
+     * @param payload   message payload bytes
+     * @param qos       quality of service level
+     * @param timeoutMs timeout budget in milliseconds used to derive the number of publish attempts
+     * @throws DeploymentException with appropriate error code if all attempts fail
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public void publish(String topic, byte[] payload, QualityOfService qos, long timeoutMs)
+            throws DeploymentException {
+        if (connection == null) {
+            throw new DeploymentException("Cannot publish - not connected",
+                    DeploymentErrorCode.MQTT_CONNECTION_FAILED);
+        }
+        if (timeoutMs <= 0) {
+            throw new DeploymentException("MQTT publish timeout must be positive, got " + timeoutMs,
+                    DeploymentErrorCode.MQTT_CONNECTION_FAILED);
+        }
+        long perAttemptTimeout = Math.min(timeoutMs, PER_ATTEMPT_TIMEOUT_MS);
+        int maxAttempts = Math.max(1, (int) (timeoutMs / perAttemptTimeout));
+        RetryUtils.RetryConfig retryConfig = RetryUtils.RetryConfig.builder()
+                .initialRetryInterval(Duration.ofSeconds(1))
+                .maxRetryInterval(Duration.ofSeconds(10))
+                .maxAttempt(maxAttempts)
+                .retryableExceptions(Collections.singletonList(Exception.class))
+                .build();
+        try {
+            RetryUtils.runWithRetry(retryConfig, () -> {
+                MqttMessage message = new MqttMessage(topic, payload, qos, false);
+                connection.publish(message).get(perAttemptTimeout, TimeUnit.MILLISECONDS);
+                logger.atDebug().kv("topic", topic).kv("clientId", clientId)
+                        .log("Standalone MQTT publish succeeded");
+                return null;
+            }, "standalone-mqtt-publish", logger);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DeploymentException("MQTT publish interrupted", e,
+                    DeploymentErrorCode.MQTT_CONNECTION_FAILED);
+        } catch (Exception e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            throw new DeploymentException("MQTT publish failed after retries", e,
                     mapExceptionToErrorCode(cause));
         }
     }

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentConfigMergerTest.java
@@ -124,8 +124,13 @@ class DeploymentConfigMergerTest {
         lenient().when(deviceConfiguration.getProxyUrl()).thenReturn("");
         lenient().when(context.get(DeploymentDirectoryManager.class)).thenReturn(deploymentDirectoryManager);
         lenient().when(context.get(DeploymentService.class)).thenReturn(deploymentService);
+        lenient().when(context.get(EndpointSwitchState.class)).thenReturn(mock(EndpointSwitchState.class));
         lenient().when(deploymentService.getRuntimeConfig()).thenReturn(runtimeTopics);
         lenient().when(runtimeTopics.lookup(any(String.class))).thenReturn(mock(Topic.class));
+        lenient().when(deviceConfiguration.getStandaloneMqttTimeout()).thenReturn(60_000L);
+        Topics mqttTopics = mock(Topics.class);
+        lenient().when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttTopics);
+        lenient().when(mqttTopics.findOrDefault(any(), any())).thenReturn(60000L);
     }
 
     @AfterEach
@@ -605,6 +610,7 @@ class DeploymentConfigMergerTest {
     private Deployment createMockDeployment(DeploymentDocument doc) {
         Deployment deployment = mock(Deployment.class);
         doReturn(doc).when(deployment).getDeploymentDocumentObj();
+        lenient().doReturn(doc.getDeploymentId()).when(deployment).getId();
         return deployment;
     }
 
@@ -733,9 +739,8 @@ class DeploymentConfigMergerTest {
         Map<String, Object> newConfig = new HashMap<>();
         newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
 
-        Topic sourceEndpointTopic = mock(Topic.class);
-        when(runtimeTopics.lookup(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
-                .thenReturn(sourceEndpointTopic);
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(context.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
 
         DeploymentConfigMerger merger = new DeploymentConfigMerger(kernel, deviceConfiguration, validator,
                 executorService);
@@ -750,7 +755,7 @@ class DeploymentConfigMergerTest {
         verify(executorService).execute(runnableCaptor.capture());
         runnableCaptor.getValue().run();
 
-        verify(sourceEndpointTopic).withValue("old-ats.iot.us-east-1.amazonaws.com");
+        verify(mockEndpointSwitchState).persist("old-ats.iot.us-east-1.amazonaws.com", "DeploymentId");
         verify(deploymentActivator).activate(any(), any(), any(Long.class), any());
     }
 
@@ -824,6 +829,7 @@ class DeploymentConfigMergerTest {
         when(deviceConfiguration.getThingName()).thenReturn(thingNameTopic);
         lenient().when(deviceConfiguration.getRootCAFilePath()).thenReturn(rootCaTopic);
         when(deviceConfiguration.getNucleusComponentName()).thenReturn(DEFAULT_NUCLEUS_COMPONENT_NAME);
+        lenient().when(deviceConfiguration.getStandaloneMqttTimeout()).thenReturn(60_000L);
         Topics mqttTopics = mock(Topics.class);
         lenient().when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttTopics);
         lenient().when(mqttTopics.findOrDefault(any(), any())).thenReturn(60_000L);
@@ -1051,9 +1057,6 @@ class DeploymentConfigMergerTest {
         Map<String, Object> newConfig = new HashMap<>();
         newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
 
-        Topic sourceEndpointTopic = mock(Topic.class);
-        when(runtimeTopics.lookup(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
-                .thenReturn(sourceEndpointTopic);
 
         DeploymentConfigMerger merger = new DeploymentConfigMerger(kernel, deviceConfiguration, validator,
                 executorService);
@@ -1102,9 +1105,6 @@ class DeploymentConfigMergerTest {
         Map<String, Object> newConfig = new HashMap<>();
         newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
 
-        Topic sourceEndpointTopic = mock(Topic.class);
-        when(runtimeTopics.lookup(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
-                .thenReturn(sourceEndpointTopic);
 
         // Mock IotCloudHelper to return 200 (credential check passes)
         IotCloudHelper iotCloudHelper = mock(IotCloudHelper.class);
@@ -1166,9 +1166,6 @@ class DeploymentConfigMergerTest {
         Map<String, Object> newConfig = new HashMap<>();
         newConfig.put(SERVICES_NAMESPACE_TOPIC, serviceConfig);
 
-        Topic sourceEndpointTopic = mock(Topic.class);
-        when(runtimeTopics.lookup(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
-                .thenReturn(sourceEndpointTopic);
 
         IotCloudHelper iotCloudHelper = mock(IotCloudHelper.class);
         IotConnectionManager iotConnectionManager = mock(IotConnectionManager.class);
@@ -1200,4 +1197,5 @@ class DeploymentConfigMergerTest {
         assertTrue(capturedUrl.contains("NewRoleAlias"));
         verify(deploymentActivator).activate(any(), any(), any(Long.class), any());
     }
+
 }

--- a/src/test/java/com/aws/greengrass/deployment/EndpointSwitchStateTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/EndpointSwitchStateTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+class EndpointSwitchStateTest {
+
+    @Mock
+    private DeploymentService deploymentService;
+    @Mock
+    private Topics runtimeConfig;
+
+    private EndpointSwitchState endpointSwitchState;
+
+    @BeforeEach
+    void beforeEach() {
+        when(deploymentService.getRuntimeConfig()).thenReturn(runtimeConfig);
+        endpointSwitchState = new EndpointSwitchState(deploymentService);
+    }
+
+    @Test
+    void GIVEN_no_keys_WHEN_isEndpointSwitchDeployment_THEN_returns_false() {
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(null);
+
+        assertFalse(endpointSwitchState.isEndpointSwitchDeployment("any-deployment-id"));
+    }
+
+    @Test
+    void GIVEN_keys_present_matching_id_WHEN_isEndpointSwitchDeployment_THEN_returns_true() {
+        Topic endpointTopic = mock(Topic.class);
+        when(endpointTopic.getOnce()).thenReturn("source.iot.us-east-1.amazonaws.com");
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(endpointTopic);
+
+        Topic deploymentIdTopic = mock(Topic.class);
+        when(deploymentIdTopic.getOnce()).thenReturn("deployment-123");
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_DEPLOYMENT_ID_KEY)).thenReturn(deploymentIdTopic);
+
+        assertTrue(endpointSwitchState.isEndpointSwitchDeployment("deployment-123"));
+    }
+
+    @Test
+    void GIVEN_keys_present_different_id_WHEN_isEndpointSwitchDeployment_THEN_returns_false() {
+        Topic endpointTopic = mock(Topic.class);
+        when(endpointTopic.getOnce()).thenReturn("source.iot.us-east-1.amazonaws.com");
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(endpointTopic);
+
+        Topic deploymentIdTopic = mock(Topic.class);
+        when(deploymentIdTopic.getOnce()).thenReturn("deployment-123");
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_DEPLOYMENT_ID_KEY)).thenReturn(deploymentIdTopic);
+
+        assertFalse(endpointSwitchState.isEndpointSwitchDeployment("other-deployment"));
+    }
+
+    @Test
+    void GIVEN_keys_present_WHEN_getSourceIotDataEndpoint_THEN_returns_value() {
+        Topic endpointTopic = mock(Topic.class);
+        when(endpointTopic.getOnce()).thenReturn("source.iot.us-east-1.amazonaws.com");
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(endpointTopic);
+
+        assertEquals("source.iot.us-east-1.amazonaws.com", endpointSwitchState.getSourceIotDataEndpoint());
+    }
+
+    @Test
+    void GIVEN_no_keys_WHEN_getSourceIotDataEndpoint_THEN_returns_null() {
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(null);
+
+        assertNull(endpointSwitchState.getSourceIotDataEndpoint());
+    }
+
+    @Test
+    void GIVEN_empty_value_WHEN_getSourceIotDataEndpoint_THEN_returns_null() {
+        Topic endpointTopic = mock(Topic.class);
+        when(endpointTopic.getOnce()).thenReturn("");
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(endpointTopic);
+
+        assertNull(endpointSwitchState.getSourceIotDataEndpoint());
+    }
+
+    @Test
+    void GIVEN_values_WHEN_persist_THEN_keys_stored() {
+        Topic endpointTopic = mock(Topic.class);
+        when(runtimeConfig.lookup(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(endpointTopic);
+        Topic deploymentIdTopic = mock(Topic.class);
+        when(runtimeConfig.lookup(EndpointSwitchState.SOURCE_DEPLOYMENT_ID_KEY)).thenReturn(deploymentIdTopic);
+
+        endpointSwitchState.persist("source.iot.us-east-1.amazonaws.com", "deployment-456");
+
+        verify(endpointTopic).withValue("source.iot.us-east-1.amazonaws.com");
+        verify(deploymentIdTopic).withValue("deployment-456");
+    }
+
+    @Test
+    void GIVEN_keys_exist_WHEN_clear_THEN_keys_removed() {
+        Topic endpointTopic = mock(Topic.class);
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(endpointTopic);
+        Topic deploymentIdTopic = mock(Topic.class);
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_DEPLOYMENT_ID_KEY)).thenReturn(deploymentIdTopic);
+
+        endpointSwitchState.clear();
+
+        verify(endpointTopic).remove();
+        verify(deploymentIdTopic).remove();
+    }
+
+    @Test
+    void GIVEN_no_keys_WHEN_clear_THEN_no_error() {
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(null);
+        when(runtimeConfig.find(EndpointSwitchState.SOURCE_DEPLOYMENT_ID_KEY)).thenReturn(null);
+
+        // Should not throw
+        endpointSwitchState.clear();
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/IotJobsHelperTest.java
@@ -15,7 +15,9 @@ import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentTaskMetadata;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.StandaloneMqttConnector;
 import com.aws.greengrass.mqttclient.WrapperMqttClientConnection;
+import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.status.model.Trigger;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -47,6 +49,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -55,6 +58,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+
+import org.mockito.MockedStatic;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_DATA_ENDPOINT;
 import static com.aws.greengrass.deployment.IotJobsClientWrapper.JOB_UPDATE_ACCEPTED_TOPIC;
@@ -71,6 +76,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -635,6 +642,228 @@ class IotJobsHelperTest {
         iotJobsHelper.getCallbacks().onConnectionResumed(false);
         verify(mockIotJobsClientWrapper, times(1)).SubscribeToJobExecutionsChangedEvents(any(), any(), any());
         verify(deploymentStatusKeeper, times(2)).publishPersistedStatusUpdates(eq(IOT_JOBS));
+    }
+
+    @Test
+    void GIVEN_source_endpoint_and_id_match_WHEN_status_changed_THEN_publishes_to_source_and_clears()
+            throws Exception {
+        iotJobsHelper.postInject();
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment("test-job-id")).thenReturn(true);
+        when(mockEndpointSwitchState.getSourceIotDataEndpoint()).thenReturn("source.iot.us-east-1.amazonaws.com");
+
+        when(deviceConfiguration.getStandaloneMqttTimeout()).thenReturn(60_000L);
+
+        SecurityService mockSecurityService = mock(SecurityService.class);
+        when(mockContext.get(SecurityService.class)).thenReturn(mockSecurityService);
+
+        try (StandaloneMqttConnector mockConnector = mock(StandaloneMqttConnector.class);
+             MockedStatic<StandaloneMqttConnector> staticMock = mockStatic(StandaloneMqttConnector.class)) {
+            staticMock.when(() -> StandaloneMqttConnector.forEndpointSwitch(any(), any(), any()))
+                    .thenReturn(mockConnector);
+
+            // Capture the consumer registered with deploymentStatusKeeper
+            ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                    ArgumentCaptor.forClass(java.util.function.Function.class);
+            verify(deploymentStatusKeeper).registerDeploymentStatusConsumer(
+                    eq(IOT_JOBS), consumerCaptor.capture(), any());
+
+            Map<String, Object> details = new HashMap<>();
+            details.put("DeploymentId", "test-job-id");
+            details.put("DeploymentStatus", "SUCCEEDED");
+            Map<String, Object> statusDetails = new HashMap<>();
+            statusDetails.put("detailed-deployment-status", "SUCCESSFUL");
+            details.put("DeploymentStatusDetails", statusDetails);
+
+            Boolean result = (Boolean) consumerCaptor.getValue().apply(details);
+            assertTrue(result);
+
+            verify(mockConnector).connect(60_000L);
+            ArgumentCaptor<byte[]> payloadCaptor = ArgumentCaptor.forClass(byte[].class);
+            verify(mockConnector).publish(
+                    eq("$aws/things/" + TEST_THING_NAME + "/jobs/test-job-id/namespace-aws-gg-deployment/update"),
+                    payloadCaptor.capture(), eq(QualityOfService.AT_LEAST_ONCE), eq(60_000L));
+            // Verify payload contains expected IoT Jobs fields
+            String payload = new String(payloadCaptor.getValue(), java.nio.charset.StandardCharsets.UTF_8);
+            assertTrue(payload.contains("\"status\":\"SUCCEEDED\""), "Payload should contain status");
+            assertTrue(payload.contains("\"jobId\":\"test-job-id\""), "Payload should contain jobId");
+            assertTrue(payload.contains("\"thingName\":\"" + TEST_THING_NAME + "\""),
+                    "Payload should contain thingName");
+            // Verify keys cleared
+            verify(mockEndpointSwitchState).clear();
+        }
+    }
+
+    @Test
+    void GIVEN_source_endpoint_id_mismatch_WHEN_status_changed_THEN_uses_normal_path()
+            throws Exception {
+        iotJobsHelper.postInject();
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment("test-job-id")).thenReturn(false);
+
+        // Capture the consumer
+        ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                ArgumentCaptor.forClass(java.util.function.Function.class);
+        verify(deploymentStatusKeeper).registerDeploymentStatusConsumer(
+                eq(IOT_JOBS), consumerCaptor.capture(), any());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("DeploymentId", "test-job-id");
+        details.put("DeploymentStatus", "SUCCEEDED");
+        Map<String, Object> statusDetails = new HashMap<>();
+        statusDetails.put("detailed-deployment-status", "SUCCESSFUL");
+        details.put("DeploymentStatusDetails", statusDetails);
+
+        when(mockIotJobsClientWrapper.SubscribeToUpdateJobExecutionAccepted(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIotJobsClientWrapper.SubscribeToUpdateJobExecutionRejected(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIotJobsClientWrapper.PublishUpdateJobExecution(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        consumerCaptor.getValue().apply(details);
+
+        // Not an endpoint-switch deployment — no source key clearing
+        verify(mockEndpointSwitchState, never()).clear();
+    }
+
+    @Test
+    void GIVEN_source_endpoint_same_as_current_WHEN_status_changed_THEN_clears_keys_uses_normal_path()
+            throws Exception {
+        iotJobsHelper.postInject();
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        // Rollback: isEndpointSwitchDeployment returns true (keys present, ID matches)
+        // but source endpoint equals current endpoint (config was reverted)
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment("test-job-id")).thenReturn(true);
+        when(mockEndpointSwitchState.getSourceIotDataEndpoint()).thenReturn("source.iot.us-east-1.amazonaws.com");
+
+        Topic currentEndpointTopic = mock(Topic.class);
+        when(currentEndpointTopic.getOnce()).thenReturn("source.iot.us-east-1.amazonaws.com");
+        when(deviceConfiguration.getIotDataEndpoint()).thenReturn(currentEndpointTopic);
+
+        ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                ArgumentCaptor.forClass(java.util.function.Function.class);
+        verify(deploymentStatusKeeper).registerDeploymentStatusConsumer(
+                eq(IOT_JOBS), consumerCaptor.capture(), any());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("DeploymentId", "test-job-id");
+        details.put("DeploymentStatus", "FAILED");
+        Map<String, Object> statusDetails = new HashMap<>();
+        statusDetails.put("detailed-deployment-status", "FAILED_ROLLBACK_COMPLETE");
+        details.put("DeploymentStatusDetails", statusDetails);
+
+        when(mockIotJobsClientWrapper.SubscribeToUpdateJobExecutionAccepted(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIotJobsClientWrapper.SubscribeToUpdateJobExecutionRejected(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIotJobsClientWrapper.PublishUpdateJobExecution(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        consumerCaptor.getValue().apply(details);
+
+        // Rollback: keys cleared, normal path publishes via main MQTT
+        verify(mockEndpointSwitchState).clear();
+    }
+
+    @Test
+    void GIVEN_no_source_endpoint_WHEN_status_changed_THEN_normal_path() throws Exception {
+        iotJobsHelper.postInject();
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment("test-job-id")).thenReturn(false);
+
+        ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                ArgumentCaptor.forClass(java.util.function.Function.class);
+        verify(deploymentStatusKeeper).registerDeploymentStatusConsumer(
+                eq(IOT_JOBS), consumerCaptor.capture(), any());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("DeploymentId", "test-job-id");
+        details.put("DeploymentStatus", "SUCCEEDED");
+        Map<String, Object> statusDetails = new HashMap<>();
+        statusDetails.put("detailed-deployment-status", "SUCCESSFUL");
+        details.put("DeploymentStatusDetails", statusDetails);
+
+        // Normal path — will try updateJobStatus which may fail, but no source routing
+        when(mockIotJobsClientWrapper.SubscribeToUpdateJobExecutionAccepted(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIotJobsClientWrapper.SubscribeToUpdateJobExecutionRejected(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        when(mockIotJobsClientWrapper.PublishUpdateJobExecution(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        consumerCaptor.getValue().apply(details);
+
+        // No source endpoint → no standalone connector used
+        // (StandaloneMqttConnector.of never called)
+    }
+
+    @Test
+    void GIVEN_source_endpoint_standalone_fails_WHEN_status_changed_THEN_clears_keys_returns_true(
+            ExtensionContext extContext) throws Exception {
+        ignoreExceptionOfType(extContext, RuntimeException.class);
+        iotJobsHelper.postInject();
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment("test-job-id")).thenReturn(true);
+        when(mockEndpointSwitchState.getSourceIotDataEndpoint()).thenReturn("source.iot.us-east-1.amazonaws.com");
+
+        when(deviceConfiguration.getStandaloneMqttTimeout()).thenReturn(60_000L);
+
+        SecurityService mockSecurityService = mock(SecurityService.class);
+        when(mockContext.get(SecurityService.class)).thenReturn(mockSecurityService);
+
+        try (StandaloneMqttConnector mockConnector = mock(StandaloneMqttConnector.class);
+             MockedStatic<StandaloneMqttConnector> staticMock = mockStatic(StandaloneMqttConnector.class)) {
+            staticMock.when(() -> StandaloneMqttConnector.forEndpointSwitch(any(), any(), any()))
+                    .thenReturn(mockConnector);
+            doThrow(new RuntimeException("connect failed")).when(mockConnector).connect(60_000L);
+
+            ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                    ArgumentCaptor.forClass(java.util.function.Function.class);
+            verify(deploymentStatusKeeper).registerDeploymentStatusConsumer(
+                    eq(IOT_JOBS), consumerCaptor.capture(), any());
+
+            Map<String, Object> details = new HashMap<>();
+            details.put("DeploymentId", "test-job-id");
+            details.put("DeploymentStatus", "SUCCEEDED");
+            Map<String, Object> statusDetails = new HashMap<>();
+            statusDetails.put("detailed-deployment-status", "SUCCESSFUL");
+            details.put("DeploymentStatusDetails", statusDetails);
+
+            Boolean result = (Boolean) consumerCaptor.getValue().apply(details);
+            assertTrue(result);
+            // Keys still cleared even on failure
+            verify(mockEndpointSwitchState).clear();
+        }
+    }
+
+    @Test
+    void GIVEN_endpoint_switch_IN_PROGRESS_WHEN_status_changed_THEN_returns_true_without_publish()
+            throws Exception {
+        iotJobsHelper.postInject();
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment("test-job-id")).thenReturn(true);
+
+        ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                ArgumentCaptor.forClass(java.util.function.Function.class);
+        verify(deploymentStatusKeeper).registerDeploymentStatusConsumer(
+                eq(IOT_JOBS), consumerCaptor.capture(), any());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("DeploymentId", "test-job-id");
+        details.put("DeploymentStatus", "IN_PROGRESS");
+        Map<String, Object> statusDetails = new HashMap<>();
+        details.put("DeploymentStatusDetails", statusDetails);
+
+        Boolean result = (Boolean) consumerCaptor.getValue().apply(details);
+        assertTrue(result);
+
+        // IN_PROGRESS should be dropped — no standalone connection, no clear
+        verify(mockEndpointSwitchState, never()).getSourceIotDataEndpoint();
+        verify(mockEndpointSwitchState, never()).clear();
     }
 
     private JobExecutionData getMockJobExecutionData(String jobId, Timestamp ts) {

--- a/src/test/java/com/aws/greengrass/deployment/ShadowDeploymentListenerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ShadowDeploymentListenerTest.java
@@ -7,11 +7,15 @@ package com.aws.greengrass.deployment;
 
 import com.aws.greengrass.config.ChildChanged;
 import com.aws.greengrass.config.Node;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.StandaloneMqttConnector;
+import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,19 +23,29 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.iotshadow.IotShadowClient;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_DATA_ENDPOINT;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,6 +53,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 public class ShadowDeploymentListenerTest {
+
+    private static final String TEST_CONFIG_ARN = "arn:aws:greengrass:us-east-1:123:config";
 
     @Mock
     private DeploymentQueue mockDeploymentQueue;
@@ -128,5 +144,175 @@ public class ShadowDeploymentListenerTest {
                 .SubscribeToUpdateNamedShadowRejected(any(), any(), any(), any());
         verify(mockIotShadowClient, timeout(1000).times(1))
                 .SubscribeToGetNamedShadowAccepted(any(), any(), any(), any());
+    }
+
+    @Test
+    void GIVEN_source_endpoint_and_id_match_WHEN_shadow_status_changed_THEN_publishes_to_source_and_clears()
+            throws Exception {
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockKernel.getContext()).thenReturn(mockContext);
+        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
+        doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowRejected(any(), any(), any(), any());
+        doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToGetNamedShadowAccepted(any(), any(), any(), any());
+
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment(TEST_CONFIG_ARN)).thenReturn(true);
+        when(mockEndpointSwitchState.getSourceIotDataEndpoint()).thenReturn("source.iot.us-east-1.amazonaws.com");
+
+        when(mockDeviceConfiguration.getStandaloneMqttTimeout()).thenReturn(60_000L);
+
+        Topic thingNameTopic = mock(Topic.class);
+        when(thingNameTopic.getOnce()).thenReturn("TestThing");
+        when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
+
+        SecurityService mockSecurityService = mock(SecurityService.class);
+        when(mockContext.get(SecurityService.class)).thenReturn(mockSecurityService);
+
+        try (StandaloneMqttConnector mockConnector = mock(StandaloneMqttConnector.class);
+             MockedStatic<StandaloneMqttConnector> staticMock = mockStatic(StandaloneMqttConnector.class)) {
+            staticMock.when(() -> StandaloneMqttConnector.forEndpointSwitch(any(), any(), any()))
+                    .thenReturn(mockConnector);
+
+            // Capture the consumer registered with deploymentStatusKeeper
+            ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                    ArgumentCaptor.forClass(java.util.function.Function.class);
+            shadowDeploymentListener.postInject();
+            verify(mockDeploymentStatusKeeper, timeout(5000)).registerDeploymentStatusConsumer(
+                    eq(DeploymentType.SHADOW), consumerCaptor.capture(), any());
+
+            Map<String, Object> details = new HashMap<>();
+            details.put("ConfigurationArn", TEST_CONFIG_ARN);
+            details.put("DeploymentStatus", "SUCCEEDED");
+            Map<String, Object> statusDetails = new HashMap<>();
+            statusDetails.put("detailed-deployment-status", "SUCCESSFUL");
+            details.put("DeploymentStatusDetails", statusDetails);
+
+            Boolean result = (Boolean) consumerCaptor.getValue().apply(details);
+            assertTrue(result);
+
+            verify(mockConnector).connect(60_000L);
+            ArgumentCaptor<byte[]> payloadCaptor = ArgumentCaptor.forClass(byte[].class);
+            verify(mockConnector).publish(
+                    contains("shadow/name/AWSManagedGreengrassV2Deployment/update"),
+                    payloadCaptor.capture(), eq(QualityOfService.AT_LEAST_ONCE), eq(60_000L));
+            // Verify shadow payload structure
+            String payload = new String(payloadCaptor.getValue(), java.nio.charset.StandardCharsets.UTF_8);
+            assertTrue(payload.contains("\"status\":\"SUCCEEDED\""), "Payload should contain status");
+            assertTrue(payload.contains("\"state\""), "Payload should have state wrapper");
+            assertTrue(payload.contains("\"reported\""), "Payload should have reported section");
+            assertFalse(payload.contains("\"version\""), "Shadow update should NOT contain version field");
+            verify(mockEndpointSwitchState).clear();
+        }
+    }
+
+    @Test
+    void GIVEN_endpoint_switch_IN_PROGRESS_WHEN_shadow_status_changed_THEN_returns_true_without_publish()
+            throws Exception {
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        lenient().when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        lenient().when(mockKernel.getContext()).thenReturn(mockContext);
+        lenient().when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
+        lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowRejected(any(), any(), any(), any());
+        lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToGetNamedShadowAccepted(any(), any(), any(), any());
+
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment(TEST_CONFIG_ARN))
+                .thenReturn(true);
+
+        ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                ArgumentCaptor.forClass(java.util.function.Function.class);
+        shadowDeploymentListener.postInject();
+        verify(mockDeploymentStatusKeeper, timeout(5000)).registerDeploymentStatusConsumer(
+                eq(DeploymentType.SHADOW), consumerCaptor.capture(), any());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("ConfigurationArn", TEST_CONFIG_ARN);
+        details.put("DeploymentStatus", "IN_PROGRESS");
+        Map<String, Object> statusDetails = new HashMap<>();
+        details.put("DeploymentStatusDetails", statusDetails);
+
+        Boolean result = (Boolean) consumerCaptor.getValue().apply(details);
+        assertTrue(result);
+
+        // IN_PROGRESS should be dropped — no standalone connection, no clear
+        verify(mockEndpointSwitchState, never()).getSourceIotDataEndpoint();
+        verify(mockEndpointSwitchState, never()).clear();
+    }
+
+    @Test
+    void GIVEN_source_endpoint_id_mismatch_WHEN_shadow_status_changed_THEN_uses_normal_path() throws Exception {
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockKernel.getContext()).thenReturn(mockContext);
+        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
+        lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowRejected(any(), any(), any(), any());
+        lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToGetNamedShadowAccepted(any(), any(), any(), any());
+
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment(TEST_CONFIG_ARN)).thenReturn(false);
+
+        ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                ArgumentCaptor.forClass(java.util.function.Function.class);
+        shadowDeploymentListener.postInject();
+        verify(mockDeploymentStatusKeeper, timeout(5000)).registerDeploymentStatusConsumer(
+                eq(DeploymentType.SHADOW), consumerCaptor.capture(), any());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("ConfigurationArn", TEST_CONFIG_ARN);
+        details.put("DeploymentStatus", "SUCCEEDED");
+        Map<String, Object> statusDetails = new HashMap<>();
+        statusDetails.put("detailed-deployment-status", "SUCCESSFUL");
+        details.put("DeploymentStatusDetails", statusDetails);
+
+        when(mockIotShadowClient.PublishUpdateNamedShadow(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        consumerCaptor.getValue().apply(details);
+
+        // Not an endpoint-switch deployment — no source key clearing
+        verify(mockEndpointSwitchState, never()).clear();
+    }
+
+    @Test
+    void GIVEN_no_source_endpoint_WHEN_shadow_status_changed_THEN_normal_path() throws Exception {
+        EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
+        when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
+        when(mockKernel.getContext()).thenReturn(mockContext);
+        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
+        doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToUpdateNamedShadowRejected(any(), any(), any(), any());
+        doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
+                .SubscribeToGetNamedShadowAccepted(any(), any(), any(), any());
+
+        when(mockEndpointSwitchState.isEndpointSwitchDeployment(TEST_CONFIG_ARN)).thenReturn(false);
+
+        ArgumentCaptor<java.util.function.Function> consumerCaptor =
+                ArgumentCaptor.forClass(java.util.function.Function.class);
+        shadowDeploymentListener.postInject();
+        verify(mockDeploymentStatusKeeper, timeout(5000)).registerDeploymentStatusConsumer(
+                eq(DeploymentType.SHADOW), consumerCaptor.capture(), any());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("ConfigurationArn", TEST_CONFIG_ARN);
+        details.put("DeploymentStatus", "SUCCEEDED");
+        Map<String, Object> statusDetails = new HashMap<>();
+        statusDetails.put("detailed-deployment-status", "SUCCESSFUL");
+        details.put("DeploymentStatusDetails", statusDetails);
+
+        // Normal path — no source routing
+        when(mockIotShadowClient.PublishUpdateNamedShadow(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        consumerCaptor.getValue().apply(details);
     }
 }

--- a/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
@@ -6,12 +6,10 @@
 package com.aws.greengrass.deployment.activator;
 
 import com.aws.greengrass.config.Configuration;
-import com.aws.greengrass.config.Topic;
-import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Crashable;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeploymentDirectoryManager;
-import com.aws.greengrass.deployment.DeploymentService;
+import com.aws.greengrass.deployment.EndpointSwitchState;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 
 import com.aws.greengrass.deployment.model.Deployment;
@@ -59,17 +57,14 @@ class DefaultActivatorTest {
     @Mock
     DeploymentDirectoryManager deploymentDirectoryManager;
     @Mock
-    DeploymentService deploymentService;
-    @Mock
-    Topics runtimeTopics;
+    EndpointSwitchState endpointSwitchState;
 
     DefaultActivator defaultActivator;
 
     @BeforeEach
     void beforeEach() {
         doReturn(deploymentDirectoryManager).when(context).get(DeploymentDirectoryManager.class);
-        doReturn(deploymentService).when(context).get(DeploymentService.class);
-        lenient().doReturn(runtimeTopics).when(deploymentService).getRuntimeConfig();
+        doReturn(endpointSwitchState).when(context).get(EndpointSwitchState.class);
         doReturn(context).when(kernel).getContext();
         lenient().doReturn(config).when(kernel).getConfig();
         lenient().doReturn(Collections.emptyList()).when(kernel).orderedDependencies();
@@ -78,10 +73,7 @@ class DefaultActivatorTest {
 
     @Test
     void GIVEN_endpoint_switch_with_DO_NOTHING_WHEN_activate_THEN_snapshot_taken() throws Exception {
-        Topic sourceEndpointTopic = mock(Topic.class);
-        when(sourceEndpointTopic.getOnce()).thenReturn("old-endpoint");
-        when(runtimeTopics.find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
-                .thenReturn(sourceEndpointTopic);
+        when(endpointSwitchState.isEndpointSwitchDeployment("testId")).thenReturn(true);
         Path snapshotPath = mock(Path.class);
         when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
 
@@ -97,10 +89,7 @@ class DefaultActivatorTest {
     void GIVEN_endpoint_switch_with_DO_NOTHING_WHEN_failure_THEN_rollback_performed(
             ExtensionContext extContext) throws Exception {
         ignoreExceptionOfType(extContext, ServiceUpdateException.class);
-        Topic sourceEndpointTopic = mock(Topic.class);
-        when(sourceEndpointTopic.getOnce()).thenReturn("old-endpoint");
-        when(runtimeTopics.find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY))
-                .thenReturn(sourceEndpointTopic);
+        when(endpointSwitchState.isEndpointSwitchDeployment("testId")).thenReturn(true);
         Path snapshotPath = mock(Path.class);
         when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
 
@@ -128,7 +117,7 @@ class DefaultActivatorTest {
     void GIVEN_non_endpoint_switch_with_DO_NOTHING_WHEN_failure_THEN_no_rollback(
             ExtensionContext extContext) throws Exception {
         ignoreExceptionOfType(extContext, ServiceUpdateException.class);
-        when(runtimeTopics.find(DeploymentService.SOURCE_IOT_DATA_ENDPOINT_KEY)).thenReturn(null);
+        when(endpointSwitchState.isEndpointSwitchDeployment("testId")).thenReturn(false);
 
         CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
 
@@ -157,6 +146,7 @@ class DefaultActivatorTest {
                 .build();
         Deployment deployment = mock(Deployment.class);
         when(deployment.getDeploymentDocumentObj()).thenReturn(doc);
+        when(deployment.getId()).thenReturn("testId");
         return deployment;
     }
 

--- a/src/test/java/com/aws/greengrass/mqttclient/StandaloneMqttConnectorTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/StandaloneMqttConnectorTest.java
@@ -15,8 +15,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,6 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import software.amazon.awssdk.crt.mqtt.MqttMessage;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.lenient;
@@ -175,5 +179,73 @@ class StandaloneMqttConnectorTest {
     void GIVEN_error_code_mapping_WHEN_null_cause_THEN_returns_MQTT_CONNECTION_FAILED() {
         assertEquals(DeploymentErrorCode.MQTT_CONNECTION_FAILED,
                 StandaloneMqttConnector.mapExceptionToErrorCode(null));
+    }
+
+    // --- publish() tests ---
+
+    @Test
+    void GIVEN_connected_WHEN_publish_THEN_succeeds() throws Exception {
+        when(mqttConnection.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mqttConnection.publish(any(MqttMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(0));
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-publish");
+        conn.connect(5000);
+        conn.publish("test/topic", "hello".getBytes(StandardCharsets.UTF_8),
+                QualityOfService.AT_LEAST_ONCE, 5000);
+
+        verify(mqttConnection).publish(any(MqttMessage.class));
+    }
+
+    @Test
+    void GIVEN_not_connected_WHEN_publish_THEN_throws_deployment_exception() {
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-publish");
+        DeploymentException ex = assertThrows(DeploymentException.class,
+                () -> conn.publish("test/topic", "hello".getBytes(StandardCharsets.UTF_8),
+                        QualityOfService.AT_LEAST_ONCE, 5000));
+        assertTrue(ex.getMessage().contains("not connected"));
+    }
+
+    @Test
+    void GIVEN_transient_publish_failure_WHEN_publish_THEN_retries_and_succeeds(
+            ExtensionContext extContext) throws Exception {
+        ignoreExceptionOfType(extContext, ExecutionException.class);
+        when(mqttConnection.connect()).thenReturn(CompletableFuture.completedFuture(true));
+
+        AtomicInteger publishAttempts = new AtomicInteger(0);
+        when(mqttConnection.publish(any(MqttMessage.class))).thenAnswer(invocation -> {
+            if (publishAttempts.incrementAndGet() < 3) {
+                CompletableFuture<Integer> f = new CompletableFuture<>();
+                f.completeExceptionally(new Exception("PUBACK timeout"));
+                return f;
+            }
+            return CompletableFuture.completedFuture(0);
+        });
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-publish");
+        conn.connect(60_000);
+        conn.publish("test/topic", "hello".getBytes(StandardCharsets.UTF_8),
+                QualityOfService.AT_LEAST_ONCE, 60_000);
+
+        assertEquals(3, publishAttempts.get());
+    }
+
+    @Test
+    void GIVEN_persistent_publish_failure_WHEN_publish_THEN_throws_after_retries(
+            ExtensionContext extContext) {
+        ignoreExceptionOfType(extContext, ExecutionException.class);
+        when(mqttConnection.connect()).thenReturn(CompletableFuture.completedFuture(true));
+
+        CompletableFuture<Integer> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new Exception("connection lost"));
+        when(mqttConnection.publish(any(MqttMessage.class))).thenReturn(failedFuture);
+
+        StandaloneMqttConnector conn = new StandaloneMqttConnector(builder, "thing-publish");
+        assertDoesNotThrow(() -> conn.connect(5000));
+
+        DeploymentException ex = assertThrows(DeploymentException.class,
+                () -> conn.publish("test/topic", "hello".getBytes(StandardCharsets.UTF_8),
+                        QualityOfService.AT_LEAST_ONCE, 30_000));
+        assertTrue(ex.getMessage().contains("publish failed"));
     }
 }


### PR DESCRIPTION
## Summary

After a successful IoT endpoint switch, the main MQTT client connects to the destination endpoint. The source endpoint's IoT Job or deployment shadow never receives the terminal deployment status (SUCCEEDED/FAILED) because the device is no longer connected there. This PR adds source endpoint status reporting via a standalone MQTT connection.

- **IoT Jobs path**: `IotJobsHelper` consumer detects endpoint-switch deployment, publishes SUCCEEDED to source IoT Job via standalone MQTT
- **Shadow path**: `ShadowDeploymentListener` consumer publishes unconditional shadow update (no version field) to source endpoint
- **EndpointSwitchState**: New class managing persisted state (source endpoint, deployment ID) for in-flight endpoint-switch deployments
- **StandaloneMqttConnector.publish()**: Reusable publish with exponential backoff and retry
- **IN_PROGRESS guard**: Dropped after nucleus restart to avoid stale publishes to the destination endpoint

## Design decisions

- Consumer-level routing within existing `DeploymentStatusKeeper` flow (inherits persistence + crash recovery)
- `GsonBuilder().disableHtmlEscaping()` matches `IotJobsClientWrapper` wire format
- Synchronous reporting (deployment is already terminal)
- Best-effort: failure logged but non-fatal (source job times out)
- Shadow update omits `version` field (unconditional update per AWS docs)

## E2E test results

Tested on containerized Greengrass Nucleus Classic devices with cross-region endpoint switch (us-east-1 to us-west-2):

| Test Case | Path | Result |
|-----------|------|--------|
| SUCCEEDED endpoint switch | IoT Jobs (thing group) | Source IoT Job shows SUCCEEDED |
| SUCCEEDED endpoint switch | Shadow (core device) | Source shadow reported.status = SUCCEEDED |
| Pre-flight failure (unreachable endpoint) | IoT Jobs | FAILED via normal path, no state change |
| Normal deployment (no endpoint change) | Shadow | No source routing, existing flow unmodified |
| Round-trip switch (east to west to east) | IoT Jobs | Both directions report correctly |

## Test plan

- [x] `EndpointSwitchStateTest` - 9 tests covering persist, detect, clear, edge cases
- [x] `IotJobsHelperTest` - source routing, ID mismatch, rollback detection, IN_PROGRESS guard, standalone failure, payload shape verification
- [x] `ShadowDeploymentListenerTest` - same patterns for shadow path, payload has no version field
- [x] `DefaultActivatorTest` - endpoint switch forces snapshot/rollback
- [x] `StandaloneMqttConnectorTest` - publish success, retry, failure after exhaustion
- [x] `DeploymentConfigMergerTest` - source keys persisted after pre-flight
- [x] Full test suite: 1174 tests pass, 0 failures
