### PR TITLE
revert: use Long for tlog integer deserialization (#1820)

### DIFF
--- a/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/GenericExternalService.java
@@ -540,7 +540,7 @@ public class GenericExternalService extends GreengrassService {
 
             Topic timeoutTopic = config.find(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, LIFECYCLE_RUN_NAMESPACE_TOPIC,
                     Lifecycle.TIMEOUT_NAMESPACE_TOPIC);
-            Integer timeout = timeoutTopic == null ? null : Coerce.toInt(timeoutTopic);
+            Integer timeout = timeoutTopic == null ? null : (Integer) timeoutTopic.getOnce();
             if (timeout != null) {
                 Exec processToClose = runResult.getExec();
                 context.get(ScheduledExecutorService.class).schedule(() -> {

--- a/src/main/java/com/aws/greengrass/util/Coerce.java
+++ b/src/main/java/com/aws/greengrass/util/Coerce.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.util;
 import com.aws.greengrass.config.Topic;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -24,8 +23,7 @@ import static com.aws.greengrass.util.Utils.isEmpty;
 public final class Coerce {
     private static final Pattern SEPARATORS = Pattern.compile(" *, *");
     private static final Pattern unwrap = Pattern.compile(" *\\[ *(.*) *\\] *");
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .enable(DeserializationFeature.USE_LONG_FOR_INTS);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private Coerce() {
     }

--- a/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationTest.java
@@ -130,7 +130,7 @@ class ConfigurationTest {
         ConfigurationWriter.dump(config, p);
         assertEquals(config.getRoot(), config.getRoot());
         Configuration c2 = ConfigurationReader.createFromTLog(config.context, p);
-        assertEquals(44L, c2.lookup("x", "z").getOnce());
+        assertEquals(44, c2.lookup("x", "z").getOnce());
         assertEquals(config, c2);
         Topic nv = config.lookup("number");
     }

--- a/src/test/java/com/aws/greengrass/config/ConfigurationWriterTest.java
+++ b/src/test/java/com/aws/greengrass/config/ConfigurationWriterTest.java
@@ -55,7 +55,7 @@ class ConfigurationWriterTest {
             // Create a Topic somewhere in the hierarchy
             config.lookup("a.x", "b", "c", "d", "e").withValue("Some Val");
             // Create another Topic and use a different data type as the value (number)
-            config.lookup("a.x", "b", "c.f", "d", "e2").withValue(2L);
+            config.lookup("a.x", "b", "c.f", "d", "e2").withValue(2);
             context.waitForPublishQueueToClear(); // Block until publish queue is empty to ensure all changes have
             // been processed
 

--- a/src/test/java/com/aws/greengrass/util/CoerceTest.java
+++ b/src/test/java/com/aws/greengrass/util/CoerceTest.java
@@ -130,7 +130,7 @@ class CoerceTest {
         assertEquals("", toObject(null));
         assertEquals("", toObject(""));
         assertEquals(12.34, toObject("12.34"));
-        assertEquals(1234L, toObject("1234"));
+        assertEquals(1234, toObject("1234"));
         assertEquals(1234567890123L, toObject("1234567890123"));
     }
 


### PR DESCRIPTION
Reverts #1820.

This reverts commit 609539c13e36c129c84b8e627f20b7e2473970d0.

## Why

As discussed in the review comments on #1820, the `USE_LONG_FOR_INTS` approach has two problems:

1. **Observable type change for all in-process components.** Every integer config value now comes back from the tlog as `Long`. #1820 itself had to fix an `(Integer)` cast in `GenericExternalService` — third-party in-process plugins (e.g. custom provisioning) with similar casts can't be audited and would get `ClassCastException` after upgrading.

2. **The mismatch is relocated, not eliminated.** Other ingestion paths still produce `Integer`: `SerializerFactory.FAIL_SAFE_JSON_OBJECT_MAPPER` (deployment documents) and `Configuration.yamlMapper` (initial config) don't have `USE_LONG_FOR_INTS`. A numeric value merged from a deployment doc enters the store as `Integer`, round-trips through the tlog as `Long`, and the next merge of the same document sees a false diff — spurious changed event, tlog write, and subscriber notifications.

The reported symptom (unnecessary `config.tlog` writes from LogManager) is fixed in aws-greengrass/aws-greengrass-log-manager#258 instead. Normalizing numeric equality in the nucleus config store (`Topic.withNewerValue`) may be explored as a follow-up.