### PR TITLE
fix: resolve race between requestUninstall and close for broken services

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Lifecycle.java
@@ -505,6 +505,11 @@ public class Lifecycle {
         } else if (State.UNINSTALLED.equals(desiredState.get()) && getState() != State.UNINSTALLED) {
             // try uninstalling from broken state
             internalReportState(State.UNINSTALLING);
+        } else if (State.FINISHED.equals(desiredState.get()) && requestedUninstall.get()) {
+            // FINISHED is unreachable from BROKEN state. When close() calls requestStop(), it sets the
+            // desired state list to [FINISHED, UNINSTALLED]. Since BROKEN cannot transition to FINISHED,
+            // skip directly to UNINSTALLING so the uninstall flow can proceed.
+            internalReportState(State.UNINSTALLING);
         } else {
             logger.atError("service-broken").log("service is broken. Deployment is needed");
         }

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/LifecycleTest.java
@@ -763,6 +763,8 @@ class LifecycleTest {
     }
 
     // Uninstall Lifecycle Tests - AC7: State transitions from BROKEN → UNINSTALLING → UNINSTALLED (direct)
+    // Tests the happy path: requestUninstall() sets desired state to [UNINSTALLED] and the lifecycle
+    // thread processes it directly without close() overwriting it.
     @Test
     void GIVEN_service_in_BROKEN_state_WHEN_requestUninstall_THEN_transitions_directly_to_UNINSTALLED() throws Exception {
         Configuration config = new Configuration(context);
@@ -787,6 +789,71 @@ class LifecycleTest {
         testService.requestUninstall();
         
         assertTrue(uninstallCalled.await(2, TimeUnit.SECONDS), "Uninstall should be called");
+        assertThat(testService::getState, eventuallyEval(is(State.UNINSTALLED)));
+    }
+
+    // Tests the race path: close() calls requestStop() after requestUninstall(), overwriting the
+    // desired state to [FINISHED, UNINSTALLED]. The lifecycle thread must handle FINISHED in BROKEN
+    // state when requestedUninstall is true by skipping to UNINSTALLING.
+    @Test
+    void GIVEN_service_in_BROKEN_state_WHEN_requestUninstall_then_requestStop_THEN_transitions_to_UNINSTALLED() throws Exception {
+        Configuration config = new Configuration(context);
+        Topics testServiceTopics = config.getRoot()
+                .createInteriorChild(GreengrassService.SERVICES_NAMESPACE_TOPIC)
+                .createInteriorChild("testService");
+        TestService testService = new TestService(testServiceTopics);
+
+        CountDownLatch uninstallCalled = new CountDownLatch(1);
+        CountDownLatch shutdownBlocking = new CountDownLatch(1);
+        CountDownLatch shutdownEntered = new CountDownLatch(1);
+        AtomicBoolean reachedBroken = new AtomicBoolean(false);
+        AtomicInteger startupAttempts = new AtomicInteger(0);
+        testService.setStartupRunnable(() -> {
+            if (startupAttempts.incrementAndGet() <= 3) {
+                testService.reportState(State.ERRORED);
+            }
+        });
+        // Use a state listener to flag reachedBroken at the exact moment of transition,
+        // before handleCurrentStateBroken submits shutdown() to the executor.
+        context.addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (newState.equals(State.BROKEN)) {
+                reachedBroken.set(true);
+            }
+        });
+        testService.setShutdownRunnable(() -> {
+            // shutdown() is called during ERRORED→STARTING cycles (STOPPING state) and also by
+            // handleCurrentStateBroken once BROKEN is reached. Only block on the latter.
+            if (!reachedBroken.get()) {
+                return;
+            }
+            shutdownEntered.countDown();
+            try {
+                shutdownBlocking.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // test failure if interrupted
+            }
+        });
+        testService.setUninstallRunnable(() -> uninstallCalled.countDown());
+
+        testService.postInject();
+        testService.requestStart();
+        assertThat(testService::getState, eventuallyEval(is(State.BROKEN)));
+
+        // Wait for the lifecycle thread to enter shutdown() inside handleCurrentStateBroken.
+        // At this point the lifecycle thread is blocked and cannot process events.
+        assertTrue(shutdownEntered.await(5, TimeUnit.SECONDS), "Lifecycle thread should enter shutdown");
+
+        // Simulate the race: requestUninstall() sets requestedUninstall=true and desired=[UNINSTALLED],
+        // then requestStop() overwrites desired to [FINISHED, UNINSTALLED] (same as close() does).
+        testService.requestUninstall();
+        testService.requestStop();
+
+        // Release the lifecycle thread. It will finish handleCurrentStateBroken (desiredState was empty),
+        // enter the event loop, wake up from queued events, go back to the top of the loop, and peek
+        // the desired state — which is now deterministically [FINISHED, UNINSTALLED].
+        shutdownBlocking.countDown();
+
+        assertTrue(uninstallCalled.await(5, TimeUnit.SECONDS), "Uninstall should be called");
         assertThat(testService::getState, eventuallyEval(is(State.UNINSTALLED)));
     }
 


### PR DESCRIPTION
## Problem

