### PR TITLE
fix: wait for MQTT reconnect before completing endpoint-switch rollback

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -14,6 +14,7 @@ import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.mqttclient.MqttClient;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -196,6 +197,17 @@ public class DefaultActivator extends DeploymentActivator {
             rollbackManager.removeObsoleteServices();
             logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv(DEPLOYMENT_ID_LOG_KEY, deploymentId)
                     .log("All services rolled back");
+
+            // For endpoint-switch deployments, wait for the MQTT client's pending reconnect to
+            // complete before signaling deployment completion. Rollback restores the original
+            // endpoint config which triggers an async MQTT reconnect. If we complete the future
+            // immediately, DeploymentService may publish FAILED status while the MQTT client is
+            // still connected to the switched (wrong) endpoint. Waiting for the reconnect attempt
+            // (success or failure) ensures the client is no longer on the wrong endpoint.
+            if (isEndpointSwitch(deploymentId)) {
+                logger.atDebug(MERGE_CONFIG_EVENT_KEY).log("Waiting for MQTT reconnect after endpoint-switch rollback");
+                kernel.getContext().get(MqttClient.class).waitForPendingReconnect();
+            }
 
             totallyCompleteFuture.complete(
                     new DeploymentResult(DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_COMPLETE, failureCause));

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -93,7 +94,7 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THI
 import static com.aws.greengrass.mqttclient.AwsIotMqttClient.TOPIC_KEY;
 import static com.aws.greengrass.util.RetryUtils.RANDOM;
 
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.ExcessiveClassLength"})
 public class MqttClient implements Closeable {
     private static final Logger logger = LogManager.getLogger(MqttClient.class);
     static final String MQTT_KEEP_ALIVE_TIMEOUT_KEY = "keepAliveTimeoutMs";
@@ -1031,6 +1032,34 @@ public class MqttClient implements Closeable {
 
     public boolean connected() {
         return !connections.isEmpty() && connections.stream().anyMatch(IndividualMqttClient::connected);
+    }
+
+    /**
+     * Wait for any pending MQTT reconnection task to complete. This blocks until the scheduled
+     * reconnect attempt finishes (success or failure). Used by endpoint-switch rollback to ensure
+     * the MQTT client is no longer pointing at the switched endpoint before deployment status
+     * is published.
+     *
+     * <p>If no reconnection is pending, returns immediately. Times out after the MQTT operation
+     * timeout (default 30s) plus the 1-second schedule delay to account for the reconnect
+     * being scheduled slightly in the future.</p>
+     */
+    public void waitForPendingReconnect() {
+        Future<?> pending = reconfigureFuture.get();
+        if (pending == null || pending.isDone() || pending.isCancelled()) {
+            return;
+        }
+        long timeoutMs = getMqttOperationTimeoutMillis() + Duration.ofSeconds(1).toMillis();
+        try {
+            pending.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            logger.atWarn().log("Timed out waiting for MQTT reconnect to complete");
+        } catch (ExecutionException | CancellationException e) {
+            // Reconnect failed or was cancelled — that's fine, we just needed to wait for the attempt
+            logger.atDebug().setCause(e).log("Pending MQTT reconnect completed with error");
+        }
     }
 
     @Override


### PR DESCRIPTION
After an endpoint-switch deployment is rolled back (e.g., due to a broken component), the main MQTT client may still be connected to the switched (wrong) endpoint when DeploymentService publishes the FAILED status. This is because rollbackConfig() restores the original endpoint config, which triggers an async MQTT reconnect (1s schedule delay + connect time), but the deployment future was completed immediately.

This fix adds waitForPendingReconnect() to MqttClient and calls it from DefaultActivator after rollback completes for endpoint-switch deployments. This ensures the MQTT client's reconnect attempt finishes before the deployment result is signaled, so status is published to the correct (source) endpoint.

Without this fix, the FAILED status could be published to the destination endpoint where the IoT Job does not exist, causing the source endpoint's job to remain stuck in IN_PROGRESS indefinitely.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
