### PR TITLE
fix: retry docker pull network errors instead of failing deployments

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,25 +40,56 @@ public class DefaultDockerClient {
     public static final Logger logger = LogManager.getLogger(DefaultDockerClient.class);
 
     /**
-     * connect error messages.
+     * Errors indicating that a docker pull failed at the network transport layer rather than being rejected by the
+     * registry. Such a failure is recoverable once connectivity is restored, so it is retried indefinitely.
+     *
+     * <p>Two shapes are matched. Go renders a {@code net.OpError} as
+     * {@code "<op> <net> <source>-><addr>: <cause>"}, so matching on the op prefix classifies a failure at the TCP
+     * layer regardless of which cause follows, including causes not seen before. Only {@code dial tcp} was matched
+     * previously, which covers a connection that fails to be established; a connection that dies mid-transfer
+     * instead reports {@code read tcp} or {@code write tcp}. The remaining entries are transport-level causes,
+     * matched on their own because docker and containerd also surface them without an op prefix, for example when
+     * wrapping an error raised while copying an image layer.
      */
-    private static final String READ_CONNECTION_TIME_OUT = "read: connection timed out";
-    private static final String NET_HTTP_TIMEOUT = "net/http";
-    private static final String TEMPORARY_FAILURE_IN_NAME_RESOLUTION = "Temporary failure in name resolution";
-    private static final String REQUEST_CANCELED = "request canceled";
-    private static final String DOCKER_PULL_TIMEOUT = "timeout";
-    private static final String NO_SUCH_HOST = "no such host";
-    private static final String DIAL_TCP = "dial tcp";
+    private static final List<String> CONNECTION_ERRORS = Collections.unmodifiableList(Arrays.asList(
+            // Go net.OpError op prefixes for the transport operations
+            "dial tcp",
+            "read tcp",
+            "write tcp",
+            // Transport-level causes
+            "connection reset by peer",
+            "connection refused",
+            "connection aborted",
+            "broken pipe",
+            "network is unreachable",
+            "network is down",
+            "host is unreachable",
+            "no route to host",
+            "read: connection timed out",
+            "i/o timeout",
+            "unexpected eof",
+            "\": eof",
+            // Timeouts and cancellations, which all mean the request did not complete rather than that the registry
+            // rejected it
+            "net/http",
+            "timeout",
+            "request canceled",
+            "context deadline exceeded",
+            // Name resolution failures
+            "no such host",
+            "temporary failure in name resolution",
+            "server misbehaving"));
 
     /**
      * Errors that a retry cannot recover from, so a docker pull failing with one of these should fail fast.
      */
-    private static final String MANIFEST_UNKNOWN = "manifest unknown";
-    private static final String NO_MATCHING_MANIFEST = "no matching manifest for";
-    private static final String INVALID_REFERENCE_FORMAT = "invalid reference format";
-    private static final String NO_SPACE_LEFT_ON_DEVICE = "no space left on device";
-    private static final String AUTHENTICATION_REQUIRED = "authentication required";
-    private static final String ACCESS_DENIED = "requested access to the resource is denied";
+    private static final List<String> NON_RETRYABLE_ERRORS = Collections.unmodifiableList(Arrays.asList(
+            "manifest unknown",
+            "no matching manifest for",
+            "invalid reference format",
+            "no space left on device",
+            "authentication required",
+            "requested access to the resource is denied"));
 
     /**
      * Sanity check for installation.
@@ -177,14 +210,7 @@ public class DefaultDockerClient {
      * @return true if the error is a known network error
      */
     static boolean isConnectionError(String err) {
-        String lowerCaseErr = err.toLowerCase();
-        return err.contains(READ_CONNECTION_TIME_OUT)
-                || err.contains(TEMPORARY_FAILURE_IN_NAME_RESOLUTION)
-                || lowerCaseErr.contains(NET_HTTP_TIMEOUT)
-                || lowerCaseErr.contains(REQUEST_CANCELED)
-                || lowerCaseErr.contains(DOCKER_PULL_TIMEOUT)
-                || lowerCaseErr.contains(NO_SUCH_HOST)
-                || lowerCaseErr.contains(DIAL_TCP);
+        return containsAny(err, CONNECTION_ERRORS);
     }
 
     /**
@@ -194,13 +220,12 @@ public class DefaultDockerClient {
      * @return true if the error is known to be non-retryable
      */
     static boolean isNonRetryableError(String err) {
-        String lowerCaseErr = err.toLowerCase();
-        return lowerCaseErr.contains(MANIFEST_UNKNOWN)
-                || lowerCaseErr.contains(NO_MATCHING_MANIFEST)
-                || lowerCaseErr.contains(INVALID_REFERENCE_FORMAT)
-                || lowerCaseErr.contains(NO_SPACE_LEFT_ON_DEVICE)
-                || lowerCaseErr.contains(AUTHENTICATION_REQUIRED)
-                || lowerCaseErr.contains(ACCESS_DENIED);
+        return containsAny(err, NON_RETRYABLE_ERRORS);
+    }
+
+    private static boolean containsAny(String err, List<String> lowerCaseNeedles) {
+        String lowerCaseErr = err.toLowerCase(Locale.ROOT);
+        return lowerCaseNeedles.stream().anyMatch(lowerCaseErr::contains);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
@@ -50,8 +50,11 @@ public class DefaultDockerClient {
      * instead reports {@code read tcp} or {@code write tcp}. The remaining entries are transport-level causes,
      * matched on their own because docker and containerd also surface them without an op prefix, for example when
      * wrapping an error raised while copying an image layer.
+     *
+     * <p>Every entry must be lower case, since {@link #containsAny} only folds the case of the error text it is
+     * matched against. {@code DefaultDockerClientTest} enforces this.
      */
-    private static final List<String> CONNECTION_ERRORS = Collections.unmodifiableList(Arrays.asList(
+    static final List<String> CONNECTION_ERRORS = Collections.unmodifiableList(Arrays.asList(
             // Go net.OpError op prefixes for the transport operations
             "dial tcp",
             "read tcp",
@@ -75,17 +78,22 @@ public class DefaultDockerClient {
             "tls: use of closed connection",
             "bad record mac",
             "tls: internal error",
-            // HTTP/2 transport failures, matched on the package prefix for the same reason "net/http" is. A stream
-            // error carries no such prefix, so it is matched separately.
-            "http2:",
+            // HTTP/2 transport failures. Matched as specific forms rather than on the "http2:" package prefix,
+            // because the prefix would also match framing and flow-control faults that are not connectivity
+            // problems and could persist, for example through a broken proxy. A stream error carries no package
+            // prefix, so it is matched separately.
+            "http2: server sent goaway",
+            "http2: client connection lost",
             "stream error: stream id",
             // Transport failures that containerd surfaces while copying an image layer, having discarded the
             // net.OpError that produced them
             "file already closed",
             // Timeouts and cancellations, which all mean the request did not complete rather than that the registry
-            // rejected it
+            // rejected it. The bare "timeout" that was previously matched is gone: "read: connection timed out",
+            // "i/o timeout" and "net/http" cover the forms it stood in for, and as a bare substring it could match
+            // an image name or registry prose and retry a permanent failure indefinitely. A timeout form matching
+            // none of these now gets the bounded unknown-error retry instead of failing outright.
             "net/http",
-            "timeout",
             "request canceled",
             "context canceled",
             "context deadline exceeded",
@@ -96,8 +104,10 @@ public class DefaultDockerClient {
 
     /**
      * Errors that a retry cannot recover from, so a docker pull failing with one of these should fail fast.
+     *
+     * <p>Lower case for the same reason as {@link #CONNECTION_ERRORS}.
      */
-    private static final List<String> NON_RETRYABLE_ERRORS = Collections.unmodifiableList(Arrays.asList(
+    static final List<String> NON_RETRYABLE_ERRORS = Collections.unmodifiableList(Arrays.asList(
             "manifest unknown",
             "no matching manifest for",
             "invalid reference format",

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
@@ -69,11 +69,25 @@ public class DefaultDockerClient {
             "i/o timeout",
             "unexpected eof",
             "\": eof",
+            // TLS transport failures. Only wire-level failures are listed. An error saying the peer rejected our
+            // certificate, or that we do not trust theirs, is a configuration problem a retry cannot fix, so
+            // "x509:", "bad certificate" and "handshake failure" are deliberately absent.
+            "tls: use of closed connection",
+            "bad record mac",
+            "tls: internal error",
+            // HTTP/2 transport failures, matched on the package prefix for the same reason "net/http" is. A stream
+            // error carries no such prefix, so it is matched separately.
+            "http2:",
+            "stream error: stream id",
+            // Transport failures that containerd surfaces while copying an image layer, having discarded the
+            // net.OpError that produced them
+            "file already closed",
             // Timeouts and cancellations, which all mean the request did not complete rather than that the registry
             // rejected it
             "net/http",
             "timeout",
             "request canceled",
+            "context canceled",
             "context deadline exceeded",
             // Name resolution failures
             "no such host",

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClient.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerLogin
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerPullException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerServiceUnavailableException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.InvalidImageOrAccessDeniedException;
+import com.aws.greengrass.componentmanager.plugins.docker.exceptions.UnknownDockerPullException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.UserNotAuthorizedForDockerException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -46,6 +47,16 @@ public class DefaultDockerClient {
     private static final String DOCKER_PULL_TIMEOUT = "timeout";
     private static final String NO_SUCH_HOST = "no such host";
     private static final String DIAL_TCP = "dial tcp";
+
+    /**
+     * Errors that a retry cannot recover from, so a docker pull failing with one of these should fail fast.
+     */
+    private static final String MANIFEST_UNKNOWN = "manifest unknown";
+    private static final String NO_MATCHING_MANIFEST = "no matching manifest for";
+    private static final String INVALID_REFERENCE_FORMAT = "invalid reference format";
+    private static final String NO_SPACE_LEFT_ON_DEVICE = "no space left on device";
+    private static final String AUTHENTICATION_REQUIRED = "authentication required";
+    private static final String ACCESS_DENIED = "requested access to the resource is denied";
 
     /**
      * Sanity check for installation.
@@ -110,7 +121,9 @@ public class DefaultDockerClient {
      *                                             the registry
      * @throws UserNotAuthorizedForDockerException when current user is not authorized to use docker
      * @throws ConnectionException                 network error
-     * @throws DockerPullException                 unexpected error
+     * @throws DockerPullException                 an error that a retry cannot recover from, or, as
+     *                                             {@link UnknownDockerPullException}, an unrecognized error that may
+     *                                             be transient
      */
     public void pullImage(Image image) throws DockerServiceUnavailableException, InvalidImageOrAccessDeniedException,
             UserNotAuthorizedForDockerException, DockerPullException, ConnectionException {
@@ -135,16 +148,18 @@ public class DefaultDockerClient {
                     throw new InvalidImageOrAccessDeniedException(
                             String.format("Invalid image or login - %s", response.err));
                 }
-                if (response.err.contains(READ_CONNECTION_TIME_OUT)
-                        || response.err.contains(TEMPORARY_FAILURE_IN_NAME_RESOLUTION)
-                        || response.err.toLowerCase().contains(NET_HTTP_TIMEOUT)
-                        || response.err.toLowerCase().contains(REQUEST_CANCELED)
-                        || response.err.toLowerCase().contains(DOCKER_PULL_TIMEOUT)
-                        || response.err.toLowerCase().contains(NO_SUCH_HOST)
-                        || response.err.toLowerCase().contains(DIAL_TCP)) {
+                if (isConnectionError(response.err)) {
                     throw new ConnectionException(String.format("Network issue when docker pull - %s", response.err));
                 }
-                throw new DockerPullException(
+                if (isNonRetryableError(response.err)) {
+                    throw new DockerPullException(
+                            String.format("Unexpected error while trying to perform docker pull - %s", response.err),
+                            response.failureCause);
+                }
+                // The error is not recognized as either a network error or a non-retryable one. Assume it may be
+                // transient and let the caller apply a small, bounded number of retries rather than failing the
+                // deployment on the first attempt.
+                throw new UnknownDockerPullException(
                         String.format("Unexpected error while trying to perform docker pull - %s", response.err),
                         response.failureCause);
             }
@@ -152,6 +167,40 @@ public class DefaultDockerClient {
             throw new DockerPullException("Unexpected error while trying to perform docker pull",
                     response.failureCause);
         }
+    }
+
+    /**
+     * Check if a docker CLI error indicates a network-level failure, which is recoverable once connectivity
+     * is restored and so is retried indefinitely.
+     *
+     * @param err stderr emitted by the docker CLI
+     * @return true if the error is a known network error
+     */
+    static boolean isConnectionError(String err) {
+        String lowerCaseErr = err.toLowerCase();
+        return err.contains(READ_CONNECTION_TIME_OUT)
+                || err.contains(TEMPORARY_FAILURE_IN_NAME_RESOLUTION)
+                || lowerCaseErr.contains(NET_HTTP_TIMEOUT)
+                || lowerCaseErr.contains(REQUEST_CANCELED)
+                || lowerCaseErr.contains(DOCKER_PULL_TIMEOUT)
+                || lowerCaseErr.contains(NO_SUCH_HOST)
+                || lowerCaseErr.contains(DIAL_TCP);
+    }
+
+    /**
+     * Check if a docker CLI error is one that a retry cannot recover from, such as a missing image or a full disk.
+     *
+     * @param err stderr emitted by the docker CLI
+     * @return true if the error is known to be non-retryable
+     */
+    static boolean isNonRetryableError(String err) {
+        String lowerCaseErr = err.toLowerCase();
+        return lowerCaseErr.contains(MANIFEST_UNKNOWN)
+                || lowerCaseErr.contains(NO_MATCHING_MANIFEST)
+                || lowerCaseErr.contains(INVALID_REFERENCE_FORMAT)
+                || lowerCaseErr.contains(NO_SPACE_LEFT_ON_DEVICE)
+                || lowerCaseErr.contains(AUTHENTICATION_REQUIRED)
+                || lowerCaseErr.contains(ACCESS_DENIED);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -321,7 +321,15 @@ public class DockerImageDownloader extends ArtifactDownloader {
             // can be fixed with retries, explicitly check if an error could be due to connectivity problem
             // we infer that based on Mqtt connection, even though not perfect, it should accurately represent if
             // device is having connectivity issues most of the times.
-            if (e instanceof DockerServiceUnavailableException && !mqttClient.getMqttOnline().get()) {
+            // The same inference applies to a pull error that could not be classified at all. Classification depends
+            // on docker's stderr text, which is not a stable contract and cannot cover every transport failure, so
+            // the device's own connectivity is used as independent evidence: if it is offline, an unrecognized
+            // failure is far more likely to be that outage than anything the registry reported, and should be
+            // retried until connectivity returns rather than given up on after a bounded number of attempts. When
+            // the device is online the bounded retry still applies, so an error that is genuinely permanent
+            // continues to surface promptly.
+            if ((e instanceof DockerServiceUnavailableException || e instanceof UnknownDockerPullException)
+                    && !mqttClient.getMqttOnline().get()) {
                 throw new ConnectionException("Device appears to be offline, should retry the task", e);
             }
             throw e;

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -72,10 +72,20 @@ public class DockerImageDownloader extends ArtifactDownloader {
     // transient, so allow a small number of retries. Deliberately much shorter than finiteAttemptsRetryConfig: the
     // error is not known to be recoverable, so this only needs to be long enough to ride out a brief blip before
     // reporting the failure.
+    //
+    // The attempt count is chosen against the offline fallback in runWithConnectionErrorCheck, which reads
+    // MqttClient's cached connection flag. That flag can lag a real outage by around 90 seconds with default
+    // keep-alive settings, so a shorter budget could expire before the device notices it is offline, defeating the
+    // fallback for the very outages it exists to catch. Seven attempts at this ceiling span roughly 195-390 seconds
+    // with jitter, which clears that lag on any draw.
+    //
+    // This bounds the retry tier, not the deployment: performDownloadSteps re-enters run() if the ECR credentials
+    // expire mid-pull, which starts a fresh budget. In practice that can happen at most once, since the refreshed
+    // token is valid for hours, so the effective worst case is about twice the figure above.
     @Setter(AccessLevel.PACKAGE)
     private RetryUtils.RetryConfig unknownErrorRetryConfig =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(10L))
-                    .maxRetryInterval(Duration.ofMinutes(2L)).maxAttempt(5).retryableExceptions(
+                    .maxRetryInterval(Duration.ofMinutes(2L)).maxAttempt(7).retryableExceptions(
                             Collections.singletonList(UnknownDockerPullException.class)).build();
 
     @Setter(AccessLevel.PACKAGE)

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -58,7 +58,7 @@ public class DockerImageDownloader extends ArtifactDownloader {
     @Setter(AccessLevel.PACKAGE)
     private RetryUtils.RetryConfig infiniteAttemptsRetryConfig =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1L))
-                    .maxRetryInterval(Duration.ofMinutes(64L)).maxAttempt(Integer.MAX_VALUE).retryableExceptions(
+                    .maxRetryInterval(Duration.ofMinutes(5L)).maxAttempt(Integer.MAX_VALUE).retryableExceptions(
                         Arrays.asList(ConnectionException.class, SdkClientException.class, ServerException.class))
                     .build();
     @Setter(AccessLevel.PACKAGE)

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.componentmanager.plugins.docker.exceptions.ConnectionE
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerImageDeleteException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerLoginException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerServiceUnavailableException;
+import com.aws.greengrass.componentmanager.plugins.docker.exceptions.UnknownDockerPullException;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.util.CrashableSupplier;
@@ -35,6 +36,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -65,6 +67,16 @@ public class DockerImageDownloader extends ArtifactDownloader {
                     .maxRetryInterval(Duration.ofMinutes(32L)).maxAttempt(30).retryableExceptions(
                             Arrays.asList(DockerServiceUnavailableException.class, DockerLoginException.class,
                             SdkClientException.class, ServerException.class)).build();
+
+    // A docker pull error that is recognized as neither a network error nor a non-retryable error may still be
+    // transient, so allow a small number of retries. Deliberately much shorter than finiteAttemptsRetryConfig: the
+    // error is not known to be recoverable, so this only needs to be long enough to ride out a brief blip before
+    // reporting the failure.
+    @Setter(AccessLevel.PACKAGE)
+    private RetryUtils.RetryConfig unknownErrorRetryConfig =
+            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(10L))
+                    .maxRetryInterval(Duration.ofMinutes(2L)).maxAttempt(5).retryableExceptions(
+                            Collections.singletonList(UnknownDockerPullException.class)).build();
 
     @Setter(AccessLevel.PACKAGE)
     private RetryUtils.RetryConfig finiteDeleteAttemptsRetryConfig =
@@ -285,8 +297,11 @@ public class DockerImageDownloader extends ArtifactDownloader {
             throws PackageDownloadException, InterruptedException {
         try {
             // Finite retry attempts for errors that are not due to connectivity issues and
-            // might need explicit intervention to recover from
-            RetryUtils.runWithRetry(finiteAttemptsRetryConfig, () -> RetryUtils
+            // might need explicit intervention to recover from, and a shorter finite retry for errors that could
+            // not be classified at all
+            RetryUtils.runWithRetry(RetryUtils.DifferentiatedRetryConfig.builder()
+                            .retryConfigList(Arrays.asList(finiteAttemptsRetryConfig, unknownErrorRetryConfig)).build(),
+                    () -> RetryUtils
                     // Indefinite retry for errors that are due to connectivity issues and can be
                     // resolved when connectivity comes back
                     .runWithRetry(infiniteAttemptsRetryConfig, () -> runWithConnectionErrorCheck(task), description,

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/exceptions/UnknownDockerPullException.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/exceptions/UnknownDockerPullException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins.docker.exceptions;
+
+/**
+ * A {@code docker pull} failure that could not be classified as either a known network error or a known
+ * non-retryable error.
+ *
+ * <p>Such a failure is treated as possibly transient and is given a small, bounded number of retries. Extends
+ * {@link DockerPullException} so that the deployment error code reported to the customer once those retries are
+ * exhausted is unchanged.
+ */
+public class UnknownDockerPullException extends DockerPullException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    public UnknownDockerPullException(String message) {
+        super(message);
+    }
+
+    public UnknownDockerPullException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/util/RetryUtils.java
+++ b/src/main/java/com/aws/greengrass/util/RetryUtils.java
@@ -61,12 +61,18 @@ public class RetryUtils {
     public static <T> T runWithRetry(DifferentiatedRetryConfig differentiatedRetryConfig,
                                      CrashableSupplier<T, Exception> task, String taskDescription, Logger logger)
             throws Exception {
-        long retryInterval = 0;
         long totalAttempts = 0;
         long totalMaxAttempts = calculateTotalMaxAttempts(differentiatedRetryConfig);
         Map<RetryConfig, Integer> attemptMap = new HashMap<>();
+        // Each config backs off independently. Sharing one interval across configs would let a config with a high
+        // ceiling ramp the interval and then have a config with a lower ceiling sleep past its own ceiling, because
+        // the sleep happens before the interval is clamped.
+        Map<RetryConfig, Long> retryIntervalMap = new HashMap<>();
         differentiatedRetryConfig.getRetryConfigList()
-                .forEach(retryConfig -> attemptMap.put(retryConfig, 1));
+                .forEach(retryConfig -> {
+                    attemptMap.put(retryConfig, 1);
+                    retryIntervalMap.put(retryConfig, retryConfig.getInitialRetryInterval().toMillis());
+                });
 
         while (totalAttempts < totalMaxAttempts) {
             if (Thread.currentThread().isInterrupted()) {
@@ -98,11 +104,10 @@ public class RetryUtils {
                         logBuilder.kv("task-attempt", attempt).setCause(e).log("task failed and will be retried");
 
                         // sleep with back-off
-                        if (retryInterval == 0) {
-                            retryInterval = retryConfig.getInitialRetryInterval().toMillis();
-                        }
+                        long retryInterval = retryIntervalMap.get(retryConfig);
                         Thread.sleep(retryInterval / 2 + RANDOM.nextInt((int) (retryInterval / 2 + 1)));
-                        retryInterval = Math.min(retryInterval * 2, retryConfig.getMaxRetryInterval().toMillis());
+                        retryIntervalMap.put(retryConfig,
+                                Math.min(retryInterval * 2, retryConfig.getMaxRetryInterval().toMillis()));
 
                         // break since exception is found
                         break;

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
@@ -43,6 +43,13 @@ class DefaultDockerClientTest {
             "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/\": dial tcp 1.2.3"
                     + ".4:443: connect: network is unreachable",
             "read tcp 10.0.0.1:52044->1.2.3.4:443: read: no route to host",
+            "read tcp 10.0.0.1:52044->1.2.3.4:443: read: network is down",
+            "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/\": dial tcp 1.2.3"
+                    + ".4:443: connect: host is unreachable",
+            "read tcp 10.0.0.1:52044->1.2.3.4:443: read: software caused connection aborted",
+            // Cancellations and DNS server faults
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": context deadline exceeded",
+            "dial tcp: lookup 1234.dkr.ecr.us-east-1.amazonaws.com on 10.0.0.53:53: server misbehaving",
             // Wire-level TLS failures, which do not arrive as a net.OpError
             "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": remote error: tls: bad record MAC",
             "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": tls: use of closed connection",

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.componentmanager.plugins.docker;
+
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith({GGExtension.class})
+class DefaultDockerClientTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": dial tcp: lookup registry-1"
+                    + ".docker.io: no such host",
+            "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/\": dial tcp 1.2.3"
+                    + ".4:443: connect: connection refused",
+            "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/\": read tcp 10.0.0"
+                    + ".1:52044->1.2.3.4:443: read: connection timed out",
+            "Get \"https://registry-1.docker.io/v2/\": net/http: TLS handshake timeout",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": request canceled while waiting "
+                    + "for connection",
+            "dial tcp: lookup 1234.dkr.ecr.us-east-1.amazonaws.com: Temporary failure in name resolution"})
+    void GIVEN_known_network_error_WHEN_classified_THEN_treated_as_connection_error(String err) {
+        assertTrue(DefaultDockerClient.isConnectionError(err));
+        // A network error must never also be claimed as non-retryable, since isConnectionError is evaluated first
+        // and the two classifications must not disagree
+        assertFalse(DefaultDockerClient.isNonRetryableError(err));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Error response from daemon: manifest for alpine:doesnotexist not found: manifest unknown: manifest "
+                    + "unknown",
+            "Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries",
+            "invalid reference format",
+            "failed to register layer: write /usr/lib/foo: no space left on device",
+            "Error response from daemon: Head \"https://registry-1.docker.io/v2/library/alpine/manifests/latest\": "
+                    + "unauthorized: authentication required",
+            "Error response from daemon: denied: requested access to the resource is denied"})
+    void GIVEN_known_non_retryable_error_WHEN_classified_THEN_treated_as_non_retryable(String err) {
+        assertTrue(DefaultDockerClient.isNonRetryableError(err));
+        assertFalse(DefaultDockerClient.isConnectionError(err));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // The error reported by a device whose LTE connection failed over mid-pull. Previously this matched
+            // no known network error string and so failed the deployment without any retry.
+            "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/vapr/manifests/sha256"
+                    + ":d35a4457caa9e9bb60dc03a45b3fd9c0d7d242b06c1b0e36410cb5ed3b594050\": read tcp 172.28.1.230"
+                    + ":52044->34.204.60.241:443: read: connection reset by peer",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": EOF",
+            "failed to copy: httpReadSeeker: failed open: unexpected status code 503",
+            "some error string docker has not emitted before"})
+    void GIVEN_unrecognized_error_WHEN_classified_THEN_neither_connection_nor_non_retryable(String err) {
+        assertFalse(DefaultDockerClient.isConnectionError(err));
+        assertFalse(DefaultDockerClient.isNonRetryableError(err));
+    }
+}

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
@@ -6,10 +6,15 @@
 package com.aws.greengrass.componentmanager.plugins.docker;
 
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -96,5 +101,38 @@ class DefaultDockerClientTest {
     void GIVEN_unrecognized_error_WHEN_classified_THEN_neither_connection_nor_non_retryable(String err) {
         assertFalse(DefaultDockerClient.isConnectionError(err));
         assertFalse(DefaultDockerClient.isNonRetryableError(err));
+    }
+
+    /**
+     * Matching folds the case of the error text, so an entry carrying an upper case character could never match.
+     * Nothing else in the suite would catch that, since a needle that never matches only makes classification
+     * quietly miss an error it was meant to cover.
+     */
+    @Test
+    void GIVEN_error_lists_WHEN_inspected_THEN_every_entry_is_lower_case() {
+        Stream.concat(DefaultDockerClient.CONNECTION_ERRORS.stream(),
+                DefaultDockerClient.NON_RETRYABLE_ERRORS.stream())
+                .forEach(needle -> assertEquals(needle.toLowerCase(Locale.ROOT), needle,
+                        "\"" + needle + "\" must be lower case to be matchable"));
+    }
+
+    /**
+     * Case folding must not depend on the device's locale. Turkish is the case that breaks a locale-sensitive
+     * {@code toLowerCase()}: it maps {@code I} to a dotless i, so a needle spelled with an ASCII i stops matching
+     * error text containing {@code I}. Several entries rely on that fold, for example the stream error below, which
+     * docker writes as {@code stream ID}.
+     */
+    @Test
+    void GIVEN_locale_with_different_case_rules_WHEN_classified_THEN_classification_is_unchanged() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            assertTrue(DefaultDockerClient
+                    .isConnectionError("failed to copy: stream error: stream ID 5; INTERNAL_ERROR"));
+            assertTrue(DefaultDockerClient.isNonRetryableError(
+                    "Error response from daemon: manifest for alpine:doesnotexist not found: manifest unknown"));
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 }

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
@@ -43,6 +43,18 @@ class DefaultDockerClientTest {
             "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/\": dial tcp 1.2.3"
                     + ".4:443: connect: network is unreachable",
             "read tcp 10.0.0.1:52044->1.2.3.4:443: read: no route to host",
+            // Wire-level TLS failures, which do not arrive as a net.OpError
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": remote error: tls: bad record MAC",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": tls: use of closed connection",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": remote error: tls: internal error",
+            // HTTP/2 transport failures
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": http2: server sent GOAWAY and "
+                    + "closed the connection",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": http2: client connection lost",
+            "failed to copy: stream error: stream ID 5; INTERNAL_ERROR; received from peer",
+            // Transport failures containerd surfaces after discarding the net.OpError
+            "failed to copy: read |0: file already closed",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": context canceled",
             // A cause at the TCP layer that docker has not been observed emitting before is still classified by its
             // op prefix
             "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": read tcp 10.0.0.1:52044->1.2.3"

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DefaultDockerClientTest.java
@@ -18,6 +18,7 @@ class DefaultDockerClientTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            // Connection never established. These matched before this change.
             "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": dial tcp: lookup registry-1"
                     + ".docker.io: no such host",
             "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/\": dial tcp 1.2.3"
@@ -27,8 +28,26 @@ class DefaultDockerClientTest {
             "Get \"https://registry-1.docker.io/v2/\": net/http: TLS handshake timeout",
             "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": request canceled while waiting "
                     + "for connection",
-            "dial tcp: lookup 1234.dkr.ecr.us-east-1.amazonaws.com: Temporary failure in name resolution"})
-    void GIVEN_known_network_error_WHEN_classified_THEN_treated_as_connection_error(String err) {
+            "dial tcp: lookup 1234.dkr.ecr.us-east-1.amazonaws.com: Temporary failure in name resolution",
+            // Established connection dying mid-transfer. The first of these is the error reported by a device whose
+            // LTE connection failed over during a pull; before this change it matched nothing and so failed the
+            // deployment on the first attempt.
+            "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/vapr/manifests/sha256"
+                    + ":d35a4457caa9e9bb60dc03a45b3fd9c0d7d242b06c1b0e36410cb5ed3b594050\": read tcp 172.28.1.230"
+                    + ":52044->34.204.60.241:443: read: connection reset by peer",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": write tcp 10.0.0.1:52044->1.2.3"
+                    + ".4:443: write: broken pipe",
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": EOF",
+            "failed to copy: httpReadSeeker: failed open: unexpected EOF",
+            // Routing lost, typically while an interface is being torn down or brought up
+            "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/\": dial tcp 1.2.3"
+                    + ".4:443: connect: network is unreachable",
+            "read tcp 10.0.0.1:52044->1.2.3.4:443: read: no route to host",
+            // A cause at the TCP layer that docker has not been observed emitting before is still classified by its
+            // op prefix
+            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": read tcp 10.0.0.1:52044->1.2.3"
+                    + ".4:443: read: some errno not seen before"})
+    void GIVEN_network_error_WHEN_classified_THEN_treated_as_connection_error(String err) {
         assertTrue(DefaultDockerClient.isConnectionError(err));
         // A network error must never also be claimed as non-retryable, since isConnectionError is evaluated first
         // and the two classifications must not disagree
@@ -52,13 +71,8 @@ class DefaultDockerClientTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-            // The error reported by a device whose LTE connection failed over mid-pull. Previously this matched
-            // no known network error string and so failed the deployment without any retry.
-            "Error response from daemon: Get \"https://1234.dkr.ecr.us-east-1.amazonaws.com/v2/vapr/manifests/sha256"
-                    + ":d35a4457caa9e9bb60dc03a45b3fd9c0d7d242b06c1b0e36410cb5ed3b594050\": read tcp 172.28.1.230"
-                    + ":52044->34.204.60.241:443: read: connection reset by peer",
-            "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": EOF",
             "failed to copy: httpReadSeeker: failed open: unexpected status code 503",
+            "Error response from daemon: failed to resolve reference: unexpected commit digest",
             "some error string docker has not emitted before"})
     void GIVEN_unrecognized_error_WHEN_classified_THEN_neither_connection_nor_non_retryable(String err) {
         assertFalse(DefaultDockerClient.isConnectionError(err));

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -713,7 +714,9 @@ public class DockerImageDownloaderTest {
         downloader.download();
 
         verify(dockerClient, times(5)).pullImage(image);
-        verify(mqttClient, times(4)).getMqttOnline();
+        // Asserted loosely on purpose: the point is that connectivity was consulted, not how many times the
+        // implementation happens to read the flag
+        verify(mqttClient, atLeastOnce()).getMqttOnline();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
@@ -685,8 +685,35 @@ public class DockerImageDownloaderTest {
 
         assertThrows(PackageDownloadException.class, () -> downloader.download());
 
-        // Bounded by unknownErrorRetryConfig's maxAttempt rather than failing on the first attempt
+        // The device is online per the default setup, so the error is not attributable to connectivity and the
+        // bounded unknownErrorRetryConfig applies rather than failing on the first attempt
         verify(dockerClient, times(3)).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_unrecognized_pull_error_and_device_offline_WHEN_connectivity_is_back_THEN_retry_and_succeed(
+            ExtensionContext extensionContext) throws Exception {
+        ignoreExceptionOfType(extensionContext, UnknownDockerPullException.class);
+        ignoreExceptionOfType(extensionContext, ConnectionException.class);
+        URI artifactUri = new URI("docker:alpine");
+        Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
+        when(mqttClient.getMqttOnline()).thenReturn(new AtomicBoolean(false));
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        // Four failures exceeds unknownErrorRetryConfig's bound of 3 attempts, so succeeding on the fifth is only
+        // reachable if the offline device caused the error to be treated as a connection error and retried by
+        // infiniteAttemptsRetryConfig instead
+        doThrow(new UnknownDockerPullException("some error docker has not emitted before"))
+                .doThrow(new UnknownDockerPullException("some error docker has not emitted before"))
+                .doThrow(new UnknownDockerPullException("some error docker has not emitted before"))
+                .doThrow(new UnknownDockerPullException("some error docker has not emitted before")).doNothing()
+                .when(dockerClient).pullImage(image);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        verify(dockerClient, times(5)).pullImage(image);
+        verify(mqttClient, times(4)).getMqttOnline();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerPullE
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.DockerServiceUnavailableException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.InvalidImageOrAccessDeniedException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.RegistryAuthException;
+import com.aws.greengrass.componentmanager.plugins.docker.exceptions.UnknownDockerPullException;
 import com.aws.greengrass.componentmanager.plugins.docker.exceptions.UserNotAuthorizedForDockerException;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -85,6 +86,11 @@ public class DockerImageDownloaderTest {
                     .maxRetryInterval(Duration.ofMillis(50L)).maxAttempt(2).retryableExceptions(
                             Arrays.asList(DockerServiceUnavailableException.class, DockerLoginException.class,
                                     SdkClientException.class, ServerException.class)).build();
+
+    private final RetryUtils.RetryConfig unknownErrorRetryConfig =
+            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(50L))
+                    .maxRetryInterval(Duration.ofMillis(50L)).maxAttempt(3).retryableExceptions(
+                            Collections.singletonList(UnknownDockerPullException.class)).build();
 
     private final RetryUtils.RetryConfig finiteDeleteAttemptsRetryConfig =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(50L))
@@ -666,12 +672,63 @@ public class DockerImageDownloaderTest {
         verify(dockerClient, times(1)).pullImage(image);
     }
 
+    @Test
+    void GIVEN_unrecognized_pull_error_WHEN_download_docker_image_THEN_retry_a_bounded_number_of_times(
+            ExtensionContext extensionContext) throws Exception {
+        ignoreExceptionOfType(extensionContext, UnknownDockerPullException.class);
+        URI artifactUri = new URI("docker:alpine");
+        Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        doThrow(new UnknownDockerPullException("connection reset by peer")).when(dockerClient).pullImage(image);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        assertThrows(PackageDownloadException.class, () -> downloader.download());
+
+        // Bounded by unknownErrorRetryConfig's maxAttempt rather than failing on the first attempt
+        verify(dockerClient, times(3)).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_unrecognized_pull_error_WHEN_it_recovers_THEN_download_succeeds(ExtensionContext extensionContext)
+            throws Exception {
+        ignoreExceptionOfType(extensionContext, UnknownDockerPullException.class);
+        URI artifactUri = new URI("docker:alpine");
+        Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        doThrow(new UnknownDockerPullException("connection reset by peer")).doNothing().when(dockerClient)
+                .pullImage(image);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        downloader.download();
+
+        verify(dockerClient, times(2)).pullImage(image);
+    }
+
+    @Test
+    void GIVEN_non_retryable_pull_error_WHEN_download_docker_image_THEN_fail_without_retrying(
+            ExtensionContext extensionContext) throws Exception {
+        ignoreExceptionOfType(extensionContext, DockerPullException.class);
+        URI artifactUri = new URI("docker:alpine");
+        Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
+        when(dockerClient.dockerInstalled()).thenReturn(true);
+        doThrow(new DockerPullException("manifest unknown")).when(dockerClient).pullImage(image);
+
+        DockerImageDownloader downloader = getDownloader(artifactUri);
+
+        assertThrows(PackageDownloadException.class, () -> downloader.download());
+
+        verify(dockerClient, times(1)).pullImage(image);
+    }
+
     private DockerImageDownloader getDownloader(URI artifactUri) {
         DockerImageDownloader downloader = new DockerImageDownloader(TEST_COMPONENT_ID,
                 ComponentArtifact.builder().artifactUri(artifactUri).build(), artifactDir, dockerClient, ecrAccessor,
                 mqttClient, componentStore);
         downloader.setInfiniteAttemptsRetryConfig(infiniteAttemptsRetryConfig);
         downloader.setFiniteAttemptsRetryConfig(finiteAttemptsRetryConfig);
+        downloader.setUnknownErrorRetryConfig(unknownErrorRetryConfig);
         downloader.setFiniteDeleteAttemptsRetryConfig(finiteDeleteAttemptsRetryConfig);
         return downloader;
     }

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
@@ -679,7 +679,7 @@ public class DockerImageDownloaderTest {
         URI artifactUri = new URI("docker:alpine");
         Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
         when(dockerClient.dockerInstalled()).thenReturn(true);
-        doThrow(new UnknownDockerPullException("connection reset by peer")).when(dockerClient).pullImage(image);
+        doThrow(new UnknownDockerPullException("some error docker has not emitted before")).when(dockerClient).pullImage(image);
 
         DockerImageDownloader downloader = getDownloader(artifactUri);
 
@@ -723,7 +723,7 @@ public class DockerImageDownloaderTest {
         URI artifactUri = new URI("docker:alpine");
         Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
         when(dockerClient.dockerInstalled()).thenReturn(true);
-        doThrow(new UnknownDockerPullException("connection reset by peer")).doNothing().when(dockerClient)
+        doThrow(new UnknownDockerPullException("some error docker has not emitted before")).doNothing().when(dockerClient)
                 .pullImage(image);
 
         DockerImageDownloader downloader = getDownloader(artifactUri);

--- a/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RetryUtilsTest {
 
@@ -78,5 +79,42 @@ class RetryUtilsTest {
             }
         }, "", logger));
         assertEquals(4, invoked.get());
+    }
+
+    @Test
+    void GIVEN_configs_with_different_ceilings_WHEN_run_with_retry_THEN_each_backs_off_independently()
+            throws Exception {
+        AtomicInteger invoked = new AtomicInteger(0);
+        List<RetryUtils.RetryConfig> configList = new ArrayList<>();
+
+        // Ramps towards a high ceiling
+        configList.add(RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(200))
+                .maxRetryInterval(Duration.ofSeconds(30)).maxAttempt(5).retryableExceptions(
+                        Collections.singletonList(IOException.class)).build());
+
+        // Must stay at its own low ceiling regardless of how far the other config has ramped
+        configList.add(RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(10))
+                .maxRetryInterval(Duration.ofMillis(10)).maxAttempt(2).retryableExceptions(
+                        Collections.singletonList(RuntimeException.class)).build());
+
+        RetryUtils.DifferentiatedRetryConfig config = RetryUtils.DifferentiatedRetryConfig.builder()
+                .retryConfigList(configList).build();
+
+        long start = System.currentTimeMillis();
+        assertThrows(RuntimeException.class, () -> RetryUtils.runWithRetry(config, () -> {
+            // Let the IOException config ramp its interval to 200/400/800/1600ms, then throw the exception whose
+            // config caps at 10ms. Sharing one interval across configs would make that final sleep ~3200ms.
+            if (invoked.getAndIncrement() < 4) {
+                throw new IOException();
+            }
+            throw new RuntimeException();
+        }, "", logger));
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertEquals(6, invoked.get());
+        // Four IOException sleeps are jittered at 50-100% of 200/400/800/1600ms, so at most 3000ms. The
+        // RuntimeException config allows one retry, whose sleep must come from its own 10ms interval rather than the
+        // 3200ms the other config ramped to.
+        assertTrue(elapsed < 3100, "elapsed " + elapsed + "ms indicates the ramped interval leaked across configs");
     }
 }

--- a/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
+++ b/src/test/java/com/aws/greengrass/util/RetryUtilsTest.java
@@ -87,12 +87,12 @@ class RetryUtilsTest {
         AtomicInteger invoked = new AtomicInteger(0);
         List<RetryUtils.RetryConfig> configList = new ArrayList<>();
 
-        // Ramps towards a high ceiling
-        configList.add(RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(200))
-                .maxRetryInterval(Duration.ofSeconds(30)).maxAttempt(5).retryableExceptions(
+        // Ramps its interval to 4s after one failure
+        configList.add(RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(2))
+                .maxRetryInterval(Duration.ofSeconds(30)).maxAttempt(2).retryableExceptions(
                         Collections.singletonList(IOException.class)).build());
 
-        // Must stay at its own low ceiling regardless of how far the other config has ramped
+        // Must stay at its own ceiling regardless of how far the other config has ramped
         configList.add(RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMillis(10))
                 .maxRetryInterval(Duration.ofMillis(10)).maxAttempt(2).retryableExceptions(
                         Collections.singletonList(RuntimeException.class)).build());
@@ -102,19 +102,20 @@ class RetryUtilsTest {
 
         long start = System.currentTimeMillis();
         assertThrows(RuntimeException.class, () -> RetryUtils.runWithRetry(config, () -> {
-            // Let the IOException config ramp its interval to 200/400/800/1600ms, then throw the exception whose
-            // config caps at 10ms. Sharing one interval across configs would make that final sleep ~3200ms.
-            if (invoked.getAndIncrement() < 4) {
+            // Let the IOException config ramp its interval to 4s, then throw the exception whose config caps at 10ms
+            if (invoked.getAndIncrement() < 1) {
                 throw new IOException();
             }
             throw new RuntimeException();
         }, "", logger));
         long elapsed = System.currentTimeMillis() - start;
 
-        assertEquals(6, invoked.get());
-        // Four IOException sleeps are jittered at 50-100% of 200/400/800/1600ms, so at most 3000ms. The
-        // RuntimeException config allows one retry, whose sleep must come from its own 10ms interval rather than the
-        // 3200ms the other config ramped to.
-        assertTrue(elapsed < 3100, "elapsed " + elapsed + "ms indicates the ramped interval leaked across configs");
+        assertEquals(3, invoked.get());
+        // Sleeps are jittered at 50-100% of the interval. One IOException sleep on a 2s interval takes 1000-2000ms,
+        // then the single RuntimeException retry sleeps 5-10ms from its own interval, so at most 2010ms. Sharing one
+        // interval across configs would instead sleep 2000-4000ms from the ramped 4s interval, so at least 3000ms.
+        // A single 2s interval rather than a ramp over several separates the two cases by ~490ms either side of the
+        // threshold, well beyond any plausible Thread.sleep overshoot.
+        assertTrue(elapsed < 2500, "elapsed " + elapsed + "ms indicates the ramped interval leaked across configs");
     }
 }


### PR DESCRIPTION
## Problem

`DefaultDockerClient.pullImage` classifies a failed `docker pull` by substring-matching docker's stderr against seven network-error strings:

```java
"read: connection timed out"  "net/http"  "Temporary failure in name resolution"
"request canceled"  "timeout"  "no such host"  "dial tcp"
```

A match becomes `ConnectionException`, which retries indefinitely. Everything else becomes `DockerPullException`, which no retry config lists as retryable, and `RetryUtils` rethrows when nothing matches. So an unmatched error fails the deployment on the first attempt, with no backoff and no second try.

A device whose connection fails over mid-pull reports:

```
DOCKER_PULL_ERROR: Failed to download docker image. Unexpected error while trying to perform
docker pull - Error response from daemon: Get "https://<acct>.dkr.ecr.<region>.amazonaws.com/v2/
<repo>/manifests/sha256:...": read tcp 172.28.1.230:52044->34.204.60.241:443:
read: connection reset by peer
```

That matches none of the seven: it says `read tcp` rather than `dial tcp`, and `read: connection reset by peer` rather than `read: connection timed out`.

`dial tcp` does match, which is why the failure looks intermittent. A failover landing before the connection opens retries indefinitely and stays invisible; one landing mid-transfer produces `read tcp` and fails outright. Pulls run long enough to make mid-transfer failover the likely case.

The gap is structural. Each incident has extended the allowlist by one string (#1369, then #1507 for `dial tcp`), so any transport error nobody anticipated fails a deployment with zero retries. Every other downloader classifies by exception *type* instead — `S3Downloader` and `GreengrassRepositoryDownloader` retry `IOException`, so a connection reset during an S3 download already retries today.

### One more string will not fix this

docker exposes no machine-readable signal. On docker 25.0.14, a DNS failure, a `manifest unknown` and an invalid reference all exit `1`, and `docker pull` offers no `--format`. The Engine API reports failures as `{"errorDetail":{"message":"..."}}` inside a 200 response — the same string wearing JSON.

Four layers wrap that text: the docker CLI, dockerd, containerd, and the Go standard library. Go once exposed the predicate this code needs and has since deprecated it:

```go
// Deprecated: Temporary errors are not well-defined.
// Most "temporary" errors are timeouts, and the few exceptions are surprising.
// Do not use this method.
Temporary() bool
```

The layer producing these errors gave up classifying them. This change therefore layers imperfect signals rather than chasing an exhaustive list.

## Fix

Six separately reviewable commits described below in logical rather than commit order, plus one test-only commit.

**1. Classify by the Go `net.OpError` shape.** Go renders an `OpError` as `"<op> <net> <source>-><addr>: <cause>"`. Matching the op prefix — `read tcp` and `write tcp`, joining `dial tcp` — catches any TCP-layer failure whatever cause follows, including causes docker has never emitted. Doing so moves the dependency onto the stable half of the string: the standard library generates the prefix and has not changed it since Go 1.0, whereas the cause is a syscall errno string that varies by platform and kernel. The old allowlist enumerated the varying half.

Transport causes still match on their own, because docker and containerd sometimes drop the op prefix when wrapping an error raised while copying a layer: `connection reset by peer`, `connection refused`, `connection aborted`, `broken pipe`, `network is unreachable`, `network is down`, `host is unreachable`, `no route to host`, `i/o timeout`, `EOF`, `unexpected EOF`, `context deadline exceeded`, `server misbehaving`.

Six of the seven original strings remain, so nothing that already retried indefinitely stops — with one deliberate exception. Bare `timeout` is dropped: the specific forms it stood in for are matched directly (`read: connection timed out`, `i/o timeout`, `net/http`), and as a bare substring it could fire on an image name, a tag, or registry prose and retry a permanent failure forever. A timeout form matching none of the specific entries now takes the bounded retry of item 4 rather than failing outright, which is what makes dropping it safe. Two of the remaining strings now match case-insensitively, which only widens them.

The HTTP/2 entries in item 2 are the two specific transport forms rather than an `http2:` package prefix, since the prefix would also match framing and flow-control faults — not connectivity, and capable of persisting through a broken intermediary, which under the prefix would retry forever.

**2. Match transport failures raised above `net`.** Some layers never build an `OpError`. `crypto/tls` reports `remote error: tls: bad record MAC`, `tls: use of closed connection` and `remote error: tls: internal error`; HTTP/2 reports `http2: server sent GOAWAY`, `http2: client connection lost` and `stream error: stream ID N; INTERNAL_ERROR`; containerd discards the `OpError` while copying a layer, leaving `read |0: file already closed`. These now match, along with `context canceled`.

Only wire-level TLS failures qualify. When the peer rejects our certificate or we distrust theirs, no retry helps, so `x509:`, `bad certificate` and `handshake failure` stay out and the code says why. Registry 5xx stays out too: retryable, but not transport, and a registry returning one persistently is a fault that should surface.

**3. Fall back on device connectivity.** `runWithConnectionErrorCheck` already infers connectivity for `DockerServiceUnavailableException`; the same inference now covers `UnknownDockerPullException`. When MQTT is down, an unrecognized pull failure more likely reflects that outage than anything the registry said, so it retries until connectivity returns. An online device still gets the bound, which preserves the no-hang property.

Two limits. MQTT reachability does not prove registry reachability, since the endpoints differ and can diverge under a proxy. And detection lags: keep-alive defaults to 60s with a 30s ping timeout, so `getMqttOnline` can report online for up to roughly 90s after connectivity drops. Item 4's retry budget is sized to outlast that lag, so an unrecognized failure during a real outage reaches the inference once the flag flips; the string matching still carries the reported case directly. This signal backs up the strings rather than replacing them.

**4. Retry the remainder instead of failing immediately.** Six unrecoverable errors — `manifest unknown`, `no matching manifest for`, `invalid reference format`, `no space left on device`, `authentication required`, `requested access to the resource is denied` — now map explicitly to `DockerPullException` and fail fast. All six already failed fast, so they become non-retryable by intent rather than by omission. Anything matching neither list becomes the new `UnknownDockerPullException` and retries 7 times at 10s→2m, roughly 195–390 seconds with jitter — sized so the budget outlasts the ~90s MQTT detection lag from item 3 on any jitter draw, since a shorter budget could expire before the device notices it is offline and the fallback ever fires. Only the currently broken bucket changes behavior.

The budget bounds this retry tier, not the deployment: an ECR credential expiring mid-pull re-enters the pull sequence with a fresh budget. That can happen at most once in practice, since the refreshed token is valid for hours, so the effective worst case is about twice the figure above.

This tier stays bounded because it catches errors nothing is known about. Nucleus imposes no deployment timeout by design — `DefaultDeploymentTask` and `DeploymentService` both block without one and delegate detection downstream — so routing unknowns to the indefinite tier would hang a deployment forever on a permanent error the list does not yet name, recoverable only by cancelling it. Guessing wrong should cost minutes, not a stuck device. That also rules out reusing `finiteAttemptsRetryConfig`, whose 30 attempts at 10s→32m take hours.

`UnknownDockerPullException extends DockerPullException`, so exhausting the retries still reports `DOCKER_PULL_ERROR` with the same text. Because `RetryUtils` matches with `isInstance` and only the subclass appears in a retry config, a plain `DockerPullException` still fails fast.

**5. Back off each differentiated retry config independently.** `runWithRetry(DifferentiatedRetryConfig)` tracked one `retryInterval` shared by every config in the list, and slept on it before clamping to the matched config's ceiling — so a config with a high ceiling could ramp the interval and leave a config with a lower ceiling sleeping far past its own. Both existing callers hid this: `DeploymentDocumentDownloader` pairs two configs both flat at 1 minute, and the single-config overload cannot interfere with itself. Pairing 32-minute and 2-minute ceilings, as item 4 does, makes it reachable — several `DockerServiceUnavailableException` failures ramp the interval toward 32 minutes, and an `UnknownDockerPullException` arriving afterwards sleeps that long despite its own ceiling. Tracking the interval per config fixes it and leaves both existing callers unaffected. Without this, item 4's bounded tier does not hold to the 195–390s it claims.

**6. Lower the indefinite tier's ceiling from 64 to 5 minutes.** Droppable without affecting the rest. At 64 minutes, a device seven failures in waits an hour between attempts, so backoff gates recovery even after the network returns. The other downloaders retry at a flat 1 minute. Five minutes keeps exponential backoff — a 225s average sleep against flat-1-minute's 45s, so roughly a fifth of the requests during a sustained outage — while bounding recovery latency.

Note the scope: `infiniteAttemptsRetryConfig` also covers the ECR auth-token fetch and docker login, so this raises their steady-state retry rate too. That looks desirable for the same reason, but it is wider than the pull path.

## Testing

`DefaultDockerClientTest` (new) covers the two extracted predicates with 35 parameterized cases across network, known non-retryable and unrecognized errors. Each case also asserts the two classifications agree, since `isConnectionError` runs first. The network group quotes the reported string verbatim and fails against the previous code, and includes a `read tcp` error whose cause is deliberately a string docker does not emit, pinning the op prefix as the mechanism rather than the cause list. Two further tests pin the matching mechanics themselves: one runs classification under `tr-TR` — whose case rules break a locale-sensitive fold, since docker writes `stream ID` and Turkish lowercases `I` to a dotless ı — and fails if the `Locale.ROOT` argument is dropped (verified by mutation); the other asserts every entry in both lists is lower case, since matching folds only the error text and an upper-case entry could never match.

`DockerImageDownloaderTest` gains four cases: an unknown error retried to the bound and then surfacing as `PackageDownloadException`, asserting the attempt count so it fails against the old single-attempt behavior; one clearing on the second attempt; one on an **offline** device succeeding on the fifth attempt, which exceeds the bounded limit and so passes only via the offline inference — reverting that inference makes it fail, confirming it discriminates; and a plain `DockerPullException` still failing in one attempt.

`RetryUtilsTest` gains a case pairing a config that ramps a 2s interval to 4s with one fixed at 10ms, asserting total elapsed time. It fails at 5641ms against the shared interval and passes at 1932ms with the per-config fix. A single large interval rather than a ramp over several small ones puts roughly 490ms either side of the 2500ms threshold, so no plausible `Thread.sleep` overshoot can flip the result.

The pre-existing `GIVEN_network_error_WHEN_download_docker_image_THEN_retry_download_image_until_succeed` passes unchanged and guards fail-fast against regression. All 65 tests across the two docker classes pass, as do `RetryUtilsTest` and `DeploymentDocumentDownloaderTest` (the other `DifferentiatedRetryConfig` caller), and `checkstyle:check`, `pmd:check` and `spotbugs:check` run clean.

## Notes

Left for separate changes:

- Bare `"timeout"` (the old `DOCKER_PULL_TIMEOUT`) is dropped rather than kept, as described in item 1 — the one deliberate exception to the rule that every previously matched string still matches.
- Classification still reads docker stderr. The `OpError` shape and the connectivity fallback narrow the exposure without removing it.
- `DockerImageDownloader.run()` nests the indefinite tier inside the finite one, so a `ConnectionException` never reaches the outer tier.

