### PR TITLE
feat(ipc): add SubscribeToIoTCoreConnectionStatus operation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
             When updating the version here, ensure you match the correct aws-crt version below.
             Get the correct version from: https://github.com/aws/aws-iot-device-sdk-java-v2/blob/main/sdk/pom.xml#L45
             !-->
-            <version>1.31.0</version>
+            <version>1.33.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk.crt</groupId>

--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.mqttclient.CallbackEventManager;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.MqttRequestException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
@@ -22,8 +23,12 @@ import com.aws.greengrass.util.Utils;
 import lombok.AccessLevel;
 import lombok.Setter;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractPublishToIoTCoreOperationHandler;
+import software.amazon.awssdk.aws.greengrass.GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractSubscribeToIoTCoreOperationHandler;
+import software.amazon.awssdk.aws.greengrass.model.ConnectionStatus;
+import software.amazon.awssdk.aws.greengrass.model.ConnectionStatusEvent;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.IoTCoreConnectionStatusEvent;
 import software.amazon.awssdk.aws.greengrass.model.IoTCoreMessage;
 import software.amazon.awssdk.aws.greengrass.model.MQTTMessage;
 import software.amazon.awssdk.aws.greengrass.model.PayloadFormat;
@@ -31,14 +36,19 @@ import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreResponse;
 import software.amazon.awssdk.aws.greengrass.model.QOS;
 import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreConnectionStatusRequest;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreConnectionStatusResponse;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreResponse;
 import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
 import software.amazon.awssdk.crt.mqtt5.packets.SubAckPacket;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -67,6 +77,29 @@ public class MqttProxyIPCAgent {
     @Setter(AccessLevel.PACKAGE)
     private AuthorizationHandler authorizationHandler;
 
+    private final Set<SubscribeToIoTCoreConnectionStatusOperationHandler> connectionStatusListeners =
+            new CopyOnWriteArraySet<>();
+
+    private final AtomicBoolean connectionStatusCallbacksRegistered = new AtomicBoolean(false);
+
+    // Broadcasts IoT Core connection status changes to all IPC subscribers. CallbackEventManager
+    // deduplicates events across the underlying connections, so these fire once per online/offline
+    // transition of the overall MQTT client.
+    private final MqttClientConnectionEvents connectionStatusCallbacks = new MqttClientConnectionEvents() {
+        @Override
+        public void onConnectionInterrupted(int errorCode) {
+            forwardConnectionStatusToListeners(ConnectionStatus.DISCONNECTED);
+        }
+
+        @Override
+        public void onConnectionResumed(boolean sessionPresent) {
+            forwardConnectionStatusToListeners(ConnectionStatus.CONNECTED);
+        }
+    };
+
+    private final CallbackEventManager.OnConnectCallback onInitialConnect =
+            connectionStatusCallbacks::onConnectionResumed;
+
     public PublishToIoTCoreOperationHandler getPublishToIoTCoreOperationHandler(
             OperationContinuationHandlerContext context) {
         return new PublishToIoTCoreOperationHandler(context);
@@ -75,6 +108,25 @@ public class MqttProxyIPCAgent {
     public SubscribeToIoTCoreOperationHandler getSubscribeToIoTCoreOperationHandler(
             OperationContinuationHandlerContext context) {
         return new SubscribeToIoTCoreOperationHandler(context);
+    }
+
+    // Handler lifecycle is managed by the eventstream RPC framework
+    // (closed via onStreamClosed/stream termination), not by the creator.
+    @SuppressWarnings("PMD.CloseResource")
+    public SubscribeToIoTCoreConnectionStatusOperationHandler getSubscribeToIoTCoreConnectionStatusOperationHandler(
+            OperationContinuationHandlerContext context) {
+        return new SubscribeToIoTCoreConnectionStatusOperationHandler(context);
+    }
+
+    // PMD false positive: iterating listeners does not transfer ownership of the closeable handlers;
+    // their lifecycle is managed by the eventstream RPC framework.
+    @SuppressWarnings("PMD.CloseResource")
+    private void forwardConnectionStatusToListeners(ConnectionStatus status) {
+        LOGGER.atDebug().kv("status", status).kv("subscribers", connectionStatusListeners.size())
+                .log("Forwarding IoT Core connection status to subscribers");
+        for (SubscribeToIoTCoreConnectionStatusOperationHandler listener : connectionStatusListeners) {
+            listener.forwardConnectionStatus(status);
+        }
     }
 
     class PublishToIoTCoreOperationHandler extends GeneratedAbstractPublishToIoTCoreOperationHandler {
@@ -272,6 +324,97 @@ public class MqttProxyIPCAgent {
                                 + "because subscription response is not yet sent",
                         m.getTopic(), serviceName);
             }
+        }
+    }
+
+    class SubscribeToIoTCoreConnectionStatusOperationHandler
+            extends GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler {
+
+        private final String serviceName;
+
+        // Guards the initial-event handoff between the MQTT callback thread and afterHandleRequest:
+        // a transition arriving during subscription setup is stashed and sent as the initial event,
+        // so no status is lost and stream events never overtake the subscribe response.
+        private final Object initialEventLock = new Object();
+        private boolean subscriptionResponseSent;
+        private ConnectionStatus deferredStatus;
+
+        protected SubscribeToIoTCoreConnectionStatusOperationHandler(OperationContinuationHandlerContext context) {
+            super(context);
+            serviceName = context.getAuthenticationData().getIdentityLabel();
+        }
+
+        @Override
+        protected void onStreamClosed() {
+            connectionStatusListeners.remove(this);
+        }
+
+        @Override
+        public SubscribeToIoTCoreConnectionStatusResponse handleRequest(
+                SubscribeToIoTCoreConnectionStatusRequest request) {
+            return translateExceptions(() -> {
+                // No authorization required: this is a local informational operation that
+                // exposes no MQTT topic data.
+
+                // Register the shared connection callbacks with the MQTT client only once,
+                // when the first subscriber shows up.
+                if (connectionStatusCallbacksRegistered.compareAndSet(false, true)) {
+                    mqttClient.addToCallbackEvents(onInitialConnect, connectionStatusCallbacks);
+                }
+                connectionStatusListeners.add(this);
+
+                return new SubscribeToIoTCoreConnectionStatusResponse();
+            });
+        }
+
+        @Override
+        public void afterHandleRequest() {
+            // The subscribe response has been sent, so stream events may now go out. Deliver the
+            // status stashed during setup, or the current one if no transition arrived.
+            synchronized (initialEventLock) {
+                if (!subscriptionResponseSent) {
+                    subscriptionResponseSent = true;
+                    ConnectionStatus status = deferredStatus;
+                    if (status == null) {
+                        status = mqttClient.getMqttOnline().get() ? ConnectionStatus.CONNECTED
+                                : ConnectionStatus.DISCONNECTED;
+                    }
+                    sendStatusEvent(status);
+                }
+            }
+        }
+
+        @Override
+        public void handleStreamEvent(EventStreamJsonMessage streamRequestEvent) {
+            // No client-to-server stream events are defined for this operation.
+        }
+
+        void forwardConnectionStatus(ConnectionStatus status) {
+            // Sending before the subscribe response would be a client error, so stash the status
+            // instead and let afterHandleRequest deliver it as the initial event.
+            synchronized (initialEventLock) {
+                if (subscriptionResponseSent) {
+                    sendStatusEvent(status);
+                } else {
+                    deferredStatus = status;
+                    LOGGER.atDebug().kv(COMPONENT_NAME, serviceName).kv("status", status)
+                            .log("Deferring connection status until the subscription response "
+                                    + "is sent; it will be the initial event");
+                }
+            }
+        }
+
+        private void sendStatusEvent(ConnectionStatus status) {
+            IoTCoreConnectionStatusEvent event = new IoTCoreConnectionStatusEvent()
+                    .withConnectionStatusEvent(new ConnectionStatusEvent().withStatus(status));
+            this.sendStreamEvent(event).exceptionally((t) -> {
+                LOGGER.atError().cause(t).kv(COMPONENT_NAME, serviceName).kv("status", status)
+                        .log("Unable to forward IoT Core connection status to subscriber");
+                // Self-heal: remove this handler to prevent listener leak on abnormal
+                // stream termination.
+                connectionStatusListeners.remove(this);
+                return null;
+            });
         }
     }
 

--- a/src/main/java/com/aws/greengrass/ipc/modules/MqttProxyIPCService.java
+++ b/src/main/java/com/aws/greengrass/ipc/modules/MqttProxyIPCService.java
@@ -50,5 +50,7 @@ public class MqttProxyIPCService implements Startable, InjectionActions {
                 (context) -> mqttProxyIPCAgent.getPublishToIoTCoreOperationHandler(context));
         greengrassCoreIPCService.setSubscribeToIoTCoreHandler(
                 (context) -> mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(context));
+        greengrassCoreIPCService.setSubscribeToIoTCoreConnectionStatusHandler(
+                (context) -> mqttProxyIPCAgent.getSubscribeToIoTCoreConnectionStatusOperationHandler(context));
     }
 }

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.IoTCoreConnectionStatusEvent;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreConnectionStatusRequest;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreConnectionStatusResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler extends OperationContinuationHandler<SubscribeToIoTCoreConnectionStatusRequest, SubscribeToIoTCoreConnectionStatusResponse, EventStreamJsonMessage, IoTCoreConnectionStatusEvent> {
+  protected GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<SubscribeToIoTCoreConnectionStatusRequest, SubscribeToIoTCoreConnectionStatusResponse, EventStreamJsonMessage, IoTCoreConnectionStatusEvent> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getSubscribeToIoTCoreConnectionStatusModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GreengrassCoreIPCService.java
@@ -58,6 +58,8 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
 
   public static final String CREATE_DEBUG_PASSWORD = SERVICE_NAMESPACE + "#CreateDebugPassword";
 
+  public static final String SUBSCRIBE_TO_IOT_CORE_CONNECTION_STATUS = SERVICE_NAMESPACE + "#SubscribeToIoTCoreConnectionStatus";
+
   public static final String GET_THING_SHADOW = SERVICE_NAMESPACE + "#GetThingShadow";
 
   public static final String SEND_CONFIGURATION_VALIDITY_REPORT = SERVICE_NAMESPACE + "#SendConfigurationValidityReport";
@@ -110,6 +112,7 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
     SERVICE_OPERATION_SET.add(AUTHORIZE_CLIENT_DEVICE_ACTION);
     SERVICE_OPERATION_SET.add(LIST_COMPONENTS);
     SERVICE_OPERATION_SET.add(CREATE_DEBUG_PASSWORD);
+    SERVICE_OPERATION_SET.add(SUBSCRIBE_TO_IOT_CORE_CONNECTION_STATUS);
     SERVICE_OPERATION_SET.add(GET_THING_SHADOW);
     SERVICE_OPERATION_SET.add(SEND_CONFIGURATION_VALIDITY_REPORT);
     SERVICE_OPERATION_SET.add(UPDATE_THING_SHADOW);
@@ -227,6 +230,11 @@ public final class GreengrassCoreIPCService extends EventStreamRPCServiceHandler
   public void setCreateDebugPasswordHandler(
       Function<OperationContinuationHandlerContext, GeneratedAbstractCreateDebugPasswordOperationHandler> handler) {
     operationSupplierMap.put(CREATE_DEBUG_PASSWORD, handler);
+  }
+
+  public void setSubscribeToIoTCoreConnectionStatusHandler(
+      Function<OperationContinuationHandlerContext, GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler> handler) {
+    operationSupplierMap.put(SUBSCRIBE_TO_IOT_CORE_CONNECTION_STATUS, handler);
   }
 
   public void setGetThingShadowHandler(

--- a/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.builtin.services.mqttproxy;
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.AuthorizationHandler.ResourceLookupPolicy;
 import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.mqttclient.CallbackEventManager;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.mqttclient.MqttRequestException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
@@ -23,22 +24,28 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
+import software.amazon.awssdk.aws.greengrass.model.ConnectionStatus;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.IoTCoreConnectionStatusEvent;
 import software.amazon.awssdk.aws.greengrass.model.IoTCoreMessage;
 import software.amazon.awssdk.aws.greengrass.model.MQTTMessage;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreResponse;
 import software.amazon.awssdk.aws.greengrass.model.QOS;
 import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreConnectionStatusRequest;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreConnectionStatusResponse;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreResponse;
 import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
 import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
@@ -50,7 +57,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -286,4 +295,92 @@ class MqttProxyIPCAgentTest {
             });
         }
     }
