### PR TITLE
fix: prevent preflight endpoint check from failing on unprovisioned devices

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -28,6 +28,7 @@ import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.Utils;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -210,8 +211,8 @@ public class DeploymentConfigMerger {
             String newRoleAlias = nucleusConfig.containsKey(DeviceConfiguration.IOT_ROLE_ALIAS_TOPIC)
                     ? Coerce.toString(nucleusConfig.get(DeviceConfiguration.IOT_ROLE_ALIAS_TOPIC))
                     : currentRoleAlias;
-            if (!Objects.equals(currentCredEndpoint, newCredEndpoint)
-                    || !Objects.equals(currentRoleAlias, newRoleAlias)) {
+            if (effectivelyChanged(currentCredEndpoint, newCredEndpoint)
+                    || effectivelyChanged(currentRoleAlias, newRoleAlias)) {
                 long credTimeout = Coerce.toLong(deviceConfiguration.getCredentialEndpointTimeoutMs());
                 if (credTimeout <= 0) {
                     credTimeout = DeviceConfiguration.DEFAULT_CREDENTIAL_ENDPOINT_TIMEOUT_MS;
@@ -322,6 +323,12 @@ public class DeploymentConfigMerger {
         return iotDataEndpoint;
     }
 
+    private static boolean effectivelyChanged(String current, String incoming) {
+        String normalizedCurrent = Utils.isEmpty(current) ? "" : current;
+        String normalizedIncoming = Utils.isEmpty(incoming) ? "" : incoming;
+        return !Objects.equals(normalizedCurrent, normalizedIncoming);
+    }
+
     /**
      * Detect whether a deployment changes the IoT data endpoint.
      *
@@ -336,7 +343,7 @@ public class DeploymentConfigMerger {
         }
         String current = Coerce.toString(deviceConfiguration.getIotDataEndpoint());
         String incoming = Coerce.toString(nucleusConfig.get(DEVICE_PARAM_IOT_DATA_ENDPOINT));
-        return !Objects.equals(current, incoming);
+        return effectivelyChanged(current, incoming);
     }
 
     @Getter


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Normalize null and empty-string to equivalent values when comparing IoT credential endpoint and role alias during deployment pre-flight checks. Added effectivelyChanged() helper that treats null and "" as the same "not configured" state, and applied it to both the credential endpoint comparison and isEndpointSwitchDeployment.

**Why is this change necessary:**
On unprovisioned devices, DeviceConfiguration getters use Topic.dflt("") which lazily initializes null Topic values to "". However, the resolved deployment config map (built via toPOJO()) reads the raw Topic value before dflt() has been triggered. This causes a false-positive change detection ("" != null) that fires the EndpointSwitchPreflightValidator credential endpoint check, which immediately fails with "Role alias must not be empty" and blocking all local deployments on unprovisioned devices.


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
