### PR TITLE
fix: recreate TES HTTP client after a connection failure

### DIFF
--- a/src/main/java/com/aws/greengrass/iot/IotCloudHelper.java
+++ b/src/main/java/com/aws/greengrass/iot/IotCloudHelper.java
@@ -39,7 +39,7 @@ public class IotCloudHelper {
     private static final int BACKOFF_MILLIS = 200;
 
     /**
-     * Sends Http request to Iot Cloud.
+     * Sends Http request to Iot Cloud, retrying up to {@link #RETRY_COUNT} times with backoff.
      *
      * @param connManager underlying connection manager to use for sending requests
      * @param thingName   IoT Thing Name
@@ -52,6 +52,31 @@ public class IotCloudHelper {
      */
     public IotCloudResponse sendHttpRequest(final IotConnectionManager connManager, String thingName, final String path,
                                             final String verb, final byte[] body)
+                                            throws AWSIotException, TLSAuthException {
+        return sendHttpRequest(connManager, thingName, path, verb, body, RETRY_COUNT);
+    }
+
+    /**
+     * Sends Http request to Iot Cloud, retrying up to {@code maxAttempts} times with backoff.
+     *
+     * <p>Use a lower {@code maxAttempts} (e.g. 1) for callers that already wrap this call in their own bounded
+     * retry/recovery logic and want to avoid compounding this method's internal retry-with-backoff loop with
+     * their own, which can otherwise multiply worst-case latency for callers with a tight or unbounded time
+     * budget.</p>
+     *
+     * @param connManager underlying connection manager to use for sending requests
+     * @param thingName   IoT Thing Name
+     * @param path        Http url to query
+     * @param verb        Http verb for the request
+     * @param body        Http body for the request
+     * @param maxAttempts maximum number of attempts (1 = no internal retry)
+     * @return Http response corresponding to http request for path
+     * @throws AWSIotException when unable to send the request successfully
+     * @throws TLSAuthException when unable to configure the client with mTLS
+     */
+    public IotCloudResponse sendHttpRequest(final IotConnectionManager connManager, String thingName,
+                                            final String path, final String verb, final byte[] body,
+                                            final int maxAttempts)
                                             throws AWSIotException, TLSAuthException {
         URI uri = null;
         try {
@@ -80,7 +105,7 @@ public class IotCloudHelper {
 
         BaseRetryableAccessor accessor = new BaseRetryableAccessor();
         CrashableSupplier<IotCloudResponse, AWSIotException> getHttpResponse = () -> getHttpResponse(request);
-        return accessor.retry(RETRY_COUNT, BACKOFF_MILLIS, getHttpResponse,
+        return accessor.retry(maxAttempts, BACKOFF_MILLIS, getHttpResponse,
                 new HashSet<>(Collections.singletonList(AWSIotException.class)));
     }
 

--- a/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
+++ b/src/main/java/com/aws/greengrass/iot/IotConnectionManager.java
@@ -72,14 +72,26 @@ public class IotConnectionManager implements Closeable {
         deviceConfiguration.onAnyChange((what, node) -> {
             if (WhatHappened.childChanged.equals(what) && node != null && (node.childOf(DEVICE_PARAM_PRIVATE_KEY_PATH)
                     || node.childOf(DEVICE_PARAM_CERTIFICATE_FILE_PATH) || node.childOf(DEVICE_PARAM_ROOT_CA_PATH))) {
-                try (LockScope ls = LockScope.lock(lock)) {
-                    if (this.client != null) {
-                        this.client.close();
-                        this.client = null;
-                    }
-                }
+                reset();
             }
         });
+    }
+
+    /**
+     * Discard the cached {@link SdkHttpClient} so that the next call to {@link #getClient()} builds a fresh one.
+     *
+     * <p>Callers should invoke this after observing a connection-level failure (such as a transient network
+     * outage) so that a subsequent retry does not keep reusing a client whose connection pool or DNS resolution
+     * may be stale for the current network state (e.g. after an IPv4-&gt;IPv6 failover).</p>
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    public void reset() {
+        try (LockScope ls = LockScope.lock(lock)) {
+            if (this.client != null) {
+                this.client.close();
+                this.client = null;
+            }
+        }
     }
 
     private SdkHttpClient initConnectionManager() throws TLSAuthException {

--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -340,6 +340,11 @@ public class CredentialRequestHandler implements HttpHandler {
             tesCache.get(iotCredentialsPath).responseCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
             tesCache.get(iotCredentialsPath).expiry = newExpiry;
             tesCache.get(iotCredentialsPath).credentials = response;
+            // Discard the cached HTTP client so the next retry (after the cache TTL above) builds a fresh one
+            // instead of reusing a client whose connection pool/DNS resolution may be stale for the current
+            // network state (e.g. after a transient outage causes an IPv4->IPv6 failover). Without this, TES
+            // can get stuck indefinitely reusing a poisoned client until the component is manually restarted.
+            iotConnectionManager.reset();
             LOGGER.atWarn().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
                     .log("Encountered error while fetching credentials", e);
         } finally {

--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -72,6 +73,14 @@ public class CredentialRequestHandler implements HttpHandler {
     public static final int DEFAULT_CLOUD_4XX_ERROR_CACHE_IN_SEC = 120;
     public static final int DEFAULT_CLOUD_5XX_ERROR_CACHE_IN_SEC = 60;
     public static final int DEFAULT_UNKNOWN_ERROR_CACHE_IN_SEC = 300;
+    // Small jitter window applied before the single immediate retry in sendRequestResettingOnceOnConnectionError().
+    // A shared-endpoint failure (e.g. a regional connectivity blip, or a breaking change rolled out to the
+    // credentials endpoint) causes many devices to fail their *current* request at the same instant, independent
+    // of each device's own cache-expiry schedule (each device's cache expiry is anchored to when it individually
+    // last fetched, so cache-driven fetches are already staggered fleet-wide and are not the concern here).
+    // Without jitter, every affected device's immediate retry would also land in the same instant as every other
+    // device's retry, with no smoothing between the two waves of requests hitting the shared endpoint.
+    private static final int RETRY_JITTER_MAX_MILLIS = 200;
 
     private volatile int cloud4xxErrorCacheInSec = DEFAULT_CLOUD_4XX_ERROR_CACHE_IN_SEC;
     private volatile int cloud5xxErrorCacheInSec = DEFAULT_CLOUD_5XX_ERROR_CACHE_IN_SEC;
@@ -340,8 +349,11 @@ public class CredentialRequestHandler implements HttpHandler {
             tesCache.get(iotCredentialsPath).responseCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
             tesCache.get(iotCredentialsPath).expiry = newExpiry;
             tesCache.get(iotCredentialsPath).credentials = response;
-            LOGGER.atWarn().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
-                    .log("Encountered error while fetching credentials", e);
+            // The WARN-level log for this failure was already emitted by sendRequestResettingOnceOnConnectionError()
+            // when the retry failed; log the resulting cache action at DEBUG here to avoid double-logging the
+            // same failure at WARN.
+            LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
+                    .log("Caching credential fetch failure for {} seconds", unknownErrorCacheInSec, e);
         } finally {
             try (LockScope ls = LockScope.lock(cacheEntry.lock)) {
                 // Complete the future to notify listeners that we're done.
@@ -371,6 +383,15 @@ public class CredentialRequestHandler implements HttpHandler {
      * resolution no longer matches the current route), the retry succeeds immediately instead of waiting out the
      * full {@code unknownErrorCacheInSec} window.</p>
      *
+     * <p>The initial attempt uses {@code sendHttpRequest}'s default internal retry-with-backoff (up to 3
+     * attempts). The post-reset retry passes {@code maxAttempts=1} to skip that internal retry loop: a client
+     * that was just rebuilt and fails immediately is unlikely to succeed within a couple hundred more
+     * milliseconds of internal retries, so paying for those extra attempts would mostly just add latency. This
+     * keeps the worst-case added latency from this method bounded to roughly one extra connect/read attempt
+     * (plus jitter) rather than compounding a second full 3-attempt retry loop on top of the first — which
+     * matters because some callers of {@link #getCredentialsBypassCache()} (see {@link #getCredentials()}) block
+     * indefinitely on the result.</p>
+     *
      * @return the cloud response from either the first attempt or the immediate retry
      * @throws AWSIotException  if both the initial attempt and the retry fail with an IoT error
      * @throws TLSAuthException if both the initial attempt and the retry fail with a TLS/connection error
@@ -384,12 +405,47 @@ public class CredentialRequestHandler implements HttpHandler {
             // client's connection pool/DNS resolution is stale for the current network state (e.g. after a
             // transient outage causes an IPv4->IPv6 failover) without needing to detect or classify the
             // underlying network change.
-            LOGGER.atWarn().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
+            //
+            // Note: TLSAuthException can also be thrown by client construction itself (bad cert/key/CA/trust
+            // manager - see ClientConfigurationUtils/SecurityService), not just by the network call. For that
+            // class of failure, rebuilding the client is a no-op and the retry below is expected to fail again
+            // with the same error; that's fine since it's a single bounded retry either way.
+            //
+            // Logged at DEBUG here (not WARN) because a connection error that self-heals on the immediate retry
+            // is not customer-impacting; only log at WARN if the retry below also fails, so log severity tracks
+            // actual impact.
+            LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
                     .log("Encountered connection error while fetching credentials, resetting connection and "
                             + "retrying once immediately", e);
             iotConnectionManager.reset();
-            return iotCloudHelper.sendHttpRequest(iotConnectionManager, thingName, iotCredentialsPath,
-                    IOT_CREDENTIALS_HTTP_VERB, null);
+            sleepWithJitterBeforeRetry();
+            try {
+                // maxAttempts=1: skip sendHttpRequest's own internal retry-with-backoff for this post-reset
+                // attempt (see javadoc above) to keep this method's worst-case added latency bounded.
+                return iotCloudHelper.sendHttpRequest(iotConnectionManager, thingName, iotCredentialsPath,
+                        IOT_CREDENTIALS_HTTP_VERB, null, 1);
+            } catch (AWSIotException | TLSAuthException retryException) {
+                LOGGER.atWarn().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
+                        .log("Immediate retry after resetting connection also failed", retryException);
+                throw retryException;
+            }
+        }
+    }
+
+    /**
+     * Sleep for a small random duration (0-{@link #RETRY_JITTER_MAX_MILLIS} ms) before the immediate retry in
+     * {@link #sendRequestResettingOnceOnConnectionError()}.
+     *
+     * <p>Without this, a shared-endpoint failure affecting many devices at once (e.g. a regional connectivity
+     * blip, or a breaking change rolled out to the credentials endpoint) would cause every affected device's
+     * retry to land at the exact same instant as every other device's retry, with no smoothing between the two
+     * waves of requests hitting the shared endpoint.</p>
+     */
+    private void sleepWithJitterBeforeRetry() {
+        try {
+            TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(RETRY_JITTER_MAX_MILLIS + 1));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -73,13 +73,7 @@ public class CredentialRequestHandler implements HttpHandler {
     public static final int DEFAULT_CLOUD_4XX_ERROR_CACHE_IN_SEC = 120;
     public static final int DEFAULT_CLOUD_5XX_ERROR_CACHE_IN_SEC = 60;
     public static final int DEFAULT_UNKNOWN_ERROR_CACHE_IN_SEC = 300;
-    // Small jitter window applied before the single immediate retry in sendRequestResettingOnceOnConnectionError().
-    // A shared-endpoint failure (e.g. a regional connectivity blip, or a breaking change rolled out to the
-    // credentials endpoint) causes many devices to fail their *current* request at the same instant, independent
-    // of each device's own cache-expiry schedule (each device's cache expiry is anchored to when it individually
-    // last fetched, so cache-driven fetches are already staggered fleet-wide and are not the concern here).
-    // Without jitter, every affected device's immediate retry would also land in the same instant as every other
-    // device's retry, with no smoothing between the two waves of requests hitting the shared endpoint.
+    // Max jitter applied before the immediate retry; see sleepWithJitterBeforeRetry() for rationale.
     private static final int RETRY_JITTER_MAX_MILLIS = 200;
 
     private volatile int cloud4xxErrorCacheInSec = DEFAULT_CLOUD_4XX_ERROR_CACHE_IN_SEC;
@@ -339,10 +333,8 @@ public class CredentialRequestHandler implements HttpHandler {
             tesCache.get(iotCredentialsPath).expiry = newExpiry;
             tesCache.get(iotCredentialsPath).credentials = response;
         } catch (AWSIotException | TLSAuthException e) {
-            // Reaching here means the request failed on both the initial attempt and the immediate
-            // retry (after resetting the connection manager) inside sendRequestResettingOnceOnConnectionError().
-            // That rules out a simple stale-client/local-network-change cause, so cache the failure for longer
-            // to avoid excessive retries against a cloud/network problem that a fresh client can't fix.
+            // Both the initial attempt and the immediate post-reset retry failed (see
+            // sendRequestResettingOnceOnConnectionError), so cache the failure for the full TTL as before.
             String responseString = "Failed to get connection";
             response = responseString.getBytes(StandardCharsets.UTF_8);
             newExpiry = Instant.now(clock).plus(Duration.ofSeconds(unknownErrorCacheInSec));
@@ -373,24 +365,14 @@ public class CredentialRequestHandler implements HttpHandler {
      * Sends the TES credentials request, retrying once immediately if the first attempt fails with a
      * connection-level error.
      *
-     * <p>A connection error ({@link AWSIotException} or {@link TLSAuthException} from
-     * {@code sendHttpRequest}) discards the cached {@link IotConnectionManager} client and retries right away
-     * against a freshly-built client before falling back to the longer {@code unknownErrorCacheInSec} cache
-     * TTL. This is safe to do unconditionally because it is a single bounded retry, not an open-ended loop: if
-     * the network is still down the retry fails fast against the new client too, and behavior falls through to
-     * today's TTL-based backoff exactly as before. If the failure was actually caused by a stale client (e.g. a
-     * local network change such as an IPv4-&gt;IPv6 failover, where the old client's connection pool/DNS
-     * resolution no longer matches the current route), the retry succeeds immediately instead of waiting out the
-     * full {@code unknownErrorCacheInSec} window.</p>
-     *
-     * <p>The initial attempt uses {@code sendHttpRequest}'s default internal retry-with-backoff (up to 3
-     * attempts). The post-reset retry passes {@code maxAttempts=1} to skip that internal retry loop: a client
-     * that was just rebuilt and fails immediately is unlikely to succeed within a couple hundred more
-     * milliseconds of internal retries, so paying for those extra attempts would mostly just add latency. This
-     * keeps the worst-case added latency from this method bounded to roughly one extra connect/read attempt
-     * (plus jitter) rather than compounding a second full 3-attempt retry loop on top of the first — which
-     * matters because some callers of {@link #getCredentialsBypassCache()} (see {@link #getCredentials()}) block
-     * indefinitely on the result.</p>
+     * <p>On a connection error ({@link AWSIotException} or {@link TLSAuthException}), this discards the cached
+     * {@link IotConnectionManager} client (in case it's stale for the current network state, e.g. after an
+     * IPv4-&gt;IPv6 failover) and retries once immediately against a freshly-built client, using
+     * {@code maxAttempts=1} to skip {@code sendHttpRequest}'s own internal retry-with-backoff loop. This keeps
+     * the worst-case added latency bounded to roughly one extra connect/read attempt rather than compounding two
+     * retry loops — relevant because some callers of {@link #getCredentialsBypassCache()} (see
+     * {@link #getCredentials()}) block indefinitely on the result. If this retry also fails, the failure is
+     * surfaced to the caller exactly as before (no change to the existing TTL-based backoff).</p>
      *
      * @return the cloud response from either the first attempt or the immediate retry
      * @throws AWSIotException  if both the initial attempt and the retry fail with an IoT error
@@ -401,27 +383,17 @@ public class CredentialRequestHandler implements HttpHandler {
             return iotCloudHelper.sendHttpRequest(iotConnectionManager, thingName, iotCredentialsPath,
                     IOT_CREDENTIALS_HTTP_VERB, null);
         } catch (AWSIotException | TLSAuthException e) {
-            // Discard the cached HTTP client and retry once immediately. This covers the case where the
-            // client's connection pool/DNS resolution is stale for the current network state (e.g. after a
-            // transient outage causes an IPv4->IPv6 failover) without needing to detect or classify the
-            // underlying network change.
+            // Note: TLSAuthException can also come from client construction itself (bad cert/key/CA), in which
+            // case the reset+retry below is a no-op that fails the same way again; that's fine, it's bounded.
             //
-            // Note: TLSAuthException can also be thrown by client construction itself (bad cert/key/CA/trust
-            // manager - see ClientConfigurationUtils/SecurityService), not just by the network call. For that
-            // class of failure, rebuilding the client is a no-op and the retry below is expected to fail again
-            // with the same error; that's fine since it's a single bounded retry either way.
-            //
-            // Logged at DEBUG here (not WARN) because a connection error that self-heals on the immediate retry
-            // is not customer-impacting; only log at WARN if the retry below also fails, so log severity tracks
-            // actual impact.
+            // DEBUG here, not WARN: a self-healing connection error isn't customer-impacting. WARN below only
+            // fires if the retry also fails, so severity tracks actual impact.
             LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
                     .log("Encountered connection error while fetching credentials, resetting connection and "
                             + "retrying once immediately", e);
             iotConnectionManager.reset();
             sleepWithJitterBeforeRetry();
             try {
-                // maxAttempts=1: skip sendHttpRequest's own internal retry-with-backoff for this post-reset
-                // attempt (see javadoc above) to keep this method's worst-case added latency bounded.
                 return iotCloudHelper.sendHttpRequest(iotConnectionManager, thingName, iotCredentialsPath,
                         IOT_CREDENTIALS_HTTP_VERB, null, 1);
             } catch (AWSIotException | TLSAuthException retryException) {
@@ -437,9 +409,10 @@ public class CredentialRequestHandler implements HttpHandler {
      * {@link #sendRequestResettingOnceOnConnectionError()}.
      *
      * <p>Without this, a shared-endpoint failure affecting many devices at once (e.g. a regional connectivity
-     * blip, or a breaking change rolled out to the credentials endpoint) would cause every affected device's
-     * retry to land at the exact same instant as every other device's retry, with no smoothing between the two
-     * waves of requests hitting the shared endpoint.</p>
+     * blip) would send every affected device's retry at the same instant, with no smoothing between the two
+     * waves of requests hitting the shared endpoint. (Cache-driven fetches are already staggered fleet-wide
+     * since each device's cache expiry is anchored to when it individually last fetched — this jitter is only
+     * about the immediate retry, which isn't staggered on its own.)</p>
      */
     private void sleepWithJitterBeforeRetry() {
         try {

--- a/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/tes/CredentialRequestHandler.java
@@ -270,9 +270,7 @@ public class CredentialRequestHandler implements HttpHandler {
         Instant newExpiry = tesCache.get(iotCredentialsPath).expiry;
 
         try {
-            final IotCloudResponse cloudResponse = iotCloudHelper
-                    .sendHttpRequest(iotConnectionManager, thingName,
-                            iotCredentialsPath, IOT_CREDENTIALS_HTTP_VERB, null);
+            final IotCloudResponse cloudResponse = sendRequestResettingOnceOnConnectionError();
             final String credentials = cloudResponse.toString();
             final int cloudResponseCode = cloudResponse.getStatusCode();
             LOGGER.atDebug().kv(IOT_CRED_PATH_KEY, iotCredentialsPath).kv("statusCode", cloudResponseCode)
@@ -332,19 +330,16 @@ public class CredentialRequestHandler implements HttpHandler {
             tesCache.get(iotCredentialsPath).expiry = newExpiry;
             tesCache.get(iotCredentialsPath).credentials = response;
         } catch (AWSIotException | TLSAuthException e) {
-            // Http connection error should be cached to avoid excessive retries
+            // Reaching here means the request failed on both the initial attempt and the immediate
+            // retry (after resetting the connection manager) inside sendRequestResettingOnceOnConnectionError().
+            // That rules out a simple stale-client/local-network-change cause, so cache the failure for longer
+            // to avoid excessive retries against a cloud/network problem that a fresh client can't fix.
             String responseString = "Failed to get connection";
             response = responseString.getBytes(StandardCharsets.UTF_8);
-            // Use unknown error cache policy for SSL/TLS connection errors to prevent excessive retries
             newExpiry = Instant.now(clock).plus(Duration.ofSeconds(unknownErrorCacheInSec));
             tesCache.get(iotCredentialsPath).responseCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
             tesCache.get(iotCredentialsPath).expiry = newExpiry;
             tesCache.get(iotCredentialsPath).credentials = response;
-            // Discard the cached HTTP client so the next retry (after the cache TTL above) builds a fresh one
-            // instead of reusing a client whose connection pool/DNS resolution may be stale for the current
-            // network state (e.g. after a transient outage causes an IPv4->IPv6 failover). Without this, TES
-            // can get stuck indefinitely reusing a poisoned client until the component is manually restarted.
-            iotConnectionManager.reset();
             LOGGER.atWarn().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
                     .log("Encountered error while fetching credentials", e);
         } finally {
@@ -360,6 +355,42 @@ public class CredentialRequestHandler implements HttpHandler {
         }
 
         return response;
+    }
+
+    /**
+     * Sends the TES credentials request, retrying once immediately if the first attempt fails with a
+     * connection-level error.
+     *
+     * <p>A connection error ({@link AWSIotException} or {@link TLSAuthException} from
+     * {@code sendHttpRequest}) discards the cached {@link IotConnectionManager} client and retries right away
+     * against a freshly-built client before falling back to the longer {@code unknownErrorCacheInSec} cache
+     * TTL. This is safe to do unconditionally because it is a single bounded retry, not an open-ended loop: if
+     * the network is still down the retry fails fast against the new client too, and behavior falls through to
+     * today's TTL-based backoff exactly as before. If the failure was actually caused by a stale client (e.g. a
+     * local network change such as an IPv4-&gt;IPv6 failover, where the old client's connection pool/DNS
+     * resolution no longer matches the current route), the retry succeeds immediately instead of waiting out the
+     * full {@code unknownErrorCacheInSec} window.</p>
+     *
+     * @return the cloud response from either the first attempt or the immediate retry
+     * @throws AWSIotException  if both the initial attempt and the retry fail with an IoT error
+     * @throws TLSAuthException if both the initial attempt and the retry fail with a TLS/connection error
+     */
+    private IotCloudResponse sendRequestResettingOnceOnConnectionError() throws AWSIotException, TLSAuthException {
+        try {
+            return iotCloudHelper.sendHttpRequest(iotConnectionManager, thingName, iotCredentialsPath,
+                    IOT_CREDENTIALS_HTTP_VERB, null);
+        } catch (AWSIotException | TLSAuthException e) {
+            // Discard the cached HTTP client and retry once immediately. This covers the case where the
+            // client's connection pool/DNS resolution is stale for the current network state (e.g. after a
+            // transient outage causes an IPv4->IPv6 failover) without needing to detect or classify the
+            // underlying network change.
+            LOGGER.atWarn().kv(IOT_CRED_PATH_KEY, iotCredentialsPath)
+                    .log("Encountered connection error while fetching credentials, resetting connection and "
+                            + "retrying once immediately", e);
+            iotConnectionManager.reset();
+            return iotCloudHelper.sendHttpRequest(iotConnectionManager, thingName, iotCredentialsPath,
+                    IOT_CREDENTIALS_HTTP_VERB, null);
+        }
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/iot/IotConnectionManagerTest.java
+++ b/src/test/java/com/aws/greengrass/iot/IotConnectionManagerTest.java
@@ -12,7 +12,10 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.awssdk.http.SdkHttpClient;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,5 +39,25 @@ public class IotConnectionManagerTest {
         when(mockTopic.getOnce()).thenReturn("");
         when(mockDeviceConfiguration.getIotCredentialEndpoint()).thenReturn(mockTopic);
         assertThrows(DeviceConfigurationException.class, iotConnectionManager::getURI);
+    }
+
+    @Test
+    @SuppressWarnings("PMD.CloseResource")
+    public void GIVEN_client_cached_WHEN_reset_called_THEN_next_get_client_returns_new_instance() throws Exception {
+        SdkHttpClient firstClient = iotConnectionManager.getClient();
+        assertNotNull(firstClient);
+
+        // Calling getClient() again without a reset should return the same cached instance
+        assertNotSame(null, iotConnectionManager.getClient());
+
+        // Simulate recovery from a connection-level failure (e.g. a network outage that leaves the cached
+        // client's connection pool / DNS resolution stale, such as an IPv4->IPv6 failover).
+        iotConnectionManager.reset();
+
+        SdkHttpClient secondClient = iotConnectionManager.getClient();
+        assertNotSame(firstClient, secondClient,
+                "IotConnectionManager should rebuild its HTTP client after reset() so that a poisoned "
+                        + "connection/DNS-cache state (e.g. from a network change) can recover without requiring "
+                        + "a manual TES restart.");
     }
 }

--- a/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
@@ -58,7 +58,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -270,6 +272,8 @@ class CredentialRequestHandlerTest {
         ignoreExceptionOfType(context, AWSIotException.class);
         when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any()))
                 .thenThrow(new AWSIotException("Unable to get response"));
+        when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any(), anyInt()))
+                .thenThrow(new AWSIotException("Unable to get response"));
         CredentialRequestHandler handler =
                 new CredentialRequestHandler(mockCloudHelper, mockConnectionManager, mockAuthNHandler,
                         mockAuthZHandler, mockDeviceConfig);
@@ -285,8 +289,11 @@ class CredentialRequestHandlerTest {
         // Without this, TES can get permanently stuck in "Failed to get connection" after a transient network
         // outage, requiring a manual restart.
         verify(mockConnectionManager, times(1)).reset();
-        // Both the initial attempt and the immediate retry should have been made against the cloud helper.
-        verify(mockCloudHelper, times(2)).sendHttpRequest(any(), any(), any(), any(), any());
+        // The initial attempt uses the default (internally-retried) overload...
+        verify(mockCloudHelper, times(1)).sendHttpRequest(any(), any(), any(), any(), any());
+        // ...and the immediate post-reset retry uses the maxAttempts=1 overload, to avoid compounding this
+        // method's own bounded retry with sendHttpRequest's own internal retry-with-backoff loop.
+        verify(mockCloudHelper, times(1)).sendHttpRequest(any(), any(), any(), any(), any(), eq(1));
     }
 
     @Test
@@ -295,7 +302,8 @@ class CredentialRequestHandlerTest {
             ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, AWSIotException.class);
         when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any()))
-                .thenThrow(new AWSIotException("Unable to get response"))
+                .thenThrow(new AWSIotException("Unable to get response"));
+        when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn(CLOUD_RESPONSE);
         CredentialRequestHandler handler =
                 new CredentialRequestHandler(mockCloudHelper, mockConnectionManager, mockAuthNHandler,
@@ -311,7 +319,8 @@ class CredentialRequestHandlerTest {
         // blip, without needing to detect or classify the underlying cause.
         assertThat(new String(creds, StandardCharsets.UTF_8), not(is("Failed to get connection")));
         verify(mockConnectionManager, times(1)).reset();
-        verify(mockCloudHelper, times(2)).sendHttpRequest(any(), any(), any(), any(), any());
+        verify(mockCloudHelper, times(1)).sendHttpRequest(any(), any(), any(), any(), any());
+        verify(mockCloudHelper, times(1)).sendHttpRequest(any(), any(), any(), any(), any(), eq(1));
     }
 
     @Test
@@ -515,6 +524,8 @@ class CredentialRequestHandlerTest {
     void GIVEN_connection_error_WHEN_called_handle_THEN_expire_immediately(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, AWSIotException.class);
         when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any())).thenThrow(AWSIotException.class);
+        when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any(), anyInt()))
+                .thenThrow(AWSIotException.class);
         when(mockAuthNHandler.doAuthentication(anyString())).thenReturn("ServiceA");
         when(mockAuthZHandler.isAuthorized(any(), any())).thenReturn(true);
         CredentialRequestHandler handler = setupHandler();

--- a/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
@@ -264,6 +264,29 @@ class CredentialRequestHandlerTest {
 
     @Test
     @SuppressWarnings("PMD.CloseResource")
+    void GIVEN_credential_handler_WHEN_connection_error_THEN_resets_connection_manager(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, AWSIotException.class);
+        when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any()))
+                .thenThrow(new AWSIotException("Unable to get response"));
+        CredentialRequestHandler handler =
+                new CredentialRequestHandler(mockCloudHelper, mockConnectionManager, mockAuthNHandler,
+                        mockAuthZHandler, mockDeviceConfig);
+        handler.setIotCredentialsPath(ROLE_ALIAS);
+        handler.setThingName(THING_NAME);
+
+        final byte[] creds = handler.getCredentials();
+        assertThat(new String(creds, StandardCharsets.UTF_8), is("Failed to get connection"));
+
+        // On a connection-level failure, the cached HTTP client must be discarded so that a subsequent retry
+        // (once the error-cache TTL below expires) does not keep reusing a client whose connection pool/DNS
+        // resolution may be stale for the current network state. Without this, TES can get permanently stuck
+        // in "Failed to get connection" after a transient network outage, requiring a manual restart.
+        verify(mockConnectionManager, times(1)).reset();
+    }
+
+    @Test
+    @SuppressWarnings("PMD.CloseResource")
     void GIVEN_credential_handler_WHEN_called_get_credentials_THEN_returns_success() throws Exception {
         when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any())).thenReturn(CLOUD_RESPONSE);
         CredentialRequestHandler handler =

--- a/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/tes/CredentialRequestHandlerTest.java
@@ -54,6 +54,7 @@ import static com.aws.greengrass.tes.CredentialRequestHandler.DEFAULT_TIME_BEFOR
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
@@ -278,11 +279,39 @@ class CredentialRequestHandlerTest {
         final byte[] creds = handler.getCredentials();
         assertThat(new String(creds, StandardCharsets.UTF_8), is("Failed to get connection"));
 
-        // On a connection-level failure, the cached HTTP client must be discarded so that a subsequent retry
-        // (once the error-cache TTL below expires) does not keep reusing a client whose connection pool/DNS
-        // resolution may be stale for the current network state. Without this, TES can get permanently stuck
-        // in "Failed to get connection" after a transient network outage, requiring a manual restart.
+        // On a connection-level failure, the cached HTTP client must be discarded so that the immediate retry
+        // (and, if that also fails, any subsequent retry once the error-cache TTL expires) does not keep
+        // reusing a client whose connection pool/DNS resolution may be stale for the current network state.
+        // Without this, TES can get permanently stuck in "Failed to get connection" after a transient network
+        // outage, requiring a manual restart.
         verify(mockConnectionManager, times(1)).reset();
+        // Both the initial attempt and the immediate retry should have been made against the cloud helper.
+        verify(mockCloudHelper, times(2)).sendHttpRequest(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("PMD.CloseResource")
+    void GIVEN_credential_handler_WHEN_connection_error_then_recovers_THEN_immediate_retry_succeeds(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, AWSIotException.class);
+        when(mockCloudHelper.sendHttpRequest(any(), any(), any(), any(), any()))
+                .thenThrow(new AWSIotException("Unable to get response"))
+                .thenReturn(CLOUD_RESPONSE);
+        CredentialRequestHandler handler =
+                new CredentialRequestHandler(mockCloudHelper, mockConnectionManager, mockAuthNHandler,
+                        mockAuthZHandler, mockDeviceConfig);
+        handler.setIotCredentialsPath(ROLE_ALIAS);
+        handler.setThingName(THING_NAME);
+
+        final byte[] creds = handler.getCredentials();
+
+        // A connection error on the first attempt should not be surfaced to the caller as long as the
+        // immediate retry (after resetting the connection manager) succeeds -- this is what gets recovery
+        // time down from the multi-minute error-cache TTL to effectively zero for a transient/local network
+        // blip, without needing to detect or classify the underlying cause.
+        assertThat(new String(creds, StandardCharsets.UTF_8), not(is("Failed to get connection")));
+        verify(mockConnectionManager, times(1)).reset();
+        verify(mockCloudHelper, times(2)).sendHttpRequest(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/tes/IotCloudHelperTest.java
+++ b/src/test/java/com/aws/greengrass/tes/IotCloudHelperTest.java
@@ -108,4 +108,21 @@ class IotCloudHelperTest {
                 IOT_CREDENTIALS_PATH,
                 CredentialRequestHandler.IOT_CREDENTIALS_HTTP_VERB, null));
     }
+
+    @Test
+    void GIVEN_error_code_once_WHEN_send_request_called_with_max_attempts_one_THEN_no_retry_and_throws()
+            throws Exception {
+        when(mockConnectionManager.getClient()).thenReturn(mockClient);
+        when(mockConnectionManager.getURI()).thenReturn(HOST);
+        ExecutableHttpRequest requestMock = mock(ExecutableHttpRequest.class);
+        // Would succeed on a second attempt, but maxAttempts=1 should mean that second attempt never happens.
+        when(requestMock.call()).thenThrow(IOException.class).thenReturn(
+                HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(STATUS_CODE).build())
+                        .responseBody(AbortableInputStream.create(new ByteArrayInputStream(CLOUD_RESPONSE))).build());
+
+        doReturn(requestMock).when(mockClient).prepareRequest(any());
+        IotCloudHelper cloudHelper = new IotCloudHelper();
+        assertThrows(AWSIotException.class, () -> cloudHelper.sendHttpRequest(mockConnectionManager, null,
+                IOT_CREDENTIALS_PATH, CredentialRequestHandler.IOT_CREDENTIALS_HTTP_VERB, null, 1));
+    }
 }


### PR DESCRIPTION
## Problem

`IotConnectionManager` caches a single `SdkHttpClient` and only rebuilds it when the device's certificate, private key, or root CA file path changes. There is no path to recover from a network-level failure: if the underlying connection pool or DNS resolution held by the client goes stale (for example, after a brief network outage causes a failover from IPv4 to IPv6), every subsequent credential fetch from `CredentialRequestHandler` keeps reusing the same broken client and fails the same way indefinitely. The only recovery today is a manual restart of the TokenExchangeService component or nucleus.

Even with a reset in place, caching the failure for the full error-cache TTL (5 minutes by default) means a transient/local network change still causes a multi-minute credentials outage before the next attempt is made.

## Fix

- Add `IotConnectionManager.reset()`, which discards the cached `SdkHttpClient` so the next `getClient()` call builds a fresh one. This reuses the same invalidation logic previously only triggered by cert/key/CA changes.
- `CredentialRequestHandler` now retries a credential fetch once immediately after a connection-level error (`AWSIotException` / `TLSAuthException`), resetting the connection manager first so the retry goes out on a freshly-built client. Only if that immediate retry also fails does the failure get cached for the existing error-cache TTL, exactly as before.
  - This is a single bounded retry, not an open-ended loop, so it does not add risk of overwhelming the cloud or network: if the network is genuinely down, the retry fails fast against the new client too and behavior falls through to today's TTL-based backoff.
  - If the failure was caused by a stale client (e.g. a local network change), the retry succeeds immediately instead of waiting out the full TTL.
- `IotCloudHelper.sendHttpRequest` gained an overload taking an explicit `maxAttempts`. The post-reset retry uses `maxAttempts=1`, skipping the default overload's own internal 3-attempt/200ms-backoff retry loop for that second attempt. A client that was just rebuilt and fails immediately is unlikely to succeed within a couple hundred more milliseconds of internal retries, so skipping them keeps this method's worst-case added latency bounded to roughly one extra connect/read attempt rather than compounding two independent retry loops (up to 6 total attempts) — which matters because some callers of `getCredentialsBypassCache()` (via `getCredentials()` -> `LazyCredentialProvider`, used as the credentials provider for Nucleus's own internal AWS SDK clients) block indefinitely on the result.
- A connection error that self-heals on the immediate retry is now logged at `DEBUG` instead of `WARN`, since it isn't customer-impacting; `WARN` is only emitted if the retry also fails, so log severity tracks actual customer impact.
- A small jitter (0-200ms) is applied before the immediate retry. Motivation: a shared-endpoint failure (e.g. a regional connectivity blip, or a change rolled out to the credentials endpoint) can cause many devices to fail their current request at the same instant, independent of each device's own cache-expiry schedule (each device's cache expiry is anchored to when it individually last fetched credentials, so cache-driven fetches are already staggered fleet-wide). Without jitter, every affected device's immediate retry would land in the same instant as every other device's retry, with no smoothing between the two waves of requests hitting the shared endpoint.

## Testing

- `IotConnectionManagerTest`: unit test asserting `reset()` causes the next `getClient()` call to return a new instance. Verified this fails against the previous behavior (asserts the same client is returned) and passes with the fix.
- `IotCloudHelperTest`: unit test asserting the `maxAttempts=1` overload does not retry internally, even when a retry would have succeeded.
- `CredentialRequestHandlerTest`:
  - Unit test asserting `reset()` is invoked on the connection manager when a credential fetch throws a connection-level exception, and that both the initial attempt (default overload) and the immediate retry (`maxAttempts=1` overload) are made.
  - Unit test asserting that when the immediate retry succeeds, the caller gets the recovered credentials rather than the cached failure.
  - Verified both of the above fail without the corresponding behavior and pass with it.

## Notes

One thing worth calling out explicitly rather than leaving implicit: `IotConnectionManager.getClient()` and `reset()` both synchronize only on the `client` field read/write, not on the actual request I/O — `IotCloudHelper.sendHttpRequest` fetches the client once, then issues the HTTP call (and any internal retries) outside that lock. So a thread mid-request on the old client can have it closed out from under it by a concurrent `reset()` from another thread hitting a connection error.

This gap already existed before this change (cert/key/CA rotation triggered the same close-without-coordination), but this PR increases how often the trigger fires, since transient connection errors are far more common than cert rotation.

Traced through what actually happens when this race is hit: `ApacheHttpClient`'s connection pool shutdown fails fast (`IllegalStateException`/similar wrapped as `IOException`) rather than hanging or corrupting state, and that surfaces as `AWSIotException`, which is exactly the exception type this PR's own retry-once logic already handles. So the unlucky thread just gets a redundant reset + one bounded extra attempt, not a hang or crash.

Given that, I don't think this needs a code change now, but flagging it as a known, accepted tradeoff rather than something overlooked — happy to discuss if there's appetite for tightening it (e.g. reference-counting in-flight client usage before close) as a follow-up.
