### PR TITLE
chore: update AWS SDK, IoT Device SDK, and CRT versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.28.27</version>
+                <version>2.46.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -238,7 +238,7 @@
             When updating the version here, ensure you match the correct aws-crt version below.
             Get the correct version from: https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/sdk/pom.xml#L45
             !-->
-            <version>1.23.0</version>
+            <version>1.31.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk.crt</groupId>
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.33.5</version>
+            <version>0.45.0</version>
             <classifier>fips-where-available</classifier>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump core AWS dependencies to their latest stable releases.

* AWS SDK for Java v2 BOM: 2.28.27 -> 2.46.7
* AWS IoT Device SDK v2: 1.23.0 -> 1.31.0
* aws-crt: 0.33.5 -> 0.45.0 (version pinned by device SDK 1.31.0)

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
