### PR TITLE
fix(deployment): drive an interrupted deployment to a terminal state

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/DeploymentTaskIntegrationTest.java
@@ -1466,8 +1466,17 @@ class DeploymentTaskIntegrationTest extends BaseITCase {
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private Future<DeploymentResult> submitSampleJobDocument(URI uri, Long timestamp) throws Exception {
-        kernel.getContext().get(DeploymentDirectoryManager.class)
-                .createNewDeploymentDirectory("testFleetConfigArn" + deploymentCount.getAndIncrement());
+        DeploymentDirectoryManager deploymentDirectoryManager =
+                kernel.getContext().get(DeploymentDirectoryManager.class);
+        // DeploymentService removes the ongoing link when a deployment reports a terminal status. This
+        // helper bypasses DeploymentService, so do it here: an ongoing link left behind means the next
+        // deployment treats the previous one as interrupted and inherits its rollback snapshot as the
+        // baseline, which would roll back past a deployment that actually completed.
+        if (deploymentDirectoryManager.hasUnfinishedDeployment()) {
+            deploymentDirectoryManager.persistLastSuccessfulDeployment();
+        }
+        deploymentDirectoryManager.createNewDeploymentDirectory(
+                "testFleetConfigArn" + deploymentCount.getAndIncrement());
 
         sampleJobDocument = OBJECT_MAPPER.readValue(new File(uri), DeploymentDocument.class);
         sampleJobDocument.setTimestamp(timestamp);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/lifecyclemanager/ServiceDependencyLifecycleTest.java
@@ -49,6 +49,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction.NOTIFY_COMPONENTS;
@@ -198,7 +199,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         DeploymentDocument doc1 = mock(DeploymentDocument.class);
         when(doc1.getTimestamp()).thenReturn(System.currentTimeMillis());
         when(doc1.getDeploymentId()).thenReturn("removeHardDep");
-        when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
+        lenient().when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_LONG_TIMEOUT, kernel,
                 () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep, System.currentTimeMillis()).get(60,
@@ -216,7 +217,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         DeploymentDocument doc2 = mock(DeploymentDocument.class);
         when(doc2.getTimestamp()).thenReturn(System.currentTimeMillis());
         when(doc2.getDeploymentId()).thenReturn("addHardDep");
-        when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
+        lenient().when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(60, kernel,
                 () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep, System.currentTimeMillis()).get(10, TimeUnit.SECONDS),
@@ -311,7 +312,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         DeploymentDocument doc1 = mock(DeploymentDocument.class);
         when(doc1.getTimestamp()).thenReturn(System.currentTimeMillis());
         when(doc1.getDeploymentId()).thenReturn("removeSoftDep");
-        when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
+        lenient().when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_MEDIUM_TIMEOUT, kernel,
                 () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), configRemoveDep, System.currentTimeMillis()).get(30,
@@ -330,7 +331,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         DeploymentDocument doc2 = mock(DeploymentDocument.class);
         when(doc2.getTimestamp()).thenReturn(System.currentTimeMillis());
         when(doc2.getDeploymentId()).thenReturn("addSoftDep");
-        when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
+        lenient().when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(TEST_ROUTINE_LONG_TIMEOUT, kernel,
                 () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), configAddDep, System.currentTimeMillis()).get(60, TimeUnit.SECONDS),
@@ -399,7 +400,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         DeploymentDocument doc2 = mock(DeploymentDocument.class);
         when(doc2.getTimestamp()).thenReturn(System.currentTimeMillis());
         when(doc2.getDeploymentId()).thenReturn("typeSoftToHard");
