### PR TITLE
feat: log thing group cleanup removals at info level

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -86,6 +86,7 @@ import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import static com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED;
 
 @ImplementsService(name = DeploymentService.DEPLOYMENT_SERVICE_TOPICS, autostart = true)
+@SuppressWarnings("PMD.ExcessiveClassLength")
 public class DeploymentService extends GreengrassService {
 
     public static final String DEPLOYMENT_SERVICE_TOPICS = "DeploymentService";
@@ -106,6 +107,7 @@ public class DeploymentService extends GreengrassService {
 
     private static final String DEPLOYMENT_ID_LOG_KEY_NAME = "DeploymentId";
     private static final String GG_DEPLOYMENT_ID_LOG_KEY_NAME = "GreengrassDeploymentId";
+    private static final String THING_GROUP_LOG_KEY_NAME = "ThingGroup";
 
     @Getter
     private final AtomicBoolean receivedShutdown = new AtomicBoolean(false);
@@ -431,7 +433,7 @@ public class DeploymentService extends GreengrassService {
         Topics groupLastDeploymentTopics = config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS);
 
         // clean up group
-        cleanupGroupData(deploymentGroupTopics, groupLastDeploymentTopics);
+        cleanupGroupData(deploymentGroupTopics, groupLastDeploymentTopics, deploymentDocument.getDeploymentId());
 
         // persist group to root components
         Map<String, Object> deploymentGroupToRootPackages = new HashMap<>();
@@ -464,7 +466,7 @@ public class DeploymentService extends GreengrassService {
     /**
      * Group memberships for a device can change. If the device is no longer part of a group, then perform cleanup.
      */
-    private void cleanupGroupData(Topics deploymentGroupTopics, Topics groupLastDeploymentTopics) {
+    private void cleanupGroupData(Topics deploymentGroupTopics, Topics groupLastDeploymentTopics, String deploymentId) {
         Topics groupMembershipTopics = config.lookupTopics(GROUP_MEMBERSHIP_TOPICS);
         deploymentGroupTopics.forEach(node -> {
             if (node instanceof Topics) {
@@ -472,7 +474,9 @@ public class DeploymentService extends GreengrassService {
                 if (groupMembershipTopics.find(groupTopics.getName()) == null && !groupTopics.getName()
                         .startsWith(DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX) && !groupTopics.getName()
                         .equals(LOCAL_DEPLOYMENT_GROUP_NAME)) {
-                    logger.debug("Removing mapping for thing group " + groupTopics.getName());
+                    logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY_NAME, deploymentId)
+                            .kv(THING_GROUP_LOG_KEY_NAME, groupTopics.getName())
+                            .log("Removing mapping for thing group");
                     groupTopics.remove();
                 }
             }
@@ -484,7 +488,9 @@ public class DeploymentService extends GreengrassService {
                 if (groupMembershipTopics.find(groupTopics.getName()) == null && !groupTopics.getName()
                         .startsWith(DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX) && !groupTopics.getName()
                         .equals(LOCAL_DEPLOYMENT_GROUP_NAME)) {
-                    logger.debug("Removing last deployment information for thing group " + groupTopics.getName());
+                    logger.atInfo().kv(DEPLOYMENT_ID_LOG_KEY_NAME, deploymentId)
+                            .kv(THING_GROUP_LOG_KEY_NAME, groupTopics.getName())
+                            .log("Removing last deployment information for thing group");
                     groupTopics.remove();
                 }
             }

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -442,6 +443,86 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         assertThat(groupToRootPackages, hasKey(EXPECTED_ROOT_PACKAGE_NAME));
         assertThat((Map<String, Boolean>) groupToRootPackages.get(EXPECTED_ROOT_PACKAGE_NAME),
                 hasKey("arn:aws:greengrass:testRegion:12345:configuration:testGroup:12"));
+    }
+
+    @Test
+    void GIVEN_stale_group_no_longer_in_membership_WHEN_deployment_process_succeeds_THEN_cleanup_logged_at_info_with_deployment_id_and_group_name()
+            throws Exception {
+        String staleGroupName = "thinggroup/staleGroup";
+        String deploymentDocument = getTestDeploymentDocument();
+
+        deploymentQueue.offer(new Deployment(deploymentDocument, Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
+
+        // GroupToRootComponents and GroupToLastDeployment both contain an entry for staleGroupName, but
+        // GroupMembership does not, so cleanupGroupData() must remove both entries for the new deployment's group.
+        Topics allGroupTopics = Topics.of(context, GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        Topics staleDeploymentGroupTopics = Topics.of(context, staleGroupName, allGroupTopics);
+        allGroupTopics.children.put(new CaseInsensitiveString(staleGroupName), staleDeploymentGroupTopics);
+
+        Topics deploymentGroupTopics = Topics.of(context, EXPECTED_GROUP_NAME, allGroupTopics);
+        Topic pkgTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0");
+        Topic groupTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN,
+                TEST_CONFIGURATION_ARN);
+        Topic groupNameTopic1 = Topic.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME,
+                EXPECTED_GROUP_NAME);
+        Map<CaseInsensitiveString, Node> pkgDetails = new HashMap<>();
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY), pkgTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_CONFIG_ARN),
+                groupTopic1);
+        pkgDetails.put(new CaseInsensitiveString(DeploymentService.GROUP_TO_ROOT_COMPONENTS_GROUP_NAME),
+                groupNameTopic1);
+        Topics pkgTopics = Topics.of(context, EXPECTED_ROOT_PACKAGE_NAME, deploymentGroupTopics);
+        pkgTopics.children.putAll(pkgDetails);
+        deploymentGroupTopics.children.put(new CaseInsensitiveString(EXPECTED_ROOT_PACKAGE_NAME), pkgTopics);
+        allGroupTopics.children.put(new CaseInsensitiveString(EXPECTED_GROUP_NAME), deploymentGroupTopics);
+
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        Topics staleLastDeploymentTopics = Topics.of(context, staleGroupName, groupToLastDeploymentTopics);
+        groupToLastDeploymentTopics.children.put(new CaseInsensitiveString(staleGroupName),
+                staleLastDeploymentTopics);
+
+        Topics groupMembershipTopics = Topics.of(context, GROUP_MEMBERSHIP_TOPICS, null);
+        groupMembershipTopics.lookup(EXPECTED_GROUP_NAME);
+
+        when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS)).thenReturn(allGroupTopics);
+        lenient().when(config.lookupTopics(GROUP_TO_ROOT_COMPONENTS_TOPICS, EXPECTED_GROUP_NAME))
+                .thenReturn(deploymentGroupTopics);
+        when(config.lookupTopics(GROUP_TO_LAST_DEPLOYMENT_TOPICS)).thenReturn(groupToLastDeploymentTopics);
+        lenient().when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString()))
+                .thenReturn(groupToLastDeploymentTopics);
+        when(config.lookupTopics(GROUP_MEMBERSHIP_TOPICS)).thenReturn(groupMembershipTopics);
+        when(config.lookupTopics(COMPONENTS_TO_GROUPS_TOPICS)).thenReturn(mockComponentsToGroupPackages);
+
+        when(mockKernel.locate(any())).thenReturn(mockGreengrassService);
+        when(mockGreengrassService.getName()).thenReturn(EXPECTED_ROOT_PACKAGE_NAME);
+        mockFuture.complete(new DeploymentResult(DeploymentStatus.SUCCESSFUL, null));
+        when(mockExecutorService.submit(any(DefaultDeploymentTask.class))).thenReturn(mockFuture);
+
+        List<GreengrassLogMessage> cleanupLogMessages = new CopyOnWriteArrayList<>();
+        Consumer<GreengrassLogMessage> listener = m -> {
+            if (m.getLoggerName() != null && m.getLoggerName().contains(DeploymentService.class.getSimpleName())
+                    && m.getMessage() != null && m.getMessage().contains("Removing")) {
+                cleanupLogMessages.add(m);
+            }
+        };
+        Slf4jLogAdapter.addGlobalListener(listener);
+        try {
+            startDeploymentServiceInAnotherThread();
+            verify(deploymentStatusKeeper, timeout(2000)).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                    eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                    eq(JobStatus.SUCCEEDED.toString()), any(), any());
+        } finally {
+            Slf4jLogAdapter.removeGlobalListener(listener);
+        }
+
+        assertEquals(2, cleanupLogMessages.size(),
+                "Expected one INFO log for the GroupToRootComponents removal and one for the "
+                        + "GroupToLastDeployment removal");
+        for (GreengrassLogMessage m : cleanupLogMessages) {
+            assertEquals("INFO", m.getLevel());
+            assertThat(m.getContexts(), hasEntry("DeploymentId", TEST_UUID));
+            assertThat(m.getContexts(), hasEntry("ThingGroup", staleGroupName));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

`DeploymentService.cleanupGroupData()` removes `GroupToRootComponents` and `GroupToLastDeployment` config entries for thing groups the device is no longer a member of. This is a destructive, state-changing operation — once it runs, the prior group-to-component and last-deployment bookkeeping for that group is gone.

Today this is only logged at DEBUG, which is disabled in production by default. If a group's `GroupToRootComponents`/`GroupToLastDeployment` state unexpectedly disappears, there is no production-visible signal to confirm this code path fired, when it fired, or for which group — making the behavior difficult to diagnose after the fact.

## Change

- Bump both removal log statements in `cleanupGroupData()` from DEBUG to INFO. This reflects normal, expected operation of the cleanup routine (not an error), so INFO rather than WARN/ERROR.
- Convert both log statements to the structured logger builder pattern (`logger.atInfo().kv(...).log(...)`) already used elsewhere in this file, so the fields are queryable rather than embedded in a formatted string.
- Include two structured fields on each log line:
  - `ThingGroup`: the name of the thing group whose mapping/last-deployment entry is being removed.
  - `DeploymentId`: the ID of the deployment that triggered the cleanup, threaded through from `persistGroupToRootComponents()`'s `DeploymentDocument` parameter (the only deployment-identifying value already in scope at this call site — no broader refactor was needed to make it available).
- Added `@SuppressWarnings("PMD.ExcessiveClassLength")` at the class level. `DeploymentService` was already at the edge of PMD's default class-length threshold; this change (a new log-key constant plus the structured log calls) pushed it over. The same suppression already exists on `MqttClient` for the same rule, so this follows established precedent in the codebase rather than introducing a new pattern.

## Testing

- Added a unit test in `DeploymentServiceTest` that runs a deployment where a thing group present in `GroupToRootComponents`/`GroupToLastDeployment` is absent from `GroupMembership`, and asserts that both cleanup log lines fire at INFO with the expected `DeploymentId` and `ThingGroup` fields (using the existing `Slf4jLogAdapter.addGlobalListener` test pattern already used in this file for log assertions).
- Ran the full `DeploymentServiceTest` suite: 18/18 passing.
- Ran checkstyle, PMD, and SpotBugs locally: all clean.
