### PR TITLE
fix: do not treat unknown thing group membership as empty membership

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -349,8 +349,7 @@ public class DefaultDeploymentTask implements DeploymentTask {
         Topics groupsToRootPackages =
                 deploymentServiceConfig.lookupTopics(DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS);
         return Optional.of(groupsToRootPackages.children.values().stream().map(Node::getName)
-                .filter(g -> !LOCAL_DEPLOYMENT_GROUP_NAME.equals(g))
-                .filter(g -> !g.startsWith(DEVICE_DEPLOYMENT_GROUP_NAME_PREFIX))
+                .filter(g -> g.startsWith(ThingGroupHelper.THING_GROUP_RESOURCE_TYPE_PREFIX))
                 .collect(Collectors.toSet()));
     }
 

--- a/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
+++ b/src/main/java/com/aws/greengrass/deployment/DefaultDeploymentTask.java
@@ -277,6 +277,15 @@ public class DefaultDeploymentTask implements DeploymentTask {
         Optional<Set<String>> groupsForDeviceOpt;
         try {
             groupsForDeviceOpt = thingGroupHelper.listThingGroupsForDevice(maxAttemptCount);
+            if (!groupsForDeviceOpt.isPresent()) {
+                // Membership is unknown (the device is not configured to talk to the cloud, so no lookup was
+                // attempted). Unknown must not be treated as an authoritative "member of no thing groups" -
+                // that would drop every recorded group's components from the merge and delete the groups'
+                // records in the post-deployment cleanup. Fall back to the memberships implied by the
+                // persisted group records, exactly as the fetch-failure paths below do.
+                logger.atDebug().log("Thing group membership is unknown, falling back to persisted membership");
+                groupsForDeviceOpt = getPersistedMembershipInfo();
+            }
         } catch (GreengrassV2DataException e) {
             if (e.statusCode() == HttpStatusCode.FORBIDDEN) {
                 // Getting group hierarchy requires permission to call the ListThingGroupsForCoreDevice API which

--- a/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
@@ -219,4 +219,33 @@ class ThingGroupMembershipPreservationTest {
                 "An authoritative empty membership response must keep removing: the device genuinely belongs "
                         + "to no thing groups");
     }
+
+    /**
+     * SCOPE-PINNING TEST (must pass with and without the fix): the unknown-membership fallback implies
+     * membership only for thing-group records ({@code thinggroup/} prefix — the only names a real membership
+     * lookup can return). A record whose name is not a thing group (for example a raw configuration ARN that
+     * failed to parse) must not be resurrected as a membership: its components are not added to the merge's
+     * preserved root set, so it cannot impose stale version constraints on later deployments.
+     */
+    @Test
+    void GIVEN_membership_unknown_WHEN_non_thing_group_record_exists_THEN_it_is_not_treated_as_membership()
+            throws Exception {
+        String nonThingGroupName = "SomeRawConfigurationArn";
+        String nonThingGroupComponent = "component3";
+        groupToRootConfig.lookupTopics(nonThingGroupName, nonThingGroupComponent)
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt())).thenReturn(Optional.empty());
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
+
+        createLocalDeploymentTask(document).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertNotNull(rootPackages);
+        assertTrue(rootPackages.contains(ROOT_COMPONENT_NAME),
+                "The thing-group record's component must still be preserved");
+        assertFalse(rootPackages.contains(nonThingGroupComponent),
+                "A non-thing-group record must not be treated as a thing group membership by the "
+                        + "unknown-membership fallback");
+    }
 }

