### PR TITLE
feat(mqtt): receive AWS IoT Core direct messages via RECEIVE_ONLY

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCMqttProxyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/IPCMqttProxyTest.java
@@ -30,11 +30,14 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.SubscribeToIoTCoreResponseHandler;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 import software.amazon.awssdk.aws.greengrass.model.IoTCoreMessage;
 import software.amazon.awssdk.aws.greengrass.model.PublishToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.QOS;
 import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
+import software.amazon.awssdk.aws.greengrass.model.SubscriptionMode;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
 import software.amazon.awssdk.eventstreamrpc.StreamResponseHandler;
@@ -57,11 +60,13 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAM
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -215,6 +220,199 @@ class IPCMqttProxyTest {
             assertThat(capturedUnsubscribeRequest.getTopic(), is(subscribeTopic));
             assertThat(capturedUnsubscribeRequest.getSubscriptionCallback(), is(callback));
         }
+    }
+
+    @Test
+    void GIVEN_receive_only_WHEN_subscribe_THEN_receive_only_registered_and_message_received() throws Exception {
+        lenient().when(mqttClient.unsubscribe(any(Unsubscribe.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        String subscribeTopic = "A/A/C/D"; // matches the mqttproxy.yaml grant "A/+/C/D*"
+        CountDownLatch messageLatch = new CountDownLatch(1);
+        GreengrassCoreIPCClient greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(subscribeTopic);
+        // RECEIVE_ONLY mode with no qos.
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        StreamResponseHandler<IoTCoreMessage> streamResponseHandler = new StreamResponseHandler<IoTCoreMessage>() {
+            @Override
+            public void onStreamEvent(IoTCoreMessage streamEvent) {
+                if (Arrays.equals(streamEvent.getMessage().getPayload(), TEST_PAYLOAD)
+                        && streamEvent.getMessage().getTopicName().equals(subscribeTopic)) {
+                    messageLatch.countDown();
+                }
+            }
+
+            @Override
+            public boolean onStreamError(Throwable error) {
+                logger.atError().cause(error).log("Subscribe stream errored");
+                return false;
+            }
+
+            @Override
+            public void onStreamClosed() {
+            }
+        };
+
+        SubscribeToIoTCoreResponseHandler responseHandler = greengrassCoreIPCClient.subscribeToIoTCore(
+                subscribeToIoTCoreRequest, Optional.of(streamResponseHandler));
+        responseHandler.getResponse().get(TIMEOUT_FOR_MQTTPROXY_SECONDS, TimeUnit.SECONDS);
+
+        ArgumentCaptor<Subscribe> subscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
+        verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
+        Subscribe capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
+        assertThat(capturedSubscribeRequest.getTopic(), is(subscribeTopic));
+        // The captured Subscribe carries the receive-only flag.
+        assertThat(capturedSubscribeRequest.isSkipCloudSubscribe(), is(true));
+
+        // A message delivered to the captured callback streams back to the component over IPC.
+        Consumer<Publish> callback = capturedSubscribeRequest.getCallback();
+        callback.accept(Publish.builder().topic(subscribeTopic).payload(TEST_PAYLOAD).build());
+        assertTrue(messageLatch.await(TIMEOUT_FOR_MQTTPROXY_SECONDS, TimeUnit.SECONDS));
+
+        // Stream close unsubscribes the registration.
+        responseHandler.closeStream();
+        Thread.sleep(500);
+        ArgumentCaptor<Unsubscribe> unsubscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Unsubscribe.class);
+        verify(mqttClient).unsubscribe(unsubscribeRequestArgumentCaptor.capture());
+        Unsubscribe capturedUnsubscribeRequest = unsubscribeRequestArgumentCaptor.getValue();
+        assertThat(capturedUnsubscribeRequest.getTopic(), is(subscribeTopic));
+        assertThat(capturedUnsubscribeRequest.getSubscriptionCallback(), is(callback));
+    }
+
+    @Test
+    void GIVEN_receive_only_with_qos_WHEN_subscribe_THEN_qos_ignored_and_receive_only_registered() throws Exception {
+        lenient().when(mqttClient.unsubscribe(any(Unsubscribe.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        String subscribeTopic = "A/A/C/D";
+        CountDownLatch messageLatch = new CountDownLatch(1);
+        GreengrassCoreIPCClient greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(subscribeTopic);
+        // qos is set alongside RECEIVE_ONLY mode; it is ignored.
+        subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        StreamResponseHandler<IoTCoreMessage> streamResponseHandler = new StreamResponseHandler<IoTCoreMessage>() {
+            @Override
+            public void onStreamEvent(IoTCoreMessage streamEvent) {
+                if (Arrays.equals(streamEvent.getMessage().getPayload(), TEST_PAYLOAD)
+                        && streamEvent.getMessage().getTopicName().equals(subscribeTopic)) {
+                    messageLatch.countDown();
+                }
+            }
+
+            @Override
+            public boolean onStreamError(Throwable error) {
+                logger.atError().cause(error).log("Subscribe stream errored");
+                return false;
+            }
+
+            @Override
+            public void onStreamClosed() {
+            }
+        };
+
+        SubscribeToIoTCoreResponseHandler responseHandler = greengrassCoreIPCClient.subscribeToIoTCore(
+                subscribeToIoTCoreRequest, Optional.of(streamResponseHandler));
+        responseHandler.getResponse().get(TIMEOUT_FOR_MQTTPROXY_SECONDS, TimeUnit.SECONDS);
+
+        ArgumentCaptor<Subscribe> subscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
+        verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
+        Subscribe capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
+        assertThat(capturedSubscribeRequest.isSkipCloudSubscribe(), is(true));
+
+        Consumer<Publish> callback = capturedSubscribeRequest.getCallback();
+        callback.accept(Publish.builder().topic(subscribeTopic).payload(TEST_PAYLOAD).build());
+        assertTrue(messageLatch.await(TIMEOUT_FOR_MQTTPROXY_SECONDS, TimeUnit.SECONDS));
+
+        responseHandler.closeStream();
+    }
+
+    @Test
+    void GIVEN_receive_only_on_unauthorized_topic_WHEN_subscribe_THEN_client_gets_unauthorized(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, ExecutionException.class);
+        ignoreExceptionOfType(context, UnauthorizedError.class);
+
+        // Topic outside the mqttproxy.yaml grant (only "A/+/C/D*" and "X/Y*Z/#" are allowed).
+        String unauthorizedTopic = "Z/unauthorized";
+        GreengrassCoreIPCClient greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(unauthorizedTopic);
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        // Subscribe is a streaming operation, so the client requires a stream handler.
+        StreamResponseHandler<IoTCoreMessage> streamResponseHandler = new StreamResponseHandler<IoTCoreMessage>() {
+            @Override
+            public void onStreamEvent(IoTCoreMessage streamEvent) {
+            }
+
+            @Override
+            public boolean onStreamError(Throwable error) {
+                return false;
+            }
+
+            @Override
+            public void onStreamClosed() {
+            }
+        };
+        SubscribeToIoTCoreResponseHandler responseHandler = greengrassCoreIPCClient.subscribeToIoTCore(
+                subscribeToIoTCoreRequest, Optional.of(streamResponseHandler));
+
+        boolean gotUnauthorized = false;
+        try {
+            responseHandler.getResponse().get(TIMEOUT_FOR_MQTTPROXY_SECONDS, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            gotUnauthorized = e.getCause() instanceof UnauthorizedError;
+        }
+        assertTrue(gotUnauthorized, "RECEIVE_ONLY on an unauthorized topic must surface UnauthorizedError");
+        // No subscription was attempted.
+        verify(mqttClient, never()).subscribe(any(Subscribe.class));
+    }
+
+    @Test
+    void GIVEN_unrecognized_subscription_mode_WHEN_subscribe_THEN_client_gets_invalid_arguments(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, ExecutionException.class);
+        ignoreExceptionOfType(context, InvalidArgumentsError.class);
+
+        String subscribeTopic = "A/A/C/D"; // matches the mqttproxy.yaml grant "A/+/C/D*"
+        GreengrassCoreIPCClient greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(subscribeTopic);
+        subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
+        subscribeToIoTCoreRequest.setSubscriptionMode("FUTURE_MODE");
+
+        // Subscribe is a streaming operation, so the client requires a stream handler.
+        StreamResponseHandler<IoTCoreMessage> streamResponseHandler = new StreamResponseHandler<IoTCoreMessage>() {
+            @Override
+            public void onStreamEvent(IoTCoreMessage streamEvent) {
+            }
+
+            @Override
+            public boolean onStreamError(Throwable error) {
+                return false;
+            }
+
+            @Override
+            public void onStreamClosed() {
+            }
+        };
+        SubscribeToIoTCoreResponseHandler responseHandler = greengrassCoreIPCClient.subscribeToIoTCore(
+                subscribeToIoTCoreRequest, Optional.of(streamResponseHandler));
+
+        Throwable cause = null;
+        try {
+            responseHandler.getResponse().get(TIMEOUT_FOR_MQTTPROXY_SECONDS, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            cause = e.getCause();
+        }
+        assertThat("an unrecognized subscriptionMode must surface InvalidArgumentsError, not UnmappedDataException",
+                cause, instanceOf(InvalidArgumentsError.class));
+        assertThat(cause.getMessage(), containsString("FUTURE_MODE"));
+        // No cloud subscription was created for a mode we could not interpret.
+        verify(mqttClient, never()).subscribe(any(Subscribe.class));
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/mqttclient/DirectMessageRoutingIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/mqttclient/DirectMessageRoutingIntegTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.mqttclient;
+
+import com.aws.greengrass.config.Configuration;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.integrationtests.ipc.IPCTestUtils;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.MqttClientRouterAccessor;
+import com.aws.greengrass.mqttclient.spool.Spool;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.TestUtils;
+import com.aws.greengrass.util.Coerce;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.SubscribeToIoTCoreResponseHandler;
+import software.amazon.awssdk.aws.greengrass.model.IoTCoreMessage;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
+import software.amazon.awssdk.aws.greengrass.model.SubscriptionMode;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.crt.mqtt5.Mqtt5Client;
+import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
+import software.amazon.awssdk.crt.mqtt5.OnConnectionSuccessReturn;
+import software.amazon.awssdk.crt.mqtt5.PublishResult;
+import software.amazon.awssdk.crt.mqtt5.packets.SubAckPacket;
+import software.amazon.awssdk.crt.mqtt5.packets.UnsubAckPacket;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
+import software.amazon.awssdk.eventstreamrpc.StreamResponseHandler;
+import software.amazon.awssdk.iot.AwsIotMqtt5ClientBuilder;
+import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.aws.greengrass.integrationtests.ipc.IPCTestUtils.TEST_SERVICE_NAME;
+import static com.aws.greengrass.ipc.AuthenticationHandler.SERVICE_UNIQUE_ID_KEY;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.PRIVATE_STORE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end test for a RECEIVE_ONLY subscribe: it runs over real IPC through the real
+ * {@code MqttProxyIPCAgent} handler AND the real {@link MqttClient} router. Unlike
+ * {@code IPCMqttProxyTest} (which mocks {@code MqttClient}), this wires a real {@code MqttClient} with a mocked
+ * CRT MQTT5 stack into the kernel, so the receive-only registration and the router's delivery pass
+ * actually execute. The inbound message is injected via {@link MqttClientRouterAccessor}, which reaches the
+ * client's package-private router from inside {@code com.aws.greengrass.mqttclient}.
+ */
+@SuppressWarnings("PMD.CloseResource")
+@ExtendWith(GGExtension.class)
+public class DirectMessageRoutingIntegTest extends BaseITCase {
+
+    private static final byte[] TEST_PAYLOAD = "directMessagePayload".getBytes(StandardCharsets.UTF_8);
+    private static final String TEST_TOPIC = "A/B/C"; // covered by the "A/#" grant in directmessages.yaml
+    private static final int TIMEOUT_SECONDS = 20;
+
+    private static final ExecutorService executorService = TestUtils.synchronousExecutorService();
+    private Kernel kernel;
+    private EventStreamRPCConnection clientConnection;
+    private SocketOptions socketOptions;
+    private MqttClient mqttClient;
+    private Mqtt5Client mockMqtt5Client;
+
+    @BeforeEach
+    void before() throws Exception {
+        kernel = new Kernel();
+        ConfigPlatformResolver.initKernelWithMultiPlatformConfig(kernel,
+                DirectMessageRoutingIntegTest.class.getResource("directmessages.yaml"));
+        Configuration config = kernel.getConfig();
+
+        DeviceConfiguration deviceConfiguration = mock(DeviceConfiguration.class);
+        Spool spool = mock(Spool.class);
+        AwsIotMqttConnectionBuilder builder = mock(AwsIotMqttConnectionBuilder.class);
+        MqttClientConnection connection = mock(MqttClientConnection.class);
+
+        Topics mqttNamespace = config.lookupTopics("mqtt");
+        when(deviceConfiguration.getMQTTNamespace()).thenReturn(mqttNamespace);
+        lenient().when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(true);
+        lenient().when(builder.build()).thenReturn(connection);
+        lenient().when(connection.connect()).thenReturn(CompletableFuture.completedFuture(false));
+        lenient().when(connection.disconnect()).thenReturn(CompletableFuture.completedFuture(null));
+
+        // Mock the CRT MQTT5 stack so the real MqttClient never opens a cloud connection.
+        AwsIotMqtt5ClientBuilder mockMqtt5Builder = mock(AwsIotMqtt5ClientBuilder.class, Answers.RETURNS_SELF);
+        lenient().when(builder.toAwsIotMqtt5ClientBuilder()).thenReturn(mockMqtt5Builder);
+        mockMqtt5Client = mock(Mqtt5Client.class);
+        lenient().when(mockMqtt5Builder.build()).thenReturn(mockMqtt5Client);
+        lenient().when(mockMqtt5Client.subscribe(any()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SubAckPacket.class, Answers.RETURNS_MOCKS)));
+        lenient().when(mockMqtt5Client.unsubscribe(any()))
+                .thenReturn(CompletableFuture.completedFuture(mock(UnsubAckPacket.class, Answers.RETURNS_MOCKS)));
+        lenient().when(mockMqtt5Client.publish(any()))
+                .thenReturn(CompletableFuture.completedFuture(mock(PublishResult.class, Answers.RETURNS_MOCKS)));
+        org.mockito.ArgumentCaptor<Mqtt5ClientOptions.LifecycleEvents> lifecycleEventCaptor =
+                org.mockito.ArgumentCaptor.forClass(Mqtt5ClientOptions.LifecycleEvents.class);
+        lenient().when(mockMqtt5Builder.withLifeCycleEvents(lifecycleEventCaptor.capture()))
+                .thenReturn(mockMqtt5Builder);
+        lenient().doAnswer((i) -> {
+            lifecycleEventCaptor.getValue().onConnectionSuccess(mockMqtt5Client,
+                    mock(OnConnectionSuccessReturn.class, Answers.RETURNS_MOCKS));
+            return null;
+        }).when(mockMqtt5Client).start();
+
+        mqttClient = spy(new MqttClient(deviceConfiguration, spool, false, (c) -> builder, executorService));
+
+        CountDownLatch awaitIpcServiceLatch = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals(TEST_SERVICE_NAME) && newState.equals(State.FINISHED)) {
+                awaitIpcServiceLatch.countDown();
+            }
+        });
+        kernel.getContext().put(MqttClient.class, mqttClient);
+        kernel.launch();
+        assertTrue(awaitIpcServiceLatch.await(10, TimeUnit.SECONDS));
+
+        Topics servicePrivateConfig = kernel.getConfig().findTopics(SERVICES_NAMESPACE_TOPIC, TEST_SERVICE_NAME,
+                PRIVATE_STORE_NAMESPACE_TOPIC);
+        String authToken = Coerce.toString(servicePrivateConfig.find(SERVICE_UNIQUE_ID_KEY));
+        socketOptions = TestUtils.getSocketOptionsForIPC();
+        clientConnection = IPCTestUtils.connectToGGCOverEventStreamIPC(socketOptions, authToken, kernel);
+    }
+
+    @AfterEach
+    void after() {
+        if (clientConnection != null) {
+            clientConnection.disconnect();
+        }
+        if (socketOptions != null) {
+            socketOptions.close();
+        }
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_receive_only_subscribe_over_ipc_WHEN_inbound_message_THEN_routed_to_component_with_no_cloud_subscribe()
+            throws Exception {
+        CountDownLatch messageLatch = new CountDownLatch(1);
+        GreengrassCoreIPCClient greengrassCoreIPCClient = new GreengrassCoreIPCClient(clientConnection);
+        SubscribeToIoTCoreRequest subscribeRequest = new SubscribeToIoTCoreRequest();
+        subscribeRequest.setTopicName(TEST_TOPIC);
+        // RECEIVE_ONLY (direct message), no qos.
+        subscribeRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        StreamResponseHandler<IoTCoreMessage> streamResponseHandler = new StreamResponseHandler<IoTCoreMessage>() {
+            @Override
+            public void onStreamEvent(IoTCoreMessage streamEvent) {
+                if (java.util.Arrays.equals(streamEvent.getMessage().getPayload(), TEST_PAYLOAD)
+                        && streamEvent.getMessage().getTopicName().equals(TEST_TOPIC)) {
+                    messageLatch.countDown();
+                }
+            }
+
+            @Override
+            public boolean onStreamError(Throwable error) {
+                return false;
+            }
+
+            @Override
+            public void onStreamClosed() {
+            }
+        };
+
+        // Subscribe over real IPC with RECEIVE_ONLY mode.
+        SubscribeToIoTCoreResponseHandler responseHandler =
+                greengrassCoreIPCClient.subscribeToIoTCore(subscribeRequest, Optional.of(streamResponseHandler));
+        responseHandler.getResponse().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        // Inject an inbound message through the real router.
+        Publish inbound = Publish.builder().topic(TEST_TOPIC).payload(TEST_PAYLOAD).build();
+        MqttClientRouterAccessor.routeInboundMessage(mqttClient, inbound);
+
+        // The message is streamed back to the component over IPC.
+        assertTrue(messageLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                "RECEIVE_ONLY inbound message was not routed back to the component over IPC");
+
+        // No cloud SUBSCRIBE was ever issued.
+        verify(mockMqtt5Client, never()).subscribe(any());
+
+        responseHandler.closeStream();
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/mqttclient/MqttClientRouterAccessor.java
+++ b/src/integrationtests/java/com/aws/greengrass/mqttclient/MqttClientRouterAccessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqttclient;
+
+import com.aws.greengrass.mqttclient.v5.Publish;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test-only accessor that delivers an inbound message through {@link MqttClient}'s inbound router,
+ * {@link MqttClient#getMessageHandlerForClient}, exactly as an arriving PUBLISH would.
+ *
+ * <p>The router and its {@link IndividualMqttClient} parameter are package-private, so this accessor lives in
+ * {@code com.aws.greengrass.mqttclient} to reach them and exposes a public entry point for tests in other packages.
+ */
+public final class MqttClientRouterAccessor {
+
+    private MqttClientRouterAccessor() {
+    }
+
+    /**
+     * Deliver an inbound message through the real router, as an arriving PUBLISH would.
+     *
+     * @param mqttClient client whose router is exercised
+     * @param message    inbound message to route
+     */
+    public static void routeInboundMessage(MqttClient mqttClient, Publish message) {
+        mqttClient.getMessageHandlerForClient(mock(IndividualMqttClient.class)).accept(message);
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqttclient/directmessages.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqttclient/directmessages.yaml
@@ -1,0 +1,22 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+      mqtt:
+        operationTimeoutMs: 0
+  main:
+    dependencies:
+      - ServiceName
+  ServiceName:
+    configuration:
+      accessControl:
+        aws.greengrass.ipc.mqttproxy:
+          policyId1:
+            policyDescription: access to IoT topics for mqtt direct messages
+            operations:
+              - 'aws.greengrass#SubscribeToIoTCore'
+            resources:
+              - "A/#"

--- a/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgent.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.aws.greengrass.model.QOS;
 import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreResponse;
+import software.amazon.awssdk.aws.greengrass.model.SubscriptionMode;
 import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.crt.mqtt5.packets.SubAckPacket;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
@@ -58,6 +59,7 @@ public class MqttProxyIPCAgent {
     private static final String NO_TOPIC_ERROR = "Topic is required";
     private static final String NO_QOS_ERROR = "QoS is required";
     private static final String INVALID_QOS_ERROR = "Invalid QoS value";
+    private static final String INVALID_SUBSCRIPTION_MODE_ERROR = "Invalid subscription mode value";
 
     @Inject
     @Setter(AccessLevel.PACKAGE)
@@ -199,9 +201,21 @@ public class MqttProxyIPCAgent {
                 }
 
                 Consumer<Publish> callback = this::forwardToSubscriber;
-                com.aws.greengrass.mqttclient.v5.QOS qos = validateQoS(request.getQosAsString(), serviceName);
-                Subscribe subscribeRequest = Subscribe.builder().callback(callback).topic(topic)
-                        .qos(qos).build();
+                // RECEIVE_ONLY registers on-device only: no cloud subscribe, qos ignored. An absent mode keeps the
+                // cloud path for pre-subscriptionMode clients. Any other mode has no branch here, so it is rejected.
+                String subscriptionMode = request.getSubscriptionModeAsString();
+                Subscribe.SubscribeBuilder subscribeBuilder = Subscribe.builder().callback(callback).topic(topic);
+                if (SubscriptionMode.RECEIVE_ONLY.getValue().equals(subscriptionMode)) {
+                    subscribeBuilder.skipCloudSubscribe(true);
+                } else if (subscriptionMode == null
+                        || SubscriptionMode.SUBSCRIBE_AND_RECEIVE.getValue().equals(subscriptionMode)) {
+                    subscribeBuilder.qos(validateQoS(request.getQosAsString(), serviceName));
+                } else {
+                    LOGGER.atError().kv(COMPONENT_NAME, serviceName).kv("subscriptionMode", subscriptionMode)
+                            .log(INVALID_SUBSCRIPTION_MODE_ERROR);
+                    throw new InvalidArgumentsError(INVALID_SUBSCRIPTION_MODE_ERROR + ": " + subscriptionMode);
+                }
+                Subscribe subscribeRequest = subscribeBuilder.build();
 
                 try {
                     subscribedTopic = topic;

--- a/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/MqttClient.java
@@ -140,6 +140,8 @@ public class MqttClient implements Closeable {
     private final Map<Subscribe, IndividualMqttClient> subscriptions = new ConcurrentHashMap<>();
     private final Map<MqttTopic, IndividualMqttClient> subscriptionTopics = new ConcurrentHashMap<>();
     private final Map<Subscribe, AtomicBoolean> subscribeCancellations = new ConcurrentHashMap<>();
+    // Receive-only (direct-message) subscriptions: routed on-device but never subscribed in the cloud.
+    private final Set<Subscribe> receiveOnlySubscriptions = ConcurrentHashMap.newKeySet();
     private final Set<Integer> activeClientIds = new HashSet<>();
     private final AtomicInteger connectionRoundRobin = new AtomicInteger(0);
     @Getter
@@ -454,6 +456,12 @@ public class MqttClient implements Closeable {
             IotCoreTopicValidator.validateTopic(request.getTopic(), getMqttVersion(),
                     IotCoreTopicValidator.Operation.SUBSCRIBE);
 
+            if (request.isSkipCloudSubscribe()) {
+                // Record for on-device routing only; send no cloud SUBSCRIBE.
+                receiveOnlySubscriptions.add(request);
+                return CompletableFuture.completedFuture(null);
+            }
+
             IndividualMqttClient connection = null;
             // Use the write scope when identifying the subscriptionTopics that exist
             try (LockScope scope = LockScope.lock(connectionLock.writeLock())) {
@@ -588,11 +596,17 @@ public class MqttClient implements Closeable {
             if (isClosed.get()) {
                 throw new MqttRequestException("MQTT client is shut down");
             }
+            // Receive-only registrations opened no cloud subscription. Match by (callback identity, topic) -- the
+            // same key the cloud loop uses below. A hit removes the receive-only registration and returns without
+            // touching the cloud path; a miss falls through to it.
+            if (receiveOnlySubscriptions.removeIf(
+                    s -> isSameSubscription(s, request.getTopic(), request.getSubscriptionCallback()))) {
+                return CompletableFuture.completedFuture(null);
+            }
             // Use the write lock because we're modifying the subscriptions and trying to consolidate them
             try (LockScope scope = LockScope.lock(connectionLock.writeLock())) {
                 for (Map.Entry<Subscribe, IndividualMqttClient> sub : subscriptions.entrySet()) {
-                    if (sub.getKey().getCallback() == request.getSubscriptionCallback() && sub.getKey().getTopic()
-                            .equals(request.getTopic())) {
+                    if (isSameSubscription(sub.getKey(), request.getTopic(), request.getSubscriptionCallback())) {
                         AtomicBoolean cancelled = subscribeCancellations.remove(sub.getKey());
                         if (cancelled != null) {
                             cancelled.set(true);
@@ -959,7 +973,7 @@ public class MqttClient implements Closeable {
                     .filter(subscriptionsMatchingTopic)
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toSet());
-            Set<Subscribe> subs = exactlyMatchingSubs;
+            Set<Subscribe> matchedCloudSubs = exactlyMatchingSubs;
             if (exactlyMatchingSubs.isEmpty()) {
                 // We found no exact matches which means that we received a message on the wrong client, or
                 // we had no subscribers at all for the topic. We will now check if there is some subscriber
@@ -967,17 +981,12 @@ public class MqttClient implements Closeable {
                 // message back to the same client which sent the update request, and not to the client that has
                 // subscribed to the update/accepted topic.
 
-                subs = subscriptions.entrySet().stream()
+                matchedCloudSubs = subscriptions.entrySet().stream()
                         .filter(subscriptionsMatchingTopic)
                         .map(Map.Entry::getKey)
                         .collect(Collectors.toSet());
 
-                if (subs.isEmpty()) {
-                    // We found no subscribers at all, so we'll log out an error and exit.
-                    logger.atError().kv(TOPIC_KEY, message.getTopic()).kv(CLIENT_ID_KEY, client.getClientId())
-                            .log("Somehow got message from topic that no one subscribed to");
-                    return;
-                } else {
+                if (!matchedCloudSubs.isEmpty()) {
                     // We did find at least one subscriber matching the topic, but it didn't match the client
                     // that we subscribed on. This is weird, but it can be expected for IoT Jobs as explained above.
                     logger.atWarn().kv(TOPIC_KEY, message.getTopic()).kv(CLIENT_ID_KEY, client.getClientId())
@@ -985,7 +994,26 @@ public class MqttClient implements Closeable {
                                     + " This is odd, but it isn't a problem");
                 }
             }
-            subs.forEach((h) -> {
+
+            // Receive-only delivery pass, independent of the cloud pass above. Matches the inbound topic against
+            // receiveOnlySubscriptions and delivers on the connection that received the message. An arriving message
+            // is an ordinary PUBLISH, so a receive-only sub receives BOTH direct messages addressed to the device
+            // AND any normal message reaching the device on a matching topic. A message reaching covering connections
+            // may therefore deliver more than once.
+            Set<Subscribe> matchedReceiveOnlySubs = new HashSet<>();
+            receiveOnlySubscriptions.stream()
+                    .filter(s -> MqttTopic.topicIsSupersetOf(s.getTopic(), message.getTopic()))
+                    .forEach(matchedReceiveOnlySubs::add);
+
+            if (matchedCloudSubs.isEmpty() && matchedReceiveOnlySubs.isEmpty()) {
+                // No cloud subscriber and no receive-only registration matched, so we'll log an error and exit.
+                logger.atError().kv(TOPIC_KEY, message.getTopic()).kv(CLIENT_ID_KEY, client.getClientId())
+                        .log("Received a message on a topic with no matching subscription or receive-only "
+                                + "registration. Dropping the message");
+                return;
+            }
+
+            matchedCloudSubs.forEach((h) -> {
                 try {
                     h.getCallback().accept(message);
                 } catch (Throwable t) {
@@ -993,7 +1021,20 @@ public class MqttClient implements Closeable {
                             .log("Unhandled error in MQTT message callback", t);
                 }
             });
+            matchedReceiveOnlySubs.forEach((h) -> {
+                try {
+                    h.getCallback().accept(message);
+                } catch (Throwable t) {
+                    logger.atError().kv("message", message).kv(CLIENT_ID_KEY, client.getClientId())
+                            .log("Unhandled error in receive-only MQTT message callback", t);
+                }
+            });
         };
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private static boolean isSameSubscription(Subscribe sub, String topic, Consumer<Publish> callback) {
+        return sub.getCallback() == callback && sub.getTopic().equals(topic);
     }
 
     protected int getNextClientIdNumber() {

--- a/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/v5/Subscribe.java
@@ -32,6 +32,11 @@ public class Subscribe {
     List<UserProperty> userProperties;
     Consumer<Publish> callback;
 
+    // When true, MqttClient records this subscription for on-device (receive-only) routing and sends no
+    // cloud SUBSCRIBE; matching inbound messages are still delivered to the callback.
+    @Builder.Default
+    boolean skipCloudSubscribe = false;
+
     /**
      * Convert a CRT SubscribePacket.
      *

--- a/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
+++ b/src/test/java/com/aws/greengrass/builtin/services/mqttproxy/MqttProxyIPCAgentTest.java
@@ -19,8 +19,10 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
@@ -32,6 +34,8 @@ import software.amazon.awssdk.aws.greengrass.model.QOS;
 import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreRequest;
 import software.amazon.awssdk.aws.greengrass.model.SubscribeToIoTCoreResponse;
+import software.amazon.awssdk.aws.greengrass.model.SubscriptionMode;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
 import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
@@ -42,7 +46,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static com.aws.greengrass.ipc.modules.MqttProxyIPCService.MQTT_PROXY_SERVICE_NAME;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,6 +56,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,6 +67,8 @@ class MqttProxyIPCAgentTest {
     private static final String TEST_SERVICE = "TestService";
     private static final String TEST_TOPIC = "TestTopic";
     private static final byte[] TEST_PAYLOAD = "TestPayload".getBytes(StandardCharsets.UTF_8);
+    // Stands in for a subscriptionMode a later SDK adds to the model but this Nucleus does not implement.
+    private static final String FUTURE_SDK_MODE = "RECEIVE_AND_FORWARD";
 
     @Mock
     OperationContinuationHandlerContext mockContext;
@@ -177,6 +187,230 @@ class MqttProxyIPCAgentTest {
             Unsubscribe capturedUnsubscribedRequest = unsubscribeRequestArgumentCaptor.getValue();
             assertThat(capturedUnsubscribedRequest.getTopic(), is(TEST_TOPIC));
             assertThat(capturedUnsubscribedRequest.getSubscriptionCallback(), is(callback));
+            // Absent subscriptionMode must take the cloud path (skipCloudSubscribe defaults to false).
+            assertThat(capturedSubscribeRequest.isSkipCloudSubscribe(), is(false));
+        }
+    }
+
+    // ---- RECEIVE_ONLY subscribe ----
+
+    @Test
+    void GIVEN_receive_only_and_no_qos_WHEN_subscribe_THEN_receive_only_registered_and_no_error() throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+        // No qos is set: RECEIVE_ONLY does not require it.
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        ArgumentCaptor<Subscribe> subscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
+        ArgumentCaptor<Unsubscribe> unsubscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Unsubscribe.class);
+        ArgumentCaptor<IoTCoreMessage> ioTCoreMessageArgumentCaptor = ArgumentCaptor.forClass(IoTCoreMessage.class);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = spy(mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext))) {
+            SubscribeToIoTCoreResponse response =
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS);
+            subscribeToIoTCoreOperationHandler.afterHandleRequest();
+
+            assertNotNull(response);
+            // Authorization is checked for the requested topic.
+            verify(authorizationHandler).isAuthorized(MQTT_PROXY_SERVICE_NAME, Permission.builder()
+                    .principal(TEST_SERVICE).operation(GreengrassCoreIPCService.SUBSCRIBE_TO_IOT_CORE)
+                    .resource(TEST_TOPIC).build(), ResourceLookupPolicy.MQTT_STYLE);
+
+            verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
+            Subscribe capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
+            assertThat(capturedSubscribeRequest.getTopic(), is(TEST_TOPIC));
+            assertThat(capturedSubscribeRequest.isSkipCloudSubscribe(), is(true));
+
+            // Inbound delivery streams to the component.
+            Consumer<Publish> callback = capturedSubscribeRequest.getCallback();
+            Publish message = Publish.builder().payload(TEST_PAYLOAD).topic(TEST_TOPIC).build();
+            doReturn(new CompletableFuture<>()).when(subscribeToIoTCoreOperationHandler).sendStreamEvent(any());
+            callback.accept(message);
+            verify(subscribeToIoTCoreOperationHandler).sendStreamEvent(ioTCoreMessageArgumentCaptor.capture());
+            MQTTMessage mqttMessage = ioTCoreMessageArgumentCaptor.getValue().getMessage();
+            assertThat(mqttMessage.getTopicName(), is(TEST_TOPIC));
+
+            // Stream close unsubscribes the registration.
+            subscribeToIoTCoreOperationHandler.onStreamClosed();
+            verify(mqttClient).unsubscribe(unsubscribeRequestArgumentCaptor.capture());
+            assertThat(unsubscribeRequestArgumentCaptor.getValue().getTopic(), is(TEST_TOPIC));
+            assertThat(unsubscribeRequestArgumentCaptor.getValue().getSubscriptionCallback(), is(callback));
+        }
+    }
+
+    @Test
+    void GIVEN_receive_only_with_qos_supplied_WHEN_subscribe_THEN_qos_ignored_and_receive_only_registered() throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        ArgumentCaptor<Subscribe> subscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = spy(mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext))) {
+            SubscribeToIoTCoreResponse response =
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS);
+            assertNotNull(response);
+
+            verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
+            Subscribe capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
+            // The supplied qos is ignored; the request is registered receive-only.
+            assertThat(capturedSubscribeRequest.isSkipCloudSubscribe(), is(true));
+        }
+    }
+
+    @Test
+    void GIVEN_receive_only_with_invalid_qos_WHEN_subscribe_THEN_qos_validation_skipped() throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        // "10" is not a valid qos; the request must still succeed in RECEIVE_ONLY mode.
+        subscribeToIoTCoreRequest.setQos("10");
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        ArgumentCaptor<Subscribe> subscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
+            SubscribeToIoTCoreResponse response =
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS);
+            assertNotNull(response);
+
+            verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
+            assertThat(subscribeRequestArgumentCaptor.getValue().isSkipCloudSubscribe(), is(true));
+        }
+    }
+
+    @Test
+    void GIVEN_explicit_subscribe_mode_WHEN_subscribe_THEN_cloud_path_taken() throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.SUBSCRIBE_AND_RECEIVE);
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        ArgumentCaptor<Subscribe> subscribeRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = spy(mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext))) {
+            subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest).get(1, TimeUnit.SECONDS);
+
+            verify(mqttClient).subscribe(subscribeRequestArgumentCaptor.capture());
+            Subscribe capturedSubscribeRequest = subscribeRequestArgumentCaptor.getValue();
+            assertThat(capturedSubscribeRequest.isSkipCloudSubscribe(), is(false));
+            assertThat(capturedSubscribeRequest.getQos(), is(com.aws.greengrass.mqttclient.v5.QOS.AT_LEAST_ONCE));
+        }
+    }
+
+    @Test
+    void GIVEN_unknown_subscription_mode_WHEN_subscribe_THEN_error_thrown() throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
+        // An unrecognized mode is rejected rather than silently subscribed in the cloud.
+        subscribeToIoTCoreRequest.setSubscriptionMode("BOGUS");
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
+            InvalidArgumentsError e = assertThrows(InvalidArgumentsError.class, () ->
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS));
+            assertThat(e.getMessage(), containsString("BOGUS"));
+            verify(mqttClient, never()).subscribe(any(Subscribe.class));
+        }
+    }
+
+    @Test
+    void GIVEN_unknown_subscription_mode_and_no_qos_WHEN_subscribe_THEN_mode_error_not_qos_error() throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        // No qos is set. The error must name the unrecognized mode, not the missing qos.
+        subscribeToIoTCoreRequest.setSubscriptionMode("BOGUS");
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
+            InvalidArgumentsError e = assertThrows(InvalidArgumentsError.class, () ->
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS));
+            assertThat(e.getMessage(), containsString("BOGUS"));
+            verify(mqttClient, never()).subscribe(any(Subscribe.class));
+        }
+    }
+
+    @Test
+    void GIVEN_mode_known_to_sdk_but_not_implemented_WHEN_subscribe_THEN_rejected_not_cloud_subscribed()
+            throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        subscribeToIoTCoreRequest.setQos(QOS.AT_LEAST_ONCE);
+        subscribeToIoTCoreRequest.setSubscriptionMode(FUTURE_SDK_MODE);
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+
+        // Simulate a later SDK bump adding a third mode: the model resolves it, but this handler has no branch for
+        // it. Validating against the model's known set would accept it here and fall through to a cloud subscribe
+        // the component never asked for, so the handler must reject anything it does not itself implement.
+        try (MockedStatic<SubscriptionMode> modeMock = mockStatic(SubscriptionMode.class);
+             MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
+            modeMock.when(() -> SubscriptionMode.get(FUTURE_SDK_MODE))
+                    .thenReturn(SubscriptionMode.SUBSCRIBE_AND_RECEIVE);
+
+            InvalidArgumentsError e = assertThrows(InvalidArgumentsError.class, () ->
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS));
+            assertThat(e.getMessage(), containsString(FUTURE_SDK_MODE));
+            verify(mqttClient, never()).subscribe(any(Subscribe.class));
+        }
+    }
+
+    @Test
+    void GIVEN_receive_only_and_unauthorized_WHEN_subscribe_THEN_unauthorized_error() throws Exception {
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(false);
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
+            // An unauthorized RECEIVE_ONLY subscribe fails with UnauthorizedError.
+            assertThrows(UnauthorizedError.class, () ->
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void GIVEN_receive_only_and_mqtt_client_rejects_WHEN_subscribe_THEN_service_error(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, MqttRequestException.class);
+        SubscribeToIoTCoreRequest subscribeToIoTCoreRequest = new SubscribeToIoTCoreRequest();
+        subscribeToIoTCoreRequest.setTopicName(TEST_TOPIC);
+        subscribeToIoTCoreRequest.setSubscriptionMode(SubscriptionMode.RECEIVE_ONLY);
+
+        when(authorizationHandler.isAuthorized(any(), any(), any())).thenReturn(true);
+        // MqttClient.subscribe throws MqttRequestException; the handler surfaces it as a ServiceError.
+        when(mqttClient.subscribe(any(Subscribe.class))).thenThrow(
+                new MqttRequestException("Unable to register subscription for topic: " + TEST_TOPIC));
+
+        try (MqttProxyIPCAgent.SubscribeToIoTCoreOperationHandler subscribeToIoTCoreOperationHandler
+                     = mqttProxyIPCAgent.getSubscribeToIoTCoreOperationHandler(mockContext)) {
+            ServiceError e = assertThrows(ServiceError.class, () ->
+                    subscribeToIoTCoreOperationHandler.handleRequestAsync(subscribeToIoTCoreRequest)
+                            .get(1, TimeUnit.SECONDS));
+            assertThat(e.getMessage(), containsString(TEST_TOPIC));
         }
     }
 

--- a/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqttclient/MqttClientTest.java
@@ -71,6 +71,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -740,6 +741,235 @@ class MqttClientTest {
 
         handler.accept(Publish.builder().topic("A/B/C").payload(new byte[0]).build());
         abc.getLeft().get(0, TimeUnit.SECONDS);
+    }
+
+    // ---- Receive-only (direct-message) subscription tests ----
+
+    @Test
+    void GIVEN_receive_only_subscribe_WHEN_subscribe_THEN_no_cloud_subscribe_and_stored_locally()
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+
+        AtomicInteger received = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true)
+                .callback((m) -> received.incrementAndGet()).build());
+
+        // No cloud connection was created and no cloud SUBSCRIBE was issued.
+        verify(client, never()).getNewMqttClient();
+        verify(mockIndividual, never()).subscribe(any());
+
+        // A message on the receive-only topic is delivered to the callback via the router.
+        Consumer<Publish> handler = client.getMessageHandlerForClient(mockIndividual);
+        handler.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+        assertEquals(1, received.get());
+    }
+
+    @Test
+    void GIVEN_receive_only_subscription_WHEN_message_matches_filter_THEN_callback_receives_it()
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+
+        AtomicInteger received = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/#").skipCloudSubscribe(true)
+                .callback((m) -> {
+                    assertThat(m.getTopic(), either(is("cmd/A")).or(is("cmd/A/B")));
+                    received.incrementAndGet();
+                }).build());
+
+        Consumer<Publish> handler = client.getMessageHandlerForClient(mockIndividual);
+        handler.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+        handler.accept(Publish.builder().topic("cmd/A/B").payload(new byte[0]).build());
+        handler.accept(Publish.builder().topic("other/X").payload(new byte[0]).build()); // no match
+
+        assertEquals(2, received.get());
+    }
+
+    @Test
+    void GIVEN_no_cloud_and_no_local_match_WHEN_message_received_THEN_dropped_without_error(ExtensionContext context)
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+
+        AtomicInteger received = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true)
+                .callback((m) -> received.incrementAndGet()).build());
+
+        // A message matching neither a cloud sub nor the receive-only filter is dropped: no delivery, no throw.
+        Consumer<Publish> handler = client.getMessageHandlerForClient(mockIndividual);
+        handler.accept(Publish.builder().topic("unmatched/topic").payload(new byte[0]).build());
+        assertEquals(0, received.get());
+    }
+
+    @Test
+    void GIVEN_receive_only_callback_throws_WHEN_message_received_THEN_other_receive_only_callbacks_still_called(
+            ExtensionContext context)
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        ignoreExceptionWithMessage(context, "Local uncaught!");
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+
+        client.subscribe(Subscribe.builder().topic("cmd/#").skipCloudSubscribe(true)
+                .callback((m) -> {
+                    throw new RuntimeException("Local uncaught!");
+                }).build());
+        AtomicInteger received = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true)
+                .callback((m) -> received.incrementAndGet()).build());
+
+        Consumer<Publish> handler = client.getMessageHandlerForClient(mockIndividual);
+        handler.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+
+        // The throwing callback must not prevent the healthy one from being invoked.
+        assertEquals(1, received.get());
+    }
+
+    @Test
+    void GIVEN_cloud_and_local_subs_on_same_topic_with_distinct_callbacks_WHEN_message_THEN_each_called_once()
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+        when(mockIndividual.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mockIndividual.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(client.getNewMqttClient()).thenReturn(mockIndividual);
+
+        // Cloud subscription on cmd/A (distinct callback), owned by mockIndividual.
+        AtomicInteger cloudReceived = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/A").callback((m) -> cloudReceived.incrementAndGet()).build());
+        // Receive-only subscription on the same topic, different callback.
+        AtomicInteger localReceived = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true)
+                .callback((m) -> localReceived.incrementAndGet()).build());
+
+        Consumer<Publish> handler = client.getMessageHandlerForClient(mockIndividual);
+        handler.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+
+        // Each callback fires exactly once for the message.
+        assertEquals(1, cloudReceived.get());
+        assertEquals(1, localReceived.get());
+    }
+
+    @Test
+    void GIVEN_receive_only_sub_covered_by_two_connections_WHEN_message_on_both_connections_THEN_delivered_on_each()
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual1 = mock(AwsIotMqttClient.class);
+        AwsIotMqttClient mockIndividual2 = mock(AwsIotMqttClient.class);
+        when(mockIndividual1.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mockIndividual2.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mockIndividual1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(mockIndividual2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(client.getNewMqttClient()).thenReturn(mockIndividual1).thenReturn(mockIndividual2);
+        // conn1 reports it cannot take another subscription, so cmd/A lands on conn1 and cmd/# opens conn2.
+        when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
+
+        client.subscribe(SubscribeRequest.builder().topic("cmd/A").callback(cb).build());
+        client.subscribe(SubscribeRequest.builder().topic("cmd/#").callback(cb).build());
+
+        // Receive-only subscription on cmd/A, covered by both connections' cloud subscriptions.
+        AtomicInteger localReceived = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true)
+                .callback((m) -> localReceived.incrementAndGet()).build());
+
+        Consumer<Publish> handler1 = client.getMessageHandlerForClient(mockIndividual1);
+        Consumer<Publish> handler2 = client.getMessageHandlerForClient(mockIndividual2);
+
+        // The message arrives on both connections; the callback fires once per receiving connection.
+        handler1.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+        handler2.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+
+        assertEquals(2, localReceived.get());
+    }
+
+    @Test
+    void GIVEN_receive_only_subscription_WHEN_unsubscribe_THEN_removed_and_no_cloud_unsubscribe()
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+        lenient().when(mockIndividual.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        lenient().when(mockIndividual.unsubscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        lenient().when(client.getNewMqttClient()).thenReturn(mockIndividual);
+
+        AtomicInteger received = new AtomicInteger(0);
+        Consumer<Publish> callback = (m) -> received.incrementAndGet();
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true).callback(callback).build());
+
+        client.unsubscribe(Unsubscribe.builder().topic("cmd/A").subscriptionCallback(callback).build());
+
+        // After unsubscribe: no cloud UNSUBSCRIBE was issued, and the callback no longer receives messages.
+        verify(mockIndividual, never()).unsubscribe(any());
+        Consumer<Publish> handler = client.getMessageHandlerForClient(mockIndividual);
+        handler.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+        assertEquals(0, received.get());
+    }
+
+    @Test
+    void GIVEN_device_offline_WHEN_receive_only_subscribe_THEN_throws() {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        when(deviceConfiguration.isDeviceConfiguredToTalkToCloud()).thenReturn(false);
+
+        MqttRequestException e = assertThrows(MqttRequestException.class, () -> client.subscribe(
+                Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true).callback((m) -> {
+                }).build()));
+        assertThat(e.getMessage(), containsString("not configured to connect to AWS"));
+        // No cloud connection was created for the rejected subscribe.
+        verify(client, never()).getNewMqttClient();
+    }
+
+    @Test
+    void GIVEN_cloud_and_receive_only_on_same_topic_WHEN_receive_only_unsubscribed_THEN_cloud_sub_intact()
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual = mock(AwsIotMqttClient.class);
+        when(mockIndividual.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mockIndividual.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(client.getNewMqttClient()).thenReturn(mockIndividual);
+
+        // Cloud subscription on cmd/A (callback cloudCb), plus a receive-only registration on cmd/A
+        // (distinct callback).
+        AtomicInteger cloudReceived = new AtomicInteger(0);
+        Consumer<Publish> cloudCb = (m) -> cloudReceived.incrementAndGet();
+        client.subscribe(Subscribe.builder().topic("cmd/A").callback(cloudCb).build());
+        Consumer<Publish> localCb = (m) -> {
+        };
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true).callback(localCb).build());
+
+        client.unsubscribe(Unsubscribe.builder().topic("cmd/A").subscriptionCallback(localCb).build());
+
+        // No cloud UNSUBSCRIBE was issued, and the cloud subscription's callback still fires.
+        verify(mockIndividual, never()).unsubscribe(any());
+        Consumer<Publish> handler = client.getMessageHandlerForClient(mockIndividual);
+        handler.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+        assertEquals(1, cloudReceived.get());
+    }
+
+    @Test
+    void GIVEN_receive_only_covered_by_two_connections_WHEN_message_on_non_first_covering_connection_THEN_delivered()
+            throws ExecutionException, InterruptedException, TimeoutException, MqttRequestException {
+        MqttClient client = spy(new MqttClient(deviceConfiguration, (c) -> builder, ses, executorService, kernel));
+        AwsIotMqttClient mockIndividual1 = mock(AwsIotMqttClient.class);
+        AwsIotMqttClient mockIndividual2 = mock(AwsIotMqttClient.class);
+        when(mockIndividual1.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mockIndividual2.connect()).thenReturn(CompletableFuture.completedFuture(true));
+        when(mockIndividual1.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(mockIndividual2.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(client.getNewMqttClient()).thenReturn(mockIndividual1).thenReturn(mockIndividual2);
+        // cmd/A -> conn1 (first covering connection); cmd/# -> conn2 (also covers cmd/A).
+        when(mockIndividual1.canAddNewSubscription()).thenReturn(false);
+
+        client.subscribe(SubscribeRequest.builder().topic("cmd/A").callback(cb).build());
+        client.subscribe(SubscribeRequest.builder().topic("cmd/#").callback(cb).build());
+
+        AtomicInteger localReceived = new AtomicInteger(0);
+        client.subscribe(Subscribe.builder().topic("cmd/A").skipCloudSubscribe(true)
+                .callback((m) -> localReceived.incrementAndGet()).build());
+
+        // Deliver only on conn2; conn1's handler never runs.
+        Consumer<Publish> handler2 = client.getMessageHandlerForClient(mockIndividual2);
+        handler2.accept(Publish.builder().topic("cmd/A").payload(new byte[0]).build());
+
+        assertEquals(1, localReceived.get());
     }
 
     @Test


### PR DESCRIPTION
Adds an on-device path for AWS IoT Core direct messages (point-to-point, no cloud subscription). A component subscribes over IPC with subscriptionMode=RECEIVE_ONLY; the Nucleus routes matching inbound messages locally without ever issuing a cloud SUBSCRIBE.
  
  - Subscribe (v5): add skipCloudSubscribe, a routing flag (not an MQTT wire
    option). Unsubscribe is unchanged — local-only removal matches by
    (topic, callback) alone.
  - MqttClient: keep local-only registrations in a separate set; the router
    runs an independent second delivery pass over them, matching each filter
    with MqttTopic.topicIsSupersetOf and invoking each callback in its own
    try/catch. The "no subscriber" drop is logged only when both the cloud
    and local-only passes miss.
  - MqttProxyIPCAgent: SubscribeToIoTCore branches on subscriptionMode.
    RECEIVE_ONLY builds a local-only Subscribe and skips qos validation (qos
    is meaningless with no cloud subscription); SUBSCRIBE/absent/unknown keep
    the existing cloud path. Authorization runs unchanged for both modes.
  - Tests: MqttClientTest (router + local-only delivery), MqttProxyIPCAgentTest
    (handler modes + auth), IPCMqttProxyTest (real IPC), and
    DirectMessageRoutingIntegTest (real IPC handler + real router end to end,
    asserting no cloud SUBSCRIBE).

Note: requires an aws-iot-device-sdk with subscriptionMode; the pom bump to a published SDK is intentionally not committed (kept as a local dev-only change).

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
