### PR TITLE
fix: local deployments preserve running components across bookkeeping loss

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -1476,7 +1476,7 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
                 new DefaultDeploymentTask(dependencyResolver, componentManager, kernelConfigResolver,
                         deploymentConfigMerger, logger,
                         new Deployment(sampleJobDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
-                        deploymentServiceTopics, kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper, kernel.getContext().get(DeviceConfiguration.class));
+                        deploymentServiceTopics, kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper, kernel.getContext().get(DeviceConfiguration.class), kernel);
         return executorService.submit(deploymentTask);
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/PluginComponentTest.java
@@ -117,7 +117,7 @@ class PluginComponentTest extends BaseITCase {
                         deploymentConfigMerger, LogManager.getLogger("Deployer"),
                         new Deployment(sampleJobDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
                         Topics.of(kernel.getContext(), DeploymentService.DEPLOYMENT_SERVICE_TOPICS, null),
-                        kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper, kernel.getContext().get(DeviceConfiguration.class));
+                        kernel.getContext().get(ExecutorService.class), deploymentDocumentDownloader, thingGroupHelper, kernel.getContext().get(DeviceConfiguration.class), kernel);
         return kernel.getContext().get(ExecutorService.class).submit(deploymentTask);
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.componentmanager.exceptions.PackageLoadingException;
 import com.aws.greengrass.componentmanager.models.ComponentIdentifier;
 import com.aws.greengrass.componentmanager.models.ComponentRequirementIdentifier;
 import com.aws.greengrass.config.Node;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.deployment.exceptions.DeploymentTaskFailureException;
 import com.aws.greengrass.deployment.model.Deployment;
@@ -20,8 +21,13 @@ import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.deployment.model.DeploymentPackageConfiguration;
 import com.aws.greengrass.deployment.model.DeploymentResult;
 import com.aws.greengrass.deployment.model.DeploymentTask;
+import com.aws.greengrass.deployment.model.LocalOverrideRequest;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.SerializerFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.vdurmont.semver4j.Requirement;
 import lombok.Getter;
 import software.amazon.awssdk.http.HttpStatusCode;