--- a/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/ThingGroupMembershipPreservationTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.deployment;
+
+import com.aws.greengrass.componentmanager.ComponentManager;
+import com.aws.greengrass.componentmanager.DependencyResolver;
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.converter.DeploymentDocumentConverter;
+import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
+import com.aws.greengrass.deployment.model.DeploymentResult;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for thing-group membership handling in
+ * {@code DefaultDeploymentTask.getNonTargetGroupToRootPackagesMap()}.
+ *
+ * <h2>The defect</h2>
+ * <p>{@code ThingGroupHelper.listThingGroupsForDevice()} returns {@code Optional.empty()} when the device is
+ * not configured to talk to the cloud (no lookup is even attempted) — membership is <em>unknown</em>. The task
+ * coerced that unknown to an empty set, i.e. an authoritative "member of no thing groups". One local deployment
+ * processed in that state drops every recorded thing group's components from the merge (removing them from the
+ * device) and rebuilds the {@code GroupMembership} snapshot empty, which lets the post-deployment cleanup
+ * delete every thing group's records. This requires no prior loss of state — a device whose cloud provisioning
+ * config is missing or invalid (including lost or corrupted config) running a local deployment is sufficient.
+ *
+ * <h2>The contract these tests encode</h2>
+ * <p>Unknown membership must be handled like the existing fetch-failure fallbacks: fall back to the membership
+ * implied by the persisted group records. Only an authoritative response may change what is preserved — a
+ * successful lookup returning an empty set (the device really belongs to no thing groups) still removes.
+ */
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class ThingGroupMembershipPreservationTest {
+
+    private static final String GROUP_NAME = "thinggroup/group1";
+    private static final String ROOT_COMPONENT_NAME = "component2";
+
+    private static Context context;
+    private final Logger logger = LogManager.getLogger("thing-group-membership-preservation");
+
+    @Mock
+    private DependencyResolver mockDependencyResolver;
+    @Mock
+    private ComponentManager mockComponentManager;
+    @Mock
+    private KernelConfigResolver mockKernelConfigResolver;
+    @Mock
+    private DeploymentConfigMerger mockDeploymentConfigMerger;
+    @Mock
+    private ExecutorService mockExecutorService;
+    @Mock
+    private DeploymentDocumentDownloader deploymentDocumentDownloader;
+    @Mock
+    private ThingGroupHelper mockThingGroupHelper;
+    @Mock
+    private DeviceConfiguration mockDeviceConfiguration;
+    @Mock
+    private Topics mockDeploymentServiceConfig;
+
+    private Topics groupToRootConfig;
+    private Topics groupMembership;
+    private ArgumentCaptor<List<String>> rootPackagesCaptor;
+
+    @BeforeAll
+    static void setupContext() {
+        context = new Context();
+    }
+
+    @AfterAll
+    static void cleanContext() throws IOException {
+        context.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        groupToRootConfig = Topics.of(context, DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS, null);
+        groupMembership = Topics.of(context, DeploymentService.GROUP_MEMBERSHIP_TOPICS, null);
+
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_MEMBERSHIP_TOPICS)))
+                .thenReturn(groupMembership);
+        lenient().when(mockDeploymentServiceConfig.lookupTopics(eq(DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS)))
+                .thenReturn(groupToRootConfig);
+
+        // A healthy record from a prior deployment: "group1" wants "component2".
+        groupToRootConfig.lookupTopics(GROUP_NAME, ROOT_COMPONENT_NAME)
+                .replaceAndWait(ImmutableMap.of(DeploymentService.GROUP_TO_ROOT_COMPONENTS_VERSION_KEY, "1.0.0"));
+    }
+
+    private DefaultDeploymentTask createLocalDeploymentTask(DeploymentDocument document) {
+        return new DefaultDeploymentTask(mockDependencyResolver, mockComponentManager, mockKernelConfigResolver,
+                mockDeploymentConfigMerger, logger,
+                new Deployment(document, Deployment.DeploymentType.LOCAL, "localJobId", DEFAULT),
+                mockDeploymentServiceConfig, mockExecutorService, deploymentDocumentDownloader, mockThingGroupHelper,
+                mockDeviceConfiguration);
+    }
+
+    private DeploymentDocument localDeploymentDocument() {
+        return DeploymentDocument.builder().deploymentId("TestLocalDeployment")
+                .timestamp(System.currentTimeMillis())
+                .groupName(DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME).build();
+    }
+
+    private void mockSuccessfulPipeline(DeploymentDocument document) throws Exception {
+        lenient().when(mockComponentManager.preparePackages(anyList()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        lenient().when(mockExecutorService.submit(any(Callable.class)))
+                .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+        lenient().when(mockDeploymentConfigMerger.mergeInNewConfig(any(), any(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new DeploymentResult(DeploymentResult.DeploymentStatus.SUCCESSFUL, null)));
+        rootPackagesCaptor = ArgumentCaptor.forClass(List.class);
+        lenient().when(mockKernelConfigResolver.resolve(anyList(), eq(document), rootPackagesCaptor.capture(),
+                anyLong())).thenReturn(Collections.emptyMap());
+    }
+
+    /**
+     * REGRESSION TEST (fails without the fix): unknown membership must not mean "member of no groups".
+     *
+     * <p>The membership lookup reports unknown ({@code Optional.empty()} — the device is not configured to talk
+     * to the cloud, so no lookup was attempted). The healthy group record must still preserve its component,
+     * exactly as the fetch-failure fallback paths already do, and the rebuilt {@code GroupMembership} snapshot
+     * must still contain the group so the post-deployment cleanup does not delete its records.
+     */
+    @Test
+    void GIVEN_membership_unknown_WHEN_local_deployment_THEN_recorded_group_components_are_preserved()
+            throws Exception {
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt())).thenReturn(Optional.empty());
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
+
+        DeploymentResult result = createLocalDeploymentTask(document).call();
+
+        assertEquals(DeploymentResult.DeploymentStatus.SUCCESSFUL, result.getDeploymentStatus());
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertTrue(rootPackages != null && rootPackages.contains(ROOT_COMPONENT_NAME),
+                "REGRESSION: membership 'unknown' was treated as an authoritative 'member of no groups', "
+                        + "dropping a healthy group record's component from the merge. Unknown membership must "
+                        + "fall back to the persisted membership info instead.");
+        assertNotNull(groupMembership.find(GROUP_NAME),
+                "GroupMembership must be rebuilt from persisted info when membership is unknown, so that "
+                        + "cleanupGroupData does not delete the group's records");
+    }
+
+    /**
+     * CONTROL TEST (passes with and without the fix): an authoritative lookup confirming membership preserves
+     * the recorded group's component.
+     */
+    @Test
+    void GIVEN_membership_confirmed_WHEN_local_deployment_THEN_recorded_group_components_are_preserved()
+            throws Exception {
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
+                .thenReturn(Optional.of(Collections.singleton(GROUP_NAME)));
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
+
+        createLocalDeploymentTask(document).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertTrue(rootPackages != null && rootPackages.contains(ROOT_COMPONENT_NAME),
+                "Control: component must be preserved when membership is confirmed");
+    }
+
+    /**
+     * LEGITIMATE-FLOW TEST (must pass with and without the fix): an authoritative lookup returning an empty
+     * set is not "unknown" — the device really belongs to no thing groups, and the recorded group's component
+     * is removed. Pins the distinction between {@code Optional.empty()} and {@code Optional.of(emptySet)},
+     * guarding the fix against over-preservation.
+     */
+    @Test
+    void GIVEN_authoritative_empty_membership_WHEN_local_deployment_THEN_recorded_group_components_are_removed()
+            throws Exception {
+        when(mockThingGroupHelper.listThingGroupsForDevice(anyInt()))
+                .thenReturn(Optional.of(Collections.emptySet()));
+        DeploymentDocument document = localDeploymentDocument();
+        mockSuccessfulPipeline(document);
+
+        createLocalDeploymentTask(document).call();
+
+        List<String> rootPackages = rootPackagesCaptor.getValue();
+        assertNotNull(rootPackages);
+        assertFalse(rootPackages.contains(ROOT_COMPONENT_NAME),
+                "An authoritative empty membership response must keep removing: the device genuinely belongs "
+                        + "to no thing groups");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a defect where an **unknown** thing-group membership response was treated as an authoritative **"member of no thing groups"** — causing a single local deployment to remove every recorded thing group's components from the device and delete the groups' bookkeeping records.

## The defect

During deployment processing, `DefaultDeploymentTask.getNonTargetGroupToRootPackagesMap()` fetches the device's current thing-group membership via `ThingGroupHelper.listThingGroupsForDevice()` to decide which recorded thing groups' components to preserve. That lookup can end three different ways, and it is important to distinguish them:

1. **Authoritative answer** — the device is configured for the cloud, the `ListThingGroupsForCoreDevice` call succeeds, and the response (possibly an empty list) is the truth about membership.
2. **Attempted and failed** — the device is configured for the cloud, the call is made, but it throws (network unreachable/offline, timeout, `FORBIDDEN`, retries exhausted). This surfaces as an exception and is handled by existing fallback paths that use the persisted group records instead. *This path was already correct and is not changed by this PR.*
3. **Unknown, never attempted (`Optional.empty()`)** — `listThingGroupsForDevice()` has a guard at the top: if `isDeviceConfiguredToTalkToCloud()` is false, it returns `Optional.empty()` **without making any cloud call**. This means the device's cloud provisioning configuration (thing name, IoT data/credential endpoints, certificate path, private key path, root CA path, AWS region) is missing or invalid, so the question "which groups am I in?" cannot even be asked.

**When does case 3 actually come up?** A device can be in that state because:
- it was provisioned for **local-only / offline operation** and never had cloud config (harmless — such a device has no thing-group records to lose); or
- it **had valid cloud config that is now missing or corrupted** — e.g. configuration state loss, a bad reconfiguration, or a partially-applied provisioning change. This is the dangerous case: the device still has thing-group records and thing-group components running, but its provisioning config no longer validates.

Note that a device that is merely **offline** (network down, cloud unreachable) does *not* produce `Optional.empty()` — its config still validates, so the call is attempted, throws, and takes the already-safe fallback path (case 2). `Optional.empty()` occurs specifically when the configuration itself is invalid.

Because case 3 returns an empty `Optional` rather than throwing, none of the case-2 fallbacks fire. The buggy code coerced the unknown into an empty membership set — an authoritative "member of no thing groups". Consequences of one local deployment processed in that state:

1. Every recorded thing group fails the membership filter → its root components are dropped from the merge's preserved root set → **removed from the device**.
2. The `GroupMembership` snapshot is rebuilt empty → the post-deployment cleanup **deletes every thing group's `GroupToRootComponents` / `GroupToLastDeployment` records**, so the components stay gone even after the configuration is repaired, until each group is redeployed from the cloud.

No prior loss of deployment state is required. A plausible end-to-end trigger: a device's cloud config becomes invalid, and a component auto-submits a local deployment at startup (a common fleet pattern) — that single local deployment uninstalls every thing-group component on the device.

## The fix

Unknown membership (`Optional.empty()`) now falls back to the membership implied by the persisted group records — exactly the behavior of the existing attempted-and-failed fallback paths. "We could not determine membership" is no longer treated as "we determined the device has no memberships". One code path, nine lines.

| Scenario | What it means | Before | After |
|---|---|---|---|
| Lookup returns unknown (`Optional.empty()`) | Cloud provisioning config missing/invalid — no lookup attempted | All recorded thing groups' components removed; all group records deleted by cleanup | Recorded groups preserved; records kept (same as fetch-failure handling) |
| Authoritative lookup confirming membership | Call succeeded; groups listed | Preserved | Preserved (unchanged) |
| Authoritative lookup returning an **empty set** | Call succeeded; device genuinely in no thing groups | Components removed, records cleaned | Removed and cleaned (unchanged) — pinned by a test |
| Lookup attempted and failed | Config valid; call made but threw (offline, timeout, `FORBIDDEN`) | Falls back to persisted membership | Unchanged |

## Tests

`ThingGroupMembershipPreservationTest`:
- Regression test (verified **failing with the fix disabled**): unknown membership preserves recorded groups' components and rebuilds `GroupMembership` from persisted info.
- Control test: confirmed membership preserves (passes with and without the fix).
- Legitimate-flow test: authoritative *empty* membership still removes — pins the `Optional.empty()` vs `Optional.of(emptySet)` distinction, guarding against over-preservation (passes with and without the fix).
- Scope-pinning test (verified **failing without the thing-group filter**): the fallback implies membership only for `thinggroup/`-prefixed records; a record whose name is not a thing group is not resurrected as a membership.

## Fallback scope

The fallback returns only `thinggroup/`-prefixed record names — the only names a real membership lookup can return. Without that restriction, a record whose group name is not a thing group (e.g. a raw configuration ARN that failed to parse) would be treated as a membership, and its pinned root components would enter the merge's preserved root set, where they can impose stale version constraints on later deployments and make dependency resolution unsatisfiable. For devices deployed through the cloud APIs this is behavior-neutral: configuration ARNs always parse, so persisted records are `thinggroup/`-prefixed, `thing/`-prefixed, or `LOCAL_DEPLOYMENT`.

Full `mvn clean test` with checkstyle/PMD/spotbugs active: 1196 tests, the only failure is pre-existing and unrelated (identical on the unmodified branch).

## Scope history

This PR was originally broader (running-component preservation for local deployments and a post-restart cleanup deferral). After further lab testing showed those changes address no remaining demonstrated failure once #1824 is deployed, they were narrowed out of this PR and parked on the `local-deployment-preservation-parked` branch for a possible future defense-in-depth PR. This defect is the one remaining demonstrated bug not covered by #1824.

## Related

#1824 fixes the loss of persisted configuration (builtin service config protection) observed in the field. This defect is independent of it — it needs no prior state loss.

