### PR TITLE
fix: flaky Windows CI - lenient stubbing in ShadowDeploymentListenerTest

### DIFF
--- a/src/test/java/com/aws/greengrass/deployment/ShadowDeploymentListenerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ShadowDeploymentListenerTest.java
@@ -251,7 +251,7 @@ public class ShadowDeploymentListenerTest {
         EndpointSwitchState mockEndpointSwitchState = mock(EndpointSwitchState.class);
         when(mockContext.get(EndpointSwitchState.class)).thenReturn(mockEndpointSwitchState);
         when(mockKernel.getContext()).thenReturn(mockContext);
-        when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
+        lenient().when(mockContext.runOnPublishQueueAndWait(any())).thenReturn(null);
         lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)
                 .SubscribeToUpdateNamedShadowAccepted(any(), any(), any(), any());
         lenient().doReturn(CompletableFuture.completedFuture(null)).when(mockIotShadowClient)


### PR DESCRIPTION
The `runOnPublishQueueAndWait` stub in `GIVEN_source_endpoint_id_mismatch_WHEN_shadow_status_changed_THEN_uses_normal_path` is consumed by an async task submitted during `postInject()`. On Windows, the task may not execute before the test completes, causing Mockito's strict stubbing to flag it as unnecessary.

Making it `lenient()` fixes the flaky Windows CI failure.

**Testing:** This is a test-only change. Verified that the same pattern is already used for the other stubs in this test method.