### PR TITLE
fix: cancel in-flight subscribes on IPC stream close

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -138,6 +138,7 @@ public class MqttClient implements Closeable {
     private final List<IndividualMqttClient> connections = new CopyOnWriteArrayList<>();
     private final Map<Subscribe, IndividualMqttClient> subscriptions = new ConcurrentHashMap<>();
     private final Map<MqttTopic, IndividualMqttClient> subscriptionTopics = new ConcurrentHashMap<>();
+    private final Map<Subscribe, AtomicBoolean> subscribeCancellations = new ConcurrentHashMap<>();
     private final Set<Integer> activeClientIds = new HashSet<>();
     private final AtomicInteger connectionRoundRobin = new AtomicInteger(0);
     @Getter
@@ -437,7 +438,7 @@ public class MqttClient implements Closeable {
      * @param request subscribe request
      * @throws MqttRequestException if the request is invalid for any reason
      */
-    @SuppressWarnings("PMD.CloseResource")
+    @SuppressWarnings({"PMD.CloseResource", "PMD.AvoidDeeplyNestedIfStmts"})
     public CompletableFuture<SubscribeResponse> subscribe(Subscribe request)
             throws MqttRequestException {
         try (LockScope ls = LockScope.lock(lock)) {
@@ -472,8 +473,28 @@ public class MqttClient implements Closeable {
             // Connection isn't null, so we should subscribe to the topic
             if (connection != null) {
                 IndividualMqttClient finalConnection = connection;
-                return connection.subscribe(request).whenComplete((i, t) -> {
+                AtomicBoolean cancelled = new AtomicBoolean(false);
+                subscribeCancellations.put(request, cancelled);
+                return connection.connect().thenCompose(ignored -> {
+                    if (cancelled.get()) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    return finalConnection.subscribe(request);
+                }).whenComplete((i, t) -> {
                     try (LockScope scope = LockScope.lock(connectionLock.readLock())) {
+                        subscribeCancellations.remove(request);
+                        if (cancelled.get()) {
+                            // Cancelled while in-flight; undo if broker subscribe already completed
+                            if (t == null && i != null && i.isSuccessful()) {
+                                finalConnection.unsubscribe(request.getTopic()).whenComplete((r, err) -> {
+                                    if (err != null) {
+                                        logger.atWarn().kv(TOPIC_KEY, request.getTopic())
+                                                .log("Failed to unsubscribe cancelled subscription", err);
+                                    }
+                                });
+                            }
+                            return;
+                        }
                         if (t == null && (i == null || i.isSuccessful())) {
                             subscriptionTopics.put(new MqttTopic(request.getTopic()), finalConnection);
                         } else {
@@ -571,6 +592,10 @@ public class MqttClient implements Closeable {
                 for (Map.Entry<Subscribe, IndividualMqttClient> sub : subscriptions.entrySet()) {
                     if (sub.getKey().getCallback() == request.getSubscriptionCallback() && sub.getKey().getTopic()
                             .equals(request.getTopic())) {
+                        AtomicBoolean cancelled = subscribeCancellations.remove(sub.getKey());
+                        if (cancelled != null) {
+                            cancelled.set(true);
+                        }
                         subscriptions.remove(sub.getKey());
                     }
 

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.mqttclient.v5.QOS;
 import com.aws.greengrass.mqttclient.v5.Subscribe;
 import com.aws.greengrass.mqttclient.v5.SubscribeResponse;
+import com.aws.greengrass.mqttclient.v5.Unsubscribe;
 import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
@@ -323,6 +324,56 @@ class MqttClientTest {
     }
 
     @Test
+    void GIVEN_pending_connect_WHEN_unsubscribe_cancels_THEN_broker_subscribe_is_skipped()
+            throws MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient iClient1 = mock(AwsIotMqttClient.class);
+        CompletableFuture<Boolean> connectFuture = new CompletableFuture<>();
+        when(iClient1.connect()).thenReturn(connectFuture);
+        when(client.getNewMqttClient()).thenReturn(iClient1);
+
+        Consumer<Publish> callback = (m) -> {};
+        Subscribe subReq = Subscribe.builder().topic("A/B/C").qos(QOS.AT_LEAST_ONCE).callback(callback).build();
+        CompletableFuture<SubscribeResponse> subFuture = client.subscribe(subReq);
+
+        // Cancel before connect completes
+        client.unsubscribe(Unsubscribe.builder().topic("A/B/C").subscriptionCallback(callback).build());
+
+        // Now complete the connect
+        connectFuture.complete(true);
+        subFuture.join();
+
+        // Broker subscribe should never have been called
+        verify(iClient1, never()).subscribe(any());
+    }
+
+    @Test
+    void GIVEN_broker_subscribe_completed_WHEN_unsubscribe_cancels_THEN_compensating_unsubscribe_fires()
+            throws MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient iClient1 = mock(AwsIotMqttClient.class);
+        when(iClient1.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        CompletableFuture<SubscribeResponse> brokerSubFuture = new CompletableFuture<>();
+        when(iClient1.subscribe(any())).thenReturn(brokerSubFuture);
+        when(iClient1.unsubscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(client.getNewMqttClient()).thenReturn(iClient1);
+
+        Consumer<Publish> callback = (m) -> {};
+        Subscribe subReq = Subscribe.builder().topic("A/B/C").qos(QOS.AT_LEAST_ONCE).callback(callback).build();
+        CompletableFuture<SubscribeResponse> subFuture = client.subscribe(subReq);
+
+        // Cancel after connect but before broker subscribe completes
+        client.unsubscribe(Unsubscribe.builder().topic("A/B/C").subscriptionCallback(callback).build());
+
+        // Complete the broker subscribe successfully (race: it already went through)
+        brokerSubFuture.complete(new SubscribeResponse(null, QOS.AT_LEAST_ONCE.getValue(), null));
+        subFuture.join();
+
+        // Compensating unsubscribe should have fired
+        verify(iClient1).unsubscribe("A/B/C");
+    }
+
+    @Test
     void GIVEN_connection_WHEN_settings_change_THEN_reconnects_on_valid_changes()
             throws InterruptedException, ExecutionException, TimeoutException {
         ArgumentCaptor<ChildChanged> cc = ArgumentCaptor.forClass(ChildChanged.class);
@@ -331,6 +382,7 @@ class MqttClientTest {
         mqttNamespace.context.waitForPublishQueueToClear();
 
         AwsIotMqttClient iClient1 = mock(AwsIotMqttClient.class);
+        when(iClient1.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(iClient1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(client.getNewMqttClient()).thenReturn(iClient1);
 
@@ -374,6 +426,8 @@ class MqttClientTest {
         MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
         AwsIotMqttClient iClient1 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient iClient2 = mock(AwsIotMqttClient.class);
+        when(iClient1.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(iClient2.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(iClient1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(iClient2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(client.getNewMqttClient()).thenReturn(iClient1).thenReturn(iClient2);
@@ -393,6 +447,9 @@ class MqttClientTest {
         AwsIotMqttClient iClient1 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient iClient2 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient iClient3 = mock(AwsIotMqttClient.class);
+        when(iClient1.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(iClient2.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(iClient3.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(iClient1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(iClient2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(iClient3.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
@@ -423,6 +480,9 @@ class MqttClientTest {
         AwsIotMqttClient iClient1 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient iClient2 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient iClient3 = mock(AwsIotMqttClient.class);
+        when(iClient1.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(iClient2.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(iClient3.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(iClient1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(iClient2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(iClient3.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
@@ -464,6 +524,7 @@ class MqttClientTest {
             throws ExecutionException, InterruptedException, TimeoutException {
         MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
         AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+        when(mockIndividual.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(mockIndividual.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(client.getNewMqttClient()).thenReturn(mockIndividual);
         assertFalse(client.connected());
@@ -508,6 +569,7 @@ class MqttClientTest {
         MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
         AwsIotMqttClient mockClient1 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient mockClient2 = mock(AwsIotMqttClient.class);
+        when(mockClient1.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(mockClient1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         // All subscriptions will go through mockClient1, but we're going to send the messages via mockClient2
         when(client.getNewMqttClient()).thenReturn(mockClient1);
@@ -550,6 +612,7 @@ class MqttClientTest {
         AwsIotMqttClient mockIndividual1 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient mockIndividual2 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient mockIndividual3 = mock(AwsIotMqttClient.class);
+        when(mockIndividual2.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(mockIndividual2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
         when(mockIndividual2.canAddNewSubscription()).thenReturn(true);
@@ -581,6 +644,7 @@ class MqttClientTest {
         AwsIotMqttClient mockIndividual1 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient mockIndividual2 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient mockIndividual3 = mock(AwsIotMqttClient.class);
+        when(mockIndividual2.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(mockIndividual2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
         when(mockIndividual2.canAddNewSubscription()).thenReturn(true);
@@ -609,6 +673,8 @@ class MqttClientTest {
         assertFalse(client.connected());
         AwsIotMqttClient mockIndividual1 = mock(AwsIotMqttClient.class);
         AwsIotMqttClient mockIndividual2 = mock(AwsIotMqttClient.class);
+        when(mockIndividual1.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mockIndividual2.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(mockIndividual1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(mockIndividual2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(client.getNewMqttClient()).thenReturn(mockIndividual1).thenReturn(mockIndividual2);
@@ -657,6 +723,7 @@ class MqttClientTest {
         ignoreExceptionWithMessage(context, "Uncaught!");
         MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
         AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+        when(mockIndividual.connect()).thenReturn(CompletableFuture.completedFuture(true));
         when(mockIndividual.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(client.getNewMqttClient()).thenReturn(mockIndividual);
         assertFalse(client.connected());


### PR DESCRIPTION
When a component's IPC stream closes while a SubscribeToIoTCore operation is still pending on the MQTT connection, the pending subscribe future was never cancelled. On reconnect, all accumulated pending subscribes would fire to the broker, leaking subscription count entries and eventually exceeding the 50-subscription-per-client limit.

Track a per-subscribe cancellation flag in MqttClient. On unsubscribe, set the flag so the pending connect().thenCompose chain skips the CRT subscribe call entirely. If the broker subscribe already completed in a race, issue a compensating unsubscribe.