### PR TITLE
feat: compact config.tlog at boot when it exceeds a size threshold

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelRestartTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/KernelRestartTest.java
@@ -10,15 +10,20 @@ import com.aws.greengrass.integrationtests.BaseITCase;
 import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.util.Coerce;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class KernelRestartTest extends BaseITCase {
@@ -105,6 +110,42 @@ class KernelRestartTest extends BaseITCase {
         // service 1 is removed
         assertThrows(ServiceLoadException.class, () -> kernel.locate("service_1"),
                 "actual kernel config: " + kernel.getConfig().toPOJO());
+    }
+
+    @Test
+    void GIVEN_config_tlog_exceeds_threshold_WHEN_kernel_restarts_THEN_compacted_and_config_preserved()
+            throws Exception {
+        // GIVEN a running kernel with a low boot-compaction threshold and an oversized config.tlog.
+        kernel = new Kernel();
+        kernel.parseArgs();
+        kernel.launch();
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.FINISHED), TIMEOUT));
+
+        Path configTlog = kernel.getNucleusPaths().configPath().resolve("config.tlog");
+
+        // Persist a low threshold (so the restart boot reads it back) and bloat the tlog with many
+        // last-writer-wins writes to one topic: many tlog lines, but a tiny effective config.
+        kernel.getContext().runOnPublishQueueAndWait(() -> {
+            kernel.getConfig().lookup("services", "aws.greengrass.Nucleus", "configuration",
+                    "bootConfigTlogCompactionThresholdBytes").withValue(20_000L);
+            for (int i = 0; i < 2000; i++) {
+                kernel.getConfig().lookup("e2eCompactionProbe", "counter").withValue(i);
+            }
+        });
+        kernel.getContext().waitForPublishQueueToClear();
+
+        long bloatedSize = Files.size(configTlog);
+        assertThat(bloatedSize, greaterThan(20_000L));
+        kernel.shutdown();
+
+        // WHEN the kernel restarts with the same root dir, boot compaction rewrites the oversized tlog.
+        kernel = new Kernel();
+        kernel.parseArgs().launch();
+        assertThat(kernel.getMain()::getState, eventuallyEval(is(State.FINISHED), TIMEOUT));
+
+        // THEN config.tlog was compacted and the probe value survived the compaction round-trip.
+        assertThat(Files.size(configTlog), lessThan(bloatedSize));
+        assertThat(Coerce.toInt(kernel.getConfig().find("e2eCompactionProbe", "counter")), is(equalTo(1999)));
     }
 
     @AfterEach

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -120,6 +120,12 @@ public class DeviceConfiguration {
     public static final String DEVICE_PARAM_PROXY_PASSWORD = "password";
     public static final long COMPONENT_STORE_MAX_SIZE_DEFAULT_BYTES = 10_000_000_000L;
     public static final long DEPLOYMENT_POLLING_FREQUENCY_DEFAULT_SECONDS = 15L;
+    // Boot-time config.tlog compaction: when config.tlog (or its config.tlog~ backup) exceeds this many
+    // bytes at startup, rewrite it from the in-memory effective config to collapse accumulated duplicate
+    // no-op entries that slow tlog replay on every boot. Enabled by default at 10 MB; set 0 to disable.
+    public static final String BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES =
+            "bootConfigTlogCompactionThresholdBytes";
+    public static final long DEFAULT_BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES = 10_000_000L;
     public static final String DEVICE_PARAM_GG_DATA_PLANE_PORT = "greengrassDataPlanePort";
     private static final int GG_DATA_PLANE_PORT_DEFAULT = 8443;
 
@@ -164,6 +170,7 @@ public class DeviceConfiguration {
         handleLoggingConfig();
         getComponentStoreMaxSizeBytes().dflt(COMPONENT_STORE_MAX_SIZE_DEFAULT_BYTES);
         getDeploymentPollingFrequencySeconds().dflt(DEPLOYMENT_POLLING_FREQUENCY_DEFAULT_SECONDS);
+        getBootConfigTlogCompactionThresholdBytes().dflt(DEFAULT_BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES);
         handleExistingSystemProperty();
         // reset the cache when device configuration changes
         onAnyChange((what, node) -> deviceConfigValidateCachedResult.set(null));
@@ -563,6 +570,10 @@ public class DeviceConfiguration {
 
     public Topic getComponentStoreMaxSizeBytes() {
         return getTopic(COMPONENT_STORE_MAX_SIZE_BYTES);
+    }
+
+    public Topic getBootConfigTlogCompactionThresholdBytes() {
+        return getTopic(BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES);
     }
 
     public Topic getDeploymentPollingFrequencySeconds() {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/KernelLifecycle.java
@@ -9,6 +9,7 @@ import com.amazon.aws.iot.greengrass.component.common.DependencyType;
 import com.aws.greengrass.componentmanager.plugins.docker.DockerApplicationManagerService;
 import com.aws.greengrass.config.ConfigurationReader;
 import com.aws.greengrass.config.ConfigurationWriter;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.dependency.EZPlugins;
@@ -39,6 +40,7 @@ import com.aws.greengrass.status.FleetStatusService;
 import com.aws.greengrass.telemetry.TelemetryAgent;
 import com.aws.greengrass.telemetry.impl.config.TelemetryConfig;
 import com.aws.greengrass.tes.TokenExchangeService;
+import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.CommitableFile;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.RetryUtils;
@@ -90,6 +92,7 @@ public class KernelLifecycle {
     // TODO:  Use the enum from common library when available
     private static final String DEFAULT_PROVISIONING_POLICY = "PROVISION_IF_NOT_PROVISIONED";
     private static final String SYSTEM_SHUTDOWN_EVENT = "system-shutdown";
+    private static final String PATH_LOG_KEY = "path";
     private static final int MAX_PROVISIONING_PLUGIN_RETRY_ATTEMPTS = 3;
 
     public static final String MULTIPLE_PROVISIONING_PLUGINS_FOUND_EXCEPTION = "Multiple provisioning plugins found "
@@ -345,6 +348,20 @@ public class KernelLifecycle {
             if (!readFromTlog) {
                 kernel.writeEffectiveConfigAsTransactionLog(transactionLogPath);
             }
+
+            // On a normal reboot config.tlog is only appended to, never rewritten, so a device that reboots
+            // frequently (never crossing the runtime 15k-entry auto-truncate, whose counter resets each boot)
+            // accumulates duplicate no-op entries without bound, slowing every subsequent boot's tlog replay.
+            // Compact here when over threshold, reusing the same crash-safe CommitableFile dump path.
+            try {
+                compactConfigTlogIfNeeded(transactionLogPath, readFromTlog);
+            } catch (IOException e) {
+                // Compaction is an optimization; a bloated-but-valid tlog still boots. Never let a failed
+                // dump (e.g. disk full) abort launch — log and continue; the next boot retries.
+                logger.atError().setCause(e).kv(PATH_LOG_KEY, transactionLogPath)
+                        .log("Failed to compact config.tlog at boot; continuing with uncompacted tlog");
+            }
+
             kernel.writeEffectiveConfig();
 
             // hook tlog to config so that changes over time are persisted to the tlog
@@ -353,6 +370,84 @@ public class KernelLifecycle {
         } catch (IOException ioe) {
             logger.atError().setEventType("nucleus-read-config-error").setCause(ioe).log();
             throw new RuntimeException(ioe);
+        }
+    }
+
+    /**
+     * Compact config.tlog and its backup at boot when either exceeds the configured size threshold.
+     *
+     * <p>Both gates reuse the existing atomic {@link Kernel#writeEffectiveConfigAsTransactionLog}
+     * (CommitableFile) path, and run before the append writer is attached, so there is no open-writer
+     * contention and no concurrent service writes:
+     * <ol>
+     *     <li>ACTIVE: on a normal reboot ({@code readFromTlog == true}) a bloated config.tlog is rewritten
+     *     from the in-memory effective config, collapsing duplicate no-op entries. The {@code !readFromTlog}
+     *     paths (deployment/rollback/recovery) already rewrote config.tlog above, so they skip this gate.</li>
+     *     <li>BACKUP: the dump above demotes the old (possibly bloated) config.tlog to config.tlog~. If that
+     *     backup is still over threshold, dump once more so the now-small config.tlog cascades into
+     *     config.tlog~, atomically evicting the bloated backup while keeping a valid, current first-tier
+     *     recovery copy. This gate also self-heals a crash that occurred between the two dumps on a
+     *     subsequent boot (active is small but the backup is still large).</li>
+     * </ol>
+     *
+     * @param transactionLogPath path to config.tlog
+     * @param readFromTlog       whether config was loaded from the existing tlog (a normal reboot)
+     * @throws IOException on failure to stat or rewrite the tlog
+     */
+    private void compactConfigTlogIfNeeded(Path transactionLogPath, boolean readFromTlog) throws IOException {
+        // Read the threshold without mutating the config tree; DeviceConfiguration seeds the default later.
+        Topic thresholdTopic = kernel.getConfig().find(SERVICES_NAMESPACE_TOPIC,
+                DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
+                DeviceConfiguration.BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES);
+        long threshold = DeviceConfiguration.DEFAULT_BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES;
+        Object rawValue = thresholdTopic == null ? null : thresholdTopic.getOnce();
+        if (rawValue instanceof Number) {
+            // Preserve the lenient numeric handling (e.g. a value deserialized as a float).
+            threshold = Coerce.toLong(rawValue);
+        } else if (rawValue != null) {
+            // Parse the raw string ourselves: Coerce.toLong collapses unparseable input to 0, which would
+            // be indistinguishable from the intentional disable value, so a typo would silently disable.
+            try {
+                threshold = Long.parseLong(Coerce.toString(rawValue).trim());
+            } catch (NumberFormatException e) {
+                logger.atWarn().kv("value", Coerce.toString(rawValue))
+                        .kv("defaultBytes", threshold)
+                        .log("Invalid bootConfigTlogCompactionThresholdBytes; using default");
+            }
+        }
+        if (threshold < 0) {
+            logger.atWarn().kv("value", threshold)
+                    .log("Negative bootConfigTlogCompactionThresholdBytes; treating as disabled");
+        }
+        if (threshold <= 0) {
+            return;
+        }
+
+        // Gate 1: compact a bloated active tlog on a normal reboot (the !readFromTlog paths already dumped).
+        if (readFromTlog && Files.exists(transactionLogPath)
+                && Files.size(transactionLogPath) > threshold) {
+            logger.atInfo().kv(PATH_LOG_KEY, transactionLogPath).kv("thresholdBytes", threshold)
+                    .kv("sizeBytes", Files.size(transactionLogPath))
+                    .log("config.tlog exceeds boot compaction threshold; compacting");
+            kernel.writeEffectiveConfigAsTransactionLog(transactionLogPath);
+        }
+
+        // Gate 2: reclaim a bloated backup (config.tlog~) left by the demote above or by a prior boot.
+        Path backupTlogPath = CommitableFile.getBackupFile(transactionLogPath);
+        if (Files.exists(backupTlogPath) && Files.size(backupTlogPath) > threshold) {
+            logger.atInfo().kv(PATH_LOG_KEY, backupTlogPath).kv("thresholdBytes", threshold)
+                    .kv("sizeBytes", Files.size(backupTlogPath))
+                    .log("config.tlog~ backup exceeds threshold; compacting to reclaim space");
+            kernel.writeEffectiveConfigAsTransactionLog(transactionLogPath);
+        }
+
+        // If the effective config itself exceeds the threshold, compaction can't get below it and would
+        // re-fire every boot. Warn so the operator can raise the threshold.
+        if (Files.exists(transactionLogPath) && Files.size(transactionLogPath) > threshold) {
+            logger.atWarn().kv(PATH_LOG_KEY, transactionLogPath).kv("thresholdBytes", threshold)
+                    .kv("sizeBytes", Files.size(transactionLogPath))
+                    .log("config.tlog still exceeds threshold after compaction; effective config may be larger "
+                            + "than the threshold — consider raising bootConfigTlogCompactionThresholdBytes");
         }
     }
 

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelLifecycleTest.java
@@ -7,6 +7,9 @@ package com.aws.greengrass.lifecyclemanager;
 
 import com.amazon.aws.iot.greengrass.component.common.DependencyType;
 import com.aws.greengrass.config.Configuration;
+import com.aws.greengrass.config.ConfigurationReader;
+import com.aws.greengrass.config.ConfigurationWriter;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.dependency.Context;
@@ -28,6 +31,7 @@ import com.aws.greengrass.provisioning.ProvisioningPluginFactory;
 import com.aws.greengrass.provisioning.exceptions.RetryableProvisioningException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
+import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.Pair;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.ClassAnnotationMatchProcessor;
@@ -45,6 +49,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -53,6 +58,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -61,6 +67,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.Kernel.DEFAULT_CONFIG_YAML_FILE_READ;
 import static com.aws.greengrass.lifecyclemanager.KernelCommandLine.MAIN_SERVICE_NAME;
@@ -401,6 +408,17 @@ class KernelLifecycleTest {
         kernelLifecycle.setPostPluginStartables(new ArrayList<>());
     }
 
+    // Boot-time tlog compaction reads its threshold via Configuration.find; unstubbed find returns null so
+    // compaction falls back to the (large) default and stays inert for the small fixture tlogs. Tests that
+    // exercise compaction call this to force a specific threshold.
+    private void stubTlogCompactionThreshold(long thresholdBytes) {
+        Topic thresholdTopic = mock(Topic.class);
+        when(thresholdTopic.getOnce()).thenReturn(thresholdBytes);
+        when(mockConfig.find(SERVICES_NAMESPACE_TOPIC, DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME,
+                CONFIGURATION_CONFIG_KEY, DeviceConfiguration.BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES))
+                .thenReturn(thresholdTopic);
+    }
+
     @Test
     void GIVEN_deployment_config_override_WHEN_read_THEN_read_persisted_config() throws Exception {
         String providedConfigPathName = "external_config.yaml";
@@ -475,6 +493,167 @@ class KernelLifecycleTest {
         verify(mockKernel, never()).writeEffectiveConfigAsTransactionLog(
                 tempRootDir.resolve("config").resolve("config.tlog"));
         verify(mockKernel).writeEffectiveConfig();
+    }
+
+    @Test
+    void GIVEN_bloated_tlog_WHEN_launch_from_tlog_THEN_active_tlog_compacted() throws Exception {
+        // Tiny threshold so the small fixture tlog counts as "bloated" and gate 1 fires.
+        stubTlogCompactionThreshold(10L);
+        Path configTlogPath = mockPaths.configPath().resolve("config.tlog");
+        Files.copy(Paths.get(this.getClass().getResource("test.tlog").toURI()), configTlogPath);
+
+        kernelLifecycle.initConfigAndTlog();
+
+        verify(mockKernel.getConfig()).read(eq(configTlogPath));
+        // Normally a read-from-tlog boot never rewrites config.tlog; gate 1 compacts it because it is bloated.
+        verify(mockKernel).writeEffectiveConfigAsTransactionLog(configTlogPath);
+        verify(mockKernel).writeEffectiveConfig();
+    }
+
+    @Test
+    void GIVEN_bloated_backup_tlog_WHEN_launch_THEN_backup_also_compacted() throws Exception {
+        // Tiny threshold so the small fixture backup counts as "bloated" and gate 2 fires.
+        stubTlogCompactionThreshold(10L);
+        // Main config.tlog absent -> config read from the backup (readFromTlog == false).
+        Path backupTlogPath = mockPaths.configPath().resolve("config.tlog~");
+        Files.copy(Paths.get(this.getClass().getResource("test.tlog").toURI()), backupTlogPath);
+        Path configTlogPath = tempRootDir.resolve("config").resolve("config.tlog");
+
+        kernelLifecycle.initConfigAndTlog();
+
+        verify(mockKernel.getConfig()).read(eq(backupTlogPath));
+        // One dump from the !readFromTlog branch, plus one from gate 2 reclaiming the bloated backup.
+        verify(mockKernel, times(2)).writeEffectiveConfigAsTransactionLog(configTlogPath);
+        verify(mockKernel).writeEffectiveConfig();
+    }
+
+    @Test
+    void GIVEN_bloated_tlog_WHEN_compaction_disabled_THEN_not_compacted() throws Exception {
+        // Threshold 0 disables boot compaction entirely.
+        stubTlogCompactionThreshold(0L);
+        Path configTlogPath = mockPaths.configPath().resolve("config.tlog");
+        Files.copy(Paths.get(this.getClass().getResource("test.tlog").toURI()), configTlogPath);
+
+        kernelLifecycle.initConfigAndTlog();
+
+        verify(mockKernel.getConfig()).read(eq(configTlogPath));
+        verify(mockKernel, never()).writeEffectiveConfigAsTransactionLog(
+                tempRootDir.resolve("config").resolve("config.tlog"));
+        verify(mockKernel).writeEffectiveConfig();
+    }
+
+    @Test
+    void GIVEN_boot_compaction_fails_WHEN_launch_THEN_boot_continues(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, IOException.class);
+        stubTlogCompactionThreshold(10L);
+        Path configTlogPath = mockPaths.configPath().resolve("config.tlog");
+        Files.copy(Paths.get(this.getClass().getResource("test.tlog").toURI()), configTlogPath);
+        // Compaction dump fails (e.g. disk full). Since compaction is an optimization, boot must continue.
+        doThrow(new IOException("disk full")).when(mockKernel)
+                .writeEffectiveConfigAsTransactionLog(configTlogPath);
+
+        kernelLifecycle.initConfigAndTlog();
+
+        // Boot proceeded past the failed compaction rather than aborting.
+        verify(mockKernel).writeEffectiveConfig();
+    }
+
+    @Test
+    void GIVEN_unparseable_threshold_WHEN_launch_THEN_uses_default_not_disabled() throws Exception {
+        // An unparseable value must fall back to the default, not silently disable (Coerce.toLong -> 0).
+        Topic thresholdTopic = mock(Topic.class);
+        when(thresholdTopic.getOnce()).thenReturn("20MB");
+        when(mockConfig.find(SERVICES_NAMESPACE_TOPIC, DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME,
+                CONFIGURATION_CONFIG_KEY, DeviceConfiguration.BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES))
+                .thenReturn(thresholdTopic);
+        // A valid config.tlog larger than the 10 MB default: compaction fires only if the default (not
+        // disable) is in effect.
+        Path configTlogPath = mockPaths.configPath().resolve("config.tlog");
+        List<String> lines = Files.readAllLines(Paths.get(this.getClass().getResource("test.tlog").toURI()));
+        try (BufferedWriter w = Files.newBufferedWriter(configTlogPath)) {
+            long size = 0;
+            while (size < 11_000_000L) {
+                for (String line : lines) {
+                    w.write(line);
+                    w.newLine();
+                    size += line.length() + 1;
+                }
+            }
+        }
+
+        kernelLifecycle.initConfigAndTlog();
+
+        verify(mockKernel).writeEffectiveConfigAsTransactionLog(configTlogPath);
+    }
+
+    @Test
+    void GIVEN_negative_threshold_WHEN_launch_THEN_not_compacted() throws Exception {
+        stubTlogCompactionThreshold(-1L);
+        Path configTlogPath = mockPaths.configPath().resolve("config.tlog");
+        Files.copy(Paths.get(this.getClass().getResource("test.tlog").toURI()), configTlogPath);
+
+        kernelLifecycle.initConfigAndTlog();
+
+        verify(mockKernel, never()).writeEffectiveConfigAsTransactionLog(configTlogPath);
+        verify(mockKernel).writeEffectiveConfig();
+    }
+
+    @Test
+    void GIVEN_real_oversized_tlog_WHEN_launch_THEN_compacted_and_config_preserved() throws Exception {
+        Path configTlog = mockPaths.configPath().resolve("config.tlog");
+        Path backupTlog = mockPaths.configPath().resolve("config.tlog~");
+        int lastValue = 1999;
+        long threshold = 20_000L;
+
+        // 1. Build a real, valid, oversized config.tlog on disk: many appends of two topics produce many
+        //    lines, but the effective (last-writer-wins) config is tiny.
+        try (Context seedCtx = new Context()) {
+            Configuration seed = new Configuration(seedCtx);
+            try (ConfigurationWriter w = ConfigurationWriter.logTransactionsTo(seed, configTlog)) {
+                for (int i = 0; i <= lastValue; i++) {
+                    seed.lookup("services", "aws.greengrass.Foo", "configuration", "counter").withValue(i);
+                    seed.lookup("services", "aws.greengrass.Foo", "configuration", "name").withValue("v" + i);
+                }
+                seedCtx.waitForPublishQueueToClear();
+            }
+        }
+        long bloatedSize = Files.size(configTlog);
+        assertTrue(bloatedSize > threshold, "precondition: seeded tlog must exceed the threshold");
+
+        // 2. Real config for the boot path, carrying a low compaction threshold in the Nucleus config.
+        try (Context bootCtx = new Context()) {
+            Configuration realConfig = new Configuration(bootCtx);
+            bootCtx.runOnPublishQueueAndWait(() -> realConfig.lookup("services",
+                    DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME, "configuration",
+                    DeviceConfiguration.BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES).withValue(threshold));
+            when(mockKernel.getConfig()).thenReturn(realConfig);
+            // 3. Make writeEffectiveConfigAsTransactionLog perform a real dump of the live config to disk.
+            doAnswer(inv -> {
+                ConfigurationWriter.dump(realConfig, inv.getArgument(0));
+                return null;
+            }).when(mockKernel).writeEffectiveConfigAsTransactionLog(any());
+
+            // 4. Boot: replay the oversized tlog, then compact.
+            kernelLifecycle.initConfigAndTlog();
+            bootCtx.waitForPublishQueueToClear();
+
+            // 5a. config.tlog was actually rewritten smaller and is now under the threshold (gate 1).
+            long compactedSize = Files.size(configTlog);
+            assertTrue(compactedSize < bloatedSize, "config.tlog should shrink after boot compaction");
+            assertTrue(compactedSize <= threshold, "compacted config.tlog should be under threshold");
+            // 5b. The bloated backup left by the demote was reclaimed, not left at the bloated size (gate 2).
+            assertTrue(Files.exists(backupTlog), "gate 2 should have produced a config.tlog~");
+            assertTrue(Files.size(backupTlog) <= threshold, "config.tlog~ backup should be reclaimed by gate 2");
+
+            // 5c. Effective config is preserved: replaying the compacted tlog yields the final values.
+            try (Context verifyCtx = new Context()) {
+                Configuration verify = ConfigurationReader.createFromTLog(verifyCtx, configTlog);
+                assertEquals(lastValue,
+                        Coerce.toLong(verify.find("services", "aws.greengrass.Foo", "configuration", "counter")));
+                assertEquals("v" + lastValue,
+                        Coerce.toString(verify.find("services", "aws.greengrass.Foo", "configuration", "name")));
+            }
+        }
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Set;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.deployment.DeviceConfiguration.BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES;
 import static com.aws.greengrass.deployment.DeviceConfiguration.COMPONENT_STORE_MAX_SIZE_BYTES;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS;
@@ -120,6 +121,8 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
                 .thenReturn(componentTypeTopic);
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 COMPONENT_STORE_MAX_SIZE_BYTES)).thenReturn(componentStoreSizeLimitTopic);
+        when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
+                BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES)).thenReturn(mock(Topic.class));
         when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 NUCLEUS_CONFIG_LOGGING_TOPICS)).thenReturn(mock(Topics.class));
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,


### PR DESCRIPTION
On a normal reboot config.tlog is only appended to, never rewritten, so a device that reboots frequently (before the runtime 15,000-entry auto-truncate can fire, since its counter resets each boot) accumulates entries without bound, slowing every subsequent boot's tlog replay.

Compact config.tlog (and its config.tlog~ backup) at startup when either exceeds a configurable size threshold, rewriting from the in-memory effective config via the existing atomic CommitableFile path, before the append writer is attached:
- Gate 1 compacts a bloated active tlog on a normal reboot (the !readFromTlog deployment/rollback/recovery paths already rewrite it).
- Gate 2 reclaims a bloated config.tlog~ backup left by the demote, and self-heals a crash between the two dumps on a later boot.

Threshold: Nucleus bootConfigTlogCompactionThresholdBytes (default 20 MB, 0 disables). Long-running devices remain bounded by the existing 15,000-entry runtime truncate.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [x] Updated or added new unit tests.
- [x] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
