### PR TITLE
fix: Use USE_LONG_FOR_INTS to prevent unnecessary config.tlog writes

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -540,7 +540,7 @@ public class GenericExternalService extends GreengrassService {
 
             Topic timeoutTopic = config.find(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, LIFECYCLE_RUN_NAMESPACE_TOPIC,
                     Lifecycle.TIMEOUT_NAMESPACE_TOPIC);
-            Integer timeout = timeoutTopic == null ? null : (Integer) timeoutTopic.getOnce();
+            Integer timeout = timeoutTopic == null ? null : Coerce.toInt(timeoutTopic);
             if (timeout != null) {
                 Exec processToClose = runResult.getExec();
                 context.get(ScheduledExecutorService.class).schedule(() -> {

--- a/src/main/java/com/aws/greengrass/util/Coerce.java
+++ b/src/main/java/com/aws/greengrass/util/Coerce.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.util;
 import com.aws.greengrass.config.Topic;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -23,7 +24,8 @@ import static com.aws.greengrass.util.Utils.isEmpty;
 public final class Coerce {
     private static final Pattern SEPARATORS = Pattern.compile(" *, *");
     private static final Pattern unwrap = Pattern.compile(" *\\[ *(.*) *\\] *");
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .enable(DeserializationFeature.USE_LONG_FOR_INTS);
 
     private Coerce() {
     }

--- a/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
@@ -130,7 +130,7 @@ class ConfigurationTest {
         ConfigurationWriter.dump(config, p);
         assertEquals(config.getRoot(), config.getRoot());
         Configuration c2 = ConfigurationReader.createFromTLog(config.context, p);
-        assertEquals(44, c2.lookup("x", "z").getOnce());
+        assertEquals(44L, c2.lookup("x", "z").getOnce());
         assertEquals(config, c2);
         Topic nv = config.lookup("number");
     }

--- a/src/test/java/com/aws/greengrass/config/ConfigurationWriterTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationWriterTest.java
@@ -55,7 +55,7 @@ class ConfigurationWriterTest {
             // Create a Topic somewhere in the hierarchy
             config.lookup("a.x", "b", "c", "d", "e").withValue("Some Val");
             // Create another Topic and use a different data type as the value (number)
-            config.lookup("a.x", "b", "c.f", "d", "e2").withValue(2);
+            config.lookup("a.x", "b", "c.f", "d", "e2").withValue(2L);
             context.waitForPublishQueueToClear(); // Block until publish queue is empty to ensure all changes have
             // been processed
 

--- a/src/test/java/com/aws/greengrass/util/CoerceTest.java
+++ b/src/test/java/com/aws/greengrass/util/CoerceTest.java
@@ -130,7 +130,7 @@ class CoerceTest {
         assertEquals("", toObject(null));
         assertEquals("", toObject(""));
         assertEquals(12.34, toObject("12.34"));
-        assertEquals(1234, toObject("1234"));
+        assertEquals(1234L, toObject("1234"));
         assertEquals(1234567890123L, toObject("1234567890123"));
     }
 


### PR DESCRIPTION
## Problem

LogManager's `ConfigUtil.updateFromMapWhenChanged()` has a guard to prevent writing unchanged values to config.tlog:

```java
if (!Objects.equals(node.getOnce(), value)) {
    node.withValueChecked(timestamp, value);
}
```

This check **always fails** for numeric values after a reboot because of a type mismatch:

- **Left side:** Jackson deserializes JSON integers from config.tlog as `java.lang.Integer` (default for values fitting in 32 bits)
- **Right side:** LogManager's `long startPosition` field autoboxes to `java.lang.Long`
- **Result:** `Objects.equals(Integer(5518), Long(5518))` → `false` in Java

This causes every tracked file position to be re-written to config.tlog on every processing cycle, regardless of whether it changed.

## Impact

On a customer device with 36 tracked log streams over 182 days:
- config.tlog grew to **773 MB** (3.4M entries)
- **98% of entries** (2.2M) were unnecessary duplicate writes
- Boot time was **~180 seconds** just to parse the tlog on an ARM Cortex-A53

## Fix

Enable `DeserializationFeature.USE_LONG_FOR_INTS` on the ObjectMapper in `Coerce.java`. This causes Jackson to deserialize all JSON integers as `Long`, matching the types LogManager produces. The equality check then correctly prevents no-op writes.

## Testing

Reproduced in Docker (Nucleus 2.15.1 + LogManager 2.3.11):
- **Before fix:** After reboot, unchanged position value `174` was re-written to tlog
- **After fix:** 72 new entries written, **0 duplicates**. Unchanged values correctly skipped.

## Related

- Previous partial fix: LogManager v2.3.11 PR #230 (cleaned up uploaded file entries but did not address the type mismatch for active files)