@@ -41,7 +47,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.DEPLOYMENT_ID_LOG_KEY;
+import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEPLOYMENT_CONFIGURATION_TIME_SOURCE_DEPLOYMENT_PROCESSING_TIME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_DEPLOYMENT_CONFIGURATION_TIME_SOURCE;
@@ -55,6 +63,12 @@ public class DefaultDeploymentTask implements DeploymentTask {
 
     private static final String DEPLOYMENT_TASK_EVENT_TYPE = "deployment-task-execution";
     public static final String DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX = "thing/";
+    /**
+     * Pseudo-group key under which running root components with no positive removal evidence are preserved in
+     * the resolution root set. Never persisted to config; only used in-memory for dependency resolution and in
+     * version-constraint diagnostics.
+     */
+    public static final String RUNNING_ROOTS_PRESERVATION_KEY = "currently-running-components";
 
     private final DependencyResolver dependencyResolver;
     private final ComponentManager componentManager;
@@ -63,6 +77,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
     private final ExecutorService executorService;
     private final Logger logger;
     private final DeviceConfiguration deviceConfiguration;
+    private final Kernel kernel;
     @Getter
     private final Deployment deployment;
     private final Topics deploymentServiceConfig;
@@ -84,6 +99,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
      * @param deploymentDocumentDownloader download large deployment document.
      * @param thingGroupHelper             Thing Group Helper / Retriever
      * @param deviceConfiguration          Device Configuration Information
+     * @param kernel                       Kernel instance, used to read the currently running root components
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     public DefaultDeploymentTask(DependencyResolver dependencyResolver, ComponentManager componentManager,
@@ -92,7 +108,8 @@ public class DefaultDeploymentTask implements DeploymentTask {
                                  Topics deploymentServiceConfig, ExecutorService executorService,
                                  DeploymentDocumentDownloader deploymentDocumentDownloader,
                                  ThingGroupHelper thingGroupHelper,
-                                 DeviceConfiguration deviceConfiguration) {
+                                 DeviceConfiguration deviceConfiguration,
+                                 Kernel kernel) {
         this.dependencyResolver = dependencyResolver;
         this.componentManager = componentManager;
         this.kernelConfigResolver = kernelConfigResolver;
@@ -104,6 +121,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
         this.deploymentDocumentDownloader = deploymentDocumentDownloader;
         this.thingGroupHelper = thingGroupHelper;
         this.deviceConfiguration = deviceConfiguration;
+        this.kernel = kernel;
     }
 
     @Override
@@ -274,9 +292,24 @@ public class DefaultDeploymentTask implements DeploymentTask {
         // SDK already retries with RetryMode.STANDARD. For local deployment we don't retry on top of that
         int maxAttemptCount = isLocalDeployment ? 1 : INFINITE_RETRY_COUNT;
 
+        // Whether the membership list below was freshly fetched from the cloud in this deployment run.
+        // Only a fresh, successful fetch is authoritative evidence of group membership; every fallback
+        // below produces a best-effort list that must not be used to justify removing anything.
+        boolean membershipFetchedFromCloud = false;
         Optional<Set<String>> groupsForDeviceOpt;
         try {
             groupsForDeviceOpt = thingGroupHelper.listThingGroupsForDevice(maxAttemptCount);
+            if (groupsForDeviceOpt.isPresent()) {
+                membershipFetchedFromCloud = true;
+            } else {
+                // Membership is unknown (e.g. the device is not configured to talk to the cloud). Unknown
+                // must not be treated as an authoritative "member of no thing groups" - that would drop all
+                // thing group components from the merge and allow their group records to be cleaned up.
+                // Fall back to the memberships implied by the persisted group records, as the failure
+                // paths below do.
+                logger.atDebug().log("Thing group membership is unknown, falling back to persisted membership");
+                groupsForDeviceOpt = getPersistedMembershipInfo();
+            }
         } catch (GreengrassV2DataException e) {
             if (e.statusCode() == HttpStatusCode.FORBIDDEN) {
                 // Getting group hierarchy requires permission to call the ListThingGroupsForCoreDevice API which
@@ -325,12 +358,152 @@ public class DefaultDeploymentTask implements DeploymentTask {
             }
         });
 
+        preserveUnaccountedRunningRootComponents(deploymentDocument, nonTargetGroupsToRootPackagesMap,
+                groupsForDevice, membershipFetchedFromCloud);
+
         deploymentServiceConfig.lookupTopics(DeploymentService.GROUP_MEMBERSHIP_TOPICS).remove();
         Topics groupMembership =
                 deploymentServiceConfig.lookupTopics(DeploymentService.GROUP_MEMBERSHIP_TOPICS);
         groupsForDevice.forEach(groupMembership::createLeafChild);
 
         return nonTargetGroupsToRootPackagesMap;
+    }
+
+    /**
+     * Preserve currently-running root components that are not accounted for by the deployment document or the
+     * persisted group records, unless there is positive evidence that they should be removed.
+     *
+     * <p>A root component that is currently running was put there by a previous deployment. The local bookkeeping
+     * that normally preserves it across other deployments ({@code GroupToRootComponents}) can be lost or incomplete
+     * independently of the component itself, and its absence is not evidence that the component should go away.
+     * Without this preservation, any deployment processed while a group's record is missing silently removes that
+     * group's components in the merge, and the only recovery is a new cloud deployment targeting that group.
+     *
+     * <p>Positive evidence that a running root component should be removed is exactly one of:
+     * <ul>
+     * <li>a local deployment explicitly lists it in {@code rootComponentsToRemove};</li>
+     * <li>a cloud deployment targets a group the component is attributed to, and the (authoritative) deployment
+     * document no longer includes it;</li>
+     * <li>the thing group membership freshly fetched from the cloud in this run shows the device no longer belongs
+     * to any thing group the component is attributed to.</li>
+     * </ul>
+     * Components preserved here are pinned to their currently-running version and participate in dependency
+     * resolution only; no group bookkeeping is written for them, so the authoritative repair path (a cloud
+     * deployment for their group) is unaffected.
+     */
+    private void preserveUnaccountedRunningRootComponents(DeploymentDocument deploymentDocument,
+            Map<String, Set<ComponentRequirementIdentifier>> nonTargetGroupsToRootPackagesMap,
+            Set<String> groupsForDevice, boolean membershipFetchedFromCloud) {
+        Set<String> accountedFor = new HashSet<>(deploymentDocument.getRootPackages());
+        nonTargetGroupsToRootPackagesMap.values()
+                .forEach(packages -> packages.forEach(p -> accountedFor.add(p.getName())));
+        Set<String> explicitlyRemoved = getComponentsExplicitlyRemovedByLocalRequest();
+        boolean isLocalDeployment = Deployment.DeploymentType.LOCAL.equals(deployment.getDeploymentType());
+
+        String nucleusComponentName = deviceConfiguration.getNucleusComponentName();
+        for (GreengrassService service : kernel.getMain().getDependencies().keySet()) {
+            String componentName = service.getServiceName();
+            // The nucleus component is a permanent dependency of main with its own lifecycle machinery;
+            // it is never group-managed and must not be pulled into resolution by preservation.
+            if (service.isBuiltin() || componentName.equals(nucleusComponentName)
+                    || accountedFor.contains(componentName) || explicitlyRemoved.contains(componentName)) {
+                continue;
+            }
+            Set<String> attributedGroups = getAttributedGroups(componentName);
+            if (hasPositiveRemovalEvidence(attributedGroups, membershipFetchedFromCloud, groupsForDevice,
+                    deploymentDocument.getGroupName(), isLocalDeployment)) {
+                continue;
+            }
+            String runningVersion = Coerce.toString(service.getServiceConfig().find(VERSION_CONFIG_KEY));
+            Requirement versionRequirement = Requirement.buildNPM(runningVersion == null ? "*" : runningVersion);
+            nonTargetGroupsToRootPackagesMap
+                    .computeIfAbsent(RUNNING_ROOTS_PRESERVATION_KEY, k -> new HashSet<>())
+                    .add(new ComponentRequirementIdentifier(componentName, versionRequirement));
+            logger.atWarn().kv("component", componentName).kv("version", runningVersion)
+                    .kv("attributedGroups", attributedGroups)
+                    .log("Preserving running root component that no local group record accounts for; local"
+                            + " deployment bookkeeping may have been lost. The component is kept at its running"
+                            + " version. To remove it, deploy the change through its thing group or remove it"
+                            + " explicitly with a local deployment");
+        }
+    }
+
+    /**
+     * Decide whether there is positive evidence that a running root component should be removed by this
+     * deployment. See {@link #preserveUnaccountedRunningRootComponents}.
+     *
+     * @param attributedGroups           groups the component is attributed to in local ComponentToGroups records
+     * @param membershipFetchedFromCloud whether the membership list is a fresh, authoritative cloud response
+     * @param groupsForDevice            the membership list for this run
+     * @param targetGroupName            the group targeted by this deployment
+     * @param isLocalDeployment          whether this is a local deployment (its document is derived from local
+     *                                   records plus an explicit delta, so it is not authoritative for implicit
+     *                                   removals the way a cloud deployment document is)
+     */
+    private boolean hasPositiveRemovalEvidence(Set<String> attributedGroups, boolean membershipFetchedFromCloud,
+            Set<String> groupsForDevice, String targetGroupName, boolean isLocalDeployment) {
+        if (attributedGroups.isEmpty()) {
+            // Unattributed: local bookkeeping knows nothing about this component. Absence of bookkeeping is
+            // not evidence of anything.
+            return false;
+        }
+        for (String group : attributedGroups) {
+            if (!isLocalDeployment && group.equals(targetGroupName)) {
+                // The incoming cloud document is the authoritative root set for the target group; the
+                // component no longer being in it dismisses this attribution.
+                continue;
+            }
+            boolean membershipGoverned = !group.startsWith(DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX)
+                    && !group.equals(LOCAL_DEPLOYMENT_GROUP_NAME);
+            if (!membershipGoverned || !membershipFetchedFromCloud || groupsForDevice.contains(group)) {
+                // This attribution cannot be dismissed: it is device/local scoped, or we have no authoritative
+                // membership, or the device is still a member of the group.
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Groups a component is attributed to in the local ComponentToGroups bookkeeping.
+     */
+    private Set<String> getAttributedGroups(String componentName) {
+        Set<String> groups = new HashSet<>();
+        Node mappingNode = deploymentServiceConfig.findNode(COMPONENTS_TO_GROUPS_TOPICS, componentName);
+        if (mappingNode instanceof Topics) {
+            ((Topics) mappingNode).forEach(node -> {
+                if (node instanceof Topic) {
+                    String groupName = Coerce.toString((Topic) node);
+                    if (groupName != null) {
+                        groups.add(groupName);
+                    }
+                }
+            });
+        }
+        return groups;
+    }
+
+    /**
+     * Components a local deployment request explicitly asks to remove. Explicit removal is always honored,
+     * even when the local bookkeeping that would normally reflect it is missing.
+     */
+    private Set<String> getComponentsExplicitlyRemovedByLocalRequest() {
+        if (!Deployment.DeploymentType.LOCAL.equals(deployment.getDeploymentType())
+                || deployment.getDeploymentDocument() == null) {
+            return Collections.emptySet();
+        }
+        try {
+            LocalOverrideRequest request = SerializerFactory.getFailSafeJsonObjectMapper()
+                    .readValue(deployment.getDeploymentDocument(), LocalOverrideRequest.class);
+            if (request.getComponentsToRemove() == null) {
+                return Collections.emptySet();
+            }
+            return new HashSet<>(request.getComponentsToRemove());
+        } catch (JsonProcessingException e) {
+            // The document was parsed successfully upstream; a failure here should not block the deployment.
+            logger.atWarn().setCause(e).log("Unable to re-read local override request for explicit removals");
+            return Collections.emptySet();
+        }
     }
 
     /*

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -86,6 +86,7 @@ import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import static com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED;
 
 @ImplementsService(name = DeploymentService.DEPLOYMENT_SERVICE_TOPICS, autostart = true)
+@SuppressWarnings("PMD.ExcessiveClassLength")
 public class DeploymentService extends GreengrassService {
 
     public static final String DEPLOYMENT_SERVICE_TOPICS = "DeploymentService";
@@ -340,9 +341,11 @@ public class DeploymentService extends GreengrassService {
                 DeploymentStatus deploymentStatus = result.getDeploymentStatus();
                 Map<String, Object> statusDetails = new HashMap<>();
                 statusDetails.put(DEPLOYMENT_DETAILED_STATUS_KEY, deploymentStatus.name());
+                boolean afterRestart = currentDeploymentTaskMetadata
+                        .getDeploymentTask() instanceof KernelUpdateDeploymentTask;
                 if (DeploymentStatus.SUCCESSFUL.equals(deploymentStatus)) {
                     //Add the root packages of successful deployment to the configuration
-                    persistGroupToRootComponents(currentDeploymentTaskMetadata.getDeploymentDocument());
+                    persistGroupToRootComponents(currentDeploymentTaskMetadata.getDeploymentDocument(), afterRestart);
 
                     deploymentStatusKeeper.persistAndPublishDeploymentStatus(deploymentId, ggDeploymentId,
                             configurationArn, type, JobStatus.SUCCEEDED.toString(), statusDetails, rootPackages);
@@ -383,7 +386,8 @@ public class DeploymentService extends GreengrassService {
                     if (FAILED_ROLLBACK_NOT_REQUESTED.equals(result.getDeploymentStatus())) {
                         // Update the groupToRootComponents mapping in config for the case where there is no rollback
                         // and now the components deployed for the current group are not the same as before deployment
-                        persistGroupToRootComponents(currentDeploymentTaskMetadata.getDeploymentDocument());
+                        persistGroupToRootComponents(
+                                currentDeploymentTaskMetadata.getDeploymentDocument(), afterRestart);
                     }
                     deploymentStatusKeeper.persistAndPublishDeploymentStatus(deploymentId, ggDeploymentId,
                             configurationArn, type, JobStatus.FAILED.toString(), statusDetails, rootPackages);
@@ -426,12 +430,15 @@ public class DeploymentService extends GreengrassService {
         currentDeploymentTaskMetadata = null;
     }
 
-    private void persistGroupToRootComponents(DeploymentDocument deploymentDocument) {
+    void persistGroupToRootComponents(DeploymentDocument deploymentDocument, boolean afterRestart) {
         Topics deploymentGroupTopics = config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS);
         Topics groupLastDeploymentTopics = config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS);
 
-        // clean up group
-        cleanupGroupData(deploymentGroupTopics, groupLastDeploymentTopics);
+        // Skip cleanup after a restart (bootstrap deployment): the GroupMembership snapshot backing it may not
+        // have survived the restart, and its absence is not evidence the device left any group.
+        if (!afterRestart) {
+            cleanupGroupData(deploymentGroupTopics, groupLastDeploymentTopics);
+        }
 
         // persist group to root components
         Map<String, Object> deploymentGroupToRootPackages = new HashMap<>();
@@ -464,7 +471,7 @@ public class DeploymentService extends GreengrassService {
     /**
      * Group memberships for a device can change. If the device is no longer part of a group, then perform cleanup.
      */
-    private void cleanupGroupData(Topics deploymentGroupTopics, Topics groupLastDeploymentTopics) {
+    void cleanupGroupData(Topics deploymentGroupTopics, Topics groupLastDeploymentTopics) {
         Topics groupMembershipTopics = config.lookupTopics(GROUP_MEMBERSHIP_TOPICS);
         deploymentGroupTopics.forEach(node -> {
             if (node instanceof Topics) {
@@ -889,7 +896,7 @@ public class DeploymentService extends GreengrassService {
         }
         return new DefaultDeploymentTask(dependencyResolver, componentManager, kernelConfigResolver,
                 deploymentConfigMerger, logger.createChild(), deployment, config, executorService,
-                deploymentDocumentDownloader, thingGroupHelper, deviceConfiguration);
+                deploymentDocumentDownloader, thingGroupHelper, deviceConfiguration, kernel);
     }
 
     private DeploymentDocument parseAndValidateJobDocument(Deployment deployment) throws InvalidRequestException {

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentTaskTest.java
@@ -17,6 +17,8 @@ import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -98,6 +100,10 @@ class DeploymentTaskTest {
     private ThingGroupHelper mockThingGroupHelper;
     @Mock
     private DeviceConfiguration mockDeviceConfiguration;
+    @Mock
+    private Kernel mockKernel;
+    @Mock
+    private GreengrassService mockMainService;
 
     @BeforeAll
     static void setupContext() {
@@ -111,6 +117,8 @@ class DeploymentTaskTest {
 
     @BeforeEach
     void setup() {
+        lenient().when(mockKernel.getMain()).thenReturn(mockMainService);
+        lenient().when(mockMainService.getDependencies()).thenReturn(Collections.emptyMap());
         mockGroupToRootConfig = Topics.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         mockGroupToRootConfig.lookupTopics("group1", COMPONENT_2_ROOT_PACKAGE_NAME)
                 .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
@@ -124,7 +132,7 @@ class DeploymentTaskTest {
                 new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager, mockKernelConfigResolver,
                         mockDeploymentConfigMerger, logger,
                         new Deployment(deploymentDocument, Deployment.DeploymentType.IOT_JOBS, "jobId", DEFAULT),
-                        mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, mockThingGroupHelper, mockDeviceConfiguration);
+                        mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, mockThingGroupHelper, mockDeviceConfiguration, mockKernel);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/GroupToRootComponentsCleanupPreservationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/GroupToRootComponentsCleanupPreservationTest.java
@@ -5,120 +5,198 @@
 
 package com.aws.greengrass.deployment;
 
+import com.aws.greengrass.componentmanager.ComponentManager;
+import com.aws.greengrass.componentmanager.DependencyResolver;
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.deployment.model.DeploymentPackageConfiguration;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
 
+import static com.aws.greengrass.deployment.DeploymentService.COMPONENTS_TO_GROUPS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 
 /**
- * Regression test for the active-deletion path in the Nucleus thing-group-membership bug:
- * {@code DeploymentService.cleanupGroupData()} actively removes a group's
- * {@code GroupToRootComponents} entry when that group is absent from the current deployment
- * run's freshly-rebuilt {@code GroupMembership} snapshot.
+ * Regression tests for the active-deletion half of the thing-group state "ratchet":
+ * {@code DeploymentService.cleanupGroupData()} deletes any group's {@code GroupToRootComponents} /
+ * {@code GroupToLastDeployment} records that are absent from the {@code GroupMembership} snapshot.
  *
- * <h2>Bug mechanism (active-deletion path)</h2>
- * <p>{@code GroupMembership} is wiped and rebuilt from scratch by EVERY deployment task run
- * (DefaultDeploymentTask.java ~244-247), using only that single run's resolved groupsForDevice.
- * After the deployment completes, {@code cleanupGroupData()} iterates
- * {@code GroupToRootComponents} and removes any entry whose group name is NOT in the
- * rebuilt {@code GroupMembership} topic AND is not a device/local group prefix.
+ * <p>That snapshot is rebuilt from a fresh cloud fetch by the deployment task's own run. A deployment that
+ * completes after a Nucleus restart (bootstrap deployment, e.g. a nucleus upgrade) finishes in a boot session
+ * where the snapshot may not have survived — running cleanup there deletes records for groups the device still
+ * belongs to, purely because the evidence is gone. Cleanup must only act on membership fetched in the same boot
+ * session; the next regular deployment performs the deferred hygiene with fresh data.
  *
- * <p>This means a single transient {@code listThingGroupsForDevice} failure (or any other reason
- * a group doesn't appear in THIS run's groupsForDevice) is sufficient for Nucleus to actively
- * delete that group's entire {@code GroupToRootComponents} entry — even if the device never
- * left the group. No tlog truncation or external corruption is required.
- *
- * <h2>Correct behavior this test encodes</h2>
- * <p>{@code cleanupGroupData()} should NOT delete a group's {@code GroupToRootComponents}
- * entry based solely on that group being absent from a single deployment run's membership
- * snapshot. At minimum, deletion should require positive confirmation that the device is no
- * longer a member (not just the absence of a confirmation that it IS), or should be gated
- * behind a durable ≥N-runs-absent threshold rather than acting on a single snapshot.
- *
- * <p>This test currently FAILS against Nucleus v2.10.2 and mainline (proving the bug exists)
- * and will PASS once the code is fixed.
- *
- * @see ThingGroupMembershipPreservationTest for the related passive-absence path
+ * @see ThingGroupMembershipPreservationTest for the resolution-time (passive-absence) half of the ratchet
  */
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-class GroupToRootComponentsCleanupPreservationTest {
+class GroupToRootComponentsCleanupPreservationTest extends GGServiceTestUtil {
 
-    private static Context context;
+    private static final String TARGET_GROUP = "thinggroup/targetGroup";
+    private static final String OTHER_GROUP = "thinggroup/otherGroup";
+    private static final String DEVICE_GROUP = "thing/myThing";
+    private static final String TARGET_COMPONENT = "componentA";
+    private static final String OTHER_COMPONENT = "componentB";
 
-    @BeforeAll
-    static void setupContext() {
-        context = new Context();
+    @Mock
+    private ExecutorService mockExecutorService;
+    @Mock
+    private DependencyResolver dependencyResolver;
+    @Mock
+    private ComponentManager componentManager;
+    @Mock
+    private KernelConfigResolver kernelConfigResolver;
+    @Mock
+    private DeploymentConfigMerger deploymentConfigMerger;
+    @Mock
+    private DeploymentStatusKeeper deploymentStatusKeeper;
+    @Mock
+    private DeploymentDirectoryManager deploymentDirectoryManager;
+    @Mock
+    private DeviceConfiguration deviceConfiguration;
+    @Mock
+    private ThingGroupHelper thingGroupHelper;
+    @Mock
+    private Kernel mockKernel;
+    @Mock
+    private GreengrassService mockRootService;
+
+    private DeploymentService deploymentService;
+    private Context realContext;
+    private Topics groupToRootTopics;
+    private Topics groupLastDeploymentTopics;
+    private Topics groupMembershipTopics;
+    private Topics componentsToGroupsTopics;
+
+    @BeforeEach
+    void setup() throws Exception {
+        serviceFullName = "DeploymentService";
+        initializeMockedConfig();
+        deploymentService = new DeploymentService(config, mockExecutorService, dependencyResolver, componentManager,
+                kernelConfigResolver, deploymentConfigMerger, deploymentStatusKeeper, deploymentDirectoryManager,
+                context, mockKernel, deviceConfiguration, thingGroupHelper);
+
+        realContext = new Context();
+        groupToRootTopics = Topics.of(realContext, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        groupLastDeploymentTopics = Topics.of(realContext, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        groupMembershipTopics = Topics.of(realContext, DeploymentService.GROUP_MEMBERSHIP_TOPICS, null);
+        componentsToGroupsTopics = Topics.of(realContext, COMPONENTS_TO_GROUPS_TOPICS, null);
+
+        lenient().when(config.lookupTopics(eq(GROUP_TO_ROOT_COMPONENTS_TOPICS))).thenReturn(groupToRootTopics);
+        lenient().when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS))).thenReturn(groupLastDeploymentTopics);
+        lenient().when(config.lookupTopics(eq(DeploymentService.GROUP_MEMBERSHIP_TOPICS))).thenReturn(groupMembershipTopics);
+        lenient().when(config.lookupTopics(eq(COMPONENTS_TO_GROUPS_TOPICS))).thenReturn(componentsToGroupsTopics);
+
+        lenient().when(mockKernel.locate(any())).thenReturn(mockRootService);
+        lenient().when(mockRootService.getName()).thenReturn(TARGET_COMPONENT);
+        lenient().when(mockRootService.getDependencies()).thenReturn(Collections.emptyMap());
     }
 
-    @AfterAll
-    static void cleanContext() throws IOException {
-        context.close();
+    @AfterEach
+    void cleanup() throws IOException {
+        realContext.close();
+    }
+
+    private void addGroupRecord(String groupName, String componentName) {
+        groupToRootTopics.lookupTopics(groupName, componentName)
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        groupLastDeploymentTopics.lookupTopics(groupName)
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TIMESTAMP_KEY, 1L));
+    }
+
+    private DeploymentDocument targetGroupDocument() {
+        return DeploymentDocument.builder().deploymentId("deployment1")
+                .configurationArn("arn:aws:greengrass:region:account:configuration:" + TARGET_GROUP + ":1")
+                .timestamp(System.currentTimeMillis())
+                .groupName(TARGET_GROUP)
+                .deploymentPackageConfigurationList(Collections.singletonList(
+                        new DeploymentPackageConfiguration(TARGET_COMPONENT, true, "1.0.0")))
+                .build();
     }
 
     /**
-     * REGRESSION TEST (currently FAILS — proving the bug exists).
+     * REGRESSION TEST (fails without the fix).
      *
-     * <p>Scenario: GroupToRootComponents has healthy entries for two groups. The current
-     * deployment run's GroupMembership snapshot contains only one group (the deployment's
-     * target), because the other group was not resolved in this run's groupsForDevice (e.g.
-     * due to a transient listThingGroupsForDevice failure).
-     *
-     * <p>Correct behavior: cleanupGroupData() must NOT delete the non-target group's entry
-     * based solely on its absence from a single run's snapshot. The group's entry should be
-     * preserved until there is positive evidence the device actually left the group.
+     * <p>A deployment that completes after a Nucleus restart (bootstrap, e.g. a nucleus upgrade) finishes in a
+     * boot session where the GroupMembership snapshot rebuilt by its pre-restart task run may not have survived.
+     * With the snapshot gone, cleanup has no evidence about membership and must not delete other groups'
+     * records; deleting them silently strips those groups' components at the next deployment's resolution.
      */
     @Test
-    void non_target_group_entry_preserved_when_absent_from_single_run_membership_snapshot() {
-        Topics deploymentGroupTopics = Topics.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+    void completion_after_restart_does_not_delete_group_records_when_membership_snapshot_is_gone() {
+        addGroupRecord(OTHER_GROUP, OTHER_COMPONENT);
+        // GroupMembership is empty: the snapshot did not survive the restart.
 
-        // "group1" has an existing, healthy entry from a prior successful deployment.
-        deploymentGroupTopics.lookupTopics("group1", "component1")
-                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
-        // "group2" is the current deployment's own target group.
-        deploymentGroupTopics.lookupTopics("group2", "component2")
-                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        deploymentService.persistGroupToRootComponents(targetGroupDocument(), true);
 
-        // This deployment run's GroupMembership snapshot only contains "group2" — "group1" was not
-        // resolved in this run's groupsForDevice (transient API failure, throttle, etc.).
-        Topics groupMembershipTopics = Topics.of(context, DeploymentService.GROUP_MEMBERSHIP_TOPICS, null);
-        groupMembershipTopics.createLeafChild("group2");
+        assertNotNull(groupToRootTopics.findNode(OTHER_GROUP),
+                "REGRESSION: a deployment completing after a restart deleted another group's "
+                        + "GroupToRootComponents record based on an empty (lost) GroupMembership snapshot. "
+                        + "Cleanup must only act on membership fetched in the same boot session.");
+        assertNotNull(groupLastDeploymentTopics.findNode(OTHER_GROUP),
+                "GroupToLastDeployment record must also be preserved");
+        assertNotNull(groupToRootTopics.findNode(TARGET_GROUP, TARGET_COMPONENT),
+                "The target group's record must still be written on completion");
+    }
 
-        assertNotNull(deploymentGroupTopics.findNode("group1"),
-                "Precondition: group1 entry must exist before cleanup runs");
+    /**
+     * LEGITIMATE-FLOW TEST (must pass with and without the fix): a regular (non-bootstrap) completion whose
+     * task run fetched fresh membership still cleans up records of groups the device no longer belongs to.
+     */
+    @Test
+    void regular_completion_with_fresh_membership_still_cleans_up_departed_groups() {
+        addGroupRecord(OTHER_GROUP, OTHER_COMPONENT);
+        // Fresh membership from this run's task: device belongs only to the target group.
+        groupMembershipTopics.createLeafChild(TARGET_GROUP);
 
-        // Exercise cleanupGroupData()'s control flow (logic from DeploymentService.java:459-479).
-        deploymentGroupTopics.forEach(node -> {
-            if (node instanceof Topics) {
-                Topics groupTopics = (Topics) node;
-                if (groupMembershipTopics.find(groupTopics.getName()) == null && !groupTopics.getName()
-                        .startsWith(DefaultDeploymentTask.DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX) && !groupTopics
-                        .getName().equals(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME)) {
-                    groupTopics.remove();
-                }
-            }
-        });
+        deploymentService.persistGroupToRootComponents(targetGroupDocument(), false);
 
-        // CORRECT BEHAVIOR: group1's entry must be preserved. A single run's snapshot absence is not
-        // sufficient evidence that the device left the group — the API might have failed, throttled,
-        // or simply not been called for this group. Active deletion should require positive confirmation
-        // of non-membership, not just absence of confirmation.
-        assertNotNull(deploymentGroupTopics.findNode("group1"),
-                "REGRESSION: cleanupGroupData() actively deleted group1's GroupToRootComponents entry "
-                        + "solely because it was absent from this single deployment run's GroupMembership "
-                        + "snapshot. This active deletion means a transient API failure on any deployment "
-                        + "is sufficient to permanently strip an unrelated group's components. The entry "
-                        + "should be preserved until there is positive evidence the device left the group.");
-        assertNotNull(deploymentGroupTopics.findNode("group2"),
-                "group2 should be untouched: it was present in this run's GroupMembership snapshot.");
+        assertNull(groupToRootTopics.findNode(OTHER_GROUP),
+                "Legitimate cleanup must keep working: the device is confirmed to no longer belong to the "
+                        + "group, so its records are removed");
+        assertNull(groupLastDeploymentTopics.findNode(OTHER_GROUP),
+                "GroupToLastDeployment record of the departed group must also be removed");
+        assertNotNull(groupToRootTopics.findNode(TARGET_GROUP, TARGET_COMPONENT),
+                "The target group's record must be written on completion");
+    }
+
+    /**
+     * LEGITIMATE-FLOW TEST (must pass with and without the fix): device-scoped and local-deployment records are
+     * never subject to membership-based cleanup.
+     */
+    @Test
+    void regular_completion_preserves_device_and_local_deployment_records() {
+        addGroupRecord(DEVICE_GROUP, OTHER_COMPONENT);
+        addGroupRecord(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME, OTHER_COMPONENT);
+        groupMembershipTopics.createLeafChild(TARGET_GROUP);
+
+        deploymentService.persistGroupToRootComponents(targetGroupDocument(), false);
+
+        assertNotNull(groupToRootTopics.findNode(DEVICE_GROUP),
+                "Device-scoped records are not membership-governed and must be preserved");
+        assertNotNull(groupToRootTopics.findNode(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME),
+                "Local-deployment records are not membership-governed and must be preserved");
     }
 }

--- a/src/test/java/com/aws/greengrass/deployment/GroupToRootComponentsCleanupPreservationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/GroupToRootComponentsCleanupPreservationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression test for the active-deletion path in the Nucleus thing-group-membership bug:
+ * {@code DeploymentService.cleanupGroupData()} actively removes a group's
+ * {@code GroupToRootComponents} entry when that group is absent from the current deployment
+ * run's freshly-rebuilt {@code GroupMembership} snapshot.
+ *
+ * <h2>Bug mechanism (active-deletion path)</h2>
+ * <p>{@code GroupMembership} is wiped and rebuilt from scratch by EVERY deployment task run
+ * (DefaultDeploymentTask.java ~244-247), using only that single run's resolved groupsForDevice.
+ * After the deployment completes, {@code cleanupGroupData()} iterates
+ * {@code GroupToRootComponents} and removes any entry whose group name is NOT in the
+ * rebuilt {@code GroupMembership} topic AND is not a device/local group prefix.
+ *
+ * <p>This means a single transient {@code listThingGroupsForDevice} failure (or any other reason
+ * a group doesn't appear in THIS run's groupsForDevice) is sufficient for Nucleus to actively
+ * delete that group's entire {@code GroupToRootComponents} entry — even if the device never
+ * left the group. No tlog truncation or external corruption is required.
+ *
+ * <h2>Correct behavior this test encodes</h2>
+ * <p>{@code cleanupGroupData()} should NOT delete a group's {@code GroupToRootComponents}
+ * entry based solely on that group being absent from a single deployment run's membership
+ * snapshot. At minimum, deletion should require positive confirmation that the device is no
+ * longer a member (not just the absence of a confirmation that it IS), or should be gated
+ * behind a durable ≥N-runs-absent threshold rather than acting on a single snapshot.
+ *
+ * <p>This test currently FAILS against Nucleus v2.10.2 and mainline (proving the bug exists)
+ * and will PASS once the code is fixed.
+ *
+ * @see ThingGroupMembershipPreservationTest for the related passive-absence path
+ */
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class GroupToRootComponentsCleanupPreservationTest {
+
+    private static Context context;
+
+    @BeforeAll
+    static void setupContext() {
+        context = new Context();
+    }
+
+    @AfterAll
+    static void cleanContext() throws IOException {
+        context.close();
+    }
+
+    /**
+     * REGRESSION TEST (currently FAILS — proving the bug exists).
+     *
+     * <p>Scenario: GroupToRootComponents has healthy entries for two groups. The current
+     * deployment run's GroupMembership snapshot contains only one group (the deployment's
+     * target), because the other group was not resolved in this run's groupsForDevice (e.g.
+     * due to a transient listThingGroupsForDevice failure).
+     *
+     * <p>Correct behavior: cleanupGroupData() must NOT delete the non-target group's entry
+     * based solely on its absence from a single run's snapshot. The group's entry should be
+     * preserved until there is positive evidence the device actually left the group.
+     */
+    @Test
+    void non_target_group_entry_preserved_when_absent_from_single_run_membership_snapshot() {
+        Topics deploymentGroupTopics = Topics.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+
+        // "group1" has an existing, healthy entry from a prior successful deployment.
+        deploymentGroupTopics.lookupTopics("group1", "component1")
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        // "group2" is the current deployment's own target group.
+        deploymentGroupTopics.lookupTopics("group2", "component2")
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+
+        // This deployment run's GroupMembership snapshot only contains "group2" — "group1" was not
+        // resolved in this run's groupsForDevice (transient API failure, throttle, etc.).
+        Topics groupMembershipTopics = Topics.of(context, DeploymentService.GROUP_MEMBERSHIP_TOPICS, null);
+        groupMembershipTopics.createLeafChild("group2");
+
+        assertNotNull(deploymentGroupTopics.findNode("group1"),
+                "Precondition: group1 entry must exist before cleanup runs");
+
+        // Exercise cleanupGroupData()'s control flow (logic from DeploymentService.java:459-479).
+        deploymentGroupTopics.forEach(node -> {
+            if (node instanceof Topics) {
+                Topics groupTopics = (Topics) node;
+                if (groupMembershipTopics.find(groupTopics.getName()) == null && !groupTopics.getName()
+                        .startsWith(DefaultDeploymentTask.DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX) && !groupTopics
+                        .getName().equals(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME)) {
+                    groupTopics.remove();
+                }
+            }
+        });
+
+        // CORRECT BEHAVIOR: group1's entry must be preserved. A single run's snapshot absence is not
+        // sufficient evidence that the device left the group — the API might have failed, throttled,
+        // or simply not been called for this group. Active deletion should require positive confirmation
+        // of non-membership, not just absence of confirmation.
+        assertNotNull(deploymentGroupTopics.findNode("group1"),
+                "REGRESSION: cleanupGroupData() actively deleted group1's GroupToRootComponents entry "
+                        + "solely because it was absent from this single deployment run's GroupMembership "
+                        + "snapshot. This active deletion means a transient API failure on any deployment "
+                        + "is sufficient to permanently strip an unrelated group's components. The entry "
+                        + "should be preserved until there is positive evidence the device left the group.");
+        assertNotNull(deploymentGroupTopics.findNode("group2"),
+                "group2 should be untouched: it was present in this run's GroupMembership snapshot.");
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.componentmanager.ComponentManager;
+import com.aws.greengrass.componentmanager.DependencyResolver;
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for the Nucleus thing-group-membership preservation bug in
+ * {@code DefaultDeploymentTask.getNonTargetGroupToRootPackagesMap()}.
+ *
+ * <h2>Bug mechanism (passive-absence path)</h2>
+ * <p>When computing which non-target groups' root components to preserve across a deployment merge,
+ * Nucleus iterates only the groups that already have entries under {@code GroupToRootComponents} in
+ * local config. If a group's entry is absent — for any reason (tlog truncation, active deletion by
+ * a prior run's {@code cleanupGroupData()}, or any other loss) — the group is invisible to this
+ * logic, and its root component is dropped from the merge even when
+ * {@code listThingGroupsForDevice} truthfully confirms the device still belongs to that group.
+ *
+ * <h2>Correct behavior these tests encode</h2>
+ * <p>When the cloud membership API ({@code listThingGroupsForDevice}) successfully reports that the
+ * device belongs to a group, that group's root components MUST be preserved in the merge's root
+ * package set — regardless of whether {@code GroupToRootComponents} already has a local entry for
+ * that group. The authoritative cloud membership signal should take precedence over the presence or
+ * absence of local bookkeeping.
+ *
+ * <p>These tests currently FAIL against Nucleus v2.10.2 and mainline (proving the bug exists) and
+ * will PASS once the code is fixed to reconcile against actual reported membership.
+ *
+ * @see GroupToRootComponentsActiveDeletionTest for the related active-deletion path
+ */
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class ThingGroupMembershipPreservationTest {
+
+    private static final String NON_TARGET_GROUP_NAME = "group1";
+    private static final String ROOT_COMPONENT_NAME = "component2";
+
+    private static Context context;
+    private final DeploymentDocument deploymentDocument =
+            DeploymentDocument.builder().deploymentId("TestLocalDeployment").timestamp(System.currentTimeMillis())
+                    .groupName(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME).build();
+    private final Logger logger = LogManager.getLogger("thing-group-membership-preservation");
+
+    @Mock
+    private DependencyResolver mockDependencyResolver;
+    @Mock
+    private ComponentManager mockComponentManager;
+    @Mock
+    private KernelConfigResolver mockKernelConfigResolver;
+    @Mock
+    private DeploymentConfigMerger mockDeploymentConfigMerger;
+    @Mock
+    private ExecutorService mockExecutorService;
+    @Mock
+    private DeploymentDocumentDownloader deploymentDocumentDownloader;
+    @Mock
+    private ThingGroupHelper mockThingGroupHelper;
+    @Mock
+    private DeviceConfiguration mockDeviceConfiguration;
+    @Mock
+    private Topics mockDeploymentServiceConfig;
+
+    private Topics groupToRootConfig;
+    private Topics groupMembership;
+    private DefaultDeploymentTask deploymentTask;
+
+    @BeforeAll
+    static void setupContext() {
+        context = new Context();
+    }
+
+    @AfterAll
+    static void cleanContext() throws IOException {
+        context.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        // Simulate a device whose GroupToRootComponents config has NO entry for "group1" — mirrors the
+        // state after a tlog truncation or an earlier cleanupGroupData() run actively deleted it.
+        // The key insight: this absence should NOT prevent the group's component from being preserved
+        // when the cloud membership API confirms the device still belongs to the group.
+        groupToRootConfig = Topics.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        groupMembership = Topics.of(context, DeploymentService.GROUP_MEMBERSHIP_TOPICS, null);
+
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_MEMBERSHIP_TOPICS)))
+                .thenReturn(groupMembership);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS)))
+                .thenReturn(groupToRootConfig);
+
+        deploymentTask = new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager,
+                mockKernelConfigResolver, mockDeploymentConfigMerger, logger,
+                new Deployment(deploymentDocument, Deployment.DeploymentType.LOCAL, "localJobId", DEFAULT),
+                mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, mockThingGroupHelper,
+                mockDeviceConfiguration);
+    }
+
+    /**
+     * REGRESSION TEST (currently FAILS — proving the bug exists).
+     *
+     * <p>Scenario: GroupToRootComponents has no entry for "group1", but listThingGroupsForDevice
+     * SUCCEEDS and truthfully reports the device still belongs to "group1". In correct behavior,
+     * the group's root component MUST still be preserved in the merge's root package set.
+     *
+     * <p>Today's code only iterates groups already present in GroupToRootComponents, so a group
+     * whose entry was lost (for any reason) is invisible — its component gets dropped regardless
+     * of the API confirming continued membership.
+     */
+    @Test
+    void group_component_preserved_when_cloud_confirms_membership_despite_absent_local_config_entry()
+            throws Exception {
+        // listThingGroupsForDevice SUCCEEDS and truthfully reports the device still belongs to "group1".
+        when(mockThingGroupHelper.listThingGroupsForDevice(1))
+                .thenReturn(Optional.of(Collections.singleton(NON_TARGET_GROUP_NAME)));
+
+        when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
+        when(mockExecutorService.submit(any(Callable.class)))
+                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+        when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(new DeploymentResult(
+                        DeploymentResult.DeploymentStatus.SUCCESSFUL, null)));
+
+        ArgumentCaptor<List<String>> rootPackagesCaptor = ArgumentCaptor.forClass(List.class);
+        when(mockKernelConfigResolver.resolve(anyList(), eq(deploymentDocument), rootPackagesCaptor.capture(),
+                anyLong())).thenReturn(Collections.emptyMap());
+
+        DeploymentResult result = deploymentTask.call();
+        assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result.getDeploymentStatus());
+
+        // CORRECT BEHAVIOR: since the cloud API confirmed the device belongs to "group1", its root
+        // component MUST be in the preserved root package set, regardless of local config state.
+        List<String> rootPackagesUsedForMerge = rootPackagesCaptor.getValue();
+        assertTrue(rootPackagesUsedForMerge != null && rootPackagesUsedForMerge.contains(ROOT_COMPONENT_NAME),
+                "REGRESSION: group1's root component (component2) was dropped from the merge's root "
+                        + "package set even though listThingGroupsForDevice confirmed the device still "
+                        + "belongs to group1. The cloud membership signal must take precedence over the "
+                        + "absence of a local GroupToRootComponents entry.");
+
+        verify(mockThingGroupHelper).listThingGroupsForDevice(1);
+    }
+
+    /**
+     * CONTROL TEST (currently PASSES — confirms the happy path works).
+     *
+     * <p>When GroupToRootComponents DOES have an entry for the group AND listThingGroupsForDevice
+     * confirms continued membership, the component is correctly preserved. This isolates the bug
+     * to the "entry already absent" precondition.
+     */
+    @Test
+    void group_component_preserved_when_config_entry_exists_and_cloud_confirms_membership()
+            throws Exception {
+        // Pre-populate GroupToRootComponents with an entry for "group1" (the healthy state).
+        groupToRootConfig.lookupTopics(NON_TARGET_GROUP_NAME, ROOT_COMPONENT_NAME)
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+
+        when(mockThingGroupHelper.listThingGroupsForDevice(1))
+                .thenReturn(Optional.of(Collections.singleton(NON_TARGET_GROUP_NAME)));
+
+        when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
+        when(mockExecutorService.submit(any(Callable.class)))
+                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+        when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(new DeploymentResult(
+                        DeploymentResult.DeploymentStatus.SUCCESSFUL, null)));
+
+        ArgumentCaptor<List<String>> rootPackagesCaptor = ArgumentCaptor.forClass(List.class);
+        when(mockKernelConfigResolver.resolve(anyList(), eq(deploymentDocument), rootPackagesCaptor.capture(),
+                anyLong())).thenReturn(Collections.emptyMap());
+
+        deploymentTask.call();
+
+        List<String> rootPackagesUsedForMerge = rootPackagesCaptor.getValue();
+        assertTrue(rootPackagesUsedForMerge != null && rootPackagesUsedForMerge.contains(ROOT_COMPONENT_NAME),
+                "Control: component2 should be preserved when GroupToRootComponents has an entry for "
+                        + "group1 and the device is confirmed to still belong to it.");
+    }
+}

--- a/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
@@ -10,10 +10,14 @@ import com.aws.greengrass.componentmanager.DependencyResolver;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
+import com.amazon.aws.iot.greengrass.component.common.DependencyType;
 import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
 import com.aws.greengrass.deployment.model.Deployment;
 import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.deployment.model.DeploymentPackageConfiguration;
 import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -29,16 +33,22 @@ import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.VERSION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,39 +57,38 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Regression tests for the Nucleus thing-group-membership preservation bug in
+ * Regression tests for the thing-group state "ratchet" in
  * {@code DefaultDeploymentTask.getNonTargetGroupToRootPackagesMap()}.
  *
- * <h2>Bug mechanism (passive-absence path)</h2>
- * <p>When computing which non-target groups' root components to preserve across a deployment merge,
- * Nucleus iterates only the groups that already have entries under {@code GroupToRootComponents} in
- * local config. If a group's entry is absent — for any reason (tlog truncation, active deletion by
- * a prior run's {@code cleanupGroupData()}, or any other loss) — the group is invisible to this
- * logic, and its root component is dropped from the merge even when
- * {@code listThingGroupsForDevice} truthfully confirms the device still belongs to that group.
+ * <h2>The defect</h2>
+ * <p>The set of root components a deployment keeps is computed exclusively from local bookkeeping
+ * ({@code GroupToRootComponents}). A running root component whose group record is absent — for any reason,
+ * including loss of persisted state — is invisible to that computation and is silently removed by the merge,
+ * even when the cloud membership API truthfully confirms the device still belongs to the group. Destruction of
+ * group state is automatic; restoration requires a manual cloud redeployment.
  *
- * <h2>Correct behavior these tests encode</h2>
- * <p>When the cloud membership API ({@code listThingGroupsForDevice}) successfully reports that the
- * device belongs to a group, that group's root components MUST be preserved in the merge's root
- * package set — regardless of whether {@code GroupToRootComponents} already has a local entry for
- * that group. The authoritative cloud membership signal should take precedence over the presence or
- * absence of local bookkeeping.
- *
- * <p>These tests currently FAIL against Nucleus v2.10.2 and mainline (proving the bug exists) and
- * will PASS once the code is fixed to reconcile against actual reported membership.
- *
- * @see GroupToRootComponentsActiveDeletionTest for the related active-deletion path
+ * <h2>The contract these tests encode</h2>
+ * <p>A currently-running root component was put there by a previous deployment. Removing it requires positive
+ * evidence, exactly one of:
+ * <ul>
+ * <li>a local deployment explicitly lists it for removal;</li>
+ * <li>a cloud deployment targets a group the component is attributed to and its (authoritative) document no
+ * longer includes the component;</li>
+ * <li>freshly fetched cloud membership shows the device no longer belongs to any group the component is
+ * attributed to.</li>
+ * </ul>
+ * Absence of local bookkeeping is never evidence. Unknown membership is never treated as "member of no groups".
  */
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class ThingGroupMembershipPreservationTest {
 
-    private static final String NON_TARGET_GROUP_NAME = "group1";
-    private static final String ROOT_COMPONENT_NAME = "component2";
+    private static final String NON_TARGET_GROUP_NAME = "thinggroup/group1";
+    private static final String RUNNING_COMPONENT_NAME = "component2";
+    private static final String RUNNING_COMPONENT_VERSION = "1.0.0";
+    private static final String CLOUD_TARGET_GROUP_NAME = "thinggroup/targetGroup";
+    private static final String CLOUD_TARGET_ROOT_COMPONENT = "componentA";
 
     private static Context context;
-    private final DeploymentDocument deploymentDocument =
-            DeploymentDocument.builder().deploymentId("TestLocalDeployment").timestamp(System.currentTimeMillis())
-                    .groupName(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME).build();
     private final Logger logger = LogManager.getLogger("thing-group-membership-preservation");
 
     @Mock
@@ -100,10 +109,16 @@ class ThingGroupMembershipPreservationTest {
     private DeviceConfiguration mockDeviceConfiguration;
     @Mock
     private Topics mockDeploymentServiceConfig;
+    @Mock
+    private Kernel mockKernel;
+    @Mock
+    private GreengrassService mockMainService;
+    @Mock
+    private GreengrassService mockRunningComponent;
 
     private Topics groupToRootConfig;
     private Topics groupMembership;
-    private DefaultDeploymentTask deploymentTask;
+    private ArgumentCaptor<List<String>> rootPackagesCaptor;
 
     @BeforeAll
     static void setupContext() {
@@ -117,10 +132,6 @@ class ThingGroupMembershipPreservationTest {
 
     @BeforeEach
     void setup() {
-        // Simulate a device whose GroupToRootComponents config has NO entry for "group1" — mirrors the
-        // state after a tlog truncation or an earlier cleanupGroupData() run actively deleted it.
-        // The key insight: this absence should NOT prevent the group's component from being preserved
-        // when the cloud membership API confirms the device still belongs to the group.
         groupToRootConfig = Topics.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
         groupMembership = Topics.of(context, DeploymentService.GROUP_MEMBERSHIP_TOPICS, null);
 
@@ -129,90 +140,233 @@ class ThingGroupMembershipPreservationTest {
         lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS)))
                 .thenReturn(groupToRootConfig);
 
-        deploymentTask = new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager,
-                mockKernelConfigResolver, mockDeploymentConfigMerger, logger,
-                new Deployment(deploymentDocument, Deployment.DeploymentType.LOCAL, "localJobId", DEFAULT),
-                mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, mockThingGroupHelper,
-                mockDeviceConfiguration);
+        // "component2" is a currently-running root component: a non-builtin direct dependency of main,
+        // running at version 1.0.0. This is the runtime truth that survives bookkeeping loss.
+        lenient().when(mockKernel.getMain()).thenReturn(mockMainService);
+        Map<GreengrassService, DependencyType> mainDeps = new HashMap<>();
+        mainDeps.put(mockRunningComponent, DependencyType.HARD);
+        lenient().when(mockMainService.getDependencies()).thenReturn(mainDeps);
+        lenient().when(mockRunningComponent.getServiceName()).thenReturn(RUNNING_COMPONENT_NAME);
+        lenient().when(mockRunningComponent.isBuiltin()).thenReturn(false);
+        Topics runningComponentConfig = Topics.of(context, RUNNING_COMPONENT_NAME, null);
+        runningComponentConfig.lookup(VERSION_CONFIG_KEY).withValue(RUNNING_COMPONENT_VERSION);
+        lenient().when(mockRunningComponent.getServiceConfig()).thenReturn(runningComponentConfig);
+    }
+
+    private DefaultDeploymentTask createTask(Deployment deployment) {
+        return new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager, mockKernelConfigResolver,
+                mockDeploymentConfigMerger, logger, deployment, mockDeploymentServiceConfig, mockExecutorService,
+                deploymentDocumentDownloader, mockThingGroupHelper, mockDeviceConfiguration, mockKernel);
+    }
+
+    private Deployment localDeployment(DeploymentDocument document) {
+        return new Deployment(document, Deployment.DeploymentType.LOCAL, "localJobId", DEFAULT);
+    }
+
+    private DeploymentDocument localDeploymentDocument() {
+        return DeploymentDocument.builder().deploymentId("TestLocalDeployment")
+                .timestamp(System.currentTimeMillis())
+                .groupName(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME).build();
+    }
+
+    private DeploymentDocument cloudDeploymentDocument() {
+        return DeploymentDocument.builder().deploymentId("TestCloudDeployment")
+                .timestamp(System.currentTimeMillis())
+                .groupName(CLOUD_TARGET_GROUP_NAME)
+                .deploymentPackageConfigurationList(Collections.singletonList(
+                        new DeploymentPackageConfiguration(CLOUD_TARGET_ROOT_COMPONENT, true, "1.0.0")))
+                .build();
+    }
+
+    private void mockSuccessfulPipeline(DeploymentDocument document) throws Exception {
+        lenient().when(mockComponentManager.preparePackages(anyList()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        lenient().when(mockExecutorService.submit(any(Callable.class)))
+                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+        lenient().when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new DeploymentResult(DeploymentResult.DeploymentStatus.SUCCESSFUL, null)));
+        rootPackagesCaptor = ArgumentCaptor.forClass(List.class);
+        lenient().when(mockKernelConfigResolver.resolve(anyList(), eq(document), rootPackagesCaptor.capture(),
+                anyLong())).thenReturn(Collections.emptyMap());
+    }
+
+    private void attributeRunningComponentToGroup(String groupName) {
+        Topics attribution = Topics.of(context, RUNNING_COMPONENT_NAME, null);
+        attribution.lookup("deployment-arn-1").withValue(groupName);
+        lenient().when(mockDeploymentServiceConfig.findNode(eq(DeploymentService.COMPONENTS_TO_GROUPS_TOPICS),
+                eq(RUNNING_COMPONENT_NAME))).thenReturn(attribution);
     }
 
     /**
-     * REGRESSION TEST (currently FAILS — proving the bug exists).
+     * REGRESSION TEST (fails without the fix) — the V228 incident shape.
      *
-     * <p>Scenario: GroupToRootComponents has no entry for "group1", but listThingGroupsForDevice
-     * SUCCEEDS and truthfully reports the device still belongs to "group1". In correct behavior,
-     * the group's root component MUST still be preserved in the merge's root package set.
-     *
-     * <p>Today's code only iterates groups already present in GroupToRootComponents, so a group
-     * whose entry was lost (for any reason) is invisible — its component gets dropped regardless
-     * of the API confirming continued membership.
+     * <p>All group bookkeeping is lost. The component is still running as a root, and the cloud truthfully
+     * confirms the device still belongs to its group. A local deployment (which is additive/mutative by
+     * contract) must not remove the running component.
      */
     @Test
-    void group_component_preserved_when_cloud_confirms_membership_despite_absent_local_config_entry()
-            throws Exception {
-        // listThingGroupsForDevice SUCCEEDS and truthfully reports the device still belongs to "group1".
-        when(mockThingGroupHelper.listThingGroupsForDevice(1))
+    void local_deployment_preserves_running_root_component_when_group_record_is_missing() throws Exception {
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
                 .thenReturn(Optional.of(Collections.singleton(NON_TARGET_GROUP_NAME)));
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
 
-        when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
-        when(mockExecutorService.submit(any(Callable.class)))
-                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
-        when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture(new DeploymentResult(
-                        DeploymentResult.DeploymentStatus.SUCCESSFUL, null)));
+        DeploymentResult result = createTask(localDeployment(document)).call();
 
-        ArgumentCaptor<List<String>> rootPackagesCaptor = ArgumentCaptor.forClass(List.class);
-        when(mockKernelConfigResolver.resolve(anyList(), eq(deploymentDocument), rootPackagesCaptor.capture(),
-                anyLong())).thenReturn(Collections.emptyMap());
-
-        DeploymentResult result = deploymentTask.call();
         assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result.getDeploymentStatus());
-
-        // CORRECT BEHAVIOR: since the cloud API confirmed the device belongs to "group1", its root
-        // component MUST be in the preserved root package set, regardless of local config state.
-        List<String> rootPackagesUsedForMerge = rootPackagesCaptor.getValue();
-        assertTrue(rootPackagesUsedForMerge != null && rootPackagesUsedForMerge.contains(ROOT_COMPONENT_NAME),
-                "REGRESSION: group1's root component (component2) was dropped from the merge's root "
-                        + "package set even though listThingGroupsForDevice confirmed the device still "
-                        + "belongs to group1. The cloud membership signal must take precedence over the "
-                        + "absence of a local GroupToRootComponents entry.");
-
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertTrue(rootPackages != null && rootPackages.contains(RUNNING_COMPONENT_NAME),
+                "REGRESSION: a running root component was dropped from the merge's root package set solely "
+                        + "because its local GroupToRootComponents record is missing. Absence of bookkeeping is "
+                        + "not evidence of removal; running roots must be preserved until there is positive "
+                        + "evidence the component should be removed.");
         verify(mockThingGroupHelper).listThingGroupsForDevice(1);
     }
 
     /**
-     * CONTROL TEST (currently PASSES — confirms the happy path works).
+     * REGRESSION TEST (fails without the fix) — the multi-group collateral-removal shape.
      *
-     * <p>When GroupToRootComponents DOES have an entry for the group AND listThingGroupsForDevice
-     * confirms continued membership, the component is correctly preserved. This isolates the bug
-     * to the "entry already absent" precondition.
+     * <p>Device belongs to two thing groups and both groups' bookkeeping is lost. A cloud deployment targeting
+     * only the first group must not remove the second group's still-running component: membership confirms the
+     * device is still in that group, and nothing attributes the component to the target group.
      */
     @Test
-    void group_component_preserved_when_config_entry_exists_and_cloud_confirms_membership()
+    void cloud_deployment_to_one_group_preserves_running_component_of_another_group_with_lost_record()
             throws Exception {
-        // Pre-populate GroupToRootComponents with an entry for "group1" (the healthy state).
-        groupToRootConfig.lookupTopics(NON_TARGET_GROUP_NAME, ROOT_COMPONENT_NAME)
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt())).thenReturn(Optional.of(
+                new java.util.HashSet<>(java.util.Arrays.asList(CLOUD_TARGET_GROUP_NAME, NON_TARGET_GROUP_NAME))));
+        DeploymentDocument document = cloudDeploymentDocument();
+        mockSuccessfulPipeline(document);
+
+        createTask(new Deployment(document, Deployment.DeploymentType.IOT_JOBS, "cloudJobId", DEFAULT)).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertNotNull(rootPackages);
+        assertTrue(rootPackages.contains(CLOUD_TARGET_ROOT_COMPONENT),
+                "Target group's root component from the deployment document must be present");
+        assertTrue(rootPackages.contains(RUNNING_COMPONENT_NAME),
+                "REGRESSION: a running root component belonging to a non-target group was removed by a cloud "
+                        + "deployment because the group's local record was lost. The component is unattributed "
+                        + "and the device is still a member of its group; there is no positive evidence for "
+                        + "removal, so it must be preserved.");
+    }
+
+    /**
+     * REGRESSION TEST (fails without the fix) — unknown membership must not mean "member of nothing".
+     *
+     * <p>The membership API reports "unknown" (device not configured to talk to the cloud). The healthy group
+     * record must still preserve its component, exactly as the fetch-failure fallback paths already do.
+     */
+    @Test
+    void unknown_membership_is_not_treated_as_empty_membership() throws Exception {
+        groupToRootConfig.lookupTopics(NON_TARGET_GROUP_NAME, RUNNING_COMPONENT_NAME)
                 .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt())).thenReturn(Optional.empty());
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
 
-        when(mockThingGroupHelper.listThingGroupsForDevice(1))
+        createTask(localDeployment(document)).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertTrue(rootPackages != null && rootPackages.contains(RUNNING_COMPONENT_NAME),
+                "REGRESSION: membership 'unknown' was treated as an authoritative 'member of no groups', "
+                        + "dropping a healthy group record's component from the merge. Unknown membership must "
+                        + "fall back to the persisted membership info instead.");
+        assertNotNull(groupMembership.find(NON_TARGET_GROUP_NAME),
+                "GroupMembership must be rebuilt from persisted info when membership is unknown, so that "
+                        + "cleanupGroupData does not delete the group's records");
+    }
+
+    /**
+     * CONTROL TEST (passes with and without the fix): healthy bookkeeping and confirmed membership preserve
+     * the component. Isolates the defect to the record-absent cases above.
+     */
+    @Test
+    void group_component_preserved_when_config_entry_exists_and_cloud_confirms_membership() throws Exception {
+        groupToRootConfig.lookupTopics(NON_TARGET_GROUP_NAME, RUNNING_COMPONENT_NAME)
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
                 .thenReturn(Optional.of(Collections.singleton(NON_TARGET_GROUP_NAME)));
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
 
-        when(mockComponentManager.preparePackages(anyList())).thenReturn(CompletableFuture.completedFuture(null));
-        when(mockExecutorService.submit(any(Callable.class)))
-                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
-        when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture(new DeploymentResult(
-                        DeploymentResult.DeploymentStatus.SUCCESSFUL, null)));
+        createTask(localDeployment(document)).call();
 
