### PR TITLE
fix: restart TES on cred endpoint changes

### DIFF
--- a/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
+++ b/src/main/java/com/aws/greengrass/tes/TokenExchangeService.java
@@ -72,6 +72,16 @@ public class TokenExchangeService extends GreengrassService implements AwsCreden
             iotRoleAlias = Coerce.toString(newv);
         });
 
+        deviceConfiguration.getIotCredentialEndpoint().subscribe((why, newv) -> {
+            if (!WhatHappened.changed.equals(why)) {
+                return;
+            }
+            logger.atInfo("tes-config-change").kv("new-value", Coerce.toString(newv))
+                    .log("Restarting TES due to credential endpoint config change");
+            credentialRequestHandler.clearCache();
+            requestRestart();
+        });
+
         this.authZHandler = authZHandler;
         this.credentialRequestHandler = credentialRequestHandler;
 

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -40,6 +40,7 @@ import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURA
 import static com.aws.greengrass.deployment.DeviceConfiguration.COMPONENT_STORE_MAX_SIZE_BYTES;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_CRED_ENDPOINT;
 import static com.aws.greengrass.deployment.DeviceConfiguration.IOT_ROLE_ALIAS_TOPIC;
 import static com.aws.greengrass.deployment.DeviceConfiguration.NUCLEUS_CONFIG_LOGGING_TOPICS;
 import static com.aws.greengrass.deployment.DeviceConfiguration.SYSTEM_NAMESPACE_KEY;
@@ -129,6 +130,11 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
         when(topics.subscribe(any())).thenReturn(topics);
         when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY)).thenReturn(topics);
         when(configuration.lookupTopics(SYSTEM_NAMESPACE_KEY)).thenReturn(topics);
+
+        // TES subscribes to the credential endpoint topic in its constructor; back it with a real topic.
+        Topic credEndpointTopic = Topic.of(context, DEVICE_PARAM_IOT_CRED_ENDPOINT, "");
+        when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
+                DEVICE_PARAM_IOT_CRED_ENDPOINT)).thenReturn(credEndpointTopic);
     }
 
     @AfterEach


### PR DESCRIPTION
**Description of changes:**
Clear cache and restart TES on cred endpoint changes

**Why is this change necessary:**
Allow components to assume new TES role

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Tested with UAT

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
