### PR TITLE
fix: mark async stubs as lenient in ShadowDeploymentListenerTest to reduce unit test flakiness

### DIFF
--- a/src/test/java/com/aws/greengrass/deployment/ShadowDeploymentListenerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ShadowDeploymentListenerTest.java
@@ -90,7 +90,7 @@ public class ShadowDeploymentListenerTest {
     @Test
     public void testCommunicationWithIotCore_successful() {
         when(mockKernel.getContext()).thenReturn(mockContext);
-        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
         doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
                 .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
         doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
@@ -123,7 +123,7 @@ public class ShadowDeploymentListenerTest {
     @Test
     public void testCommunicationWithIotCore_unsuccessful_THEN_retry_on_update() throws DeviceConfigurationException {
         when(mockKernel.getContext()).thenReturn(mockContext);
-        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
         doThrow(new DeviceConfigurationException("Error")).doNothing().when(mockDeviceConfiguration).validate();
         doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
                 .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
@@ -152,7 +152,7 @@ public class ShadowDeploymentListenerTest {
         EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
         when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
         when(mockKernel.getContext()).thenReturn(mockContext);
-        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
         doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
                 .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
         doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
@@ -251,7 +251,7 @@ public class ShadowDeploymentListenerTest {
         EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
         when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
         when(mockKernel.getContext()).thenReturn(mockContext);
-        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
         lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
                 .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
         lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
@@ -287,7 +287,7 @@ public class ShadowDeploymentListenerTest {
         EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
         when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
         when(mockKernel.getContext()).thenReturn(mockContext);
-        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
         doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
                 .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
         doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)


### PR DESCRIPTION
## Summary

Fix flaky `UnnecessaryStubbingException` in `ShadowDeploymentListenerTest`

## Root Cause

`setupShadowCommunications()` registers the deployment status consumer **synchronously**, then submits an async task to the executor that calls `kernel.getContext().runOnPublishQueueAndWait()`. The test stubs `runOnPublishQueueAndWait` strictly, but whether the async task actually reaches that call before Mockito's post-test strict-stub validation depends on thread scheduling.

On Windows CI (slower), the async task often hasn't consumed the stub by the time the test method returns → Mockito flags it as unnecessary → test fails.                                                                              
                                 
```                                                                                          
TEST THREAD                         EXECUTOR THREAD                                                                        
    │                                     │                                                                                
    │  1. Set up stub:                    │                                                                                
    │     when(runOnPublishQueueAndWait)  │                                                                               
    │       → return null                 │                                                                                
    │                                     │                                                                                
    │  2. Call setupShadowCommunications()│                                                                                
    │        │                            │                                                                                
    │        ├─ register consumer         │                                                                                
    │        └─ executor.submit(task) ────┤──→ task queued                                                                 
    │                                     │                                                                                
    │  3. Test assertions run...          │    (task may or may not                                                        
    │                                     │     have started yet)
    │  4. Test method returns             │
    │                                     │
    │  5. Mockito checks:                 │
    │     "Was every stub used?" ←────────┼── RACE!
    │                                     │
    ├── FAST machine (Linux CI) ──────────┤
    │   Task ran → stub WAS consumed      │   ✅ PASS
    │   Mockito: all good                 │
    │                                     │
    ├── SLOW machine (Windows CI) ────────┤
    │   Task hasn't run yet               │   ❌ FAIL
    │   Mockito: "Unnecessary stub!"      │
    └─────────────────────────────────────┘
```

## Why Mockito Complains

Mockito's strict mode (the default with @ExtendWith(MockitoExtension.class)) enforces that every stub you set up must be called during the test. If a stub is never consumed, it assumes you made a mistake.

The stub only exists to prevent a NullPointerException if the async task happens to run. The test isn't testing 
runOnPublishQueueAndWait — it's testing shadow subscription behavior. The stub is just infrastructure to keep the 
background thread from crashing.

## Fix

Mark all `runOnPublishQueueAndWait` stubs as `lenient()` since they exist only to prevent NPE in the async path and are not the subject under test. The sub can never be called and the test should still pass.