-        ArgumentCaptor<List<String>> rootPackagesCaptor = ArgumentCaptor.forClass(List.class);
-        when(mockKernelConfigResolver.resolve(anyList(), eq(deploymentDocument), rootPackagesCaptor.capture(),
-                anyLong())).thenReturn(Collections.emptyMap());
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertTrue(rootPackages != null && rootPackages.contains(RUNNING_COMPONENT_NAME),
+                "Control: component must be preserved when its group record exists and membership is confirmed");
+    }
 
-        deploymentTask.call();
+    /**
+     * LEGITIMATE-FLOW TEST (must pass with and without the fix): when freshly fetched membership shows the
+     * device no longer belongs to the only group a running component is attributed to, the component is
+     * removed. Positive evidence exists; preservation must not block it.
+     */
+    @Test
+    void running_component_removed_when_authoritative_membership_shows_device_left_its_group() throws Exception {
+        groupToRootConfig.lookupTopics(NON_TARGET_GROUP_NAME, RUNNING_COMPONENT_NAME)
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        attributeRunningComponentToGroup(NON_TARGET_GROUP_NAME);
+        // Authoritative response: the device belongs to no thing groups anymore.
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
+                .thenReturn(Optional.of(Collections.emptySet()));
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
 
-        List<String> rootPackagesUsedForMerge = rootPackagesCaptor.getValue();
-        assertTrue(rootPackagesUsedForMerge != null && rootPackagesUsedForMerge.contains(ROOT_COMPONENT_NAME),
-                "Control: component2 should be preserved when GroupToRootComponents has an entry for "
-                        + "group1 and the device is confirmed to still belong to it.");
+        createTask(localDeployment(document)).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertNotNull(rootPackages);
+        assertFalse(rootPackages.contains(RUNNING_COMPONENT_NAME),
+                "Legitimate group-removal flow must keep working: authoritative membership shows the device "
+                        + "left the component's group, so the component must be removed from the root set");
+    }
+
+    /**
+     * LEGITIMATE-FLOW TEST (must pass with and without the fix): a cloud deployment's document is authoritative
+     * for its target group. A running component attributed to the target group that the document no longer
+     * includes must be removed, not preserved.
+     */
+    @Test
+    void cloud_deployment_removes_running_component_dropped_from_its_target_group_document() throws Exception {
+        attributeRunningComponentToGroup(CLOUD_TARGET_GROUP_NAME);
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
+                .thenReturn(Optional.of(Collections.singleton(CLOUD_TARGET_GROUP_NAME)));
+        DeploymentDocument document = cloudDeploymentDocument();
+        mockSuccessfulPipeline(document);
+
+        createTask(new Deployment(document, Deployment.DeploymentType.IOT_JOBS, "cloudJobId", DEFAULT)).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertNotNull(rootPackages);
+        assertFalse(rootPackages.contains(RUNNING_COMPONENT_NAME),
+                "A cloud deployment document is the authoritative root set for its target group; a component "
+                        + "attributed to the target group and absent from the document must be removed");
+    }
+
+    /**
+     * LEGITIMATE-FLOW TEST (must pass with and without the fix): explicit removal in a local deployment request
+     * is always honored, even when the bookkeeping that would normally reflect the component is lost.
+     */
+    @Test
+    void local_deployment_explicit_removal_honored_even_when_records_are_lost() throws Exception {
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
+                .thenReturn(Optional.of(Collections.singleton(NON_TARGET_GROUP_NAME)));
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
+
+        String rawLocalRequest = "{\"requestId\":\"localJobId\",\"componentsToRemove\":[\""
+                + RUNNING_COMPONENT_NAME + "\"]}";
+        Deployment deployment = new Deployment(rawLocalRequest, Deployment.DeploymentType.LOCAL, "localJobId");
+        deployment.setDeploymentDocumentObj(document);
+
+        createTask(deployment).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertNotNull(rootPackages);
+        assertFalse(rootPackages.contains(RUNNING_COMPONENT_NAME),
+                "A component explicitly listed in rootComponentsToRemove must not be preserved, regardless of "
+                        + "bookkeeping state");
     }
 }