`PluginComponentTest.GIVEN_kernel_WHEN_deploy_new_plugin_broken_THEN_rollback_succeeds` is flaky due to a race condition in the lifecycle state machine.

The desiredStateList is a queue of waypoints, not a single destination. It tells the lifecycle thread: "visit these states in this order."

During rollback, `removeObsoleteServices()` calls:
1. `service.requestUninstall()` — sets desired state to `[UNINSTALLED]`
2. `service.close().get()` — internally calls `requestStop()` which overwrites desired state to `[FINISHED, UNINSTALLED]`

The lifecycle thread in BROKEN state cannot process FINISHED (it's unreachable from BROKEN), so `handleCurrentStateBroken` just logs "service is broken" and the thread blocks on the event queue indefinitely. This is a small thread + memory leak due to the thread never being cleaned up. It never reaches the UNINSTALLED entry in the desired state list, so the `close()` future never completes, causing the 30-second timeout.

The race is timing-dependent: if the lifecycle thread processes UNINSTALLED before `requestStop()` overwrites the list, the test passes.

### The happy path (no race, test passes)
```
Timeline:
─────────────────────────────────────────────────────────────────────────

  Main Thread                          Lifecycle Thread (state: BROKEN)
  ───────────                          ─────────────────────────────────
  requestUninstall()
  → desired = [UNINSTALLED]
  → enqueue event ─────────────────►   wakes up
                                        sees desired = UNINSTALLED
                                        transitions: BROKEN → UNINSTALLING → UNINSTALLED
                                        ✓ loop exits, thread finishes
  close().get()
  → returns immediately (thread already done)
  ✅ SUCCESS
```

### The bad path (race triggers, test hangs)
```
Timeline:
─────────────────────────────────────────────────────────────────────────

  Main Thread                          Lifecycle Thread (state: BROKEN)
  ───────────                          ─────────────────────────────────
  requestUninstall()
  → desired = [UNINSTALLED]
  → enqueue event
                                        (hasn't woken up yet)
  close()
  → requestStop()
  → desired = [FINISHED, UNINSTALLED]   NOW wakes up
    (overwrites!)                        peeks first item: FINISHED
                                         │
                                         ▼
                                        handleCurrentStateBroken(FINISHED):
                                          "I don't know what to do with FINISHED"
                                          logs "service is broken"
                                          returns without transitioning
                                         │
                                         ▼
                                        waits for next event...
                                        💀 NO MORE EVENTS COMING
                                         │
                                         ▼
                                        (blocked forever)

  close().get()
  → waiting for lifecycle thread...
  → 💀 BLOCKED (30s timeout → test fails)
```

### Why FINISHED gets stuck

The desired state list is [FINISHED, UNINSTALLED]. The lifecycle thread always peeks the first item, and only removes it if it matches the current state:
```
  Desired state list: [ FINISHED, UNINSTALLED ]
                        ^^^^^^^^
                        always peeked, never removed
                        (because FINISHED ≠ BROKEN)

  Result: UNINSTALLED is permanently hidden behind FINISHED
```

And handleCurrentStateBroken only knows how to handle:
- NEW → reinstall
- UNINSTALLED → begin uninstall
- anything else → log error, do nothing ← FINISHED lands here


## Fix

Add handling for FINISHED in the BROKEN state when uninstall is requested:
```
handleCurrentStateBroken(desiredState):

    if desiredState == NEW        → transition to NEW (reinstall)
    if desiredState == UNINSTALLED → transition to UNINSTALLING
  + if desiredState == FINISHED    → transition to UNINSTALLING (skip unreachable FINISHED)
       && requestedUninstall
    else                          → log "service is broken"
```

### After the fix
```
Timeline (same race, but now works):
─────────────────────────────────────────────────────────────────────────

  Main Thread                          Lifecycle Thread (state: BROKEN)
  ───────────                          ─────────────────────────────────
  requestUninstall()
  close()
  → desired = [FINISHED, UNINSTALLED]   wakes up
                                        peeks first item: FINISHED
                                         │
                                         ▼
                                        handleCurrentStateBroken(FINISHED):
                                          requestedUninstall is true
                                          → transition to UNINSTALLING ✓
                                         │
                                         ▼
                                        state: UNINSTALLING → runs uninstall → UNINSTALLED
                                        ✓ loop exits, thread finishes

  close().get()
  → returns (thread finished)
  ✅ SUCCESS
```

## Testing

Two deterministic unit tests cover both possible orderings of the race:

1. **Happy path** (`GIVEN_service_in_BROKEN_state_WHEN_requestUninstall_THEN_transitions_directly_to_UNINSTALLED`): `requestUninstall()` alone sets desired state to `[UNINSTALLED]` — lifecycle thread handles it directly.

2. **Race path** (`GIVEN_service_in_BROKEN_state_WHEN_requestUninstall_then_requestStop_THEN_transitions_to_UNINSTALLED`): Blocks the lifecycle thread inside `handleCurrentStateBroken`'s shutdown, then calls `requestUninstall()` + `requestStop()` to deterministically set desired state to `[FINISHED, UNINSTALLED]`. After releasing the thread, asserts it transitions through UNINSTALLING to UNINSTALLED.

The race path test deterministically fails without the fix (5s timeout waiting for uninstall) and passes with it.