+
+    @Test
+    void GIVEN_MqttProxyIPCAgent_WHEN_subscribe_to_connection_status_THEN_current_status_and_changes_forwarded()
+            throws Exception {
+        when(mqttClient.getMqttOnline()).thenReturn(new AtomicBoolean(true));
+
+        ArgumentCaptor<CallbackEventManager.OnConnectCallback> onConnectArgumentCaptor
+                = ArgumentCaptor.forClass(CallbackEventManager.OnConnectCallback.class);
+        ArgumentCaptor<MqttClientConnectionEvents> connectionEventsArgumentCaptor
+                = ArgumentCaptor.forClass(MqttClientConnectionEvents.class);
+        ArgumentCaptor<IoTCoreConnectionStatusEvent> statusEventArgumentCaptor
+                = ArgumentCaptor.forClass(IoTCoreConnectionStatusEvent.class);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreConnectionStatusOperationHandler handler
+                     = spy(mqttProxyIPCAgent.getSubscribeToIoTCoreConnectionStatusOperationHandler(mockContext))) {
+            doReturn(new CompletableFuture<>()).when(handler).sendStreamEvent(any());
+
+            SubscribeToIoTCoreConnectionStatusResponse response =
+                    handler.handleRequest(new SubscribeToIoTCoreConnectionStatusRequest());
+
+            assertNotNull(response);
+            verify(mqttClient).addToCallbackEvents(onConnectArgumentCaptor.capture(),
+                    connectionEventsArgumentCaptor.capture());
+            MqttClientConnectionEvents connectionEvents = connectionEventsArgumentCaptor.getValue();
+
+            // Streaming events must not go out before the subscription response is sent
+            verify(handler, never()).sendStreamEvent(any());
+
+            // With no transition during setup, the current status (CONNECTED) is the initial event
+            handler.afterHandleRequest();
+            verify(handler).sendStreamEvent(statusEventArgumentCaptor.capture());
+            assertThat(statusEventArgumentCaptor.getValue().getConnectionStatusEvent().getStatus(),
+                    is(ConnectionStatus.CONNECTED));
+
+            // Connection interruption is forwarded as DISCONNECTED
+            connectionEvents.onConnectionInterrupted(0);
+            verify(handler, times(2)).sendStreamEvent(statusEventArgumentCaptor.capture());
+            assertThat(statusEventArgumentCaptor.getValue().getConnectionStatusEvent().getStatus(),
+                    is(ConnectionStatus.DISCONNECTED));
+
+            // Initial connect is forwarded as CONNECTED
+            onConnectArgumentCaptor.getValue().onConnect(true);
+            verify(handler, times(3)).sendStreamEvent(statusEventArgumentCaptor.capture());
+            assertThat(statusEventArgumentCaptor.getValue().getConnectionStatusEvent().getStatus(),
+                    is(ConnectionStatus.CONNECTED));
+
+            // After the stream is closed, no more events are forwarded
+            handler.onStreamClosed();
+            connectionEvents.onConnectionInterrupted(0);
+            verify(handler, times(3)).sendStreamEvent(any());
+        }
+    }
+
+    @Test
+    void GIVEN_status_changes_during_subscription_setup_WHEN_response_sent_THEN_it_becomes_initial_event()
+            throws Exception {
+        // getMqttOnline() is deliberately not stubbed: the stashed status must be used instead,
+        // so a regression back to polling fails here on strict stubbing.
+        ArgumentCaptor<MqttClientConnectionEvents> connectionEventsArgumentCaptor
+                = ArgumentCaptor.forClass(MqttClientConnectionEvents.class);
+        ArgumentCaptor<IoTCoreConnectionStatusEvent> statusEventArgumentCaptor
+                = ArgumentCaptor.forClass(IoTCoreConnectionStatusEvent.class);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreConnectionStatusOperationHandler handler
+                     = spy(mqttProxyIPCAgent.getSubscribeToIoTCoreConnectionStatusOperationHandler(mockContext))) {
+            doReturn(new CompletableFuture<>()).when(handler).sendStreamEvent(any());
+
+            assertNotNull(handler.handleRequest(new SubscribeToIoTCoreConnectionStatusRequest()));
+            verify(mqttClient).addToCallbackEvents(any(), connectionEventsArgumentCaptor.capture());
+
+            // A transition arriving before the response must not go out yet, nor be lost
+            connectionEventsArgumentCaptor.getValue().onConnectionInterrupted(0);
+            verify(handler, never()).sendStreamEvent(any());
+
+            // The stashed status becomes the initial event, exactly once
+            handler.afterHandleRequest();
+            verify(handler, times(1)).sendStreamEvent(statusEventArgumentCaptor.capture());
+            assertThat(statusEventArgumentCaptor.getValue().getConnectionStatusEvent().getStatus(),
+                    is(ConnectionStatus.DISCONNECTED));
+
+            // Subsequent transitions flow normally
+            connectionEventsArgumentCaptor.getValue().onConnectionResumed(false);
+            verify(handler, times(2)).sendStreamEvent(statusEventArgumentCaptor.capture());
+            assertThat(statusEventArgumentCaptor.getValue().getConnectionStatusEvent().getStatus(),
+                    is(ConnectionStatus.CONNECTED));
+        }
+    }
+
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add support for the SubscribeToIoTCoreConnectionStatus IPC operation introduced in aws-iot-device-sdk 1.33.0. Components can subscribe to receive the IoT Core MQTT connection status (`CONNECTED`/`DISCONNECTED`) as a stream of `IoTCoreConnectionStatusEvent` messages.

