### PR TITLE
test: extend await timeouts in rollback cancellation test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentServiceIntegrationTest.java
@@ -677,12 +677,14 @@ class DeploymentServiceIntegrationTest extends BaseITCase {
                     "TestComponentTakesLongToStartupNoNotify", DeploymentType.SHADOW);
 
             // WHEN
-            assertTrue(firstDeploymentCompleted.await(20, TimeUnit.SECONDS));
+            // The install script sleeps 15 seconds; leave generous headroom for deployment machinery
+            // and slow runners on top of that mandatory delay.
+            assertTrue(firstDeploymentCompleted.await(60, TimeUnit.SECONDS));
             // FleetConfigWithComponentTakesLongToStartupAndBrokenService.json
             submitSampleCloudDeploymentDocument(
                     DeploymentServiceIntegrationTest.class.getResource("FleetConfigWithComponentTakesLongToStartupAndBrokenService.json")
                             .toURI(), "DeployBrokenComponent", DeploymentType.SHADOW);
-            assertTrue(secondDeploymentFailed.await(15, TimeUnit.SECONDS));
+            assertTrue(secondDeploymentFailed.await(60, TimeUnit.SECONDS));
 
             // THEN
             submitSampleCloudDeploymentDocument(


### PR DESCRIPTION
## Problem

`DeploymentServiceIntegrationTest.GIVEN_deployment_with_broken_component_WHEN_deployment_is_cancelled_during_rollback_THEN_deployment_cancelled` fails intermittently in CI, predominantly on Windows runners, at its first gating assertion:

```
assertTrue(firstDeploymentCompleted.await(20, TimeUnit.SECONDS));
```

The first deployment installs `ComponentTakesLongToStartup`, whose install script mandatorily sleeps 15 seconds. A failing Windows CI run shows the budget being lost to ordinary machinery overhead, not to any product defect:

- deployment submitted and received: `t+0.0s`
- deployment execution started: `t+3.4s` (kernel/deployment machinery)
- install script started: `t+3.8s` (powershell startup adds ~1s)
- `Finish install.` logged: `t+19.3s`
- 20-second await expired before the deployment success status was stored

15s mandatory sleep + 1–2s powershell startup + 3–4s deployment machinery leaves at most a few seconds of margin — and negative margin on a slow runner. The second gating await (`secondDeploymentFailed.await(15, TimeUnit.SECONDS)`) has a similarly thin budget.

## Fix

Extend both gating awaits to 60 seconds. The latches count down on log events, so longer timeouts only add tolerance on slow runners; passing runs are not slowed.

## Testing

- `mvn test-compile` clean.
- The change is timeout-only; no assertion logic or scenario ordering changes.
