### PR TITLE
feat(spool): add default methods to CloudMessageSpool for fast startu…

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttclient/spool/CloudMessageSpool.java
+++ b/src/main/java/com/aws/greengrass/mqttclient/spool/CloudMessageSpool.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.mqttclient.spool;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface CloudMessageSpool {
 
@@ -16,6 +17,35 @@ public interface CloudMessageSpool {
     void add(long id, SpoolMessage message) throws IOException;
 
     Iterable<Long> getAllMessageIds() throws IOException;
+
+    /**
+     * Get the maximum message ID currently stored in the spool.
+     * This is used to set the next ID for new messages without iterating all messages.
+     *
+     * <p>Default returns -1 (not supported) for backward compatibility with older plugin versions.
+     * When -1 is returned, the nucleus falls back to iterating all message IDs.</p>
+     *
+     * @return the maximum message ID, or -1 if the spool is empty or not supported
+     * @throws IOException if an I/O error occurs
+     */
+    default long getMaxMessageId() throws IOException {
+        return -1;
+    }
+
+    /**
+     * Get all message IDs with their payload sizes, ordered by ID ascending.
+     * Returns a list of [messageId, payloadSizeInBytes] pairs without reading full payloads.
+     * This enables fast capacity tracking during startup without per-message I/O.
+     *
+     * <p>Default returns null (not supported) for backward compatibility with older plugin versions.
+     * When null is returned, the nucleus falls back to reading each message individually.</p>
+     *
+     * @return ordered list of (id, size) pairs, or null if not supported
+     * @throws IOException if an I/O error occurs
+     */
+    default List<long[]> getAllMessageIdsWithSizes() throws IOException {
+        return null;
+    }
 
     void initializeSpooler() throws IOException;
 }


### PR DESCRIPTION
…p sync

Add `getMaxMessageId()` and `getAllMessageIdsWithSizes()` as default methods on the `CloudMessageSpool` interface to support DiskSpooler startup optimization (issue #1832).
   
### Problem

When the Greengrass Nucleus boots with Disk spooler storage configured, the Spool constructor calls `persistentQueueSync()` which iterates every persisted message and calls `getMessageById()` for each one. This reads the full message payload from SQLite only to extract payload.length for capacity tracking. The payload itself is discarded immediately.

See: https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1832 (https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/1832)

   ### Changes

Add two default methods to the `CloudMessageSpool` interface:

- `getMaxMessageId()` — Returns the highest message ID stored in the spool. The nucleus uses this to set its nextId counter without iterating all rows. Spooler plugin reads this from DB. 

- `getAllMessageIdsWithSizes()` — Returns an ordered list of [messageId, payloadSizeInBytes] pairs. The nucleus uses this to populate its dispatch queue and track capacity in a single pass without reading any payload blobs. The DiskSpooler plugin can implement this as `SELECT message_id, LENGTH(payload) FROM spooler ORDER BY
   message_id ASC`  a single table scan where LENGTH() reads from SQLite row headers, not blob content.

###    Default values

   Both methods have default implementations on the interface:

- getMaxMessageId() returns -1 — signals "not supported." The nucleus interprets this as: fall back to discovering the max ID by iterating all message IDs
   (existing behavior).
- getAllMessageIdsWithSizes() returns null — signals "not supported." The nucleus interprets this as: fall back to calling getMessageById() per message on a
   background thread (the slow path, but still improved over blocking the main thread).

The DiskSpooler plugin is deployed independently of the nucleus. Customers may upgrade their nucleus without upgrading the spooler plugin (or vice versa). Default
   methods ensure:

   - Old plugin + new nucleus: The nucleus calls the new methods, gets -1/null from the defaults, and gracefully falls back to the background-thread approach. No breakage, still an improvement over the 5-minute block.
   - New plugin + old nucleus: The old nucleus never calls these methods. They exist on the plugin class but are never invoked. No breakage.
   - New plugin + new nucleus: Full benefit — synchronous startup in milliseconds.

###    Testing

Existing tests pass (39/39). No behavioral change in this PR — the nucleus does not yet consume these methods. The consuming logic will be in a follow-up PR.


**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
