### PR TITLE
ci: Use windows-2025 runner for Windows CI build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
       fail-fast: false
     name: Build on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## What

Pin the Windows leg of the Java CI matrix (`.github/workflows/maven.yml`) to `windows-2025` instead of `windows-latest`.

```diff
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
```

## Why

- **Deterministic runner OS.** GitHub is migrating `windows-latest` from Server 2022 to Server 2025; pinning explicitly avoids the runner shifting underneath the build mid-migration.
- **Validate on the OS customers run.** Windows Server 2025 is now GA and is what we want CI coverage against.

## WMIC.exe note (safety check)

Windows Server 2025 removed `WMIC.exe` by default, which can break Java tooling that shells out to it (e.g. `zt-process-killer`'s `WindowsProcess.isAlive()`). Nucleus was checked and is **not** affected:

- Windows process management (`WindowsPlatform`, `WindowsExec`) uses `taskkill` and `java.lang.Process` APIs.
- It calls `zt-process-killer`'s `destroy()` (which uses `taskkill`), never `isAlive()` (the WMIC path).
- No source references `wmic`/`Wbem`; tests use JVM-native `PidUtil`/`pgrep`.

So the WMIC code path is dead code in nucleus's usage, and the `mvn verify` Windows build is expected to pass on `windows-2025`.