Bump dependencies:
* AWS IoT Device SDK v2: 1.31.0 -> 1.33.0

aws-crt is intentionally kept at 0.45.0 (not bumped to the 0.47.0 pinned by device SDK 1.33.0).

Vendor the generated server-side stubs for the new operation:
* GreengrassCoreIPCService: add operation constant, register it in the service operation set, and add setSubscribeToIoTCoreConnectionStatusHandler
* GeneratedAbstractSubscribeToIoTCoreConnectionStatusOperationHandler (new)

Implement the operation in the MQTT proxy (`MqttProxyIPCAgent` / `MqttProxyIPCService`):
* Register shared connection callbacks with the MQTT client once, on first subscription, via `CallbackEventManager` (which deduplicates events across underlying connections)
* Send the current connection status as the initial stream event so subscribers learn the present state without waiting for the next transition
* Guarantee the non-streaming subscribe response precedes any stream event, and that a status transition racing subscription setup is stashed and delivered as the initial event rather than dropped — both paths hold a single lock, so nothing is lost and wire order matches status order (same approach as client-device-auth's `SubscribeToCertificateUpdatesOperationHandler`)
* Remove subscribers on stream close and self-heal on stream-send failure to prevent listener leaks

Design decision — no authorization required: this is a local informational operation that exposes no MQTT topic data, following the same pattern as other ungated informational IPC operations (e.g. SubscribeToConfigurationUpdate). It is intentionally not registered with the AuthorizationHandler, and components do not need an `accessControl` policy to use it.

**Why is this change necessary:**
Components (e.g. stream processors, offline-first apps) need a supported way to react to the core device's IoT Core connectivity state without probing the network themselves. The device SDKs (Java v2 1.33.0+) already ship the client-side model for this operation; this PR adds the nucleus server-side implementation.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [x] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

Unit tests (`MqttProxyIPCAgentTest`, 12 tests) cover the full event sequencing contract: no events forwarded before the subscribe response is sent, initial status delivered after the response, DISCONNECTED forwarded on connection interruption, CONNECTED forwarded on resume/initial connect, and no events after stream close. A dedicated test covers the race where a transition arrives during subscription setup, asserting it is delivered as the initial event exactly once instead of being dropped.

End-to-end verification on a real core device (aarch64 container, nucleus built from this branch, provisioned against IoT Core): a Java SDK v2 test component subscribed via IPC and observed the complete lifecycle —
```
[INITIAL] Connection status: CONNECTED      (initial event on subscribe)
[CHANGED] Connection status: DISCONNECTED   (network severed; detected via MQTT keepalive)
[CHANGED] Connection status: CONNECTED      (network restored)
```
Exactly one event per transition, in order, with no duplicates.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

