### PR TITLE
fix: remove sudo from reboot command in loader script

### DIFF
--- a/scripts/loader
+++ b/scripts/loader
@@ -85,7 +85,7 @@ while [ $j -le 3 ] && [ $sigterm_received -eq 0 ];  do
     ;;
   101)
     echo "Rebooting host"
-    sudo reboot
+    reboot
     exit 0
     ;;
   *)


### PR DESCRIPTION
## Summary

Remove the `sudo` prefix from the `reboot` call in `scripts/loader` (line 88).

## Motivation

Customers need the ability to override the reboot command used when the Nucleus exits with code 101. Since the loader script is replaced on every Nucleus update, local patches are not durable.

Without `sudo`, customers can override reboot behavior via a systemd drop-in that prepends a custom directory to `PATH`:

```ini
# /etc/systemd/system/greengrass.service.d/override.conf
[Service]
Environment="PATH=/opt/greengrass-overrides:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```

With `sudo` present, this is impossible because `sudo` resolves commands via its own `secure_path`, ignoring the caller's `$PATH`.

## Why this is safe

- **Running as root (default):** `sudo` is a no-op.
- **Running as non-root:** The service user should already have reboot permissions configured (polkit, sudoers, or CAP_SYS_BOOT).

## Testing

This is a one-line shell script change with no behavioral difference for the default (root) installation. Non-root installations already require explicit permission configuration.

Fixes #1795