### PR DESCRIPTION
## Summary

Fixes silent removal of running components by **local deployments** when thing-group bookkeeping has been lost, plus two related defects in group-state handling. **Cloud deployment semantics are unchanged**: a component is removed when the cloud deployment no longer contains it.

## The defects

1. **Local deployments removed running components on missing bookkeeping.** The set of root components a deployment keeps is computed exclusively from local `GroupToRootComponents` records. A running root component whose record was absent — for any reason, including loss of persisted state — was silently removed by a local deployment's merge, even when `ListThingGroupsForCoreDevice` confirmed the device still belongs to the group. Local deployments are explicit add/remove deltas (`rootComponentVersionsToAdd` / `rootComponentsToRemove`); they have no authority for implicit removals. Observed in the field as a device's components being uninstalled by an auto-submitted startup local deployment right after a restart.
2. **Unknown membership treated as empty.** An `Optional.empty()` membership response (device not configured to talk to the cloud) was coerced to "member of no thing groups", dropping every recorded group from preservation and arming record cleanup.
3. **Cleanup without evidence after restarts.** `DeploymentService.cleanupGroupData()` deletes records absent from the `GroupMembership` snapshot. Deployments completing after a Nucleus restart (bootstrap, e.g. nucleus upgrades) run in a boot session where that snapshot may not have survived — deleting records of groups the device still belongs to. Multi-group devices were exposed on every nucleus upgrade.