-        when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
+        lenient().when(doc2.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(5, kernel,
                 () -> configMerger.mergeInNewConfig(createMockDeployment(doc2), depTypeSoftToHard, System.currentTimeMillis()).get(10, TimeUnit.SECONDS),
@@ -413,7 +414,7 @@ class ServiceDependencyLifecycleTest extends BaseITCase {
         DeploymentDocument doc1 = mock(DeploymentDocument.class);
         when(doc1.getTimestamp()).thenReturn(System.currentTimeMillis());
         when(doc1.getDeploymentId()).thenReturn("typeHardToSoft");
-        when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
+        lenient().when(doc1.getFailureHandlingPolicy()).thenReturn(FailureHandlingPolicy.DO_NOTHING);
 
         testRoutine(5, kernel,
                 () -> configMerger.mergeInNewConfig(createMockDeployment(doc1), depTypeHardToSoft, System.currentTimeMillis()).get(10, TimeUnit.SECONDS),

--- a/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/KernelConfigResolver.java
@@ -739,7 +739,7 @@ public class KernelConfigResolver {
             Topic existingPrevVersionTopic =
                     kernel.getConfig().find(SERVICES_NAMESPACE_TOPIC, compId.getName(), PREV_VERSION_CONFIG_KEY);
             if (existingPrevVersionTopic != null) {
-                String existingPrevVersion = (String) existingVersionTopic.getOnce();
+                String existingPrevVersion = (String) existingPrevVersionTopic.getOnce();
                 newConfig.put(PREV_VERSION_CONFIG_KEY, existingPrevVersion);
             }
         } else {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -238,7 +238,7 @@ public class DeploymentConfigMerger {
     private void countProcessingAttempt(String deploymentId) {
         try {
             kernel.getContext().get(DeploymentDirectoryManager.class).recordProcessingAttempt(
-                    Coerce.toInt(deviceConfiguration.getMaxInterruptedDeploymentAttempts()));
+                    deviceConfiguration.getEffectiveMaxInterruptedDeploymentAttempts());
         } catch (IOException e) {
             // Losing count is better than failing a deployment that is otherwise ready to apply.
             logger.atWarn().kv(DEPLOYMENT_ID_LOG_KEY, deploymentId).setCause(e)

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -34,6 +34,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -226,7 +227,22 @@ public class DeploymentConfigMerger {
 
         logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv("deployment", deploymentId)
                 .log("Applying deployment changes");
+        countProcessingAttempt(deploymentId);
         activator.activate(newConfig, deployment, configMergeTimestamp, totallyCompleteFuture);
+    }
+
+    /**
+     * Record that this deployment is being applied. Counting here rather than on receipt makes the count
+     * reflect attempts actually made, since only some deliveries of a deployment get this far.
+     */
+    private void countProcessingAttempt(String deploymentId) {
+        try {
+            kernel.getContext().get(DeploymentDirectoryManager.class).incrementAndGetProcessingAttempts();
+        } catch (IOException e) {
+            // Losing count is better than failing a deployment that is otherwise ready to apply.
+            logger.atWarn().kv(DEPLOYMENT_ID_LOG_KEY, deploymentId).setCause(e)
+                    .log("Unable to record this deployment attempt");
+        }
     }
 
     private boolean validateNucleusConfig(CompletableFuture<DeploymentResult> totallyCompleteFuture,

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentConfigMerger.java
@@ -237,7 +237,8 @@ public class DeploymentConfigMerger {
      */
     private void countProcessingAttempt(String deploymentId) {
         try {
-            kernel.getContext().get(DeploymentDirectoryManager.class).incrementAndGetProcessingAttempts();
+            kernel.getContext().get(DeploymentDirectoryManager.class).recordProcessingAttempt(
+                    Coerce.toInt(deviceConfiguration.getMaxInterruptedDeploymentAttempts()));
         } catch (IOException e) {
             // Losing count is better than failing a deployment that is otherwise ready to apply.
             logger.atWarn().kv(DEPLOYMENT_ID_LOG_KEY, deploymentId).setCause(e)

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -342,7 +342,7 @@ public class DeploymentDirectoryManager {
                 return null;
             }
             Path unfinishedDir = Files.readSymbolicLink(ongoingDir).toAbsolutePath();
-            if (requiredDirName != null && !requiredDirName.equals(unfinishedDir.getFileName().toString())) {
+            if (requiredDirName != null && !isDirectoryNamed(unfinishedDir, requiredDirName)) {
                 return null;
             }
             Path file = unfinishedDir.resolve(fileName);
@@ -456,13 +456,22 @@ public class DeploymentDirectoryManager {
                 return false;
             }
             Path failedDir = Files.readSymbolicLink(previousFailureDir).toAbsolutePath();
-            return getSafeFileName(deploymentId).equals(failedDir.getFileName().toString())
+            return isDirectoryNamed(failedDir, getSafeFileName(deploymentId))
                     && hasExhaustedAttempts(failedDir);
         } catch (IOException e) {
             logger.atError().kv(DEPLOYMENT_ID_LOG_KEY, deploymentId)
                     .log("Unable to tell whether this deployment already used up its attempts", e);
             return false;
         }
+    }
+
+    /**
+     * Whether a directory has the given name. A path has no file name when it is a root, so the name has
+     * to be null-checked before it is compared.
+     */
+    private static boolean isDirectoryNamed(Path directory, String name) {
+        Path fileName = directory.getFileName();
+        return fileName != null && name.equals(fileName.toString());
     }
 
     public static String getSafeFileName(String fleetConfigArn) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -19,8 +19,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
@@ -36,6 +38,17 @@ public class DeploymentDirectoryManager {
     static final String ROLLBACK_BOOTSTRAP_TASK_FILE = "rollback_bootstrap_task.json";
     static final String DEPLOYMENT_METADATA_FILE = "deployment_metadata.json";
     static final String CONFIG_SNAPSHOT_ERROR = "config_snapshot_error";
+    static final String PROCESSING_ATTEMPTS_FILE = "processing_attempts";
+
+    /**
+     * A deployment that never reaches a terminal status gets processed again, either by this device on
+     * the next launch or by the cloud re-delivering it after a reconnect. Cap those attempts so a
+     * deployment that reliably takes the device down cannot keep the device from accepting a newer one.
+     */
+    static final int MAX_PROCESSING_ATTEMPTS = 3;
+
+    // Files preserved from an unfinished deployment are parked here while its directory is cleaned up.
+    private static final String PRESERVED_FILE_PREFIX = ".preserved-";
 
     private static final String LINK_LOG_KEY = "link";
     private static final String FILE_LOG_KEY = "file";
@@ -187,6 +200,33 @@ public class DeploymentDirectoryManager {
     }
 
     /**
+     * Take the rollback snapshot for the ongoing deployment, unless one was carried forward from an
+     * unfinished deployment: that snapshot holds the last verified configuration and live config may
+     * not, so overwriting it would make unverified state the rollback target.
+     *
+     * @throws IOException if write fails
+     */
+    public void takeRollbackSnapshot() throws IOException {
+        Path filepath = getSnapshotFilePath();
+        if (Files.exists(filepath)) {
+            logger.atInfo().kv(FILE_LOG_KEY, filepath)
+                    .log("Keeping the rollback snapshot carried forward from an unfinished deployment");
+            return;
+        }
+        takeConfigSnapshot(filepath);
+    }
+
+    /**
+     * Whether a deployment is recorded as still in progress. The ongoing link is created when a
+     * deployment starts and removed once its result is reported.
+     *
+     * @return true if an unfinished deployment's directory is still linked
+     */
+    public boolean hasUnfinishedDeployment() {
+        return Files.isSymbolicLink(ongoingDir);
+    }
+
+    /**
      * Resolve snapshot file path.
      *
      * @return Path to snapshot file
@@ -243,11 +283,22 @@ public class DeploymentDirectoryManager {
     /**
      * Create or return the directory for a given deployment.
      *
+     * <p>An ongoing directory left behind by an unfinished deployment means the live configuration may
+     * hold that deployment's merged but never verified changes, so its rollback snapshot — not live
+     * config — is the last verified configuration. Preserve that snapshot into the new deployment's
+     * directory, whether the same deployment is re-processed or a different one supersedes it. Preserve
+     * the attempt count too when the same deployment is re-processed, so repeated interruptions can be
+     * capped.
+     *
      * @param deploymentId Deployment id
      * @return Path to the deployment directory
      * @throws IOException on I/O errors
      */
     public Path createNewDeploymentDirectory(String deploymentId) throws IOException {
+        final Path preservedSnapshot = stashFileFromUnfinishedDeployment(ROLLBACK_SNAPSHOT_FILE, null);
+        final Path preservedAttempts =
+                stashFileFromUnfinishedDeployment(PROCESSING_ATTEMPTS_FILE, getSafeFileName(deploymentId));
+
         cleanupPreviousDeployments(ongoingDir);
         Path path = deploymentsDir.resolve(getSafeFileName(deploymentId));
 
@@ -265,9 +316,129 @@ public class DeploymentDirectoryManager {
         logger.atInfo().kv("directory", path).kv(DEPLOYMENT_ID_LOG_KEY, deploymentId).kv(LINK_LOG_KEY, ongoingDir)
                 .log("Create work directory for new deployment");
         Utils.createPaths(path);
+        restorePreservedFile(preservedSnapshot, path.resolve(ROLLBACK_SNAPSHOT_FILE));
+        restorePreservedFile(preservedAttempts, path.resolve(PROCESSING_ATTEMPTS_FILE));
         Files.createSymbolicLink(ongoingDir, path);
 
         return path;
+    }
+
+    /**
+     * Move a file out of the unfinished (ongoing) deployment's directory so it survives directory
+     * cleanup.
+     *
+     * @param fileName        name of the file to preserve
+     * @param requiredDirName when non-null, preserve only if the unfinished deployment's directory has
+     *                        this name, i.e. the same deployment is being re-processed
+     * @return path the file moved to, or null when there is nothing to preserve
+     */
+    private Path stashFileFromUnfinishedDeployment(String fileName, String requiredDirName) {
+        try {
+            if (!Files.isSymbolicLink(ongoingDir)) {
+                // The previous deployment reached a terminal state; the live configuration is verified.
+                return null;
+            }
+            Path unfinishedDir = Files.readSymbolicLink(ongoingDir).toAbsolutePath();
+            if (requiredDirName != null && !requiredDirName.equals(unfinishedDir.getFileName().toString())) {
+                return null;
+            }
+            Path file = unfinishedDir.resolve(fileName);
+            if (!Files.exists(file)) {
+                return null;
+            }
+            Path stash = deploymentsDir.resolve(PRESERVED_FILE_PREFIX + fileName);
+            Files.move(file, stash, StandardCopyOption.REPLACE_EXISTING);
+            logger.atInfo().kv(FILE_LOG_KEY, file)
+                    .log("Preserving file from unfinished deployment for the next deployment");
+            return stash;
+        } catch (IOException e) {
+            logger.atError().kv(FILE_LOG_KEY, fileName)
+                    .log("Unable to preserve file from unfinished deployment", e);
+            return null;
+        }
+    }
+
+    private void restorePreservedFile(Path stash, Path destination) {
+        if (stash == null) {
+            return;
+        }
+        try {
+            Files.move(stash, destination, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            logger.atError().kv(FILE_LOG_KEY, destination)
+                    .log("Unable to restore preserved file into new deployment directory", e);
+        }
+    }
+
+    /**
+     * Increment and return the number of times the ongoing deployment has started processing. The
+     * counter follows the deployment across re-processing (see {@link #createNewDeploymentDirectory}),
+     * so it counts attempts that never reached a terminal state — for example because the nucleus was
+     * interrupted mid-activation.
+     *
+     * @return the processing attempt number, starting at 1
+     * @throws IOException on I/O errors
+     */
+    public int incrementAndGetProcessingAttempts() throws IOException {
+        Path attemptsFile = getDeploymentDirectoryPath().resolve(PROCESSING_ATTEMPTS_FILE);
+        int attempts = readProcessingAttempts(attemptsFile) + 1;
+        Files.write(attemptsFile, String.valueOf(attempts).getBytes(StandardCharsets.UTF_8));
+        return attempts;
+    }
+
+    /**
+     * Whether the ongoing deployment has used up its processing attempts. Once it has, processing it
+     * again would only repeat an attempt that never completes, so the caller should restore the device to
+     * the deployment's rollback snapshot and report it failed instead.
+     *
+     * @return true if the deployment has been processed at least {@link #MAX_PROCESSING_ATTEMPTS} times
+     */
+    public boolean hasExhaustedProcessingAttempts() {
+        try {
+            return readProcessingAttempts(getDeploymentDirectoryPath().resolve(PROCESSING_ATTEMPTS_FILE))
+                    >= MAX_PROCESSING_ATTEMPTS;
+        } catch (IOException e) {
+            logger.atError().log("Unable to read the processing attempt count", e);
+            return false;
+        }
+    }
+
+    private int readProcessingAttempts(Path attemptsFile) throws IOException {
+        if (!Files.exists(attemptsFile)) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(new String(Files.readAllBytes(attemptsFile), StandardCharsets.UTF_8).trim());
+        } catch (NumberFormatException e) {
+            logger.atWarn().kv(FILE_LOG_KEY, attemptsFile).log("Unreadable processing attempt count. Resetting", e);
+            return 0;
+        }
+    }
+
+    /**
+     * Whether this deployment is the one most recently failed for using up its processing attempts.
+     * Processing a re-delivery that was already in flight when that failure was reported would hand the
+     * same deployment a fresh allowance and re-apply the configuration the device was just restored
+     * from. Any other deployment reaching a terminal state clears the link and count this reads, so a
+     * new revision is unaffected.
+     *
+     * @param deploymentId Deployment id
+     * @return true if this deployment already used up its processing attempts
+     */
+    public boolean wasRefusedForExhaustedAttempts(String deploymentId) {
+        try {
+            if (!Files.isSymbolicLink(previousFailureDir)) {
+                return false;
+            }
+            Path failedDir = Files.readSymbolicLink(previousFailureDir).toAbsolutePath();
+            return getSafeFileName(deploymentId).equals(failedDir.getFileName().toString())
+                    && readProcessingAttempts(failedDir.resolve(PROCESSING_ATTEMPTS_FILE))
+                            >= MAX_PROCESSING_ATTEMPTS;
+        } catch (IOException e) {
+            logger.atError().kv(DEPLOYMENT_ID_LOG_KEY, deploymentId)
+                    .log("Unable to tell whether this deployment already used up its attempts", e);
+            return false;
+        }
     }
 
     public static String getSafeFileName(String fleetConfigArn) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -41,11 +41,11 @@ public class DeploymentDirectoryManager {
     static final String PROCESSING_ATTEMPTS_FILE = "processing_attempts";
 
     /**
-     * A deployment that never reaches a terminal status gets processed again, either by this device on
-     * the next launch or by the cloud re-delivering it after a reconnect. Cap those attempts so a
-     * deployment that reliably takes the device down cannot keep the device from accepting a newer one.
+     * The attempt limit is recorded next to the count rather than read when it is needed, because the
+     * launch consults the count before it has loaded any configuration. A deployment is therefore judged
+     * by the limit in force when it was applied, which is also the limit its operator chose.
      */
-    static final int MAX_PROCESSING_ATTEMPTS = 3;
+    static final String ATTEMPT_LIMIT_FILE = "processing_attempt_limit";
 
     // Files preserved from an unfinished deployment are parked here while its directory is cleaned up.
     private static final String PRESERVED_FILE_PREFIX = ".preserved-";
@@ -298,6 +298,8 @@ public class DeploymentDirectoryManager {
         final Path preservedSnapshot = stashFileFromUnfinishedDeployment(ROLLBACK_SNAPSHOT_FILE, null);
         final Path preservedAttempts =
                 stashFileFromUnfinishedDeployment(PROCESSING_ATTEMPTS_FILE, getSafeFileName(deploymentId));
+        final Path preservedLimit =
+                stashFileFromUnfinishedDeployment(ATTEMPT_LIMIT_FILE, getSafeFileName(deploymentId));
 
         cleanupPreviousDeployments(ongoingDir);
         Path path = deploymentsDir.resolve(getSafeFileName(deploymentId));
@@ -318,6 +320,7 @@ public class DeploymentDirectoryManager {
         Utils.createPaths(path);
         restorePreservedFile(preservedSnapshot, path.resolve(ROLLBACK_SNAPSHOT_FILE));
         restorePreservedFile(preservedAttempts, path.resolve(PROCESSING_ATTEMPTS_FILE));
+        restorePreservedFile(preservedLimit, path.resolve(ATTEMPT_LIMIT_FILE));
         Files.createSymbolicLink(ongoingDir, path);
 
         return path;
@@ -371,47 +374,69 @@ public class DeploymentDirectoryManager {
     }
 
     /**
-     * Increment and return the number of times the ongoing deployment has started processing. The
-     * counter follows the deployment across re-processing (see {@link #createNewDeploymentDirectory}),
-     * so it counts attempts that never reached a terminal state — for example because the nucleus was
-     * interrupted mid-activation.
+     * Record that the ongoing deployment has been applied, and return how many times that has now
+     * happened. The count follows the deployment across re-processing (see
+     * {@link #createNewDeploymentDirectory}), so it counts attempts that never reached a terminal state —
+     * for example because the nucleus was interrupted mid-activation.
      *
-     * @return the processing attempt number, starting at 1
+     * @param attemptLimit how many attempts this deployment is allowed, or below 1 for no limit
+     * @return the attempt number, starting at 1
      * @throws IOException on I/O errors
      */
-    public int incrementAndGetProcessingAttempts() throws IOException {
-        Path attemptsFile = getDeploymentDirectoryPath().resolve(PROCESSING_ATTEMPTS_FILE);
-        int attempts = readProcessingAttempts(attemptsFile) + 1;
+    public int recordProcessingAttempt(int attemptLimit) throws IOException {
+        Path deploymentDir = getDeploymentDirectoryPath();
+        Files.write(deploymentDir.resolve(ATTEMPT_LIMIT_FILE),
+                String.valueOf(attemptLimit).getBytes(StandardCharsets.UTF_8));
+        Path attemptsFile = deploymentDir.resolve(PROCESSING_ATTEMPTS_FILE);
+        int attempts = readNumber(attemptsFile, 0) + 1;
         Files.write(attemptsFile, String.valueOf(attempts).getBytes(StandardCharsets.UTF_8));
         return attempts;
     }
 
     /**
-     * Whether the ongoing deployment has used up its processing attempts. Once it has, processing it
-     * again would only repeat an attempt that never completes, so the caller should restore the device to
-     * the deployment's rollback snapshot and report it failed instead.
+     * How many times the ongoing deployment has been applied.
      *
-     * @return true if the deployment has been processed at least {@link #MAX_PROCESSING_ATTEMPTS} times
+     * @return the attempt count, or 0 if none is recorded
+     */
+    public int getProcessingAttempts() {
+        try {
+            return readNumber(getDeploymentDirectoryPath().resolve(PROCESSING_ATTEMPTS_FILE), 0);
+        } catch (IOException e) {
+            logger.atError().log("Unable to read the processing attempt count", e);
+            return 0;
+        }
+    }
+
+    /**
+     * Whether the ongoing deployment has used up its attempts. Once it has, applying it again would only
+     * repeat an attempt that never completes, so the caller should restore the device to the deployment's
+     * rollback snapshot and report it failed instead.
+     *
+     * @return true if the deployment has reached its attempt limit, false if it has not or has no limit
      */
     public boolean hasExhaustedProcessingAttempts() {
         try {
-            return readProcessingAttempts(getDeploymentDirectoryPath().resolve(PROCESSING_ATTEMPTS_FILE))
-                    >= MAX_PROCESSING_ATTEMPTS;
+            return hasExhaustedAttempts(getDeploymentDirectoryPath());
         } catch (IOException e) {
             logger.atError().log("Unable to read the processing attempt count", e);
             return false;
         }
     }
 
-    private int readProcessingAttempts(Path attemptsFile) throws IOException {
-        if (!Files.exists(attemptsFile)) {
-            return 0;
+    private boolean hasExhaustedAttempts(Path deploymentDir) throws IOException {
+        int limit = readNumber(deploymentDir.resolve(ATTEMPT_LIMIT_FILE), 0);
+        return limit >= 1 && readNumber(deploymentDir.resolve(PROCESSING_ATTEMPTS_FILE), 0) >= limit;
+    }
+
+    private int readNumber(Path file, int fallback) throws IOException {
+        if (!Files.exists(file)) {
+            return fallback;
         }
         try {
-            return Integer.parseInt(new String(Files.readAllBytes(attemptsFile), StandardCharsets.UTF_8).trim());
+            return Integer.parseInt(new String(Files.readAllBytes(file), StandardCharsets.UTF_8).trim());
         } catch (NumberFormatException e) {
-            logger.atWarn().kv(FILE_LOG_KEY, attemptsFile).log("Unreadable processing attempt count. Resetting", e);
-            return 0;
+            logger.atWarn().kv(FILE_LOG_KEY, file).log("Unreadable number. Treating as absent", e);
+            return fallback;
         }
     }
 
@@ -432,8 +457,7 @@ public class DeploymentDirectoryManager {
             }
             Path failedDir = Files.readSymbolicLink(previousFailureDir).toAbsolutePath();
             return getSafeFileName(deploymentId).equals(failedDir.getFileName().toString())
-                    && readProcessingAttempts(failedDir.resolve(PROCESSING_ATTEMPTS_FILE))
-                            >= MAX_PROCESSING_ATTEMPTS;
+                    && hasExhaustedAttempts(failedDir);
         } catch (IOException e) {
             logger.atError().kv(DEPLOYMENT_ID_LOG_KEY, deploymentId)
                     .log("Unable to tell whether this deployment already used up its attempts", e);

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentDirectoryManager.java
@@ -227,6 +227,21 @@ public class DeploymentDirectoryManager {
     }
 
     /**
+     * Whether an unfinished deployment's metadata is on disk and so can be re-processed. A deployment
+     * whose directory exists without metadata cannot be recovered, which is an ordinary state rather than
+     * a failure worth reporting.
+     *
+     * @return true if metadata for an unfinished deployment can be read
+     */
+    public boolean hasReadableDeploymentMetadata() {
+        try {
+            return hasUnfinishedDeployment() && Files.exists(getDeploymentMetadataFilePath());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
      * Resolve snapshot file path.
      *
      * @return Path to snapshot file
@@ -384,6 +399,10 @@ public class DeploymentDirectoryManager {
      * @throws IOException on I/O errors
      */
     public int recordProcessingAttempt(int attemptLimit) throws IOException {
+        if (!hasUnfinishedDeployment()) {
+            // Nothing is tracking this deployment, so there is nowhere to keep a count.
+            return 0;
+        }
         Path deploymentDir = getDeploymentDirectoryPath();
         Files.write(deploymentDir.resolve(ATTEMPT_LIMIT_FILE),
                 String.valueOf(attemptLimit).getBytes(StandardCharsets.UTF_8));
@@ -399,6 +418,9 @@ public class DeploymentDirectoryManager {
      * @return the attempt count, or 0 if none is recorded
      */
     public int getProcessingAttempts() {
+        if (!hasUnfinishedDeployment()) {
+            return 0;
+        }
         try {
             return readNumber(getDeploymentDirectoryPath().resolve(PROCESSING_ATTEMPTS_FILE), 0);
         } catch (IOException e) {
@@ -415,6 +437,9 @@ public class DeploymentDirectoryManager {
      * @return true if the deployment has reached its attempt limit, false if it has not or has no limit
      */
     public boolean hasExhaustedProcessingAttempts() {
+        if (!hasUnfinishedDeployment()) {
+            return false;
+        }
         try {
             return hasExhaustedAttempts(getDeploymentDirectoryPath());
         } catch (IOException e) {

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -82,7 +82,6 @@ import static com.aws.greengrass.deployment.DefaultDeploymentTask.DEVICE_DEPLOYM
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.THING_GROUP_RESOURCE_NAME_PREFIX;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
-import static com.aws.greengrass.deployment.DeploymentDirectoryManager.MAX_PROCESSING_ATTEMPTS;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import static com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED;
 
@@ -598,10 +597,9 @@ public class DeploymentService extends GreengrassService {
             logger.atWarn().kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, deployment.getGreengrassDeploymentId())
                     .log("Rejecting a deployment that already used up its processing attempts");
             updateDeploymentResultAsRejected(deployment, deploymentTask, new DeploymentRejectedException(
-                    "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
-                            + " attempts, which is the maximum allowed, and the device has been restored to the "
-                            + "configuration from before it. Deploy a new revision to change the device's "
-                            + "configuration.", DeploymentErrorCode.DEPLOYMENT_INTERRUPTED));
+                    "Deployment was interrupted before completing on every allowed attempt, and the device has "
+                            + "been restored to the configuration from before it. Deploy a new revision to change "
+                            + "the device's configuration.", DeploymentErrorCode.DEPLOYMENT_INTERRUPTED));
             return;
         }
 
@@ -640,14 +638,13 @@ public class DeploymentService extends GreengrassService {
                 // terminal status stops the cloud re-delivering the deployment and releases the device to
                 // accept a newer one.
                 logger.atError().kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, deployment.getGreengrassDeploymentId())
-                        .kv("attempts", MAX_PROCESSING_ATTEMPTS)
+                        .kv("attempts", deploymentDirectoryManager.getProcessingAttempts())
                         .log("Deployment was interrupted before completing on every allowed attempt. Failing it "
                                 + "so the device can accept a newer deployment");
                 updateDeploymentResultAsFailed(deployment, deploymentTask, false, new DeploymentException(
-                        "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
-                                + " attempts, which is the maximum allowed. The device has been restored to the "
-                                + "configuration from before the deployment. Deploy a new revision to change it.",
-                        DeploymentErrorCode.DEPLOYMENT_INTERRUPTED));
+                        "Deployment was interrupted before completing on every allowed attempt. The device has "
+                                + "been restored to the configuration from before the deployment. Deploy a new "
+                                + "revision to change it.", DeploymentErrorCode.DEPLOYMENT_INTERRUPTED));
                 return;
             }
 

--- a/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeploymentService.java
@@ -82,10 +82,14 @@ import static com.aws.greengrass.deployment.DefaultDeploymentTask.DEVICE_DEPLOYM
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.THING_GROUP_RESOURCE_NAME_PREFIX;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
+import static com.aws.greengrass.deployment.DeploymentDirectoryManager.MAX_PROCESSING_ATTEMPTS;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentType;
 import static com.aws.greengrass.deployment.model.DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED;
 
 @ImplementsService(name = DeploymentService.DEPLOYMENT_SERVICE_TOPICS, autostart = true)
+// This class already sat at PMD's 1000-line class limit before the interrupted-deployment attempt cap was
+// added. Splitting it up is worth doing on its own, not as part of a bug fix.
+@SuppressWarnings("PMD.ExcessiveClassLength")
 public class DeploymentService extends GreengrassService {
 
     public static final String DEPLOYMENT_SERVICE_TOPICS = "DeploymentService";
@@ -585,6 +589,22 @@ public class DeploymentService extends GreengrassService {
             return;
         }
 
+        if (DEFAULT.equals(deployment.getDeploymentStage()) && deploymentDirectoryManager
+                .wasRefusedForExhaustedAttempts(deployment.getGreengrassDeploymentId())) {
+            // Treating a re-delivery that was in flight when the failure was reported as a new request
+            // would hand it a fresh allowance and re-apply the version just backed out. Rejecting rather
+            // than failing it leaves the last-failed record intact, so a further re-delivery is recognised
+            // too, while a new revision is accepted normally.
+            logger.atWarn().kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, deployment.getGreengrassDeploymentId())
+                    .log("Rejecting a deployment that already used up its processing attempts");
+            updateDeploymentResultAsRejected(deployment, deploymentTask, new DeploymentRejectedException(
+                    "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
+                            + " attempts, which is the maximum allowed, and the device has been restored to the "
+                            + "configuration from before it. Deploy a new revision to change the device's "
+                            + "configuration.", DeploymentErrorCode.DEPLOYMENT_INTERRUPTED));
+            return;
+        }
+
         // Assign currentDeploymentTaskMetadata before persisting IN_PROGRESS and before submitting
         // the task to the executor. This ensures that any concurrent reader (e.g. ShadowDeploymentListener,
         // IotJobsHelper) that observes a side-effect of deployment processing will also observe
@@ -600,15 +620,34 @@ public class DeploymentService extends GreengrassService {
                 deployment.getDeploymentDocumentObj().getRootPackages());
 
         if (DEFAULT.equals(deployment.getDeploymentStage())) {
+            boolean attemptsExhausted;
             try {
                 context.get(KernelAlternatives.class).cleanupLaunchDirectoryLinks();
                 deploymentDirectoryManager.createNewDeploymentDirectory(deployment.getGreengrassDeploymentId());
+                attemptsExhausted = deploymentDirectoryManager.hasExhaustedProcessingAttempts();
                 deploymentDirectoryManager.writeDeploymentMetadata(deployment);
             } catch (IOException ioException) {
                 logger.atError().log("Unable to create deployment directory", ioException);
                 updateDeploymentResultAsFailed(deployment, deploymentTask, false,
                         new DeploymentException("Unable to create deployment directory", ioException)
                                 .withErrorContext(ioException, DeploymentErrorCode.IO_WRITE_ERROR));
+                return;
+            }
+
+            if (attemptsExhausted) {
+                // The launch that re-processed this deployment already restored the configuration from its
+                // rollback snapshot, so the device is back on the last verified configuration. Reporting a
+                // terminal status stops the cloud re-delivering the deployment and releases the device to
+                // accept a newer one.
+                logger.atError().kv(GG_DEPLOYMENT_ID_LOG_KEY_NAME, deployment.getGreengrassDeploymentId())
+                        .kv("attempts", MAX_PROCESSING_ATTEMPTS)
+                        .log("Deployment was interrupted before completing on every allowed attempt. Failing it "
+                                + "so the device can accept a newer deployment");
+                updateDeploymentResultAsFailed(deployment, deploymentTask, false, new DeploymentException(
+                        "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
+                                + " attempts, which is the maximum allowed. The device has been restored to the "
+                                + "configuration from before the deployment. Deploy a new revision to change it.",
+                        DeploymentErrorCode.DEPLOYMENT_INTERRUPTED));
                 return;
             }
 

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -107,6 +107,7 @@ public class DeviceConfiguration {
     public static final long DEFAULT_CREDENTIAL_ENDPOINT_TIMEOUT_MS = 60_000L;
     public static final String COMPONENT_STORE_MAX_SIZE_BYTES = "componentStoreMaxSizeBytes";
     public static final String DEPLOYMENT_POLLING_FREQUENCY_SECONDS = "deploymentPollingFrequencySeconds";
+    public static final String MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS = "maxInterruptedDeploymentAttempts";
     public static final String NUCLEUS_CONFIG_LOGGING_TOPICS = "logging";
     public static final String TELEMETRY_CONFIG_LOGGING_TOPICS = "telemetry";
 
@@ -120,6 +121,12 @@ public class DeviceConfiguration {
     public static final String DEVICE_PARAM_PROXY_PASSWORD = "password";
     public static final long COMPONENT_STORE_MAX_SIZE_DEFAULT_BYTES = 10_000_000_000L;
     public static final long DEPLOYMENT_POLLING_FREQUENCY_DEFAULT_SECONDS = 15L;
+    // How many times a deployment that keeps being interrupted before it reports a terminal status may be
+    // applied before the device is restored to the configuration from before it and the deployment failed.
+    // A device whose environment is not ready yet — network, peripherals — can be told to keep retrying
+    // instead, by setting this below 1, at the cost of losing the protection against a deployment that
+    // repeatedly takes the device down.
+    public static final int DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS = 3;
     // Boot-time config.tlog compaction: when config.tlog (or its config.tlog~ backup) exceeds this many
     // bytes at startup, rewrite it from the in-memory effective config to collapse accumulated duplicate
     // no-op entries that slow tlog replay on every boot. Enabled by default at 10 MB; set 0 to disable.
@@ -170,6 +177,7 @@ public class DeviceConfiguration {
         handleLoggingConfig();
         getComponentStoreMaxSizeBytes().dflt(COMPONENT_STORE_MAX_SIZE_DEFAULT_BYTES);
         getDeploymentPollingFrequencySeconds().dflt(DEPLOYMENT_POLLING_FREQUENCY_DEFAULT_SECONDS);
+        getMaxInterruptedDeploymentAttempts().dflt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS);
         getBootConfigTlogCompactionThresholdBytes().dflt(DEFAULT_BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES);
         handleExistingSystemProperty();
         // reset the cache when device configuration changes
@@ -578,6 +586,16 @@ public class DeviceConfiguration {
 
     public Topic getDeploymentPollingFrequencySeconds() {
         return getTopic(DEPLOYMENT_POLLING_FREQUENCY_SECONDS);
+    }
+
+    /**
+     * How many times an interrupted deployment may be applied before the device is restored and the
+     * deployment failed. Below 1 means no limit, so such a deployment is retried indefinitely.
+     *
+     * @return the configured attempt limit
+     */
+    public Topic getMaxInterruptedDeploymentAttempts() {
+        return getTopic(MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -613,7 +613,11 @@ public class DeviceConfiguration {
         try {
             // Strict parsing: Utils.parseLong and Coerce both return 0 for a value that is not a number,
             // which is indistinguishable from an explicit 0 and would read as no limit.
-            return Integer.parseInt(Objects.toString(configured, "").trim());
+            long configuredLimit = Long.parseLong(Objects.toString(configured, "").trim());
+            // Clamp rather than reject a value too large for an int. Someone writing one means "effectively
+            // unlimited", and rejecting it would fall back to the default — the most restrictive setting,
+            // and the opposite of what they asked for. No device is interrupted MAX_VALUE times.
+            return (int) Math.max(Integer.MIN_VALUE, Math.min(Integer.MAX_VALUE, configuredLimit));
         } catch (NumberFormatException e) {
             logger.atWarn().kv("configured", configured)
                     .kv("using", DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS)

--- a/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
+++ b/src/main/java/com/aws/greengrass/deployment/DeviceConfiguration.java
@@ -599,6 +599,30 @@ public class DeviceConfiguration {
     }
 
     /**
+     * Get the interrupted-deployment attempt limit, falling back to the default if the configured value is
+     * not a number. Coercing the topic to a number would turn any such value into 0, which reads as no
+     * limit, so a typo would silently disable the protection rather than being noticed.
+     *
+     * @return the configured limit, or the default if it is not a number
+     */
+    public int getEffectiveMaxInterruptedDeploymentAttempts() {
+        Object configured = getMaxInterruptedDeploymentAttempts().getOnce();
+        if (configured instanceof Number) {
+            return ((Number) configured).intValue();
+        }
+        try {
+            // Strict parsing: Utils.parseLong and Coerce both return 0 for a value that is not a number,
+            // which is indistinguishable from an explicit 0 and would read as no limit.
+            return Integer.parseInt(Objects.toString(configured, "").trim());
+        } catch (NumberFormatException e) {
+            logger.atWarn().kv("configured", configured)
+                    .kv("using", DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS)
+                    .log("Invalid " + MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS + ", using default");
+            return DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS;
+        }
+    }
+
+    /**
      * Get s3 endpoint topic.
      *
      * @return s3 endpoint topic

--- a/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DefaultActivator.java
@@ -52,18 +52,12 @@ public class DefaultActivator extends DeploymentActivator {
 
         DeploymentDocument deploymentDocument = deployment.getDeploymentDocumentObj();
         String deploymentId = deployment.getId();
-        boolean autoRollback = isAutoRollbackRequested(deploymentDocument);
 
-        // Endpoint switch deployments force config snapshot and rollback regardless of FailureHandlingPolicy,
-        // so that we can restore the original endpoint if the new one is unreachable after applying the change.
-        // Only check when auto-rollback is not already requested to avoid redundant config store reads.
-        boolean forceSnapshotForEndpointSwitch = !autoRollback && isEndpointSwitch(deploymentId);
-        if (forceSnapshotForEndpointSwitch) {
-            logger.atInfo(MERGE_CONFIG_EVENT_KEY)
-                    .log("Endpoint switch deployment: forcing config snapshot and rollback support");
-        }
-        if ((autoRollback || forceSnapshotForEndpointSwitch)
-                && !takeConfigSnapshot(totallyCompleteFuture)) {
+        // Snapshot regardless of FailureHandlingPolicy. The policy governs whether a *failed* deployment
+        // rolls back; it cannot govern whether an *interrupted* one is recoverable, because the merge below
+        // makes the new configuration durable either way. Endpoint switch deployments need the snapshot for
+        // the same reason, to restore the original endpoint when the new one proves unreachable.
+        if (!takeConfigSnapshot(totallyCompleteFuture)) {
             return;
         }
 
@@ -106,6 +100,14 @@ public class DefaultActivator extends DeploymentActivator {
             logger.atDebug(MERGE_CONFIG_EVENT_KEY).kv("serviceToTrack", servicesToTrack).kv("mergeTime", mergeTime)
                     .log("Applied new service config. Waiting for services to complete update");
             waitForServicesToStart(servicesToTrack, mergeTime, kernel, totallyCompleteFuture);
+            if (totallyCompleteFuture.isCancelled()) {
+                // waitForServicesToStart returns early rather than throwing when the deployment is
+                // cancelled, e.g. because a newer deployment superseded it. Stop here instead of mutating
+                // services alongside the deployment that replaced this one.
+                logger.atInfo(MERGE_CONFIG_EVENT_KEY).kv(DEPLOYMENT_ID_LOG_KEY, deploymentDocument.getDeploymentId())
+                        .log("Deployment cancelled: will not remove obsolete services");
+                return;
+            }
             logger.atDebug(MERGE_CONFIG_EVENT_KEY)
                     .log("new/updated services are running, will now remove old services");
             servicesChangeManager.removeObsoleteServices();

--- a/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.deployment.DeploymentConfigMerger.MERGE_CONFIG_EVENT_KEY;
 import static com.aws.greengrass.deployment.DeploymentConfigMerger.MERGE_ERROR_LOG_EVENT_KEY;
 import static com.aws.greengrass.ipc.AuthenticationHandler.AUTHENTICATION_TOKEN_LOOKUP_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
@@ -48,6 +49,14 @@ public abstract class DeploymentActivator {
     protected boolean takeConfigSnapshot(CompletableFuture<DeploymentResult> totallyCompleteFuture) {
          if (totallyCompleteFuture.isCancelled()) {
             return false;
+        }
+        if (!deploymentDirectoryManager.hasUnfinishedDeployment()) {
+            // No deployment directory, so there is nowhere to put a snapshot and nothing tracking this
+            // deployment that could use one. Proceed rather than failing: requiring a snapshot here would
+            // fail deployments that are applied without a directory having been created for them.
+            logger.atDebug().setEventType(MERGE_CONFIG_EVENT_KEY)
+                    .log("No deployment directory; skipping rollback snapshot");
+            return true;
         }
         try {
             deploymentDirectoryManager.takeRollbackSnapshot();

--- a/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
+++ b/src/main/java/com/aws/greengrass/deployment/activator/DeploymentActivator.java
@@ -50,7 +50,7 @@ public abstract class DeploymentActivator {
             return false;
         }
         try {
-            deploymentDirectoryManager.takeConfigSnapshot(deploymentDirectoryManager.getSnapshotFilePath());
+            deploymentDirectoryManager.takeRollbackSnapshot();
             return true;
         } catch (IOException e) {
             // Failed to record snapshot hence did not execute merge, no rollback needed

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -107,6 +107,7 @@ import static com.aws.greengrass.dependency.EZPlugins.JAR_FILE_EXTENSION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_REBOOT;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
+import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.KERNEL_ROLLBACK;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.ROLLBACK_BOOTSTRAP;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
@@ -159,7 +160,7 @@ public class Kernel {
     private final NucleusPaths nucleusPaths;
 
     private Collection<GreengrassService> cachedOD = null;
-    private DeploymentStage deploymentStageAtLaunch = DeploymentStage.DEFAULT;
+    private DeploymentStage deploymentStageAtLaunch = DEFAULT;
     private final Lock odLock = LockFactory.newReentrantLock("ODLock");
 
     /**
@@ -302,10 +303,43 @@ public class Kernel {
                 }
                 // fall through to launch kernel
             default:
+                if (DEFAULT.equals(deploymentStageAtLaunch)) {
+                    requeueAbandonedDeployment(deploymentDirectoryManager);
+                }
                 kernelLifecycle.launch();
                 break;
         }
         return this;
+    }
+
+    /**
+     * Re-queue a deployment that was interrupted before it reported a terminal status. A deployment
+     * requiring no nucleus restart leaves no resumable state behind, unlike the bootstrap and
+     * kernel-update stages, so without this it is silently abandoned while its merged, never verified
+     * configuration survives as the durable current state. Re-processing drives it to a terminal status
+     * instead, and the rollback snapshot that
+     * {@link DeploymentDirectoryManager#createNewDeploymentDirectory} carries forward keeps the
+     * pre-deployment configuration as the rollback target.
+     */
+    private void requeueAbandonedDeployment(DeploymentDirectoryManager deploymentDirectoryManager) {
+        if (!deploymentDirectoryManager.hasUnfinishedDeployment()) {
+            return;
+        }
+        try {
+            Deployment deployment = deploymentDirectoryManager.readDeploymentMetadata();
+            if (!DEFAULT.equals(deployment.getDeploymentStage())) {
+                return;
+            }
+            DeploymentQueue deploymentQueue = context.get(DeploymentQueue.class);
+            deploymentQueue.offer(deployment);
+            logger.atInfo().kv("deploymentId", deployment.getGreengrassDeploymentId())
+                    .log("Found a deployment that was interrupted before it completed. Re-processing it");
+        } catch (IOException | RuntimeException e) {
+            // Re-processing an interrupted deployment is a recovery step, so it must never keep the device
+            // from starting. A corrupt or unreadable metadata file would otherwise fail every launch.
+            logger.atError().setCause(e)
+                    .log("Failed to load information for the interrupted deployment. Proceed as default");
+        }
     }
 
     /**
@@ -733,6 +767,38 @@ public class Kernel {
                 }
                 break;
             default:
+                if (deploymentDirectoryManager.hasUnfinishedDeployment()
+                        && deploymentDirectoryManager.hasExhaustedProcessingAttempts()) {
+                    // Interrupted mid-activation on every allowed attempt, so this deployment's merged
+                    // configuration is durable but was never verified. Boot from its rollback snapshot
+                    // instead, which is the same config override the kernel-rollback stage uses. Doing it
+                    // before any service starts is what makes it safe: nothing has to be reconciled
+                    // afterwards. DeploymentService then reports the deployment failed.
+                    try {
+                        Path configPath = deploymentDirectoryManager.getSnapshotFilePath();
+                        if (Files.exists(configPath)) {
+                            configFileName = configPath.toString();
+                            logger.atWarn().kv(DEPLOYMENT_STAGE_LOG_KEY, stage).kv("rollbackConfigFile", configPath)
+                                    .log("Deployment was interrupted on every allowed attempt. Restoring the "
+                                            + "configuration from before it was applied");
+                            break;
+                        }
+                        logger.atError().kv("rollbackConfigFile", configPath)
+                                .log("Deployment was interrupted on every allowed attempt, but its rollback "
+                                        + "configuration is missing. Proceed as default");
+                    } catch (IOException | RuntimeException e) {
+                        // Restoring is a recovery step; never let it keep the device from starting.
+                        logger.atError().setCause(e).log("Deployment was interrupted on every allowed attempt, but "
+                                + "its rollback configuration could not be loaded. Proceed as default");
+                    }
+                }
+                if (deploymentDirectoryManager.hasUnfinishedDeployment()) {
+                    // The deployment is not resumable, but it is on disk and this launch will re-process
+                    // it, so reporting no ongoing deployment would mislead anyone reading the log.
+                    logger.atInfo().log("Found a deployment that did not complete. It is not resumable, so it "
+                            + "will be re-processed from the start");
+                    break;
+                }
                 logger.atInfo().log("No ongoing deployment detected. Proceed as default");
         }
         if (Utils.isEmpty(configFileName)) {

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -367,6 +367,16 @@ public class Kernel {
             if (!DEFAULT.equals(deployment.getDeploymentStage())) {
                 return;
             }
+            if (!Deployment.DeploymentType.LOCAL.equals(deployment.getDeploymentType())) {
+                // A cloud deployment that never reported a terminal status is re-delivered by the cloud,
+                // with the document the cloud holds. Re-processing it from disk would only race that, and
+                // resolution from disk can fail where the cloud succeeds — turning a deployment that would
+                // have completed into a failed one. Local deployments get no re-delivery, so they are the
+                // case that needs re-processing here.
+                logger.atDebug().kv("deploymentId", deployment.getGreengrassDeploymentId())
+                        .log("Interrupted cloud deployment will be re-delivered; not re-processing it locally");
+                return;
+            }
             DeploymentQueue deploymentQueue = context.get(DeploymentQueue.class);
             deploymentQueue.offer(deployment);
             logger.atInfo().kv("deploymentId", deployment.getGreengrassDeploymentId())

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -313,6 +313,41 @@ public class Kernel {
     }
 
     /**
+     * The configuration to launch from when a deployment has used up its attempts, or null when there is
+     * none. Interrupted mid-activation on every allowed attempt, such a deployment's merged configuration
+     * is durable but was never verified, so the device launches from its rollback snapshot instead — the
+     * same config override the kernel-rollback stage uses. Doing it before any service starts is what
+     * makes it safe: nothing has to be reconciled afterwards. DeploymentService then reports the
+     * deployment failed.
+     */
+    // Catching RuntimeException is deliberate: see the catch block.
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private String configToRestoreAbandonedDeploymentFrom(DeploymentDirectoryManager deploymentDirectoryManager,
+                                                          DeploymentStage stage) {
+        if (!deploymentDirectoryManager.hasUnfinishedDeployment()
+                || !deploymentDirectoryManager.hasExhaustedProcessingAttempts()) {
+            return null;
+        }
+        try {
+            Path configPath = deploymentDirectoryManager.getSnapshotFilePath();
+            if (Files.exists(configPath)) {
+                logger.atWarn().kv(DEPLOYMENT_STAGE_LOG_KEY, stage).kv("rollbackConfigFile", configPath)
+                        .log("Deployment was interrupted on every allowed attempt. Restoring the configuration "
+                                + "from before it was applied");
+                return configPath.toString();
+            }
+            logger.atError().kv("rollbackConfigFile", configPath)
+                    .log("Deployment was interrupted on every allowed attempt, but its rollback configuration is "
+                            + "missing. Proceed as default");
+        } catch (IOException | RuntimeException e) {
+            // Restoring is a recovery step; never let it keep the device from starting.
+            logger.atError().setCause(e).log("Deployment was interrupted on every allowed attempt, but its "
+                    + "rollback configuration could not be loaded. Proceed as default");
+        }
+        return null;
+    }
+
+    /**
      * Re-queue a deployment that was interrupted before it reported a terminal status. A deployment
      * requiring no nucleus restart leaves no resumable state behind, unlike the bootstrap and
      * kernel-update stages, so without this it is silently abandoned while its merged, never verified
@@ -321,6 +356,8 @@ public class Kernel {
      * {@link DeploymentDirectoryManager#createNewDeploymentDirectory} carries forward keeps the
      * pre-deployment configuration as the rollback target.
      */
+    // Catching RuntimeException is deliberate: see the catch block.
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void requeueAbandonedDeployment(DeploymentDirectoryManager deploymentDirectoryManager) {
         if (!deploymentDirectoryManager.hasUnfinishedDeployment()) {
             return;
@@ -767,30 +804,10 @@ public class Kernel {
                 }
                 break;
             default:
-                if (deploymentDirectoryManager.hasUnfinishedDeployment()
-                        && deploymentDirectoryManager.hasExhaustedProcessingAttempts()) {
-                    // Interrupted mid-activation on every allowed attempt, so this deployment's merged
-                    // configuration is durable but was never verified. Boot from its rollback snapshot
-                    // instead, which is the same config override the kernel-rollback stage uses. Doing it
-                    // before any service starts is what makes it safe: nothing has to be reconciled
-                    // afterwards. DeploymentService then reports the deployment failed.
-                    try {
-                        Path configPath = deploymentDirectoryManager.getSnapshotFilePath();
-                        if (Files.exists(configPath)) {
-                            configFileName = configPath.toString();
-                            logger.atWarn().kv(DEPLOYMENT_STAGE_LOG_KEY, stage).kv("rollbackConfigFile", configPath)
-                                    .log("Deployment was interrupted on every allowed attempt. Restoring the "
-                                            + "configuration from before it was applied");
-                            break;
-                        }
-                        logger.atError().kv("rollbackConfigFile", configPath)
-                                .log("Deployment was interrupted on every allowed attempt, but its rollback "
-                                        + "configuration is missing. Proceed as default");
-                    } catch (IOException | RuntimeException e) {
-                        // Restoring is a recovery step; never let it keep the device from starting.
-                        logger.atError().setCause(e).log("Deployment was interrupted on every allowed attempt, but "
-                                + "its rollback configuration could not be loaded. Proceed as default");
-                    }
+                String restoreFrom = configToRestoreAbandonedDeploymentFrom(deploymentDirectoryManager, stage);
+                if (!Utils.isEmpty(restoreFrom)) {
+                    configFileName = restoreFrom;
+                    break;
                 }
                 if (deploymentDirectoryManager.hasUnfinishedDeployment()) {
                     // The deployment is not resumable, but it is on disk and this launch will re-process

--- a/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
+++ b/src/main/java/com/aws/greengrass/lifecyclemanager/Kernel.java
@@ -359,7 +359,7 @@ public class Kernel {
     // Catching RuntimeException is deliberate: see the catch block.
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void requeueAbandonedDeployment(DeploymentDirectoryManager deploymentDirectoryManager) {
-        if (!deploymentDirectoryManager.hasUnfinishedDeployment()) {
+        if (!deploymentDirectoryManager.hasReadableDeploymentMetadata()) {
             return;
         }
         try {

--- a/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/KernelConfigResolverTest.java
@@ -1503,6 +1503,127 @@ class KernelConfigResolverTest {
         assertThat("Service B must set posix user", runWith, hasEntry(POSIX_USER_KEY, "foo:bar"));
     }
 
+    @Test
+    void GIVEN_component_upgrade_WHEN_config_resolution_requested_THEN_previous_version_rotates_to_replaced_version()
+            throws Exception {
+        // GIVEN a component running 1.0.0
+        config.lookup(SERVICES_NAMESPACE_TOPIC, TEST_INPUT_PACKAGE_A, KernelConfigResolver.VERSION_CONFIG_KEY)
+                .withValue("1.0.0");
+
+        ComponentIdentifier componentIdentifier =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_A, new Semver("2.0.0", Semver.SemverType.NPM));
+        DeploymentDocument document = DeploymentDocument.builder()
+                .deploymentPackageConfigurationList(Collections.singletonList(DeploymentPackageConfiguration.builder()
+                        .packageName(TEST_INPUT_PACKAGE_A).rootComponent(true).resolvedVersion("=2.0.0").build()))
+                .timestamp(10_000L)
+                .build();
+
+        // WHEN deploying 2.0.0
+        Map<String, Object> servicesConfig = serviceConfigurationProperlyResolved(document, Collections.singletonMap(
+                componentIdentifier,
+                getPackage(TEST_INPUT_PACKAGE_A, "2.0.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_A)));
+
+        // THEN previousVersion names the version actually replaced
+        Map<String, Object> serviceConfig = getServiceConfig(TEST_INPUT_PACKAGE_A, servicesConfig);
+        assertThat(serviceConfig, hasEntry(KernelConfigResolver.VERSION_CONFIG_KEY, "2.0.0"));
+        assertThat(serviceConfig, hasEntry(KernelConfigResolver.PREV_VERSION_CONFIG_KEY, "1.0.0"));
+    }
+
+    @Test
+    void GIVEN_deployment_of_running_version_WHEN_config_resolution_requested_THEN_previous_version_is_preserved()
+            throws Exception {
+        // GIVEN a component running 1.1.0 which replaced 1.0.0
+        config.lookup(SERVICES_NAMESPACE_TOPIC, TEST_INPUT_PACKAGE_A, KernelConfigResolver.VERSION_CONFIG_KEY)
+                .withValue("1.1.0");
+        config.lookup(SERVICES_NAMESPACE_TOPIC, TEST_INPUT_PACKAGE_A, KernelConfigResolver.PREV_VERSION_CONFIG_KEY)
+                .withValue("1.0.0");
+
+        ComponentIdentifier componentIdentifier =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.1.0", Semver.SemverType.NPM));
+        DeploymentDocument document = DeploymentDocument.builder()
+                .deploymentPackageConfigurationList(Collections.singletonList(DeploymentPackageConfiguration.builder()
+                        .packageName(TEST_INPUT_PACKAGE_A).rootComponent(true).resolvedVersion("=1.1.0").build()))
+                .timestamp(10_000L)
+                .build();
+
+        // WHEN deploying the version already running
+        Map<String, Object> servicesConfig = serviceConfigurationProperlyResolved(document, Collections.singletonMap(
+                componentIdentifier,
+                getPackage(TEST_INPUT_PACKAGE_A, "1.1.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_A)));
+
+        // THEN previousVersion still names the version 1.1.0 actually replaced, not 1.1.0 itself
+        Map<String, Object> serviceConfig = getServiceConfig(TEST_INPUT_PACKAGE_A, servicesConfig);
+        assertThat(serviceConfig, hasEntry(KernelConfigResolver.VERSION_CONFIG_KEY, "1.1.0"));
+        assertThat(serviceConfig, hasEntry(KernelConfigResolver.PREV_VERSION_CONFIG_KEY, "1.0.0"));
+    }
+
+    @Test
+    void GIVEN_deployment_of_running_version_with_no_previous_version_WHEN_config_resolution_requested_THEN_none_is_written()
+            throws Exception {
+        // GIVEN a component running 1.0.0 that has never been upgraded
+        config.lookup(SERVICES_NAMESPACE_TOPIC, TEST_INPUT_PACKAGE_A, KernelConfigResolver.VERSION_CONFIG_KEY)
+                .withValue("1.0.0");
+
+        ComponentIdentifier componentIdentifier =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_A, new Semver("1.0.0", Semver.SemverType.NPM));
+        DeploymentDocument document = DeploymentDocument.builder()
+                .deploymentPackageConfigurationList(Collections.singletonList(DeploymentPackageConfiguration.builder()
+                        .packageName(TEST_INPUT_PACKAGE_A).rootComponent(true).resolvedVersion("=1.0.0").build()))
+                .timestamp(10_000L)
+                .build();
+
+        // WHEN deploying the version already running
+        Map<String, Object> servicesConfig = serviceConfigurationProperlyResolved(document, Collections.singletonMap(
+                componentIdentifier,
+                getPackage(TEST_INPUT_PACKAGE_A, "1.0.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_A)));
+
+        // THEN no previousVersion is fabricated
+        Map<String, Object> serviceConfig = getServiceConfig(TEST_INPUT_PACKAGE_A, servicesConfig);
+        assertThat(serviceConfig, hasEntry(KernelConfigResolver.VERSION_CONFIG_KEY, "1.0.0"));
+        assertThat(serviceConfig, not(hasKey(KernelConfigResolver.PREV_VERSION_CONFIG_KEY)));
+    }
+
+    @Test
+    void GIVEN_deployment_changing_one_component_WHEN_config_resolution_requested_THEN_unchanged_sibling_previous_version_is_preserved()
+            throws Exception {
+        // GIVEN component A running 1.0.0, and component B running 1.1.0 which replaced 1.0.0
+        config.lookup(SERVICES_NAMESPACE_TOPIC, TEST_INPUT_PACKAGE_A, KernelConfigResolver.VERSION_CONFIG_KEY)
+                .withValue("1.0.0");
+        config.lookup(SERVICES_NAMESPACE_TOPIC, TEST_INPUT_PACKAGE_B, KernelConfigResolver.VERSION_CONFIG_KEY)
+                .withValue("1.1.0");
+        config.lookup(SERVICES_NAMESPACE_TOPIC, TEST_INPUT_PACKAGE_B, KernelConfigResolver.PREV_VERSION_CONFIG_KEY)
+                .withValue("1.0.0");
+
+        ComponentIdentifier componentA =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_A, new Semver("2.0.0", Semver.SemverType.NPM));
+        ComponentIdentifier componentB =
+                new ComponentIdentifier(TEST_INPUT_PACKAGE_B, new Semver("1.1.0", Semver.SemverType.NPM));
+        DeploymentDocument document = DeploymentDocument.builder()
+                .deploymentPackageConfigurationList(Arrays.asList(
+                        DeploymentPackageConfiguration.builder().packageName(TEST_INPUT_PACKAGE_A).rootComponent(true)
+                                .resolvedVersion("=2.0.0").build(),
+                        DeploymentPackageConfiguration.builder().packageName(TEST_INPUT_PACKAGE_B).rootComponent(true)
+                                .resolvedVersion("=1.1.0").build()))
+                .timestamp(10_000L)
+                .build();
+
+        Map<ComponentIdentifier, ComponentRecipe> componentsToResolve = new HashMap<>();
+        componentsToResolve.put(componentA,
+                getPackage(TEST_INPUT_PACKAGE_A, "2.0.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_A));
+        componentsToResolve.put(componentB,
+                getPackage(TEST_INPUT_PACKAGE_B, "1.1.0", Collections.emptyMap(), TEST_INPUT_PACKAGE_B));
+
+        // WHEN a deployment upgrades only component A, with B unchanged in the closure
+        Map<String, Object> servicesConfig = serviceConfigurationProperlyResolved(document, componentsToResolve);
+
+        // THEN the changed component rotates and the unchanged sibling is untouched
+        Map<String, Object> serviceConfigA = getServiceConfig(TEST_INPUT_PACKAGE_A, servicesConfig);
+        assertThat(serviceConfigA, hasEntry(KernelConfigResolver.PREV_VERSION_CONFIG_KEY, "1.0.0"));
+        Map<String, Object> serviceConfigB = getServiceConfig(TEST_INPUT_PACKAGE_B, servicesConfig);
+        assertThat(serviceConfigB, hasEntry(KernelConfigResolver.VERSION_CONFIG_KEY, "1.1.0"));
+        assertThat(serviceConfigB, hasEntry(KernelConfigResolver.PREV_VERSION_CONFIG_KEY, "1.0.0"));
+    }
+
     private Map<String, Object> serviceConfigurationProperlyResolved(DeploymentDocument deploymentDocument,
                                                                      Map<ComponentIdentifier,
                                                                              ComponentRecipe> componentsToResolve)

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentDirectoryManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentDirectoryManagerTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.BOOTSTRAP_TASK_FILE;
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.DEPLOYMENT_METADATA_FILE;
-import static com.aws.greengrass.deployment.DeploymentDirectoryManager.MAX_PROCESSING_ATTEMPTS;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS;
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.ROLLBACK_SNAPSHOT_FILE;
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.TARGET_CONFIG_FILE;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
@@ -182,7 +182,7 @@ class DeploymentDirectoryManagerTest {
             throws Exception {
         Path first = createNewDeploymentDir(mockArn);
         Files.write(first.resolve(ROLLBACK_SNAPSHOT_FILE), "verified".getBytes(StandardCharsets.UTF_8));
-        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        assertEquals(1, deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS));
 
         // No persistLast*Deployment call, so the ongoing link survives: the deployment never completed.
         Path second = createNewDeploymentDir(mockArn);
@@ -190,7 +190,7 @@ class DeploymentDirectoryManagerTest {
         assertEquals(first, second);
         assertEquals("verified",
                 new String(Files.readAllBytes(second.resolve(ROLLBACK_SNAPSHOT_FILE)), StandardCharsets.UTF_8));
-        assertEquals(2, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        assertEquals(2, deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS));
     }
 
     @Test
@@ -198,14 +198,14 @@ class DeploymentDirectoryManagerTest {
             throws Exception {
         Path first = createNewDeploymentDir(mockArn);
         Files.write(first.resolve(ROLLBACK_SNAPSHOT_FILE), "verified".getBytes(StandardCharsets.UTF_8));
-        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        assertEquals(1, deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS));
 
         Path second = createNewDeploymentDir(mockArn + "-superseding");
 
         assertEquals("verified",
                 new String(Files.readAllBytes(second.resolve(ROLLBACK_SNAPSHOT_FILE)), StandardCharsets.UTF_8));
         // A different deployment gets its own attempt budget.
-        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        assertEquals(1, deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS));
     }
 
     @Test
@@ -217,7 +217,7 @@ class DeploymentDirectoryManagerTest {
         Path second = createNewDeploymentDir(mockArn + "-next");
 
         assertThat(second.resolve(ROLLBACK_SNAPSHOT_FILE).toFile(), not(anExistingFileOrDirectory()));
-        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        assertEquals(1, deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS));
     }
 
     @Test
@@ -255,19 +255,19 @@ class DeploymentDirectoryManagerTest {
             throws Exception {
         createNewDeploymentDir(mockArn);
 
-        for (int attempt = 1; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
-            assertEquals(attempt, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        for (int attempt = 1; attempt < DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS; attempt++) {
+            assertEquals(attempt, deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS));
             assertFalse(deploymentDirectoryManager.hasExhaustedProcessingAttempts());
         }
-        assertEquals(MAX_PROCESSING_ATTEMPTS, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        assertEquals(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS, deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS));
         assertTrue(deploymentDirectoryManager.hasExhaustedProcessingAttempts());
     }
 
     @Test
     void GIVEN_deployment_failed_for_exhausted_attempts_WHEN_redelivered_THEN_recognised() throws Exception {
         createNewDeploymentDir(mockArn);
-        for (int attempt = 0; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
-            deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        for (int attempt = 0; attempt < DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS; attempt++) {
+            deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS);
         }
         deploymentDirectoryManager.persistLastFailedDeployment();
 
@@ -279,7 +279,7 @@ class DeploymentDirectoryManagerTest {
     @Test
     void GIVEN_deployment_failed_with_attempts_remaining_WHEN_redelivered_THEN_not_recognised() throws Exception {
         createNewDeploymentDir(mockArn);
-        deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS);
         deploymentDirectoryManager.persistLastFailedDeployment();
 
         assertFalse(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
@@ -288,8 +288,8 @@ class DeploymentDirectoryManagerTest {
     @Test
     void GIVEN_deployment_succeeded_WHEN_redelivered_THEN_not_recognised() throws Exception {
         createNewDeploymentDir(mockArn);
-        for (int attempt = 0; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
-            deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        for (int attempt = 0; attempt < DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS; attempt++) {
+            deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS);
         }
         deploymentDirectoryManager.persistLastSuccessfulDeployment();
 
@@ -300,8 +300,8 @@ class DeploymentDirectoryManagerTest {
     void GIVEN_another_deployment_finished_WHEN_refused_deployment_redelivered_THEN_no_longer_recognised()
             throws Exception {
         createNewDeploymentDir(mockArn);
-        for (int attempt = 0; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
-            deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        for (int attempt = 0; attempt < DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS; attempt++) {
+            deploymentDirectoryManager.recordProcessingAttempt(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS);
         }
         deploymentDirectoryManager.persistLastFailedDeployment();
         assertTrue(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
@@ -315,6 +315,31 @@ class DeploymentDirectoryManagerTest {
         deploymentDirectoryManager.persistLastSuccessfulDeployment();
 
         assertFalse(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
+    }
+
+    @Test
+    void GIVEN_no_attempt_limit_configured_WHEN_deployment_applied_repeatedly_THEN_attempts_never_exhausted()
+            throws Exception {
+        createNewDeploymentDir(mockArn);
+
+        // Below 1 means no limit: a device whose environment is not ready yet keeps retrying rather than
+        // being restored and failed.
+        for (int attempt = 1; attempt <= DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS + 5; attempt++) {
+            assertEquals(attempt, deploymentDirectoryManager.recordProcessingAttempt(0));
+            assertFalse(deploymentDirectoryManager.hasExhaustedProcessingAttempts());
+        }
+        assertFalse(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
+    }
+
+    @Test
+    void GIVEN_attempt_limit_lowered_WHEN_deployment_applied_THEN_the_limit_in_force_applies() throws Exception {
+        createNewDeploymentDir(mockArn);
+
+        // The limit recorded with the attempt is the one that decides, so a deployment is judged by the
+        // limit its operator had configured when it was applied.
+        deploymentDirectoryManager.recordProcessingAttempt(1);
+
+        assertTrue(deploymentDirectoryManager.hasExhaustedProcessingAttempts());
     }
 
     private Path createNewDeploymentDir(String arn) throws IOException {

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentDirectoryManagerTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentDirectoryManagerTest.java
@@ -22,11 +22,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.BOOTSTRAP_TASK_FILE;
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.DEPLOYMENT_METADATA_FILE;
+import static com.aws.greengrass.deployment.DeploymentDirectoryManager.MAX_PROCESSING_ATTEMPTS;
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.ROLLBACK_SNAPSHOT_FILE;
 import static com.aws.greengrass.deployment.DeploymentDirectoryManager.TARGET_CONFIG_FILE;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
@@ -37,6 +39,8 @@ import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.hamcrest.io.FileMatchers.anExistingFileOrDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -171,6 +175,146 @@ class DeploymentDirectoryManagerTest {
         assertEquals(actual.resolve(ROLLBACK_SNAPSHOT_FILE), deploymentDirectoryManager.getSnapshotFilePath());
         assertEquals(actual.resolve(TARGET_CONFIG_FILE), deploymentDirectoryManager.getTargetConfigFilePath());
         assertEquals(actual.resolve(BOOTSTRAP_TASK_FILE), deploymentDirectoryManager.getBootstrapTaskFilePath());
+    }
+
+    @Test
+    void GIVEN_unfinished_deployment_WHEN_same_deployment_reprocessed_THEN_rollback_snapshot_and_attempts_carried_forward()
+            throws Exception {
+        Path first = createNewDeploymentDir(mockArn);
+        Files.write(first.resolve(ROLLBACK_SNAPSHOT_FILE), "verified".getBytes(StandardCharsets.UTF_8));
+        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+
+        // No persistLast*Deployment call, so the ongoing link survives: the deployment never completed.
+        Path second = createNewDeploymentDir(mockArn);
+
+        assertEquals(first, second);
+        assertEquals("verified",
+                new String(Files.readAllBytes(second.resolve(ROLLBACK_SNAPSHOT_FILE)), StandardCharsets.UTF_8));
+        assertEquals(2, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+    }
+
+    @Test
+    void GIVEN_unfinished_deployment_WHEN_superseded_THEN_rollback_snapshot_carried_forward_but_attempts_reset()
+            throws Exception {
+        Path first = createNewDeploymentDir(mockArn);
+        Files.write(first.resolve(ROLLBACK_SNAPSHOT_FILE), "verified".getBytes(StandardCharsets.UTF_8));
+        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+
+        Path second = createNewDeploymentDir(mockArn + "-superseding");
+
+        assertEquals("verified",
+                new String(Files.readAllBytes(second.resolve(ROLLBACK_SNAPSHOT_FILE)), StandardCharsets.UTF_8));
+        // A different deployment gets its own attempt budget.
+        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+    }
+
+    @Test
+    void GIVEN_completed_deployment_WHEN_new_deployment_starts_THEN_nothing_carried_forward() throws Exception {
+        Path first = createNewDeploymentDir(mockArn);
+        Files.write(first.resolve(ROLLBACK_SNAPSHOT_FILE), "verified".getBytes(StandardCharsets.UTF_8));
+        deploymentDirectoryManager.persistLastSuccessfulDeployment();
+
+        Path second = createNewDeploymentDir(mockArn + "-next");
+
+        assertThat(second.resolve(ROLLBACK_SNAPSHOT_FILE).toFile(), not(anExistingFileOrDirectory()));
+        assertEquals(1, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+    }
+
+    @Test
+    void GIVEN_carried_forward_snapshot_WHEN_take_rollback_snapshot_THEN_snapshot_kept() throws Exception {
+        Path dir = createNewDeploymentDir(mockArn);
+        Files.write(dir.resolve(ROLLBACK_SNAPSHOT_FILE), "verified".getBytes(StandardCharsets.UTF_8));
+
+        deploymentDirectoryManager.takeRollbackSnapshot();
+
+        verify(kernel, times(0)).writeEffectiveConfigAsTransactionLog(any());
+        assertEquals("verified",
+                new String(Files.readAllBytes(dir.resolve(ROLLBACK_SNAPSHOT_FILE)), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void GIVEN_no_snapshot_WHEN_take_rollback_snapshot_THEN_snapshot_written() throws Exception {
+        createNewDeploymentDir(mockArn);
+
+        deploymentDirectoryManager.takeRollbackSnapshot();
+
+        verify(kernel, times(1)).writeEffectiveConfigAsTransactionLog(deploymentDirectoryManager.getSnapshotFilePath());
+    }
+
+    @Test
+    void WHEN_deployment_completes_THEN_no_unfinished_deployment_reported() throws Exception {
+        assertFalse(deploymentDirectoryManager.hasUnfinishedDeployment());
+        createNewDeploymentDir(mockArn);
+        assertTrue(deploymentDirectoryManager.hasUnfinishedDeployment());
+        deploymentDirectoryManager.persistLastSuccessfulDeployment();
+        assertFalse(deploymentDirectoryManager.hasUnfinishedDeployment());
+    }
+
+    @Test
+    void GIVEN_deployment_processed_repeatedly_WHEN_attempts_reach_the_cap_THEN_attempts_reported_exhausted()
+            throws Exception {
+        createNewDeploymentDir(mockArn);
+
+        for (int attempt = 1; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
+            assertEquals(attempt, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+            assertFalse(deploymentDirectoryManager.hasExhaustedProcessingAttempts());
+        }
+        assertEquals(MAX_PROCESSING_ATTEMPTS, deploymentDirectoryManager.incrementAndGetProcessingAttempts());
+        assertTrue(deploymentDirectoryManager.hasExhaustedProcessingAttempts());
+    }
+
+    @Test
+    void GIVEN_deployment_failed_for_exhausted_attempts_WHEN_redelivered_THEN_recognised() throws Exception {
+        createNewDeploymentDir(mockArn);
+        for (int attempt = 0; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
+            deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        }
+        deploymentDirectoryManager.persistLastFailedDeployment();
+
+        assertTrue(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
+        // A different deployment is unaffected, so a new revision still gets processed.
+        assertFalse(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn + "-next"));
+    }
+
+    @Test
+    void GIVEN_deployment_failed_with_attempts_remaining_WHEN_redelivered_THEN_not_recognised() throws Exception {
+        createNewDeploymentDir(mockArn);
+        deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        deploymentDirectoryManager.persistLastFailedDeployment();
+
+        assertFalse(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
+    }
+
+    @Test
+    void GIVEN_deployment_succeeded_WHEN_redelivered_THEN_not_recognised() throws Exception {
+        createNewDeploymentDir(mockArn);
+        for (int attempt = 0; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
+            deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        }
+        deploymentDirectoryManager.persistLastSuccessfulDeployment();
+
+        assertFalse(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
+    }
+
+    @Test
+    void GIVEN_another_deployment_finished_WHEN_refused_deployment_redelivered_THEN_no_longer_recognised()
+            throws Exception {
+        createNewDeploymentDir(mockArn);
+        for (int attempt = 0; attempt < MAX_PROCESSING_ATTEMPTS; attempt++) {
+            deploymentDirectoryManager.incrementAndGetProcessingAttempts();
+        }
+        deploymentDirectoryManager.persistLastFailedDeployment();
+        assertTrue(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
+
+        // A later deployment reaching a terminal state takes over the last-failed and last-successful
+        // links, which is what keeps the device able to accept new revisions. The refused deployment is
+        // consequently forgotten: a re-delivery of it arriving this late is treated as a new request. That
+        // is bounded elsewhere — a cloud deployment older than the group's last one is rejected as stale,
+        // and a local deployment is never re-delivered.
+        createNewDeploymentDir(mockArn + "-next");
+        deploymentDirectoryManager.persistLastSuccessfulDeployment();
+
+        assertFalse(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(mockArn));
     }
 
     private Path createNewDeploymentDir(String arn) throws IOException {

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -66,7 +66,6 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_SERVICE_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
-import static com.aws.greengrass.deployment.DeploymentDirectoryManager.MAX_PROCESSING_ATTEMPTS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_NAME_KEY;
@@ -82,6 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -519,9 +519,9 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
                 groupToLastDeploymentTopics);
         ignoreExceptionUltimateCauseWithMessage(extContext,
-                "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
-                        + " attempts, which is the maximum allowed. The device has been restored to the "
-                        + "configuration from before the deployment. Deploy a new revision to change it.");
+                "Deployment was interrupted before completing on every allowed attempt. The device has been "
+                        + "restored to the configuration from before the deployment. Deploy a new revision to "
+                        + "change it.");
 
         when(deploymentDirectoryManager.hasExhaustedProcessingAttempts()).thenReturn(true);
 
@@ -535,7 +535,7 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         verify(mockExecutorService, times(0)).submit(any(DefaultDeploymentTask.class));
         // Attempts are counted when a deployment is applied, not when it is received: the same deployment
         // can be delivered several times while only some deliveries reach the point of changing anything.
-        verify(deploymentDirectoryManager, never()).incrementAndGetProcessingAttempts();
+        verify(deploymentDirectoryManager, never()).recordProcessingAttempt(anyInt());
     }
 
     @Test
@@ -545,10 +545,9 @@ class DeploymentServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
                 groupToLastDeploymentTopics);
         ignoreExceptionUltimateCauseWithMessage(extContext,
-                "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
-                        + " attempts, which is the maximum allowed, and the device has been restored to the "
-                        + "configuration from before it. Deploy a new revision to change the device's "
-                        + "configuration.");
+                "Deployment was interrupted before completing on every allowed attempt, and the device has "
+                        + "been restored to the configuration from before it. Deploy a new revision to change the "
+                        + "device's configuration.");
 
         when(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(any())).thenReturn(true);
 

--- a/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeploymentServiceTest.java
@@ -66,6 +66,7 @@ import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_FAILURE
 import static com.aws.greengrass.deployment.DeploymentService.DEPLOYMENT_SERVICE_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_MEMBERSHIP_TOPICS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_ROOT_COMPONENTS_TOPICS;
+import static com.aws.greengrass.deployment.DeploymentDirectoryManager.MAX_PROCESSING_ATTEMPTS;
 import static com.aws.greengrass.deployment.DeploymentService.GROUP_TO_LAST_DEPLOYMENT_TOPICS;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICE_NAME_KEY;
@@ -89,6 +90,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -507,6 +509,60 @@ class DeploymentServiceTest extends GGServiceTestUtil {
                 (List<String>) statusDetails.getValue().get(DEPLOYMENT_ERROR_STACK_KEY));
         assertListEquals(Arrays.asList("DEVICE_ERROR"),
                 (List<String>) statusDetails.getValue().get(DEPLOYMENT_ERROR_TYPES_KEY));
+    }
+
+    @Test
+    void GIVEN_deployment_interrupted_repeatedly_WHEN_attempt_limit_exceeded_THEN_report_failed_job_status(
+            ExtensionContext extContext)
+            throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+        ignoreExceptionUltimateCauseWithMessage(extContext,
+                "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
+                        + " attempts, which is the maximum allowed. The device has been restored to the "
+                        + "configuration from before the deployment. Deploy a new revision to change it.");
+
+        when(deploymentDirectoryManager.hasExhaustedProcessingAttempts()).thenReturn(true);
+
+        deploymentQueue.offer(new Deployment(getTestDeploymentDocument(),
+                Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
+        startDeploymentServiceInAnotherThread();
+
+        verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.FAILED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+        verify(mockExecutorService, times(0)).submit(any(DefaultDeploymentTask.class));
+        // Attempts are counted when a deployment is applied, not when it is received: the same deployment
+        // can be delivered several times while only some deliveries reach the point of changing anything.
+        verify(deploymentDirectoryManager, never()).incrementAndGetProcessingAttempts();
+    }
+
+    @Test
+    void GIVEN_deployment_already_used_up_its_attempts_WHEN_redelivered_THEN_reject_it(ExtensionContext extContext)
+            throws Exception {
+        Topics groupToLastDeploymentTopics = Topics.of(context, GROUP_TO_LAST_DEPLOYMENT_TOPICS, null);
+        when(config.lookupTopics(eq(GROUP_TO_LAST_DEPLOYMENT_TOPICS), anyString())).thenReturn(
+                groupToLastDeploymentTopics);
+        ignoreExceptionUltimateCauseWithMessage(extContext,
+                "Deployment was interrupted before completing on " + MAX_PROCESSING_ATTEMPTS
+                        + " attempts, which is the maximum allowed, and the device has been restored to the "
+                        + "configuration from before it. Deploy a new revision to change the device's "
+                        + "configuration.");
+
+        when(deploymentDirectoryManager.wasRefusedForExhaustedAttempts(any())).thenReturn(true);
+
+        deploymentQueue.offer(new Deployment(getTestDeploymentDocument(),
+                Deployment.DeploymentType.IOT_JOBS, TEST_JOB_ID_1));
+        startDeploymentServiceInAnotherThread();
+
+        verify(deploymentStatusKeeper, WAIT_FOUR_SECONDS).persistAndPublishDeploymentStatus(eq(TEST_JOB_ID_1),
+                eq(TEST_UUID), eq(TEST_CONFIGURATION_ARN), eq(Deployment.DeploymentType.IOT_JOBS),
+                eq(JobStatus.REJECTED.toString()), any(), eq(EXPECTED_ROOT_PACKAGE_LIST));
+        // Nothing is applied and no new deployment directory is created, so the record of the refusal
+        // survives for any further re-delivery.
+        verify(mockExecutorService, times(0)).submit(any(DefaultDeploymentTask.class));
+        verify(deploymentDirectoryManager, never()).createNewDeploymentDirectory(any());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -102,6 +102,11 @@ class DeviceConfigurationTest {
 
         limitTopic.withValue("5");
         assertEquals(5, deviceConfiguration.getEffectiveMaxInterruptedDeploymentAttempts());
+
+        // A value too large for an int means "effectively unlimited", so it is clamped rather than
+        // rejected: falling back to the default would be the most restrictive setting instead.
+        limitTopic.withValue("99999999999999");
+        assertEquals(Integer.MAX_VALUE, deviceConfiguration.getEffectiveMaxInterruptedDeploymentAttempts());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/DeviceConfigurationTest.java
@@ -30,6 +30,8 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAM
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SETENV_CONFIG_NAMESPACE;
 import static com.aws.greengrass.lifecyclemanager.Kernel.SERVICE_TYPE_TOPIC_KEY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS;
+import static com.aws.greengrass.deployment.DeviceConfiguration.MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -80,6 +82,26 @@ class DeviceConfigurationTest {
         verify(deviceConfiguration, times(1)).validate(true);
         deviceConfiguration.isDeviceConfiguredToTalkToCloud();
         verify(deviceConfiguration, times(1)).validate(true);
+    }
+
+    @Test
+    void GIVEN_unparseable_attempt_limit_WHEN_resolved_THEN_default_used_rather_than_no_limit(
+            @Mock Context mockContext) {
+        Topic limitTopic = Topic.of(mockContext, MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS, null);
+        lenient().when(configuration.lookup(anyString(), anyString(), anyString(),
+                eq(MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS))).thenReturn(limitTopic);
+        deviceConfiguration = new DeviceConfiguration(configuration, kernelCommandLine);
+
+        limitTopic.withValue("three");
+        assertEquals(DEFAULT_MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS,
+                deviceConfiguration.getEffectiveMaxInterruptedDeploymentAttempts());
+
+        // An explicit value below 1 is a deliberate choice to retry indefinitely, so it is honoured.
+        limitTopic.withValue(0);
+        assertEquals(0, deviceConfiguration.getEffectiveMaxInterruptedDeploymentAttempts());
+
+        limitTopic.withValue("5");
+        assertEquals(5, deviceConfiguration.getEffectiveMaxInterruptedDeploymentAttempts());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
@@ -79,17 +79,13 @@ class DefaultActivatorTest {
     }
 
     @Test
-    void GIVEN_endpoint_switch_with_DO_NOTHING_WHEN_activate_THEN_snapshot_taken() throws Exception {
-        when(endpointSwitchState.isEndpointSwitchDeployment("testId")).thenReturn(true);
-        Path snapshotPath = mock(Path.class);
-        when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
-
+    void GIVEN_rollback_not_requested_WHEN_activate_THEN_snapshot_taken() throws Exception {
         CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
 
         defaultActivator.activate(createNewConfig(), createDeployment(FailureHandlingPolicy.DO_NOTHING),
                 System.currentTimeMillis(), future);
 
-        verify(deploymentDirectoryManager).takeConfigSnapshot(snapshotPath);
+        verify(deploymentDirectoryManager).takeRollbackSnapshot();
     }
 
     @Test
@@ -97,8 +93,6 @@ class DefaultActivatorTest {
             ExtensionContext extContext) throws Exception {
         ignoreExceptionOfType(extContext, ServiceUpdateException.class);
         when(endpointSwitchState.isEndpointSwitchDeployment("testId")).thenReturn(true);
-        Path snapshotPath = mock(Path.class);
-        when(deploymentDirectoryManager.getSnapshotFilePath()).thenReturn(snapshotPath);
 
         CompletableFuture<DeploymentResult> future = new CompletableFuture<>();
 
@@ -142,7 +136,9 @@ class DefaultActivatorTest {
 
         assertEquals(DeploymentResult.DeploymentStatus.FAILED_ROLLBACK_NOT_REQUESTED,
                 future.get().getDeploymentStatus());
-        verify(deploymentDirectoryManager, never()).takeConfigSnapshot(any());
+        // The snapshot is taken regardless of policy so an interrupted deployment stays undoable; the
+        // policy governs only whether a failed deployment rolls back.
+        verify(deploymentDirectoryManager).takeRollbackSnapshot();
     }
 
     private Deployment createDeployment(FailureHandlingPolicy policy) {
@@ -155,6 +151,32 @@ class DefaultActivatorTest {
         when(deployment.getDeploymentDocumentObj()).thenReturn(doc);
         when(deployment.getId()).thenReturn("testId");
         return deployment;
+    }
+
+    @Test
+    void GIVEN_deployment_cancelled_after_merge_WHEN_services_wait_returns_THEN_deployment_stops() throws Exception {
+        lenient().doReturn(Collections.emptySet()).when(kernel).findAutoStartableServicesToTrack();
+
+        CompletableFuture<DeploymentResult> future = spy(new CompletableFuture<>());
+
+        // Cancel while the merge's listeners are running, i.e. after the configuration has been applied
+        // but before the services have been waited on — the window a superseding deployment lands in.
+        AtomicInteger callCount = new AtomicInteger();
+        doAnswer(i -> {
+            ((Crashable) i.getArgument(0)).run();
+            if (callCount.getAndIncrement() == 1) {
+                future.cancel(true);
+            }
+            return null;
+        }).when(context).runOnPublishQueueAndWait(any(Crashable.class));
+
+        defaultActivator.activate(createNewConfig(), createDeployment(FailureHandlingPolicy.ROLLBACK),
+                System.currentTimeMillis(), future);
+
+        // Neither completed as successful nor rolled back: a cancelled deployment stops where it is rather
+        // than removing services alongside the deployment that replaced it.
+        verify(future, never()).complete(any());
+        verify(defaultActivator, never()).rollback(any(), any(), any(), any());
     }
 
     private Map<String, Object> createNewConfig() {

--- a/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/DefaultActivatorTest.java
@@ -71,6 +71,9 @@ class DefaultActivatorTest {
     @BeforeEach
     void beforeEach() {
         doReturn(deploymentDirectoryManager).when(context).get(DeploymentDirectoryManager.class);
+        // A deployment directory exists for every deployment DeploymentService submits.
+        lenient().doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+
         lenient().doReturn(endpointSwitchState).when(context).get(EndpointSwitchState.class);
         doReturn(context).when(kernel).getContext();
         lenient().doReturn(config).when(kernel).getConfig();

--- a/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
@@ -106,11 +106,11 @@ class KernelUpdateActivatorTest {
     }
 
     @Test
-    void GIVEN_deployment_activate_WHEN_takeConfigSnapshot_fails_THEN_deployment_fails(ExtensionContext context) throws Exception{
+    void GIVEN_deployment_activate_WHEN_takeRollbackSnapshot_fails_THEN_deployment_fails(ExtensionContext context) throws Exception{
         ignoreExceptionOfType(context, IOException.class);
 
         IOException mockIOE = new IOException();
-        doThrow(mockIOE).when(deploymentDirectoryManager).takeConfigSnapshot(any());
+        doThrow(mockIOE).when(deploymentDirectoryManager).takeRollbackSnapshot();
         kernelUpdateActivator.activate(newConfig, deployment, System.currentTimeMillis(), totallyCompleteFuture);
         ArgumentCaptor<DeploymentResult> captor = ArgumentCaptor.forClass(DeploymentResult.class);
         verify(totallyCompleteFuture).complete(captor.capture());

--- a/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
+++ b/src/test/java/com/aws/greengrass/deployment/activator/KernelUpdateActivatorTest.java
@@ -93,6 +93,8 @@ class KernelUpdateActivatorTest {
 
     @BeforeEach
     void beforeEach() {
+        // A deployment directory exists for every deployment DeploymentService submits.
+        lenient().doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
         doReturn(deploymentDirectoryManager).when(context).get(eq(DeploymentDirectoryManager.class));
         doReturn(kernelAlternatives).when(context).get(eq(KernelAlternatives.class));
         doReturn(nucleusPaths).when(kernel).getNucleusPaths();

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -97,9 +97,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
-// This test class was already at PMD's object-coupling limit before the interrupted-deployment
-// cases were added. Splitting it up is worth doing on its own, not as part of a bug fix.
-@SuppressWarnings("PMD.CouplingBetweenObjects")
+// This test class was already at PMD's object-coupling and class-length limits before the
+// interrupted-deployment cases were added. Splitting it up is worth doing on its own, not as part of a
+// bug fix.
+@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.ExcessiveClassLength"})
 class KernelTest {
     private static final String EXPECTED_CONFIG_OUTPUT =
             "  main:\n"

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -22,7 +22,6 @@ import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorType;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
-import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.spool.CloudMessageSpool;
@@ -98,6 +97,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
+// This test class was already at PMD's object-coupling limit before the interrupted-deployment
+// cases were added. Splitting it up is worth doing on its own, not as part of a bug fix.
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 class KernelTest {
     private static final String EXPECTED_CONFIG_OUTPUT =
             "  main:\n"
@@ -416,7 +418,7 @@ class KernelTest {
             throws Exception {
         DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
         doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
-        doReturn(new Deployment(mock(DeploymentDocument.class), Deployment.DeploymentType.IOT_JOBS, "mockId", DEFAULT))
+        doReturn(new Deployment("{}", Deployment.DeploymentType.IOT_JOBS, "mockId"))
                 .when(deploymentDirectoryManager).readDeploymentMetadata();
 
         launchWithDefaultStage(deploymentDirectoryManager);
@@ -445,7 +447,7 @@ class KernelTest {
         doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
         doReturn(true).when(deploymentDirectoryManager).hasExhaustedProcessingAttempts();
         doReturn(snapshotPath).when(deploymentDirectoryManager).getSnapshotFilePath();
-        doReturn(new Deployment(mock(DeploymentDocument.class), Deployment.DeploymentType.IOT_JOBS, "mockId", DEFAULT))
+        doReturn(new Deployment("{}", Deployment.DeploymentType.IOT_JOBS, "mockId"))
                 .when(deploymentDirectoryManager).readDeploymentMetadata();
 
         KernelLifecycle kernelLifecycle = launchWithDefaultStage(deploymentDirectoryManager, true);

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.deployment.errorcode.DeploymentErrorCode;
 import com.aws.greengrass.deployment.errorcode.DeploymentErrorType;
 import com.aws.greengrass.deployment.exceptions.ServiceUpdateException;
 import com.aws.greengrass.deployment.model.Deployment;
+import com.aws.greengrass.deployment.model.DeploymentDocument;
 import com.aws.greengrass.lifecyclemanager.exceptions.InputValidationException;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.spool.CloudMessageSpool;
@@ -65,6 +66,7 @@ import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.NO_OP
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_REBOOT;
 import static com.aws.greengrass.deployment.bootstrap.BootstrapSuccessCode.REQUEST_RESTART;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.BOOTSTRAP;
+import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.DEFAULT;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.KERNEL_ACTIVATION;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.KERNEL_ROLLBACK;
 import static com.aws.greengrass.deployment.model.Deployment.DeploymentStage.ROLLBACK_BOOTSTRAP;
@@ -407,6 +409,96 @@ class KernelTest {
 
         DeploymentQueue deployments = kernel.getContext().get(DeploymentQueue.class);
         assertThat(deployments.toArray(), hasSize(1));
+    }
+
+    @Test
+    void GIVEN_kernel_launch_WHEN_deployment_was_interrupted_without_completing_THEN_reprocess_it()
+            throws Exception {
+        DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
+        doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+        doReturn(new Deployment(mock(DeploymentDocument.class), Deployment.DeploymentType.IOT_JOBS, "mockId", DEFAULT))
+                .when(deploymentDirectoryManager).readDeploymentMetadata();
+
+        launchWithDefaultStage(deploymentDirectoryManager);
+
+        assertThat(kernel.getContext().get(DeploymentQueue.class).toArray(), hasSize(1));
+    }
+
+    @Test
+    void GIVEN_kernel_launch_WHEN_no_deployment_in_progress_THEN_nothing_reprocessed() throws Exception {
+        DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
+        doReturn(false).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+
+        launchWithDefaultStage(deploymentDirectoryManager);
+
+        assertThat(kernel.getContext().get(DeploymentQueue.class).toArray(), hasSize(0));
+        verify(deploymentDirectoryManager, times(0)).readDeploymentMetadata();
+    }
+
+    @Test
+    void GIVEN_kernel_launch_WHEN_interrupted_deployment_exhausted_its_attempts_THEN_boot_from_rollback_snapshot()
+            throws Exception {
+        Path snapshotPath = tempRootDir.resolve("rollback_snapshot.tlog");
+        Files.createFile(snapshotPath);
+
+        DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
+        doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+        doReturn(true).when(deploymentDirectoryManager).hasExhaustedProcessingAttempts();
+        doReturn(snapshotPath).when(deploymentDirectoryManager).getSnapshotFilePath();
+        doReturn(new Deployment(mock(DeploymentDocument.class), Deployment.DeploymentType.IOT_JOBS, "mockId", DEFAULT))
+                .when(deploymentDirectoryManager).readDeploymentMetadata();
+
+        KernelLifecycle kernelLifecycle = launchWithDefaultStage(deploymentDirectoryManager, true);
+
+        verify(kernelLifecycle).initConfigAndTlog(snapshotPath.toString());
+        // Still re-queued, so DeploymentService reports the deployment failed rather than leaving it
+        // outstanding for the cloud to deliver again.
+        assertThat(kernel.getContext().get(DeploymentQueue.class).toArray(), hasSize(1));
+    }
+
+    @Test
+    void GIVEN_kernel_launch_WHEN_interrupted_deployment_cannot_be_read_THEN_launch_still_proceeds(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, RuntimeException.class);
+
+        DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
+        doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+        doThrow(new RuntimeException("corrupt metadata")).when(deploymentDirectoryManager).readDeploymentMetadata();
+
+        KernelLifecycle kernelLifecycle = launchWithDefaultStage(deploymentDirectoryManager, false);
+
+        // Re-processing is a recovery step: failing it must not keep the device from starting.
+        verify(kernelLifecycle).launch();
+        assertThat(kernel.getContext().get(DeploymentQueue.class).toArray(), hasSize(0));
+    }
+
+    private void launchWithDefaultStage(DeploymentDirectoryManager deploymentDirectoryManager) throws Exception {
+        launchWithDefaultStage(deploymentDirectoryManager, false);
+    }
+
+    private KernelLifecycle launchWithDefaultStage(DeploymentDirectoryManager deploymentDirectoryManager,
+                                                  boolean expectConfigOverride) throws Exception {
+        KernelLifecycle kernelLifecycle = mock(KernelLifecycle.class);
+        doNothing().when(kernelLifecycle).launch();
+        if (expectConfigOverride) {
+            doNothing().when(kernelLifecycle).initConfigAndTlog(any());
+        } else {
+            doNothing().when(kernelLifecycle).initConfigAndTlog();
+        }
+        kernel.setKernelLifecycle(kernelLifecycle);
+
+        KernelAlternatives kernelAlternatives = mock(KernelAlternatives.class);
+        doReturn(DEFAULT).when(kernelAlternatives).determineDeploymentStage(any(), any());
+        doReturn(tempFile).when(kernelAlternatives).getLaunchParamsPath();
+        kernel.getContext().put(KernelAlternatives.class, kernelAlternatives);
+
+        KernelCommandLine kernelCommandLine = mock(KernelCommandLine.class);
+        doReturn(deploymentDirectoryManager).when(kernelCommandLine).getDeploymentDirectoryManager();
+        doReturn(mock(BootstrapManager.class)).when(kernelCommandLine).getBootstrapManager();
+        kernel.setKernelCommandLine(kernelCommandLine);
+
+        kernel.parseArgs().launch();
+        return kernelLifecycle;
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -417,7 +417,7 @@ class KernelTest {
     void GIVEN_kernel_launch_WHEN_deployment_was_interrupted_without_completing_THEN_reprocess_it()
             throws Exception {
         DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
-        doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+        doReturn(true).when(deploymentDirectoryManager).hasReadableDeploymentMetadata();
         doReturn(new Deployment("{}", Deployment.DeploymentType.IOT_JOBS, "mockId"))
                 .when(deploymentDirectoryManager).readDeploymentMetadata();
 
@@ -429,7 +429,7 @@ class KernelTest {
     @Test
     void GIVEN_kernel_launch_WHEN_no_deployment_in_progress_THEN_nothing_reprocessed() throws Exception {
         DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
-        doReturn(false).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+        doReturn(false).when(deploymentDirectoryManager).hasReadableDeploymentMetadata();
 
         launchWithDefaultStage(deploymentDirectoryManager);
 
@@ -445,6 +445,7 @@ class KernelTest {
 
         DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
         doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+        doReturn(true).when(deploymentDirectoryManager).hasReadableDeploymentMetadata();
         doReturn(true).when(deploymentDirectoryManager).hasExhaustedProcessingAttempts();
         doReturn(snapshotPath).when(deploymentDirectoryManager).getSnapshotFilePath();
         doReturn(new Deployment("{}", Deployment.DeploymentType.IOT_JOBS, "mockId"))
@@ -464,7 +465,7 @@ class KernelTest {
         ignoreExceptionOfType(context, RuntimeException.class);
 
         DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
-        doReturn(true).when(deploymentDirectoryManager).hasUnfinishedDeployment();
+        doReturn(true).when(deploymentDirectoryManager).hasReadableDeploymentMetadata();
         doThrow(new RuntimeException("corrupt metadata")).when(deploymentDirectoryManager).readDeploymentMetadata();
 
         KernelLifecycle kernelLifecycle = launchWithDefaultStage(deploymentDirectoryManager, false);

--- a/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
+++ b/src/test/java/com/aws/greengrass/lifecyclemanager/KernelTest.java
@@ -418,12 +418,27 @@ class KernelTest {
             throws Exception {
         DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
         doReturn(true).when(deploymentDirectoryManager).hasReadableDeploymentMetadata();
-        doReturn(new Deployment("{}", Deployment.DeploymentType.IOT_JOBS, "mockId"))
+        doReturn(new Deployment("{}", Deployment.DeploymentType.LOCAL, "mockId"))
                 .when(deploymentDirectoryManager).readDeploymentMetadata();
 
         launchWithDefaultStage(deploymentDirectoryManager);
 
         assertThat(kernel.getContext().get(DeploymentQueue.class).toArray(), hasSize(1));
+    }
+
+    @Test
+    void GIVEN_kernel_launch_WHEN_interrupted_cloud_deployment_THEN_left_for_the_cloud_to_redeliver()
+            throws Exception {
+        DeploymentDirectoryManager deploymentDirectoryManager = mock(DeploymentDirectoryManager.class);
+        doReturn(true).when(deploymentDirectoryManager).hasReadableDeploymentMetadata();
+        doReturn(new Deployment("{}", Deployment.DeploymentType.IOT_JOBS, "mockId"))
+                .when(deploymentDirectoryManager).readDeploymentMetadata();
+
+        launchWithDefaultStage(deploymentDirectoryManager);
+
+        // Re-processing it from disk would race the cloud's own re-delivery, which carries the document
+        // the cloud holds and can resolve components this device cannot.
+        assertThat(kernel.getContext().get(DeploymentQueue.class).toArray(), hasSize(0));
     }
 
     @Test
@@ -448,7 +463,7 @@ class KernelTest {
         doReturn(true).when(deploymentDirectoryManager).hasReadableDeploymentMetadata();
         doReturn(true).when(deploymentDirectoryManager).hasExhaustedProcessingAttempts();
         doReturn(snapshotPath).when(deploymentDirectoryManager).getSnapshotFilePath();
-        doReturn(new Deployment("{}", Deployment.DeploymentType.IOT_JOBS, "mockId"))
+        doReturn(new Deployment("{}", Deployment.DeploymentType.LOCAL, "mockId"))
                 .when(deploymentDirectoryManager).readDeploymentMetadata();
 
         KernelLifecycle kernelLifecycle = launchWithDefaultStage(deploymentDirectoryManager, true);

--- a/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
+++ b/src/test/java/com/aws/greengrass/tes/TokenExchangeServiceTest.java
@@ -41,6 +41,7 @@ import static com.aws.greengrass.deployment.DeviceConfiguration.BOOT_CONFIG_TLOG
 import static com.aws.greengrass.deployment.DeviceConfiguration.COMPONENT_STORE_MAX_SIZE_BYTES;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEFAULT_NUCLEUS_COMPONENT_NAME;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEPLOYMENT_POLLING_FREQUENCY_SECONDS;
+import static com.aws.greengrass.deployment.DeviceConfiguration.MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_IOT_CRED_ENDPOINT;
 import static com.aws.greengrass.deployment.DeviceConfiguration.IOT_ROLE_ALIAS_TOPIC;
 import static com.aws.greengrass.deployment.DeviceConfiguration.NUCLEUS_CONFIG_LOGGING_TOPICS;
@@ -123,6 +124,8 @@ class TokenExchangeServiceTest extends GGServiceTestUtil {
                 COMPONENT_STORE_MAX_SIZE_BYTES)).thenReturn(componentStoreSizeLimitTopic);
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 BOOT_CONFIG_TLOG_COMPACTION_THRESHOLD_BYTES)).thenReturn(mock(Topic.class));
+        when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
+                MAX_INTERRUPTED_DEPLOYMENT_ATTEMPTS)).thenReturn(mock(Topic.class));
         when(configuration.lookupTopics(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,
                 NUCLEUS_CONFIG_LOGGING_TOPICS)).thenReturn(mock(Topics.class));
         when(configuration.lookup(SERVICES_NAMESPACE_TOPIC, DEFAULT_NUCLEUS_COMPONENT_NAME, CONFIGURATION_CONFIG_KEY,


### PR DESCRIPTION
**Issue #, if available:** None. (#1837 was filed while investigating this, but is a separate defect that this change does not address.)

**Description of changes:**

A deployment that requires no Nucleus restart takes the `DefaultActivator` path, which merges the new configuration into the live config tree with the transaction-log writer attached and flushing immediately. The merged version therefore reaches durable storage before anything knows whether the component starts, and the config tree is the only record of current state — nothing distinguishes a running, verified version from one written a moment ago.

Interrupt the Nucleus between that merge and a terminal deployment status, and three things follow. The unverified version survives as the device's current state, because `initConfigAndTlog` prefers `config.tlog` and nothing marks the value provisional. Nothing resumes or reverts it, because `determineDeploymentStage` returns `DEFAULT` unless kernel-alts directories exist and the `DEFAULT` launch path never reads `deployment_metadata.json`. Processing the deployment again then rewrites its rollback snapshot from that state, so a later rollback restores the version being deployed rather than the one that was running.

Superseding a deployment mid-activation reaches the same state with no interruption at all: `waitForServicesToStart` returns early on cancellation instead of throwing, so `DefaultActivator` never rolls back, and the superseding deployment inherits the cancelled deployment's merged version as its rollback baseline.

Seven changes:

- **Snapshot regardless of `FailureHandlingPolicy`.** `DefaultActivator` previously recorded a rollback snapshot only when the deployment requested rollback or switched the IoT data endpoint, so a `DO_NOTHING` deployment — the default for local deployments — left nothing to restore from. The policy governs whether a *failed* deployment rolls back; it cannot govern whether an *interrupted* one is recoverable.
- **Carry the rollback snapshot forward.** A terminal status is what removes the `ongoing` link, so finding that link when a new deployment starts means live config may hold unverified changes. The unfinished deployment's `rollback_snapshot.tlog` is then the last verified configuration, so preserve it into the new deployment's directory — which `createNewDeploymentDirectory` otherwise deletes — and keep it rather than overwriting it from live config. This covers re-processing the same deployment and a different deployment superseding it.
- **Re-process an abandoned local deployment at launch.** When the launch stage is `DEFAULT` and an unfinished *local* deployment's metadata is still on disk, offer it back onto the deployment queue, as the kernel-activation stage already does. Only local deployments: a cloud deployment that never reported a terminal status is re-delivered by the cloud with the document the cloud holds, so re-processing it from disk would race a better-informed mechanism — and resolution from disk can fail where the cloud succeeds, turning a deployment that would have completed into a failed one. Local deployments get no re-delivery, so they are the case that needs this.
- **Count an attempt where the deployment is applied, not where it is received.** The same deployment can be delivered several times — by the device re-processing it at launch and by the cloud re-delivering it after a reconnect — while only some deliveries reach the point of changing anything.
- **Cap the attempts, and restore the device when they run out.** A deployment that reliably takes the device down mid-activation would otherwise retry forever. The launch then boots from the deployment's rollback snapshot rather than `config.tlog`, which is the same config override the kernel-rollback stage uses; doing it before any service starts is what makes it safe. `DeploymentService` reports `FAILED`, which stops cloud re-delivery and releases the device to accept a newer deployment. `maxInterruptedDeploymentAttempts` sets the limit, defaulting to three; below 1 there is no limit, for a fleet whose devices may legitimately need several attempts because the environment is not ready yet. The value is parsed strictly, because coercing it would turn anything non-numeric into 0 and silently disable the protection; a malformed value falls back to the default and one too large for an int is clamped rather than rejected. The limit is recorded alongside the count when the deployment is applied, because the launch consults the count from `parseArgs`, before `config.tlog` has been read — so a deployment is judged by the limit in force when it was applied.
- **Remember a refused deployment until something else finishes.** Reporting the failure clears the `ongoing` link, so a re-delivery already in flight would otherwise get a fresh allowance and re-apply the version just backed out. Such a re-delivery is now rejected, identified by the last-failed link and the attempt count inside it. Rejecting rather than failing it leaves that record intact; any other deployment reaching a terminal state clears it, so a new revision is always accepted.
- **Stop a cancelled deployment before `removeObsoleteServices`,** rather than mutating services alongside the deployment that superseded it.

The re-queue and the restore both swallow any failure. They are recovery steps, so a corrupt metadata file must never keep the device from starting.

**Why is this change necessary:**

If the unverified version is broken the device does not recover, and getting there needs no operator action: a device that never reported a terminal status re-delivers the deployment to itself after reconnecting, and that re-delivery is what poisons the rollback snapshot.

This affects any deployment that changes only components, which is most routine application deployments. Deployments that update the Nucleus or include a component with a `bootstrap` step take the restart-based path and are unaffected, because `KernelUpdateActivator` closes the transaction-log writer before merging and records its target separately.

A second, independent defect is fixed in the first commit: the same-version branch of `handleComponentVersionConfigs` read `previousVersion` from the version topic, so any deployment silently rotated `previousVersion` onto the current version for every component whose version was not changing. `ComponentManager.getVersionsToKeep` reads that field to decide which versions are non-stale, so the replaced version's artifacts became eligible for cleanup.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [x] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy. (No network calls added.)

Unit tests cover each part: the snapshot carry-forward and its boundaries, the attempt counter, the cap and its unlimited setting, recognising a re-delivery of a refused deployment, the launch-time re-queue and restore, a failing re-queue still letting the device start, and a cancelled deployment stopping before it removes services. Each test that pins a defect was checked in both directions — it fails with the corresponding production change reverted.

End-to-end coverage is an 18-scenario suite run on devices; it is not held in this repository. Twelve reproduce the defects and fail on the current release line; six are controls guarding behaviour that already works, including the restart-based path surviving the same interruption and an interruption during a rollback. All 18 pass with this change, with the interrupted-deployment scenarios stable both alone and in the full suite. A full sweep of the wider suite — 787 scenarios — found one regression, an interrupted custom-nucleus deployment that this change re-processed locally instead of leaving for the cloud to re-deliver; that is what narrowed re-processing to local deployments.

**Any additional information or context required to review the change:**

Three deliberate behaviour changes worth your attention:

- A failed snapshot write now fails any deployment rather than only rollback-enabled ones, matching what `KernelUpdateActivator` already does. Note the distinction from a *missing* deployment directory, which is not a failure: with no directory there is nowhere to put a snapshot and nothing tracking the deployment that could use one, so the snapshot is skipped and the deployment proceeds. `DeploymentService` creates the directory before submitting, so every deployment that reaches a device is still snapshotted.
- A deployment interrupted on every allowed attempt is failed and reverted, where previously another attempt could succeed. This trades eventual success for a predictable failure the operator can retry, and is what keeps a deployment that repeatedly takes the device down from blocking newer ones. It defaults to three attempts and can be turned off with `maxInterruptedDeploymentAttempts`, which restores the previous behaviour.
- A re-delivery of a deployment that used up its attempts is rejected, so it reports `REJECTED` where it previously reported `IN_PROGRESS` and then a result.

Two properties I chose not to change:

- Constructing a `Kernel` performs the boot-time restore even in a process that never launches, because the restore works by choosing which file `initConfigAndTlog` reads. That is what makes it safe — no services are running, so nothing has to be reconciled — and moving it into `launch()` would mean merging a snapshot into an already-loaded configuration. `KERNEL_ACTIVATION` and `KERNEL_ROLLBACK` already override the config file the same way; this change widens when that happens, not what it does. Untested consequence: a second process constructing a `Kernel` while the Nucleus is running with attempts exhausted would rewrite `config.tlog` from the snapshot.
- A re-delivery arriving after a *different* deployment has reached a terminal state gets a fresh allowance, because that deployment's terminal status clears the record. A cloud deployment older than the group's last one is rejected as stale, and a local deployment is never re-delivered, so this is bounded elsewhere. A unit test documents the boundary.

Cancellation *semantics* are unchanged: a cancelled deployment still does not revert, and the log still tells the operator to deploy again. What changes is that the next deployment no longer inherits unverified state as its rollback baseline.

**Documentation Checklist:**
 - [ ] Updated the README if applicable. (Not applicable — no user-facing configuration or interface changes.)

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume any deprecated method or type. (No dependency changes.)

Nothing is removed or renamed and no new requirement is added, so no customer has to change anything. The behaviour changes above alter recovery outcomes only; if you read any of them as requiring a corresponding customer change, that is the part to push back on.
