### PR TITLE
fix(systemd): Depend on time-sync.target

### DIFF
--- a/scripts/greengrass.service.template
+++ b/scripts/greengrass.service.template
@@ -1,7 +1,7 @@
 [Unit]
 Description=Greengrass Core
 After=network.target
-After=systemd-time-wait-sync.service
+After=time-sync.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
systemd-time-wait-sync.service is systemd-timesyncd's specific service for fulfilling time-sync.target. By ordering after the target instead, we order after other implementations furfilling time-sync.target as well.

This change preserves current semantics, while making it more general. We may want to switch from time-sync.target to time-set.target, though that would make GG start earlier and no longer wait for network up.