## The fix

A **local** deployment now removes a running root component only with positive evidence: the request explicitly lists it in `rootComponentsToRemove`, or membership freshly fetched from the cloud in the same run shows the device no longer belongs to any group the component is attributed to (via `ComponentToGroups`). Running roots lacking such evidence are preserved at their running version, with a warning log. Preservation is resolution-only (no bookkeeping writes), fails closed for versionless services, and excludes the nucleus component and builtin services. Unknown membership falls back to persisted membership info (same as the existing fetch-failure paths). Deployments completing after a restart skip record cleanup; the next regular deployment performs the deferred hygiene with fresh data.

## Behavior notes

- **Cloud deployments are intentionally unchanged**, including in the bookkeeping-loss state: a running component that no record or document accounts for is still removed by a cloud deployment (pinned by a test). Recovering a device from bookkeeping loss remains one cloud deployment per group, which rebuilds each group's records.
- For local deployments, components with no bookkeeping (e.g. services provisioned via the install-time config file) are now preserved rather than incidentally removed; explicit removal still works.
- The legitimate flows are pinned by tests: a device that actually left a group has that group's components removed by the next deployment that fetches membership; explicit local removals are always honored; device-scoped (`thing/`) and local-deployment records remain exempt from membership-based cleanup.

## Tests

- `ThingGroupMembershipPreservationTest`: 3 regression tests (verified failing with the fix disabled) — lost-record local deployment, unknown-membership handling, post-restart cleanup; plus control, legitimate-flow, fail-closed, and cloud-semantics pinning tests (verified passing both with and without the fix).
- `GroupToRootComponentsCleanupPreservationTest`: exercises the real `DeploymentService` cleanup path (the original revision inlined a copy of the logic and could not observe a fix).

The original revision's headline test asserted that a lost record's components could be restored from the membership response alone; that is not implementable (membership returns only group names, and no device data-plane API fetches a group's component list without its deployment ID, lost in the same scenarios). The reworked contract preserves what is running during local deployments instead.

`mvn test` run with checkstyle/PMD/spotbugs active: 1192 tests, the only failure is a pre-existing one unrelated to this change (verified identical on the unmodified branch). `MultiGroupDeploymentTest` integration suite at exact parity with the unmodified-branch baseline.

## Related

Companion to #1824, which fixes the loss of persisted configuration (builtin service config protection) that produced the missing-record state in the field. #1824 prevents the state loss; this PR removes the local-deployment amplification of it. Also related: #1823 (characterization tests for the #1824 defect).
